### PR TITLE
[java_17_migration] Enable disabled tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,11 +58,6 @@ subprojects {
 
 }
 
-buildScan {
-    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-    termsOfServiceAgree = 'yes'
-}
-
 dependencies {
     constraints {
         //implementation 'org.springframework:spring-web:5.0.2.RELEASE'

--- a/cli/ballerina-cli/build.gradle
+++ b/cli/ballerina-cli/build.gradle
@@ -92,7 +92,6 @@ test {
     dependsOn createTestDistributionCache
     dependsOn createTestBre
 
-    maxParallelForks = 1
     systemProperty "ballerina.home", "$buildDir"
 
     useTestNG() {

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/NewCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/NewCommandTest.java
@@ -79,7 +79,7 @@ public class NewCommandTest extends BaseCommandTest {
         ProjectUtils.deleteDirectory(centralCache);
     }
 
-    @Test(description = "Create a new project", enabled = false)
+    @Test(description = "Create a new project")
     public void testNewCommand() throws IOException {
         System.setProperty(USER_NAME, "testuserorg");
         Path packageDir = tmpDir.resolve("project_name");
@@ -943,7 +943,7 @@ public class NewCommandTest extends BaseCommandTest {
         Assert.assertFalse(Files.isDirectory(tmpDir.resolve("parent").resolve("sub_dir").resolve("sample")));
     }
 
-    @Test(description = "Test new command with invalid length package name", enabled = false)
+    @Test(description = "Test new command with invalid length package name")
     public void testNewCommandWithInvalidLengthPackageName() throws IOException {
         String longPkgName = "thisIsVeryLongPackageJustUsingItForTesting"
                 + "thisIsVeryLongPackageJustUsingItForTesting"

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/HierarchicalPackageNameTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/HierarchicalPackageNameTests.java
@@ -96,7 +96,7 @@ public class HierarchicalPackageNameTests {
                 "Unexpected number of dependencies");
     }
 
-    @Test(enabled = false)
+    @Test
     public void testResolveHierarchicalPackageInDist() {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_x.y.z");
         Environment environment = EnvironmentBuilder.getBuilder().setUserHome(customUserHome).build();
@@ -143,7 +143,7 @@ public class HierarchicalPackageNameTests {
         }
     }
 
-    @Test(enabled = false, dependsOnMethods = "testResolveHierarchicalPackageInDist")
+    @Test(dependsOnMethods = "testResolveHierarchicalPackageInDist")
     public void testResolveDifferentPackagesFromEachRepo() {
         Path centralCache = customUserHome.resolve("repositories/central.ballerina.io");
         BCompileUtil.compileAndCacheBala("hierarchical_pkg_names/package_a.c", centralCache);

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBalaProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBalaProject.java
@@ -244,7 +244,7 @@ public class TestBalaProject {
         }
     }
 
-    @Test(enabled = false)
+    @Test
     public void testProjectRefresh() {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_refresh_tests").resolve("package_refresh_bala");
         Project project = TestUtils.loadProject(projectDirPath);

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -1818,7 +1818,7 @@ public class TestBuildProject extends BaseTest {
         return resources;
     }
 
-    @Test(enabled = false)
+    @Test
     public void testProjectClearCaches() {
         Path projectDirPath = tempResourceDir.resolve("projects_for_refresh_tests").resolve("package_refresh_one");
         BuildProject buildProject = TestUtils.loadBuildProject(projectDirPath);

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestSingleFileProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestSingleFileProject.java
@@ -256,7 +256,7 @@ public class TestSingleFileProject {
                         .fileName(), "main_with_error.bal");
     }
 
-    @Test(enabled = false)
+    @Test
     public void testProjectRefresh() {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_refresh_tests").resolve("single-file")
                 .resolve("main.bal");

--- a/settings.gradle
+++ b/settings.gradle
@@ -266,3 +266,10 @@ buildCache {
         push = true
     }
 }
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+    }
+}

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ExcludeFromCodeCoverageTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ExcludeFromCodeCoverageTest.java
@@ -51,7 +51,7 @@ public class ExcludeFromCodeCoverageTest extends BaseTestCase {
                 .resolve("test_results.json");
     }
 
-    @Test(description = "Exclude coverage with relative source paths and wildcards", enabled = false)
+    @Test(description = "Exclude coverage with relative source paths and wildcards")
     public void testExcludingBalFileCoverage() throws BallerinaTestException, IOException {
         String [][] exclusionListOfList = {{"./main.bal", "./modules/util/util.bal", "./generated/util/util_gen.bal",
                 "./generated/util2/util2_gen.bal", "./generated/main_gen.bal"},


### PR DESCRIPTION
## Purpose
> $title
> Disabled Project-api tests are now enabled after done a fix on package resolution.  

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
