### PR TITLE
[2201.7.x] Fix parameter default value function getting null

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -985,7 +985,8 @@ public class JvmTypeGen {
             } else {
                 mv.visitInsn(ICONST_0);
             }
-            BInvokableSymbol bInvokableSymbol = invokableSymbol.defaultValues.get(paramSymbol.originalName.value);
+            BInvokableSymbol bInvokableSymbol = invokableSymbol.defaultValues.get(
+                    Utils.decodeIdentifier(paramSymbol.name.value));
             if (bInvokableSymbol == null) {
                 mv.visitInsn(ACONST_NULL);
             } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.desugar;
 
+import io.ballerina.identifier.Utils;
 import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.Flag;
@@ -555,7 +556,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
         env.enclPkg.symbol.scope.define(function.symbol.name, function.symbol);
         env.enclPkg.functions.add(function);
         env.enclPkg.topLevelNodes.add(function);
-        symbol.defaultValues.put(paramName, varSymbol);
+        symbol.defaultValues.put(Utils.unescapeBallerina(paramName), varSymbol);
         return returnStmt.expr;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.desugar;
 
+import io.ballerina.identifier.Utils;
 import io.ballerina.runtime.api.constants.RuntimeConstants;
 import io.ballerina.tools.diagnostics.Location;
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -6467,7 +6468,7 @@ public class Desugar extends BLangNodeVisitor {
                 continue;
             }
 
-            BInvokableSymbol invokableSymbol = defaultValues.get(paramName);
+            BInvokableSymbol invokableSymbol = defaultValues.get(Utils.unescapeBallerina(paramName));
             BLangInvocation closureInvocation = getInvocation(invokableSymbol);
             for (int m = 0; m < invokableSymbol.params.size(); m++) {
                 String langLibFuncParam = invokableSymbol.params.get(m).name.value;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -477,6 +477,13 @@ public class Values {
         return StringUtils.fromString(parameter.name);
     }
 
+    public static BString getParameterDefaultFunctionNameFromResource(BTypedesc type) {
+        BServiceType serviceType = (BServiceType) type.getDescribingType();
+        ResourceMethodType resourceMethod = serviceType.getResourceMethods()[1];
+        Parameter parameter = resourceMethod.getParameters()[0];
+        return StringUtils.fromString(parameter.defaultFunctionName);
+    }
+
     public static BArray getParamNamesFromObjectInit(BObject object) {
         ObjectType objectType = object.getType();
         MethodType initMethodtype = objectType.getInitMethod();

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/identifier_utils/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/identifier_utils/main.bal
@@ -31,6 +31,10 @@ service class AccountService {
         email: "john.doe@email.com",
         phone: "1234567890"
     };
+    resource function get packages(int? 'limit = ()) returns json => {
+        'limit: 'limit,
+        body: "hello"
+    };
 }
 
 public function main() {
@@ -43,6 +47,8 @@ public function main() {
 function testFunctionParameters() {
     test:assertEquals(getParameterName(function(string account\-id) {}), "account-id");
     test:assertEquals(getParameterNameFromResource(AccountService), "account-id");
+    test:assertEquals(getParameterDefaultFunctionNameFromResource(AccountService),
+    "$AccountService_$get$packages_limit");
 }
 
 function testIdentifierDecoding() {
@@ -89,5 +95,9 @@ function getParameterName(function f) returns string = @java:Method {
 } external;
 
 function getParameterNameFromResource(typedesc<any> serviceObj) returns string = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+function getParameterDefaultFunctionNameFromResource(typedesc<any> serviceObj) returns string = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;


### PR DESCRIPTION
## Purpose
$subject 

Fixes #41057 

## Approach
The fix done in https://github.com/ballerina-platform/ballerina-lang/commit/adb76332c41bf1cb71a17f09ae2b5777ddfee81d
breaks for quoted identifier parameterss when it contains a default value function. 
The fix populates the default values map using the decoded parameter identifiers and retrieves them at code generation.

## Samples
```ballerina
import ballerina/http;

listener http:Listener webAPIEP = new (9090);

service / on webAPIEP {

    isolated resource function get packages(int? 'limit = (), string? package = (), boolean? user\-packages = false) returns http:Ok|http:BadRequest|http:InternalServerError|http:Unauthorized {
        return <http:Ok>{
            body: "hello"
        };
    }

}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
