### PR TITLE
[Java_17_migration] Restore deprecated jacocoMergeExec task

### DIFF
--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -162,10 +162,6 @@ test {
         events "failed"
         exceptionFormat "full"
     }
-
-    jacoco {
-        destinationFile = file("$buildDir/jacoco/jacoco.exec")
-    }
 }
 
 jacocoTestReport {
@@ -185,10 +181,11 @@ check {
     dependsOn createJavadoc
 }
 
-task jacocoMergeExec(type: JacocoReport) {
-    getExecutionData().setFrom(fileTree("$buildDir/jacoco/").matching {
+task jacocoMergeExec(type: JacocoMerge) {
+    destinationFile = file("$buildDir/jacoco/jacoco.exec")
+    executionData = fileTree("$buildDir/jacoco/").matching {
         include "**.exec"
-    } as FileCollection)
+    } as FileCollection
 }
 
 publishing {


### PR DESCRIPTION
## Purpose
> `jacocoMergeExec` task is deprecated and still available in Gradle 7.6.2 we can restore that task for now.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
