### PR TITLE
[2201.7.x] Remove public constructs check in API docs generation

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -108,10 +108,9 @@ public class Generator {
      * @param semanticModel semantic model
      * @return whether the module has any public constructs.
      */
-    public static boolean setModuleFromSyntaxTree(Module module, SyntaxTree syntaxTree,
+    public static void setModuleFromSyntaxTree(Module module, SyntaxTree syntaxTree,
                                                   SemanticModel semanticModel) {
 
-        boolean hasPublicConstructs = false;
         if (syntaxTree.containsModulePart()) {
             ModulePartNode modulePartNode = syntaxTree.rootNode();
             for (Node node : modulePartNode.members()) {
@@ -120,13 +119,12 @@ public class Generator {
                     if (typeDefinition.visibilityQualifier().isPresent() && typeDefinition.visibilityQualifier().get()
                             .kind().equals(SyntaxKind.PUBLIC_KEYWORD) ||
                             isTypePramOrBuiltinSubtype(typeDefinition.metadata())) {
-                        hasPublicConstructs = addTypeDefinition(typeDefinition, module, semanticModel);
+                        addTypeDefinition(typeDefinition, module, semanticModel);
                     }
                 } else if (node.kind() == SyntaxKind.CLASS_DEFINITION) {
                     ClassDefinitionNode classDefinition = (ClassDefinitionNode) node;
                     if (classDefinition.visibilityQualifier().isPresent() && classDefinition.visibilityQualifier().get()
                             .kind().equals(SyntaxKind.PUBLIC_KEYWORD)) {
-                        hasPublicConstructs = true;
                         BClass cls = getClassModel((ClassDefinitionNode) node, semanticModel, module);
                         if (cls instanceof Client) {
                             module.clients.add((Client) cls);
@@ -138,17 +136,14 @@ public class Generator {
                     }
                 } else if (node.kind() == SyntaxKind.FUNCTION_DEFINITION &&
                         containsToken(((FunctionDefinitionNode) node).qualifierList(), SyntaxKind.PUBLIC_KEYWORD)) {
-                    hasPublicConstructs = true;
                     module.functions.add(getFunctionModel((FunctionDefinitionNode) node, semanticModel, module));
                 } else if (node.kind() == SyntaxKind.CONST_DECLARATION && ((ConstantDeclarationNode) node)
                         .visibilityQualifier().isPresent() && ((ConstantDeclarationNode) node).visibilityQualifier()
                         .get().kind().equals(SyntaxKind.PUBLIC_KEYWORD)) {
-                    hasPublicConstructs = true;
                     module.constants.add(getConstantTypeModel((ConstantDeclarationNode) node, semanticModel, module));
                 } else if (node.kind() == SyntaxKind.ANNOTATION_DECLARATION && ((AnnotationDeclarationNode) node)
                         .visibilityQualifier().isPresent() && ((AnnotationDeclarationNode) node)
                         .visibilityQualifier().get().kind().equals(SyntaxKind.PUBLIC_KEYWORD)) {
-                    hasPublicConstructs = true;
                     module.annotations.add(getAnnotationModel((AnnotationDeclarationNode) node, semanticModel, module));
                 } else if (node.kind() == SyntaxKind.ENUM_DECLARATION &&
                         ((EnumDeclarationNode) node).qualifier().isPresent() &&
@@ -163,10 +158,9 @@ public class Generator {
                 }
             }
         }
-        return hasPublicConstructs;
     }
 
-    public static boolean addTypeDefinition(TypeDefinitionNode typeDefinition, Module module, SemanticModel
+    public static void addTypeDefinition(TypeDefinitionNode typeDefinition, Module module, SemanticModel
             semanticModel) {
 
         String typeName = typeDefinition.typeName().text();
@@ -286,10 +280,7 @@ public class Generator {
                 typeDefinition.typeDescriptor().kind() == SyntaxKind.ANY_TYPE_DESC) {
             module.types.add(getUnionTypeModel(typeDefinition.typeDescriptor(), typeName, metaDataNode, semanticModel,
                     module));
-        } else {
-            return false;
         }
-        return true;
         // TODO: handle value type nodes
         // TODO: handle built in ref type
         // TODO: handle constrained types

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -106,7 +106,6 @@ public class Generator {
      * @param module  module constructs model to fill.
      * @param syntaxTree syntax tree of the document.
      * @param semanticModel semantic model
-     * @return whether the module has any public constructs.
      */
     public static void setModuleFromSyntaxTree(Module module, SyntaxTree syntaxTree,
                                                   SemanticModel semanticModel) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -493,37 +493,30 @@ public class BallerinaDocGenerator {
             // collect module's doc resources
             module.resources.addAll(moduleDoc.getValue().resources);
 
-            boolean hasPublicConstructs = false;
             // Loop through bal files
             for (Map.Entry<String, SyntaxTree> syntaxTreeMapEntry : moduleDoc.getValue().syntaxTreeMap.entrySet()) {
-                boolean hasPublicConstructsTemp = Generator.setModuleFromSyntaxTree(module,
+                Generator.setModuleFromSyntaxTree(module,
                         syntaxTreeMapEntry.getValue(), model);
-                if (hasPublicConstructsTemp) {
-                    hasPublicConstructs = true;
-                }
             }
-            if (hasPublicConstructs) {
-                module.records.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.functions.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.classes.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.clients.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.listeners.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.objectTypes.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.enums.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.types.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.constants.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.annotations.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.errors.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                moduleDocs.add(module);
-                ModuleMetaData moduleMeta = new ModuleMetaData();
-                moduleMeta.id = module.id;
-                moduleMeta.orgName = module.orgName;
-                moduleMeta.summary = module.summary;
-                moduleMeta.version = module.version;
-                moduleMeta.isDefaultModule = module.isDefaultModule;
-                relatedModules.add(moduleMeta);
-            }
-
+            module.records.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.functions.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.classes.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.clients.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.listeners.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.objectTypes.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.enums.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.types.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.constants.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.annotations.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.errors.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            moduleDocs.add(module);
+            ModuleMetaData moduleMeta = new ModuleMetaData();
+            moduleMeta.id = module.id;
+            moduleMeta.orgName = module.orgName;
+            moduleMeta.summary = module.summary;
+            moduleMeta.version = module.version;
+            moduleMeta.isDefaultModule = module.isDefaultModule;
+            relatedModules.add(moduleMeta);
         }
         moduleDocs.sort((module1, module2) -> module1.id.compareToIgnoreCase(module2.id));
         if (relatedModules.size() > 1) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -495,8 +495,7 @@ public class BallerinaDocGenerator {
 
             // Loop through bal files
             for (Map.Entry<String, SyntaxTree> syntaxTreeMapEntry : moduleDoc.getValue().syntaxTreeMap.entrySet()) {
-                Generator.setModuleFromSyntaxTree(module,
-                        syntaxTreeMapEntry.getValue(), model);
+                Generator.setModuleFromSyntaxTree(module, syntaxTreeMapEntry.getValue(), model);
             }
             module.records.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
             module.functions.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));


### PR DESCRIPTION
## Purpose
Currently API docs are not generated for ballerina projects which doesn't have public constructs. But There is an issue in ballerina-central when `api-docs.json` is not generated. We have to generate an empty `api-docs.json` even if the ballerina project doesn't have any public constructs.

Fixes #38588

