### PR TITLE
Add `copyToLib` dependency for benchmark tests 

### DIFF
--- a/tests/jballerina-benchmark-test/build.gradle
+++ b/tests/jballerina-benchmark-test/build.gradle
@@ -115,3 +115,4 @@ test {
     }
 }
 
+generateMetadataFileForMavenJavaPublication.dependsOn(copyToLib)


### PR DESCRIPTION
## Purpose
$subject

## Approach
Add `copyToLib` dependency for `generateMetadataFileForMavenJavaPublication` gradle task in `jballerina-benchmark-tests`
 
## CheckList 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
