### PR TITLE
[2201.7.x] Include resource path for client object resource methods

### DIFF
--- a/.github/workflows/pull_request_ubuntu_build.yml
+++ b/.github/workflows/pull_request_ubuntu_build.yml
@@ -61,8 +61,7 @@ jobs:
         run: |
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-          ./gradlew build -Pnative.test --max-workers=2 --scan --no-daemon 
-          find ~/.gradle/caches/ -name "*.lock" -type f -delete
+          ./gradlew build -Pnative.test --max-workers=2 --scan --no-daemon
 
       - name: Generate Jacoco report
         if: github.event_name == 'pull_request'
@@ -138,7 +137,6 @@ jobs:
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           ./gradlew build sonarqube --info -x test -x check --max-workers=2 --scan --no-daemon
-          find ~/.gradle/caches/ -name "*.lock" -type f -delete
 
       - name: Print log message
         env:

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -513,7 +513,7 @@ public class Generator {
                     String methodName = "";
                     String accessor = "";
                     String resourcePath = "";
-                    if (methodNode.kind() == SyntaxKind.RESOURCE_ACCESSOR_DEFINITION) {
+                    if (methodNode.kind() == SyntaxKind.RESOURCE_ACCESSOR_DECLARATION) {
                         accessor = methodNode.methodName().text();
                         resourcePath = methodNode.relativeResourcePath().stream().
                                 collect(StringBuilder::new, (firstString,


### PR DESCRIPTION
## Purpose
API doc generation does not work properly when there are resource methods inside a client object. This will fix the issue.

Fixes #41264

