### PR TITLE
[2201.5.x] Fix XML parser truncating large texts 

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -54,6 +54,7 @@ import io.ballerina.runtime.api.values.BMapInitialValueEntry;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
+import io.ballerina.runtime.api.values.BXml;
 import io.ballerina.runtime.internal.TypeChecker;
 import io.ballerina.runtime.internal.types.BArrayType;
 import io.ballerina.runtime.internal.types.BFunctionType;
@@ -61,6 +62,7 @@ import io.ballerina.runtime.internal.types.BRecordType;
 import io.ballerina.runtime.internal.types.BTupleType;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -460,5 +462,27 @@ public class Values {
         }
         BString annotKey = StringUtils.fromString("testorg/types.typeref:1:String");
         return TypeChecker.checkIsType(((BMap) annotation).get(annotKey), constraint.getDescribingType());
+    }
+
+    public static BXml getXMLValueFromString1() {
+        return ValueCreator.createXmlValue("<book>The Lost World</book>");
+    }
+
+    public static BXml getXMLValueFromString2() {
+        return ValueCreator.createXmlValue("<reservationID>12345678901234567890123456789012345678901234567890" +
+                "12345678901234567890123456789012345678901234567890aaaaaa</reservationID>");
+    }
+
+    public static BXml getXMLValueFromInputStream1() {
+        return ValueCreator.createXmlValue(new ByteArrayInputStream("<book>The Lost World</book>".getBytes()));
+    }
+
+    public static BXml getXMLValueFromInputStream2() {
+        String xmlString = "<Reservation>\n" +
+                "<reservationID>1234567890123456789012345678901234567890123456789012345678901234567890" +
+                "12345678901234567890123456789exceeding100chars</reservationID>\n" +
+                "    <confirmationID>RPFABE</confirmationID>\n" +
+                "</Reservation>";
+        return ValueCreator.createXmlValue(new ByteArrayInputStream(xmlString.getBytes()));
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/main.bal
@@ -18,6 +18,7 @@ import values.records;
 import values.objects;
 import values.maps;
 import values.arrays;
+import values.xml_values;
 import values.enums;
 import ballerina/lang.test as test;
 
@@ -67,4 +68,5 @@ public function main() {
     records:validateAPI();
     enums:validateAPI();
     arrays:validateAPI();
+    xml_values:validateAPI();
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/xml_values/xml_values.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/xml_values/xml_values.bal
@@ -1,0 +1,79 @@
+// Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import ballerina/jballerina.java;
+
+public function validateAPI() {
+    xml xmlVal = getXMLValueFromString1();
+    test:assertEquals(xmlVal.toString(), "<book>The Lost World</book>");
+    test:assertEquals(xmlVal.data(), "The Lost World");
+
+    xmlVal = getXMLValueFromString2();
+    test:assertEquals(xmlVal.toString(), "<reservationID>12345678901234567890123456789012345678901234567890" +
+    "12345678901234567890123456789012345678901234567890aaaaaa</reservationID>");
+    test:assertEquals(xmlVal.data(), "1234567890123456789012345678901234567890123456789012345678901234567890" +
+    "123456789012345678901234567890aaaaaa");
+
+    xmlVal = getXMLValueFromInputStream1();
+    test:assertEquals(xmlVal.toString(), "<book>The Lost World</book>");
+    test:assertEquals(xmlVal.data(), "The Lost World");
+
+    xmlVal = getXMLValueFromInputStream2();
+
+    test:assertEquals(xmlVal.children().length(), 5);
+    test:assertEquals(xmlVal.children()[0].toString(), "\n");
+
+    test:assertTrue(xmlVal.children()[1] is xml:Element);
+    xml:Element child1 = <xml:Element>xmlVal.children()[1];
+    test:assertEquals(child1.toString(), "<reservationID>123456789012345678901234567890123456789012345678901234567890" +
+    "123456789012345678901234567890123456789exceeding100chars</reservationID>");
+    test:assertEquals(child1.getName(), "reservationID");
+    test:assertEquals(child1.children().length(), 1);
+    test:assertTrue(child1.children()[0] is xml:Text);
+
+    xml:Text text = <xml:Text>child1.children()[0];
+    string xmlString = "12345678901234567890123456789012345678901234567890123456789012345678901234567890" +
+    "1234567890123456789exceeding100chars";
+    test:assertEquals(text.data(), xmlString);
+
+    test:assertEquals(xmlVal.children()[2].toString(), "\n    ");
+
+    test:assertTrue(xmlVal.children()[3] is xml:Element);
+    xml:Element child2 = <xml:Element>xmlVal.children()[3];
+    test:assertEquals(child2.getName(), "confirmationID");
+    test:assertEquals(child2.children().length(), 1);
+    test:assertTrue(child2.children()[0] is xml:Text);
+    test:assertEquals(child2.children()[0].data(), "RPFABE");
+
+    test:assertEquals(xmlVal.children()[4].toString(), "\n");
+}
+
+function getXMLValueFromString1() returns xml = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+function getXMLValueFromString2() returns xml = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+function getXMLValueFromInputStream1() returns xml = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+function getXMLValueFromInputStream2() returns xml = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;


### PR DESCRIPTION
## Purpose
$subject

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/41267

## Approach
Improved the XML parser logic to return only when all the chars are combined. 
reference : https://stackoverflow.com/questions/29498587/xmlstreamreader-doesnt-read-complete-tag


## Samples
``` ballerina
import ballerina/io;
import ballerina/xmldata;
import ballerina/http;

type Reservation record {
    string reservationID;
    string confirmationID;   
};

listener http:Listener httpListener = new (8080);

service / on httpListener {
    resource function post hello(@http:Payload xml data) returns Reservation|error  {
        
        Reservation res = check  xmldata:fromXml(data);
        io:println(res);
        return res;
    }
}
```
The binding failed for the following request
```
POST http://localhost:8080/hello HTTP/1.1
Content-Type: application/xml

<Reservation>
<reservationID>1123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789aaaaaa</reservationID>
    <confirmationID>RPFABE</confirmationID>
</Reservation>
```

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
