### PR TITLE
[2201.6.x] Fix XML parser truncating large texts

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/XmlTreeBuilder.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/XmlTreeBuilder.java
@@ -74,7 +74,6 @@ public class XmlTreeBuilder {
     private Map<String, String> namespaces; // xml ns declarations from Bal source [xmlns "http://ns.com" as ns]
     private Deque<BXmlSequence> seqDeque;
     private Deque<List<BXml>> siblingDeque;
-    private boolean readText = false;
 
     public XmlTreeBuilder(String str) {
         this(new StringReader(str));
@@ -105,9 +104,16 @@ public class XmlTreeBuilder {
     }
 
     public BXml parse() {
+        boolean readNext = false;
+        int next;
         try {
             while (xmlStreamReader.hasNext()) {
-                int next = getNextElementType();
+                if (readNext) {
+                    readNext = false;
+                    next = xmlStreamReader.getEventType();
+                } else {
+                    next = xmlStreamReader.next();
+                }
                 switch (next) {
                     case START_ELEMENT:
                         readElement(xmlStreamReader);
@@ -124,6 +130,7 @@ public class XmlTreeBuilder {
                     case CDATA:
                     case CHARACTERS:
                         readText(xmlStreamReader);
+                        readNext = true;
                         break;
                     case END_DOCUMENT:
                         return buildDocument();
@@ -141,15 +148,6 @@ public class XmlTreeBuilder {
         return null;
     }
 
-    private int getNextElementType() throws XMLStreamException {
-        if (readText) {
-            readText = false;
-            return xmlStreamReader.getEventType();
-        } else {
-            return xmlStreamReader.next();
-        }
-    }
-
     private void handleDTD(XMLStreamReader xmlStreamReader) {
         // ignore
     }
@@ -165,7 +163,6 @@ public class XmlTreeBuilder {
         while (xmlStreamReader.getEventType() == CHARACTERS) {
             textBuilder.append(xmlStreamReader.getText());
             xmlStreamReader.next();
-            readText = true;
         }
         siblingDeque.peek().add(new XmlText(textBuilder.toString()));
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/XmlTreeBuilder.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/XmlTreeBuilder.java
@@ -74,6 +74,7 @@ public class XmlTreeBuilder {
     private Map<String, String> namespaces; // xml ns declarations from Bal source [xmlns "http://ns.com" as ns]
     private Deque<BXmlSequence> seqDeque;
     private Deque<List<BXml>> siblingDeque;
+    private boolean readText = false;
 
     public XmlTreeBuilder(String str) {
         this(new StringReader(str));
@@ -106,7 +107,7 @@ public class XmlTreeBuilder {
     public BXml parse() {
         try {
             while (xmlStreamReader.hasNext()) {
-                int next = xmlStreamReader.next();
+                int next = getNextElementType();
                 switch (next) {
                     case START_ELEMENT:
                         readElement(xmlStreamReader);
@@ -140,6 +141,15 @@ public class XmlTreeBuilder {
         return null;
     }
 
+    private int getNextElementType() throws XMLStreamException {
+        if (readText) {
+            readText = false;
+            return xmlStreamReader.getEventType();
+        } else {
+            return xmlStreamReader.next();
+        }
+    }
+
     private void handleDTD(XMLStreamReader xmlStreamReader) {
         // ignore
     }
@@ -150,8 +160,14 @@ public class XmlTreeBuilder {
         siblingDeque.peek().add(xmlItem);
     }
 
-    private void readText(XMLStreamReader xmlStreamReader) {
-        siblingDeque.peek().add(new XmlText(xmlStreamReader.getText()));
+    private void readText(XMLStreamReader xmlStreamReader) throws XMLStreamException {
+        StringBuilder textBuilder = new StringBuilder();
+        while (xmlStreamReader.getEventType() == CHARACTERS) {
+            textBuilder.append(xmlStreamReader.getText());
+            xmlStreamReader.next();
+            readText = true;
+        }
+        siblingDeque.peek().add(new XmlText(textBuilder.toString()));
     }
 
     private void readComment(XMLStreamReader xmlStreamReader) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -54,6 +54,7 @@ import io.ballerina.runtime.api.values.BMapInitialValueEntry;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
+import io.ballerina.runtime.api.values.BXml;
 import io.ballerina.runtime.internal.TypeChecker;
 import io.ballerina.runtime.internal.types.BArrayType;
 import io.ballerina.runtime.internal.types.BFunctionType;
@@ -62,6 +63,7 @@ import io.ballerina.runtime.internal.types.BServiceType;
 import io.ballerina.runtime.internal.types.BTupleType;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -461,6 +463,28 @@ public class Values {
         }
         BString annotKey = StringUtils.fromString("testorg/types.typeref:1:String");
         return TypeChecker.checkIsType(((BMap) annotation).get(annotKey), constraint.getDescribingType());
+    }
+
+    public static BXml getXMLValueFromString1() {
+        return ValueCreator.createXmlValue("<book>The Lost World</book>");
+    }
+
+    public static BXml getXMLValueFromString2() {
+        return ValueCreator.createXmlValue("<reservationID>12345678901234567890123456789012345678901234567890" +
+                "12345678901234567890123456789012345678901234567890aaaaaa</reservationID>");
+    }
+
+    public static BXml getXMLValueFromInputStream1() {
+        return ValueCreator.createXmlValue(new ByteArrayInputStream("<book>The Lost World</book>".getBytes()));
+    }
+
+    public static BXml getXMLValueFromInputStream2() {
+        String xmlString = "<Reservation>\n" +
+                "<reservationID>1234567890123456789012345678901234567890123456789012345678901234567890" +
+                "12345678901234567890123456789exceeding100chars</reservationID>\n" +
+                "    <confirmationID>RPFABE</confirmationID>\n" +
+                "</Reservation>";
+        return ValueCreator.createXmlValue(new ByteArrayInputStream(xmlString.getBytes()));
     }
 
     public static BString getParameterName(BFunctionPointer fpValue) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/main.bal
@@ -18,6 +18,7 @@ import values.records;
 import values.objects;
 import values.maps;
 import values.arrays;
+import values.xml_values;
 import values.enums;
 import ballerina/lang.test as test;
 
@@ -67,4 +68,5 @@ public function main() {
     records:validateAPI();
     enums:validateAPI();
     arrays:validateAPI();
+    xml_values:validateAPI();
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/xml_values/xml_values.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/xml_values/xml_values.bal
@@ -1,0 +1,79 @@
+// Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import ballerina/jballerina.java;
+
+public function validateAPI() {
+    xml xmlVal = getXMLValueFromString1();
+    test:assertEquals(xmlVal.toString(), "<book>The Lost World</book>");
+    test:assertEquals(xmlVal.data(), "The Lost World");
+
+    xmlVal = getXMLValueFromString2();
+    test:assertEquals(xmlVal.toString(), "<reservationID>12345678901234567890123456789012345678901234567890" +
+    "12345678901234567890123456789012345678901234567890aaaaaa</reservationID>");
+    test:assertEquals(xmlVal.data(), "1234567890123456789012345678901234567890123456789012345678901234567890" +
+    "123456789012345678901234567890aaaaaa");
+
+    xmlVal = getXMLValueFromInputStream1();
+    test:assertEquals(xmlVal.toString(), "<book>The Lost World</book>");
+    test:assertEquals(xmlVal.data(), "The Lost World");
+
+    xmlVal = getXMLValueFromInputStream2();
+
+    test:assertEquals(xmlVal.children().length(), 5);
+    test:assertEquals(xmlVal.children()[0].toString(), "\n");
+
+    test:assertTrue(xmlVal.children()[1] is xml:Element);
+    xml:Element child1 = <xml:Element>xmlVal.children()[1];
+    test:assertEquals(child1.toString(), "<reservationID>123456789012345678901234567890123456789012345678901234567890" +
+    "123456789012345678901234567890123456789exceeding100chars</reservationID>");
+    test:assertEquals(child1.getName(), "reservationID");
+    test:assertEquals(child1.children().length(), 1);
+    test:assertTrue(child1.children()[0] is xml:Text);
+
+    xml:Text text = <xml:Text>child1.children()[0];
+    string xmlString = "12345678901234567890123456789012345678901234567890123456789012345678901234567890" +
+    "1234567890123456789exceeding100chars";
+    test:assertEquals(text.data(), xmlString);
+
+    test:assertEquals(xmlVal.children()[2].toString(), "\n    ");
+
+    test:assertTrue(xmlVal.children()[3] is xml:Element);
+    xml:Element child2 = <xml:Element>xmlVal.children()[3];
+    test:assertEquals(child2.getName(), "confirmationID");
+    test:assertEquals(child2.children().length(), 1);
+    test:assertTrue(child2.children()[0] is xml:Text);
+    test:assertEquals(child2.children()[0].data(), "RPFABE");
+
+    test:assertEquals(xmlVal.children()[4].toString(), "\n");
+}
+
+function getXMLValueFromString1() returns xml = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+function getXMLValueFromString2() returns xml = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+function getXMLValueFromInputStream1() returns xml = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+function getXMLValueFromInputStream2() returns xml = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;


### PR DESCRIPTION
## Purpose
$subject

Fixes https://github.com/wso2-enterprise/internal-support-ballerina/issues/416

## Approach
Improved the XML parser logic to return only when all the chars are combined. 
reference : https://stackoverflow.com/questions/29498587/xmlstreamreader-doesnt-read-complete-tag


## Samples
``` ballerina
import ballerina/io;
import ballerina/xmldata;
import ballerina/http;

type Reservation record {
    string reservationID;
    string confirmationID;   
};

listener http:Listener httpListener = new (8080);

service / on httpListener {
    resource function post hello(@http:Payload xml data) returns Reservation|error  {
        
        Reservation res = check  xmldata:fromXml(data);
        io:println(res);
        return res;
    }
}
```
The binding failed for the following request
```
POST http://localhost:8080/hello HTTP/1.1
Content-Type: application/xml

<Reservation>
<reservationID>1123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789aaaaaa</reservationID>
    <confirmationID>RPFABE</confirmationID>
</Reservation>
```

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
