### PR TITLE
Remove public constructs check in API doc generation

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -115,12 +115,10 @@ public class Generator {
      * @param module  module constructs model to fill.
      * @param syntaxTree syntax tree of the document.
      * @param semanticModel semantic model
-     * @return whether the module has any public constructs.
      */
-    public static boolean setModuleFromSyntaxTree(Module module, SyntaxTree syntaxTree,
+    public static void setModuleFromSyntaxTree(Module module, SyntaxTree syntaxTree,
                                                   SemanticModel semanticModel) {
 
-        boolean hasPublicConstructs = false;
         if (syntaxTree.containsModulePart()) {
             ModulePartNode modulePartNode = syntaxTree.rootNode();
             for (Node node : modulePartNode.members()) {
@@ -129,13 +127,12 @@ public class Generator {
                     if (typeDefinition.visibilityQualifier().isPresent() && typeDefinition.visibilityQualifier().get()
                             .kind().equals(SyntaxKind.PUBLIC_KEYWORD) ||
                             isTypePramOrBuiltinSubtype(typeDefinition.metadata())) {
-                        hasPublicConstructs = addTypeDefinition(typeDefinition, module, semanticModel);
+                        addTypeDefinition(typeDefinition, module, semanticModel);
                     }
                 } else if (node.kind() == SyntaxKind.CLASS_DEFINITION) {
                     ClassDefinitionNode classDefinition = (ClassDefinitionNode) node;
                     if (classDefinition.visibilityQualifier().isPresent() && classDefinition.visibilityQualifier().get()
                             .kind().equals(SyntaxKind.PUBLIC_KEYWORD)) {
-                        hasPublicConstructs = true;
                         BClass cls = getClassModel((ClassDefinitionNode) node, semanticModel, module);
                         if (cls instanceof Client) {
                             module.clients.add((Client) cls);
@@ -147,17 +144,14 @@ public class Generator {
                     }
                 } else if (node.kind() == SyntaxKind.FUNCTION_DEFINITION &&
                         containsToken(((FunctionDefinitionNode) node).qualifierList(), SyntaxKind.PUBLIC_KEYWORD)) {
-                    hasPublicConstructs = true;
                     module.functions.add(getFunctionModel((FunctionDefinitionNode) node, semanticModel, module));
                 } else if (node.kind() == SyntaxKind.CONST_DECLARATION && ((ConstantDeclarationNode) node)
                         .visibilityQualifier().isPresent() && ((ConstantDeclarationNode) node).visibilityQualifier()
                         .get().kind().equals(SyntaxKind.PUBLIC_KEYWORD)) {
-                    hasPublicConstructs = true;
                     module.constants.add(getConstantTypeModel((ConstantDeclarationNode) node, semanticModel, module));
                 } else if (node.kind() == SyntaxKind.ANNOTATION_DECLARATION && ((AnnotationDeclarationNode) node)
                         .visibilityQualifier().isPresent() && ((AnnotationDeclarationNode) node)
                         .visibilityQualifier().get().kind().equals(SyntaxKind.PUBLIC_KEYWORD)) {
-                    hasPublicConstructs = true;
                     module.annotations.add(getAnnotationModel((AnnotationDeclarationNode) node, semanticModel, module));
                 } else if (node.kind() == SyntaxKind.ENUM_DECLARATION &&
                         ((EnumDeclarationNode) node).qualifier().isPresent() &&
@@ -172,10 +166,9 @@ public class Generator {
                 }
             }
         }
-        return hasPublicConstructs;
     }
 
-    public static boolean addTypeDefinition(TypeDefinitionNode typeDefinition, Module module, SemanticModel
+    public static void addTypeDefinition(TypeDefinitionNode typeDefinition, Module module, SemanticModel
             semanticModel) {
 
         String typeName = typeDefinition.typeName().text();
@@ -321,10 +314,7 @@ public class Generator {
         } else if (syntaxKind.equals(SyntaxKind.STREAM_TYPE_DESC)) {
             module.streamTypes.add(getUnionTypeModel(typeDefinition.typeDescriptor(), typeName, metaDataNode,
                     semanticModel, module));
-        } else {
-            return false;
         }
-        return true;
         // TODO: handle value type nodes
         // TODO: handle built in ref type
         // TODO: handle constrained types

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -493,37 +493,29 @@ public class BallerinaDocGenerator {
             // collect module's doc resources
             module.resources.addAll(moduleDoc.getValue().resources);
 
-            boolean hasPublicConstructs = false;
             // Loop through bal files
             for (Map.Entry<String, SyntaxTree> syntaxTreeMapEntry : moduleDoc.getValue().syntaxTreeMap.entrySet()) {
-                boolean hasPublicConstructsTemp = Generator.setModuleFromSyntaxTree(module,
-                        syntaxTreeMapEntry.getValue(), model);
-                if (hasPublicConstructsTemp) {
-                    hasPublicConstructs = true;
-                }
+                Generator.setModuleFromSyntaxTree(module, syntaxTreeMapEntry.getValue(), model);
             }
-            if (hasPublicConstructs) {
-                module.records.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.functions.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.classes.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.clients.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.listeners.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.objectTypes.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.enums.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.types.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.constants.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.annotations.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                module.errors.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
-                moduleDocs.add(module);
-                ModuleMetaData moduleMeta = new ModuleMetaData();
-                moduleMeta.id = module.id;
-                moduleMeta.orgName = module.orgName;
-                moduleMeta.summary = module.summary;
-                moduleMeta.version = module.version;
-                moduleMeta.isDefaultModule = module.isDefaultModule;
-                relatedModules.add(moduleMeta);
-            }
-
+            module.records.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.functions.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.classes.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.clients.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.listeners.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.objectTypes.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.enums.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.types.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.constants.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.annotations.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            module.errors.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+            moduleDocs.add(module);
+            ModuleMetaData moduleMeta = new ModuleMetaData();
+            moduleMeta.id = module.id;
+            moduleMeta.orgName = module.orgName;
+            moduleMeta.summary = module.summary;
+            moduleMeta.version = module.version;
+            moduleMeta.isDefaultModule = module.isDefaultModule;
+            relatedModules.add(moduleMeta);
         }
         moduleDocs.sort((module1, module2) -> module1.id.compareToIgnoreCase(module2.id));
         if (relatedModules.size() > 1) {


### PR DESCRIPTION
## Purpose
Currently API docs are not generated for ballerina projects which doesn't have public constructs. But There is an issue in ballerina-central when `api-docs.json` is not generated. We have to generate an empty `api-docs.json` even if the ballerina project doesn't have any public constructs.

Fixes #38588

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
