### PR TITLE
Fix invalid diagnostic location for regex expressions

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/RegExpParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/RegExpParser.java
@@ -789,8 +789,17 @@ public class RegExpParser extends AbstractParser {
     private STNode invalidateNonDigitNodesAndAddToTrailingMinutiae(STNode node, boolean isLeastDigits) {
         node = addInvalidNodeStackToTrailingMinutiae(node);
 
-        while (isInvalidDigit(peek(), isLeastDigits)) {
-            node = addTrailingInvalidNode(node, DiagnosticErrorCode.ERROR_INVALID_QUANTIFIER_IN_REG_EXP);
+        STToken nodeBuffer = peek();
+        while (isInvalidDigit(nodeBuffer, isLeastDigits)) {
+            if (nodeBuffer.kind == SyntaxKind.INTERPOLATION_START_TOKEN) {
+                consume();
+                consume();
+                node = SyntaxErrors.cloneWithTrailingInvalidNodeMinutiae(node, this.interpolationExprs.remove(),
+                        DiagnosticErrorCode.ERROR_INVALID_QUANTIFIER_IN_REG_EXP);
+            } else {
+                node = addTrailingInvalidNode(node, DiagnosticErrorCode.ERROR_INVALID_QUANTIFIER_IN_REG_EXP);
+            }
+            nodeBuffer = peek();
         }
 
         return node;
@@ -811,8 +820,17 @@ public class RegExpParser extends AbstractParser {
     private STNode invalidateNonFlagNodesAndAddToTrailingMinutiae(STNode node, boolean isLhsFlag) {
         node = addInvalidNodeStackToTrailingMinutiae(node);
 
-        while (isInvalidFlag(peek(), isLhsFlag)) {
-            node = addTrailingInvalidNode(node, DiagnosticErrorCode.ERROR_INVALID_FLAG_IN_REG_EXP);
+        STToken nodeBuffer = peek();
+        while (isInvalidFlag(nodeBuffer, isLhsFlag)) {
+            if (nodeBuffer.kind == SyntaxKind.INTERPOLATION_START_TOKEN) {
+                consume();
+                consume();
+                node = SyntaxErrors.cloneWithTrailingInvalidNodeMinutiae(node, this.interpolationExprs.remove(),
+                        DiagnosticErrorCode.ERROR_INVALID_FLAG_IN_REG_EXP);
+            } else {
+                node = addTrailingInvalidNode(node, DiagnosticErrorCode.ERROR_INVALID_FLAG_IN_REG_EXP);
+            }
+            nodeBuffer = peek();
         }
 
         return node;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/regexp/RegExpValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/regexp/RegExpValueTest.java
@@ -107,13 +107,15 @@ public class RegExpValueTest {
         validateError(negativeResult, index++, "invalid token in regular expression", 37, 16);
         validateError(negativeResult, index++, "invalid token in regular expression", 38, 16);
         validateError(negativeResult, index++, "invalid token in regular expression", 39, 16);
+        validateError(negativeResult, index++, "invalid quantifier in regular expression", 40, 19);
+        validateError(negativeResult, index++, "invalid flag in regular expression", 41, 15);
         validateError(negativeResult, index++, "incompatible types: expected 'boolean', found " +
-                "'regexp:RegExp'", 40, 9);
-        validateError(negativeResult, index++, "missing backtick token", 42, 1);
-        validateError(negativeResult, index++, "missing close brace token", 42, 1);
-        validateError(negativeResult, index++, "missing colon token", 42, 1);
-        validateError(negativeResult, index++, "missing expression", 42, 1);
-        validateError(negativeResult, index++, "missing semicolon token", 42, 1);
+                "'regexp:RegExp'", 42, 9);
+        validateError(negativeResult, index++, "missing backtick token", 44, 1);
+        validateError(negativeResult, index++, "missing close brace token", 44, 1);
+        validateError(negativeResult, index++, "missing colon token", 44, 1);
+        validateError(negativeResult, index++, "missing expression", 44, 1);
+        validateError(negativeResult, index++, "missing semicolon token", 44, 1);
         assertEquals(negativeResult.getErrorCount(), index);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_negative_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_negative_test.bal
@@ -37,5 +37,7 @@ function testRegExpNegative() {
     _ = re `\p{Lz}`;
     _ = re `\p{NNz}`;
     _ = re `\p{NN}`;
+    _ = re `(a{12,${ab}})`;
+    _ = re `(?${""}:)`;
     _ = re `[AB\p{gc=Lu}]+` ? `;
 }


### PR DESCRIPTION
## Purpose

The current implementation ignores the interpolation variable once an error is detected. This leads to the mispositioning of subsequent diagnostic locations, with an offset equal to the length of the variable string.

Fixes #41282

## Approach

The PR modifies the regex parser to manually include the interpolation once an error is detected.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
