### PR TITLE
Add --dump-build-time support for RunCommand

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunExecutableTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunExecutableTask.java
@@ -19,6 +19,7 @@
 package io.ballerina.cli.task;
 
 import io.ballerina.cli.launcher.RuntimePanicException;
+import io.ballerina.cli.utils.BuildTime;
 import io.ballerina.projects.JBallerinaBackend;
 import io.ballerina.projects.JarLibrary;
 import io.ballerina.projects.JarResolver;
@@ -68,12 +69,19 @@ public class RunExecutableTask implements Task {
 
     @Override
     public void execute(Project project) {
+        long start = 0;
+        if (project.buildOptions().dumpBuildTime()) {
+            start = System.currentTimeMillis();
+        }
 
         out.println();
         out.println("Running executable");
         out.println();
 
         this.runGeneratedExecutable(project.currentPackage().getDefaultModule(), project);
+        if (project.buildOptions().dumpBuildTime()) {
+            BuildTime.getInstance().runningExecutableDuration = System.currentTimeMillis() - start;
+        }
     }
 
     private void runGeneratedExecutable(Module executableModule, Project project) {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/BuildTime.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/BuildTime.java
@@ -37,6 +37,7 @@ public class BuildTime {
     public long codeGenDuration;
     public long emitArtifactDuration;
     public long testingExecutionDuration;
+    public long runningExecutableDuration;
     public long totalDuration;
 
     private BuildTime() {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #41311 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
Sample output looks like
```
Compiling source
        main.bal

Running executable

Hello, World!

Dumping build time information
        build-time.json
        timestamp : 1693290565302
        offline : false
        compile : false
        projectLoadDuration : 351
        packageResolutionDuration : 6758
        codeGeneratorPluginDuration : 80
        codeModifierPluginDuration : 0
        packageCompilationDuration : 6
        codeGenDuration : 90
        emitArtifactDuration : 0
        testingExecutionDuration : 0
        runningExecutableDuration : 198
        totalDuration : 15690
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
