### PR TITLE
Add JSON parser support for exponential values

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
@@ -860,10 +860,11 @@ public class JsonParser {
                             setValueToJsonType(type, new DecimalValue(str));
                             break;
                         default:
-                            if (isValidFloat(str) && (isNegativeZero(str) || isHexadecimal(str))) {
+                            if (isNegativeZero(str)) {
                                 setValueToJsonType(type, Double.parseDouble(str));
                             } else {
-                                setValueToJsonType(type, new DecimalValue(str));
+                                String decimalStr = isHexadecimal(str) ? String.valueOf(Double.parseDouble(str)) : str;
+                                setValueToJsonType(type, new DecimalValue(decimalStr));
                             }
                             break;
                     }
@@ -927,12 +928,14 @@ public class JsonParser {
                                 setValueToJsonType(type, new DecimalValue(str));
                                 break;
                             default:
-                                if (!isNegativeZero(str) && !isExponential(str)) {
-                                    setValueToJsonType(type, Long.parseLong(str));
-                                } else if (isValidFloat(str)) {
+                                if (isNegativeZero(str)) {
                                     setValueToJsonType(type, Double.parseDouble(str));
+                                } else if (isExponential(str) || isHexadecimal(str)) {
+                                    String decimalStr = isHexadecimal(str) ? String.valueOf(Double.parseDouble(str)) :
+                                            str;
+                                    setValueToJsonType(type, new DecimalValue(decimalStr));
                                 } else {
-                                    setValueToJsonType(type, new DecimalValue(str));
+                                    setValueToJsonType(type, Long.parseLong(str));
                                 }
                                 break;
                         }
@@ -949,33 +952,6 @@ public class JsonParser {
 
         private boolean isExponential(String str) {
             return str.contains("e") || str.contains("E") || str.contains("p") || str.contains("P");
-        }
-
-        boolean isValidFloat(String numericLiteral) {
-            // same validation used in Ballerina parser
-            double value;
-            try {
-                value = Double.parseDouble(numericLiteral);
-            } catch (Exception e) {
-                return false;
-            }
-            if (Double.isInfinite(value)) {
-                return false;
-            }
-            if (value != 0.0) {
-                return true;
-            }
-            List<Character> exponentIndicator = List.of('e', 'E', 'p', 'P');
-            for (int i = 0; i < numericLiteral.length(); i++) {
-                char character = numericLiteral.charAt(i);
-                if (exponentIndicator.contains(character)) {
-                    break;
-                }
-                if (numericLiteral.charAt(i) >= '1' && numericLiteral.charAt(i) <= '9') {
-                    return false;
-                }
-            }
-            return true;
         }
 
         private void setValueToJsonType(ValueType type, Object value) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
@@ -862,8 +862,7 @@ public class JsonParser {
                             if (isNegativeZero(str)) {
                                 setValueToJsonType(type, Double.parseDouble(str));
                             } else {
-                                String decimalStr = isHexadecimal(str) ? String.valueOf(Double.parseDouble(str)) : str;
-                                setValueToJsonType(type, new DecimalValue(decimalStr));
+                                setValueToJsonType(type, new DecimalValue(str));
                             }
                             break;
                     }
@@ -929,10 +928,8 @@ public class JsonParser {
                             default:
                                 if (isNegativeZero(str)) {
                                     setValueToJsonType(type, Double.parseDouble(str));
-                                } else if (isExponential(str) || isHexadecimal(str)) {
-                                    String decimalStr = isHexadecimal(str) ? String.valueOf(Double.parseDouble(str)) :
-                                            str;
-                                    setValueToJsonType(type, new DecimalValue(decimalStr));
+                                } else if (isExponential(str)) {
+                                    setValueToJsonType(type, new DecimalValue(str));
                                 } else {
                                     setValueToJsonType(type, Long.parseLong(str));
                                 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
@@ -942,12 +942,8 @@ public class JsonParser {
             }
         }
 
-        private boolean isHexadecimal(String str) {
-            return str.startsWith("0x") || str.startsWith("0X");
-        }
-
         private boolean isExponential(String str) {
-            return str.contains("e") || str.contains("E") || str.contains("p") || str.contains("P");
+            return str.contains("e") || str.contains("E");
         }
 
         private void setValueToJsonType(ValueType type, Object value) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
@@ -43,7 +43,6 @@ import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.List;
 
 import static io.ballerina.runtime.api.utils.JsonUtils.NonStringValueProcessingMode.FROM_JSON_DECIMAL_STRING;
 import static io.ballerina.runtime.api.utils.JsonUtils.NonStringValueProcessingMode.FROM_JSON_FLOAT_STRING;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/JsonValues.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/JsonValues.java
@@ -20,6 +20,7 @@ package org.ballerinalang.nativeimpl.jvm.runtime.api.tests;
 
 import io.ballerina.runtime.api.types.StructureType;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.utils.JsonUtils;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
@@ -53,5 +54,9 @@ public class JsonValues {
 
     public static BString convertJSONToString(Object jValue) {
         return StringUtils.fromString(StringUtils.getJsonString(jValue));
+    }
+
+    public static Object convertStringToJson(BString str) {
+        return JsonUtils.parse(str);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/main.bal
@@ -19,4 +19,5 @@ import testorg/utils.jsons;
 public function main() {
     jsons:validateAPI();
     jsons:validateStringAPI();
+    jsons:validateJsonAPI();
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/modules/jsons/jsons.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/modules/jsons/jsons.bal
@@ -57,13 +57,21 @@ function testConvertJSONToRecord() {
 }
 
 type numUnion1 int|decimal|float;
+
 type singleton1 1|"1"|true|"one";
+
 type singleton2 2|"2"|true|"two";
+
 type singletonunion singleton1|singleton2|false;
+
 type union1 string|byte;
+
 type union2 int|int:Signed16;
+
 type union3 singletonunion|union1|union2;
+
 type intArray int[];
+
 type stringMap map<string>;
 
 function testConvertJSON() {
@@ -99,9 +107,9 @@ function testConvertJSON() {
     jval_result = trap convertJSON(jval, json);
     test:assertEquals(jval_result, {"a": true});
 
-    jval = [12,-1,0,15];
+    jval = [12, -1, 0, 15];
     jval_result = trap convertJSON(jval, intArray);
-    test:assertEquals(jval_result, [12,-1,0,15]);
+    test:assertEquals(jval_result, [12, -1, 0, 15]);
 
     jval = {"a": "true"};
     jval_result = trap convertJSON(jval, stringMap);
@@ -149,9 +157,9 @@ public function validateStringAPI() {
     "\"map\":{\"value\":\"a\"b\\c\td\"},\"arr_map\":[\"foo\",{\"value\":\"a\"b\\c\td\"},87]}");
 
     anydata tab = table [
-            {a: 1, b: " 2"},
-            {c: "3", d: "4"}
-        ];
+        {a: 1, b: " 2"},
+        {c: "3", d: "4"}
+    ];
     string|error res = convertJSONToString(tab);
     test:assertTrue(res is string);
     test:assertEquals(res, "[{\"a\":1, \"b\":\" 2\"}, {\"c\":\"3\", \"d\":\"4\"}]");
@@ -180,3 +188,38 @@ function convertJSONToString(any|error v) returns string = @java:Method {
     name: "convertJSONToString"
 } external;
 
+public function validateJsonAPI() {
+    string s = "0e-18";
+    json j = convertStringToJson(s);
+    test:assertEquals(j, 0e-18);
+
+    s = "{\"val\" : 0e-19}";
+    j = convertStringToJson(s);
+    test:assertEquals(j, {"val": 0e-19});
+
+    s = "99.9E+6143";
+    j = convertStringToJson(s);
+    test:assertEquals(j, 9.99E+6144d);
+
+    s = "0x0.0p1";
+    j = convertStringToJson(s);
+    test:assertEquals(j, 0.0f);
+
+    s = "0x1.0p23";
+    j = convertStringToJson(s);
+    test:assertEquals(j, 8388608.0f);
+
+    s = "4.9e-325";
+    j = convertStringToJson(s);
+    test:assertEquals(j, 4.9E-325d);
+
+    s = "{\r\n\"factMap\":{\r\n\"105!T\":{\r\n\"aggregates\":[\r\n{\r\n\"label\":\"USD 0.00\"," +
+    "\r\n\"value\":0e-18\r\n}\r\n]\r\n}\r\n}\r\n}";
+    j = convertStringToJson(s);
+    test:assertEquals(j, {"factMap": {"105!T": {"aggregates": [{"label": "USD 0.00", "value": 0.0}]}}});
+}
+
+function convertStringToJson(string v) returns json = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.JsonValues",
+    name: "convertStringToJson"
+} external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/modules/jsons/jsons.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/modules/jsons/jsons.bal
@@ -191,11 +191,11 @@ function convertJSONToString(any|error v) returns string = @java:Method {
 public function validateJsonAPI() {
     string s = "0e-18";
     json j = convertStringToJson(s);
-    test:assertEquals(j, 0e-18);
+    test:assertEquals(j, 0e-18d);
 
     s = "{\"val\" : 0e-19}";
     j = convertStringToJson(s);
-    test:assertEquals(j, {"val": 0e-19});
+    test:assertEquals(j, {"val": 0e-19d});
 
     s = "99.9E+6143";
     j = convertStringToJson(s);
@@ -207,11 +207,11 @@ public function validateJsonAPI() {
 
     s = "0x0.0p1";
     j = convertStringToJson(s);
-    test:assertEquals(j, 0.0f);
+    test:assertEquals(j, 0.0d);
 
     s = "0x1.0p23";
     j = convertStringToJson(s);
-    test:assertEquals(j, 8388608.0f);
+    test:assertEquals(j, 8388608.0d);
 
     s = "4.9e-325";
     j = convertStringToJson(s);
@@ -220,7 +220,7 @@ public function validateJsonAPI() {
     s = "{\r\n\"factMap\":{\r\n\"105!T\":{\r\n\"aggregates\":[\r\n{\r\n\"label\":\"USD 0.00\"," +
     "\r\n\"value\":0e-18\r\n}\r\n]\r\n}\r\n}\r\n}";
     j = convertStringToJson(s);
-    test:assertEquals(j, {"factMap": {"105!T": {"aggregates": [{"label": "USD 0.00", "value": 0.0}]}}});
+    test:assertEquals(j, {"factMap": {"105!T": {"aggregates": [{"label": "USD 0.00", "value": 0e-18d}]}}});
 }
 
 function convertStringToJson(string v) returns json = @java:Method {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/modules/jsons/jsons.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/modules/jsons/jsons.bal
@@ -201,6 +201,10 @@ public function validateJsonAPI() {
     j = convertStringToJson(s);
     test:assertEquals(j, 9.99E+6144d);
 
+    s = "999E6142";
+    j = convertStringToJson(s);
+    test:assertEquals(j, 9.99E+6144d);
+
     s = "0x0.0p1";
     j = convertStringToJson(s);
     test:assertEquals(j, 0.0f);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/modules/jsons/jsons.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/modules/jsons/jsons.bal
@@ -205,14 +205,6 @@ public function validateJsonAPI() {
     j = convertStringToJson(s);
     test:assertEquals(j, 9.99E+6144d);
 
-    s = "0x0.0p1";
-    j = convertStringToJson(s);
-    test:assertEquals(j, 0.0d);
-
-    s = "0x1.0p23";
-    j = convertStringToJson(s);
-    test:assertEquals(j, 8388608.0d);
-
     s = "4.9e-325";
     j = convertStringToJson(s);
     test:assertEquals(j, 4.9E-325d);
@@ -221,6 +213,24 @@ public function validateJsonAPI() {
     "\r\n\"value\":0e-18\r\n}\r\n]\r\n}\r\n}\r\n}";
     j = convertStringToJson(s);
     test:assertEquals(j, {"factMap": {"105!T": {"aggregates": [{"label": "USD 0.00", "value": 0e-18d}]}}});
+
+    s = "0x0.0p1";
+    json|error result = trap convertStringToJson(s);
+    test:assertTrue(result is error);
+    error e = <error>result;
+    test:assertEquals(e.message(), "unrecognized token '0x0.0p1' at line: 1 column: 9");
+
+    s = "999E6143";
+    result = trap convertStringToJson(s);
+    test:assertTrue(result is error);
+    e = <error>result;
+    test:assertEquals(e.message(), "{ballerina}NumberOverflow");
+
+    s = "99.9E+6144";
+    result = trap convertStringToJson(s);
+    test:assertTrue(result is error);
+    e = <error>result;
+    test:assertEquals(e.message(), "{ballerina}NumberOverflow");
 }
 
 function convertStringToJson(string v) returns json = @java:Method {


### PR DESCRIPTION
## Purpose
$subject

Fixes #41334 

## Approach
Added logic for creating numerical Ballerina values if the string contains a valid exponential value. 
As per spec, 
- if the numerical value is a negative zero -> return float zero value
- if the numerical value is syntactically integer (no decimal points & no exponents) -> return equivalent int value
- else return an equivalent decimal value

## Samples
In runtime API usage,
```java
Object obj = JsonUtils.parse("0e-18"); // throws error earlier
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
