### PR TITLE
[WIP] Remove node cloning for expressions that require `CET` for it's sub expressions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -7529,7 +7529,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         switch (expr.getKind()) {
             case GROUP_EXPR:
                 return requireTypeInference(((BLangGroupExpr) expr).expression, inferTypeForNumericLiteral);
-            case ARROW_EXPR: // why
+            case ARROW_EXPR:
             case LIST_CONSTRUCTOR_EXPR:
             case RECORD_LITERAL_EXPR:
             case OBJECT_CTOR_EXPRESSION:

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BinaryExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BinaryExprTest.java
@@ -143,6 +143,11 @@ public class BinaryExprTest {
         Assert.assertEquals(((Byte) returns.get(3)).longValue(), b & d);
     }
 
+    @Test
+    public void testLengthyBinaryExpressionsForOOM() {
+        BRunUtil.invoke(result, "testLengthyBinaryExpressionsForOOM");
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/checkedexpr/CheckedExpressionOperatorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/checkedexpr/CheckedExpressionOperatorTest.java
@@ -238,6 +238,7 @@ public class CheckedExpressionOperatorTest {
                 "test-src/expressions/checkedexpr/check_expr_with_json_access.bal");
         Assert.assertEquals(result.getErrorCount(), 0);
         BRunUtil.invoke(result, "testJsonAccessWithCheckWithSubTypesOfSimpleBasicTypesCET");
+        BRunUtil.invoke(result, "testPropagatedCETForCheckExpression");
     }
 
     @Test
@@ -255,6 +256,9 @@ public class CheckedExpressionOperatorTest {
                 "found '(json|error)'", 24, 42);
         BAssertUtil.validateError(result, i++, "incompatible types: expected '(map<int>|IntMax|1d|error)', found '" +
                 "(json|error)'", 25, 34);
+        BAssertUtil.validateError(result, i++, "operator '+' not defined for 'xml:Text' and 'json'", 28, 13);
+        BAssertUtil.validateError(result, i++, "incompatible types: expected '(float|error)', found 'anydata'", 31, 25);
+        BAssertUtil.validateError(result, i++, "incompatible types: expected '(float|error)', found 'int'", 32, 25);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
@@ -286,6 +286,11 @@ public class ArrowExprTest {
         BRunUtil.invoke(basic, "testExpressionBodiedFunctionWithBinaryExpr");
     }
 
+    @Test
+    public void testCETViaTypeCastExpressionForArrowExpr() {
+        BRunUtil.invoke(basic, "testCETViaTypeCastExpressionForArrowExpr");
+    }
+
     @AfterClass
     public void tearDown() {
         basic = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/rawtemplate/RawTemplateLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/rawtemplate/RawTemplateLiteralTest.java
@@ -131,6 +131,8 @@ public class RawTemplateLiteralTest {
                 "'(ballerina/lang.object:0:RawTemplate & readonly)'", 194, 5);
         validateError(errors, indx++, "cannot update 'readonly' value of type " +
                 "'((any|error)[] & readonly)'", 195, 5);
+        validateError(errors, indx++, "incompatible types: expected 'string', found 'int'", 204, 41);
+        validateError(errors, indx++, "incompatible types: expected 'string', found 'int'", 204, 61);
 
         assertEquals(errors.getErrorCount(), indx);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/unaryoperations/UnaryExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/unaryoperations/UnaryExprTest.java
@@ -191,6 +191,11 @@ public class UnaryExprTest {
         BRunUtil.invoke(result, "testResultingTypeOfUnaryPlus");
     }
 
+    @Test
+    public void testLengthyUnaryExpressionsForOOM() {
+        BRunUtil.invoke(result, "testLengthyUnaryExpressionsForOOM");
+    }
+
     @Test(description = "Test unary statement with errors")
     public void testUnaryStmtNegativeCases() {
         Assert.assertEquals(resultNegative.getErrorCount(), 19);
@@ -201,7 +206,7 @@ public class UnaryExprTest {
         BAssertUtil.validateError(resultNegative, 4, "incompatible types: expected 'int:Unsigned8', found 'int'",
                  34, 24);
         BAssertUtil.validateError(resultNegative, 5, "incompatible types: expected 'int:Signed8', found 'int'",
-                35, 23);
+                35, 22);
         BAssertUtil.validateError(resultNegative, 6, "incompatible types: expected 'byte', found 'int'",
                 38, 15);
         BAssertUtil.validateError(resultNegative, 7, "incompatible types: expected 'int:Unsigned8', found 'int'",
@@ -214,8 +219,8 @@ public class UnaryExprTest {
                 56, 11);
         BAssertUtil.validateError(resultNegative, 13, "incompatible types: expected 'B', found 'float'",
                 59, 11);
-        BAssertUtil.validateError(resultNegative, 14, "incompatible types: expected 'int', found 'C'", 74, 14);
-        BAssertUtil.validateError(resultNegative, 15, "incompatible types: expected 'int', found 'D'", 77, 14);
+        BAssertUtil.validateError(resultNegative, 14, "operator '-' not defined for 'C'", 74, 13);
+        BAssertUtil.validateError(resultNegative, 15, "operator '-' not defined for 'D'", 77, 13);
         BAssertUtil.validateError(resultNegative, 16, "operator '+' not defined for '(decimal|DecimalType1)'", 80, 24);
         BAssertUtil.validateError(resultNegative, 17, "operator '-' not defined for 'DecimalType1'", 83, 24);
         BAssertUtil.validateError(resultNegative, 18, "operator '+' not defined for '(decimal|DecimalType2)'", 86, 24);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/InferredDependentlyTypeFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/InferredDependentlyTypeFunctionTest.java
@@ -199,10 +199,10 @@ public class InferredDependentlyTypeFunctionTest {
         validateError(negativeResult, index++, "incompatible types: expected 'function (typedesc<(any|error)>," +
                 "typedesc<boolean>) returns ((t|td))', found 'function (typedesc<(any|error)>,typedesc<boolean>) " +
                 "returns ((int|string))'", 180, 74);
-        validateError(negativeResult, index++, "cannot infer the 'typedesc' argument for parameter 'td': expected " +
-                "an argument for the parameter or a contextually-expected type to infer the argument", 185, 44);
-        validateError(negativeResult, index++, "cannot infer the 'typedesc' argument for parameter 'td': expected " +
-                "an argument for the parameter or a contextually-expected type to infer the argument", 186, 52);
+        validateError(negativeResult, index++, "incompatible type for parameter 'td' with inferred typedesc" +
+                " value: expected 'typedesc<int>', found 'typedesc<boolean>'", 185, 44);
+        validateError(negativeResult, index++, "incompatible type for parameter 'td' with inferred typedesc " +
+                "value: expected 'typedesc<stream<int>>', found 'typedesc<BooleanStream>'", 186, 52);
         validateError(negativeResult, index++, "cannot infer the 'typedesc' argument for parameter 'td': expected " +
                         "an argument for the parameter or a contextually-expected type to infer the argument", 196, 5);
         validateError(negativeResult, index++, "cannot infer the 'typedesc' argument for parameter 'td2': expected " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionWithVarTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionWithVarTypeTest.java
@@ -271,7 +271,8 @@ public class QueryExpressionWithVarTypeTest {
                 "testUsingAnIntersectionTypeInQueryExpr",
                 "testUsingDestructuringRecordingBindingPatternWithAnIntersectionTypeInFromClause2",
                 "testUsingDestructuringRecordingBindingPatternWithAnIntersectionTypeInJoinClause2",
-                "testUsingAnIntersectionTypeInQueryExpr2"
+                "testUsingAnIntersectionTypeInQueryExpr2",
+                "testPropagatedCETForQueryExpression"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteArrayValueNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteArrayValueNegativeTest.java
@@ -65,13 +65,12 @@ public class BByteArrayValueNegativeTest {
         BAssertUtil.validateError(result, index++, "incompatible types: expected 'int[3]', found 'byte[2]'", 24, 16);
         BAssertUtil.validateError(result, index++, "incompatible types: expected 'byte[2]', found 'byte[3]'", 28, 17);
         BAssertUtil.validateError(result, index++, "incompatible types: expected 'int[2]', found 'byte[3]'", 30, 16);
-        BAssertUtil.validateError(result, index++, "incompatible types: 'byte[2]' cannot be cast to " +
-                "'(byte[3] & readonly)'", 33, 16);
-        BAssertUtil.validateError(result, index++, "incompatible types: 'byte[3]' cannot be cast to " +
-                "'(int[2] & readonly)'", 34, 15);
-
-        BAssertUtil.validateError(result, index++, "incompatible types: 'byte[3]' cannot be cast to " +
-                "'(string[] & readonly)'", 35, 18);
+        BAssertUtil.validateError(result, index++, "incompatible types: 'byte[2] & readonly' cannot be " +
+                "cast to '(byte[3] & readonly)'", 33, 16);
+        BAssertUtil.validateError(result, index++, "incompatible types: 'byte[3] & readonly' cannot be " +
+                "cast to '(int[2] & readonly)'", 34, 15);
+        BAssertUtil.validateError(result, index++, "incompatible types: 'byte[3] & readonly' cannot be " +
+                "cast to '(string[] & readonly)'", 35, 18);
         BAssertUtil.validateError(result, index++, "incompatible types: expected 'byte[3]', found 'byte[2]'", 39, 17);
         Assert.assertEquals(result.getErrorCount(), index);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
@@ -57,14 +57,14 @@ public class BByteValueNegativeTest {
         BAssertUtil.validateError(result, 2, msg1 , 4, 15);
         BAssertUtil.validateError(result, 3, msg1 , 5, 15);
         BAssertUtil.validateError(result, 4, msg2 , 6, 15);
-        BAssertUtil.validateError(result, 5, msg2 , 7, 16);
+        BAssertUtil.validateError(result, 5, msg2 , 7, 15);
         BAssertUtil.validateError(result, 6, msg2 , 8, 15);
         BAssertUtil.validateError(result, 7, msg1 , 9, 24);
         BAssertUtil.validateError(result, 8, msg1 , 10, 21);
         BAssertUtil.validateError(result, 9, msg2 , 11, 21);
         BAssertUtil.validateError(result, 10, msg1 , 11, 30);
         BAssertUtil.validateError(result, 11, msg1 , 11, 35);
-        BAssertUtil.validateError(result, 12, msg2 , 12, 22);
+        BAssertUtil.validateError(result, 12, msg2 , 12, 21);
         BAssertUtil.validateError(result, 13, msg2 , 12, 27);
         BAssertUtil.validateError(result, 14, msg1 , 12, 35);
         BAssertUtil.validateError(result, 15, msg1 , 15, 14);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
@@ -75,7 +75,7 @@ public class BDecimalValueNegativeTest {
         BAssertUtil.validateError(negative, i++, "operator '*' not defined for 'decimal' and 'float'", 37, 17);
         BAssertUtil.validateError(negative, i++, "operator '+' not defined for 'float' and 'decimal'", 38, 17);
         BAssertUtil.validateError(negative, i++, "operator '-' not defined for 'float' and 'decimal'", 39, 17);
-        BAssertUtil.validateError(negative, i++, "operator '+' not defined for 'decimal' and 'float'", 41, 17);
+        BAssertUtil.validateError(negative, i++, "operator '/' not defined for 'decimal' and 'float'", 41, 29);
         BAssertUtil.validateError(negative, i++, "'9.9999999999999999999999999999999999e6144' is out of range" +
                 " for 'decimal'", 48, 17);
         BAssertUtil.validateError(negative, i++, "'9.999999999999999999999999999999999e6145' is out of range" +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeNegativeTest.java
@@ -163,7 +163,7 @@ public class FiniteTypeNegativeTest {
                 183, 12);
         validateError(resultNegativeTwo, i++, "incompatible types: expected '2d', found 'string'",
                 187, 12);
-        validateError(resultNegativeTwo, i++, "incompatible types: 'int' cannot be cast to '2f'",
+        validateError(resultNegativeTwo, i++, "incompatible types: expected '2d', found '2f'",
                 191, 12);
         validateError(resultNegativeTwo, i++, "incompatible types: expected '3d', found '4f'",
                 192, 12);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary-expr.bal
@@ -37,3 +37,87 @@ function bitwiseAnd(int a, int b, byte c, byte d) returns [int, byte, byte, byte
     res [3] = b & d;
     return res;
 }
+
+function testLengthyBinaryExpressionsForOOM() {
+
+    decimal d1 = 1;
+    decimal d2 = 1;
+    decimal d3 = 0;
+    decimal d4 = 0;
+    decimal d5 = 1;
+    decimal d6 = 0;
+    decimal d7 = 0;
+    decimal d8 = 0;
+    decimal d9 = 1;
+    decimal d10 = 0;
+    decimal d11 = 0;
+    decimal d12 = 0;
+    decimal d13 = 1;
+    decimal d14 = 0;
+    decimal d15 = 0;
+    decimal d16 = 0;
+    decimal d17 = 0;
+    decimal d18 = 0;
+    decimal d19 = 0;
+    decimal d20 = 0;
+    decimal d21 = 0;
+    decimal d22 = 0;
+    decimal d23 = 0;
+    decimal d24 = 0;
+
+    decimal totalOtherCost = + d1
+                             + d2
+                             + d3
+                             + d4
+                             + d5
+                             + d6
+                             + d7
+                             + d8
+                             + d9
+                             + d10
+                             + d11
+                             + d12
+                             + d13
+                             + d14
+                             + d15
+                             + d16
+                             + d17
+                             + d18
+                             + d19
+                             + d20
+                             + d21
+                             + d22
+                             + d23
+                             + d24
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 0
+                             + 1
+                             + 1
+                             + 1
+                             + 1
+                             + 1;
+    assertEquality(totalOtherCost, 10d);
+}
+
+function assertEquality(any actual, any expected) {
+    if actual is anydata && expected is anydata && actual == expected {
+        return;
+    }
+    panic error("expected '" + expected.toString() + "', found '" + actual.toString() + "'");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/check_expr_with_json_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/check_expr_with_json_access.bal
@@ -62,6 +62,24 @@ function testJsonAccessWithCheckWithSubTypesOfSimpleBasicTypesCET() returns erro
                    check f2Err.detail()["message"].ensureType());
 }
 
+function testPropagatedCETForCheckExpression() returns error? {
+    json a = {name: "John", "age": 31, "city": "New York"};
+    float a1 = 1 + check a.age;
+    assertEquality(32f, a1);
+
+    json b = {key: 22};
+    var b1 = <float>check b.key;
+    assertEquality(22f, b1);
+
+    json c = "true";
+    boolean c1 = !check c;
+    assertEquality(false, c1);
+
+    json d = "1";
+    float d1 = -check d;
+    assertEquality(1f, d1);
+}
+
 function assertTrue(anydata actual) {
     assertEquality(true, actual);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/check_expr_with_json_access_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/check_expr_with_json_access_negative.bal
@@ -23,4 +23,16 @@ function testJsonAccessWithCheckNegative(json j) returns error? {
     "foo"|xml[] _ = check j.b;
     int[]|BooleanOrStringValue _ = check j.c;
     IntMax|1d|map<int> _ = check j.d;
+
+    json a = {name: "John", "age": 31, "city": "New York"};
+    xml _ = xml `some txt` + check a.age;
+
+    _Frame e = {id: 101};
+    float _ = 1 + check e["age"];
+    float _ = 1 + check e.id;
 }
+
+type _Frame record {|
+    int id;
+    anydata...;
+|};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
@@ -256,6 +256,11 @@ function testGlobalArrowExpressionsWithClosure() {
     assertEquality(expected, result);
 }
 
+function testCETViaTypeCastExpressionForArrowExpr() {
+    var func = <function (int) returns int>(a => a); // add this test case
+    assertEquality(func(1), 1);
+}
+
 function testExpressionBodiedFunctionWithBinaryExpr() {
     string[] a = ["foo","bar","baz"].map(s => s + "1");
     assertEquality(<string[]> ["foo1", "bar1", "baz1"], a);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/rawtemplate/raw_template_literal_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/rawtemplate/raw_template_literal_negative.bal
@@ -194,3 +194,12 @@ function testRawTemplateWithIntersectionType() {
     tmp6.insertions[0] = 10;
     tmp6.insertions.push(30);
 }
+
+public type RawTemplate1 distinct object {
+    *object:RawTemplate;
+    public string[] insertions;
+};
+
+function testPropagatedCETForRawTemplate() {
+    var _ = <RawTemplate1> `some text ${1} some more text ${2}`;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/unary-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/unary-operation.bal
@@ -357,6 +357,11 @@ function testResultingTypeOfUnaryPlus() {
     assertEquality(k1, 32);
 }
 
+function testLengthyUnaryExpressionsForOOM() {
+    float a = ----------------------------------------------------------------------------------1;
+    assertEquality(a, 1f);
+}
+
 function assertEquality(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-var-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-var-type.bal
@@ -566,6 +566,21 @@ function testMethodCallExprsOnQueryExprs() {
     assertEquality(["c", "b", "a"], words);
 }
 
+function testPropagatedCETForQueryExpression() {
+    string[] x = ["a", "b"];
+    var var1 = <string>from var s in x
+        select s;
+    assertEquality("ab", var1);
+    string z = "ab";
+    var var2 = <string[]>from var s in z
+        select s;
+    assertEquality(["a", "b"], var2);
+    table<map<anydata>> t = table [{a: 1, b: 2}];
+    var var3 = <anydata[]>from var s in t
+        select s["a"];
+    assertEquality([1], var3);
+}
+
 function assertEquality(anydata expected, anydata actual) {
     if expected == actual {
         return;


### PR DESCRIPTION
## Purpose
$title

Fixes #40658, #38104, #41433

## Approach
The requirement to clone nodes and type check is that we need to flow down the CET to the operands that will be used by the numeric literals. Since node cloning causes OOM for lengthy binary expressions this will remove node cloning and flow down the CET using `AnalyzerData`

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
