### PR TITLE
Add formatting configurations through `Ballerina.toml` file

### DIFF
--- a/compiler/ballerina-lang/src/main/resources/ballerina-toml-schema.json
+++ b/compiler/ballerina-lang/src/main/resources/ballerina-toml-schema.json
@@ -352,32 +352,38 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
+        "alignConsecutiveDefinitions": {
+          "type": "boolean"
+        },
         "columnLimit": {
           "type": "integer"
+        },
+        "recordBraceSpacing": {
+          "type": "boolean"
         },
         "tabWidth": {
           "type": "integer"
         },
-        "allowShortBlocksOnASingleLine": {
-          "type": "boolean"
-        },
-        "allowShortMatchLabelsOnASingleLine": {
-          "type": "boolean"
-        },
-        "allowShortIfStatementsOnASingleLine": {
-          "type": "boolean"
-        },
-        "allowShortLoopsOnASingleLine": {
-          "type": "boolean"
-        },
-        "alignConsecutiveDefinitions": {
-          "type": "boolean"
-        },
-        "elseBlocksOnANewLine": {
-          "type": "boolean"
-        },
-        "recordBraceSpacing": {
-          "type": "boolean"
+        "block": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "allowShortBlocksOnASingleLine": {
+              "type": "boolean"
+            },
+            "allowShortMatchLabelsOnASingleLine": {
+              "type": "boolean"
+            },
+            "allowShortIfStatementsOnASingleLine": {
+              "type": "boolean"
+            },
+            "allowShortLoopsOnASingleLine": {
+              "type": "boolean"
+            },
+            "elseBlocksOnANewLine": {
+              "type": "boolean"
+            }
+          }
         },
         "function": {
           "type": "object",
@@ -387,6 +393,18 @@
               "type": "boolean"
             },
             "paranAlign": {
+              "type": "boolean"
+            }
+          }
+        },
+        "import": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "groupImports": {
+              "type": "boolean"
+            },
+            "sortImports": {
               "type": "boolean"
             }
           }

--- a/compiler/ballerina-lang/src/main/resources/ballerina-toml-schema.json
+++ b/compiler/ballerina-lang/src/main/resources/ballerina-toml-schema.json
@@ -347,6 +347,51 @@
           "type": "boolean"
         }
       }
+    },
+    "format": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "columnLimit": {
+          "type": "integer"
+        },
+        "tabWidth": {
+          "type": "integer"
+        },
+        "allowShortBlocksOnASingleLine": {
+          "type": "boolean"
+        },
+        "allowShortMatchLabelsOnASingleLine": {
+          "type": "boolean"
+        },
+        "allowShortIfStatementsOnASingleLine": {
+          "type": "boolean"
+        },
+        "allowShortLoopsOnASingleLine": {
+          "type": "boolean"
+        },
+        "alignConsecutiveDefinitions": {
+          "type": "boolean"
+        },
+        "elseBlocksOnANewLine": {
+          "type": "boolean"
+        },
+        "recordBraceSpacing": {
+          "type": "boolean"
+        },
+        "function": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "oneArgPerLine": {
+              "type": "boolean"
+            },
+            "paranAlign": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -19,6 +19,7 @@ import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.directory.BuildProject;
+import io.ballerina.projects.directory.SingleFileProject;
 import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.formatter.core.Formatter;
@@ -442,11 +443,18 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 if (syntaxTree.isEmpty()) {
                     return Collections.emptyList();
                 }
-                Path rootPath = context.workspace().projectRoot(context.filePath());
-                BuildProject project = BuildProject.load(rootPath, BuildOptions.builder().build());
-                FormattingOptions options = FormattingOptions.builder()
-                        .build(project.currentPackage().manifest().getValue("format"));
-                String formattedSource = Formatter.format(syntaxTree.get(), options).toSourceCode();
+                    String formattedSource;
+                if (context.currentModule().isPresent() &&
+                        !(context.currentModule().get().project() instanceof SingleFileProject)) {
+                    Path rootPath = context.workspace().projectRoot(context.filePath());
+                    BuildProject project = BuildProject.load(rootPath, BuildOptions.builder().build());
+                    FormattingOptions options = FormattingOptions.builder()
+                            .build(project.currentPackage().manifest().getValue("format"));
+                    formattedSource = Formatter.format(syntaxTree.get(), options).toSourceCode();
+                } else {
+                    formattedSource = Formatter.format(syntaxTree.get()).toSourceCode();
+                }
+
                 LinePosition eofPos = syntaxTree.get().rootNode().lineRange().endLine();
                 Range range = new Range(new Position(0, 0), new Position(eofPos.line() + 1, eofPos.offset()));
                 TextEdit textEdit = new TextEdit(range, formattedSource);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -18,8 +18,8 @@ package org.ballerinalang.langserver;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.Module;
+import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.directory.BuildProject;
-import io.ballerina.projects.directory.SingleFileProject;
 import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.formatter.core.Formatter;
@@ -443,9 +443,9 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 if (syntaxTree.isEmpty()) {
                     return Collections.emptyList();
                 }
-                    String formattedSource;
+                String formattedSource;
                 if (context.currentModule().isPresent() &&
-                        !(context.currentModule().get().project() instanceof SingleFileProject)) {
+                        !(context.currentModule().get().project().kind() == ProjectKind.SINGLE_FILE_PROJECT)) {
                     Path rootPath = context.workspace().projectRoot(context.filePath());
                     BuildProject project = BuildProject.load(rootPath, BuildOptions.builder().build());
                     FormattingOptions options = FormattingOptions.builder()

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
@@ -77,6 +77,36 @@ public class FormattingTest {
         Assert.assertEquals(actual, expected);
     }
 
+    @Test(description = "test formatting functionality on functions with configurations")
+    public void formatTestSuiteWithConfigurations() throws IOException {
+        Path inputProject = formattingDirectory.resolve("project");
+        Path expectedProject = formattingDirectory.resolve("projectExpected");
+        Path expectedFilePath = expectedProject.resolve("main.bal");
+        Path inputFilePath = inputProject.resolve("main.bal");
+
+        String expected = new String(Files.readAllBytes(expectedFilePath));
+        expected = expected.replaceAll("\\r\\n", "\n");
+        DocumentFormattingParams documentFormattingParams = new DocumentFormattingParams();
+
+        TextDocumentIdentifier textDocumentIdentifier1 = new TextDocumentIdentifier();
+        textDocumentIdentifier1.setUri(Paths.get(inputFilePath.toString()).toUri().toString());
+
+        FormattingOptions formattingOptions = new FormattingOptions();
+
+        documentFormattingParams.setOptions(formattingOptions);
+        documentFormattingParams.setTextDocument(textDocumentIdentifier1);
+
+        TestUtil.openDocument(this.serviceEndpoint, inputFilePath);
+
+        String result = TestUtil.getFormattingResponse(documentFormattingParams, this.serviceEndpoint);
+        Gson gson = new Gson();
+        ResponseMessage responseMessage = gson.fromJson(result, ResponseMessage.class);
+        String actual = (String) ((LinkedTreeMap) ((List) responseMessage.getResult()).get(0)).get("newText");
+        actual = actual.replaceAll("\\r\\n", "\n");
+        TestUtil.closeDocument(this.serviceEndpoint, inputFilePath);
+        Assert.assertEquals(actual, expected);
+    }
+
     @AfterClass
     public void shutdownLanguageServer() throws IOException {
         TestUtil.shutdownLanguageServer(this.serviceEndpoint);

--- a/language-server/modules/langserver-core/src/test/resources/formatting/project/Ballerina.toml
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/project/Ballerina.toml
@@ -1,0 +1,12 @@
+[format]
+columnLimit = 80
+tabWidth = 2
+recordBraceSpacing = true
+
+[format.function]
+oneArgPerLine = false
+paranAlign = true
+
+[format.block]
+allowShortMatchLabelsOnASingleLine = true
+elseBlocksOnANewLine = true

--- a/language-server/modules/langserver-core/src/test/resources/formatting/project/main.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/project/main.bal
@@ -1,0 +1,15 @@
+function getDateFormatIncludingDayName (string year,int month,int day,  int dayNumber ) returns string  {
+  string? text =  () ;
+    match dayNumber  {
+        1  => {text =  "Sunday";}
+        2  => {  text =  "Monday";}
+        3 => { text =  "Tuesday"; }
+        4 =>  {text =  "Wednesday";}
+        5 => {text =  "Thursday" ;}
+        6 =>  {text =  "Friday";}
+        7 =>  {text =  "Saturday" ;}
+     }
+     if text !is () {  return string`${year} ${month} ${text} ${day}`;
+     }
+     else { return string`${year} ${month} ${day}`; }
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/projectExpected/main.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/projectExpected/main.bal
@@ -1,0 +1,19 @@
+function getDateFormatIncludingDayName(string year, int month, int day, 
+                                       int dayNumber) returns string {
+  string? text = ();
+  match dayNumber {
+    1 => { text = "Sunday"; }
+    2 => { text = "Monday"; }
+    3 => { text = "Tuesday"; }
+    4 => { text = "Wednesday"; }
+    5 => { text = "Thursday"; }
+    6 => { text = "Friday"; }
+    7 => { text = "Saturday"; }
+  }
+  if text !is () {
+    return string `${year} ${month} ${text} ${day}`;
+  }
+  else {
+    return string `${year} ${month} ${day}`;
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/toml/ballerina_toml/completion/config/table_array_context/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/toml/ballerina_toml/completion/config/table_array_context/config1.json
@@ -92,6 +92,34 @@
       "detail": "Table Array",
       "sortText": "C",
       "insertText": "[[dependency]]"
+    },
+    {
+      "label":"format",
+      "kind":"Snippet",
+      "detail":"Table",
+      "sortText":"C",
+      "insertText":"[format]"
+    },
+    {
+      "label":"format.function",
+      "kind":"Snippet",
+      "detail":"Table",
+      "sortText":"C",
+      "insertText":"[format.function]"
+    },
+    {
+      "label":"format.import",
+      "kind":"Snippet",
+      "detail":"Table",
+      "sortText":"C",
+      "insertText":"[format.import]"
+    },
+    {
+      "label":"format.block",
+      "kind":"Snippet",
+      "detail":"Table",
+      "sortText":"C",
+      "insertText":"[format.block]"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/toml/ballerina_toml/completion/config/table_array_context/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/toml/ballerina_toml/completion/config/table_array_context/config1.json
@@ -94,32 +94,32 @@
       "insertText": "[[dependency]]"
     },
     {
-      "label":"format",
-      "kind":"Snippet",
-      "detail":"Table",
-      "sortText":"C",
-      "insertText":"[format]"
+      "label": "format",
+      "kind": "Snippet",
+      "detail": "Table",
+      "sortText": "C",
+      "insertText": "[format]"
     },
     {
-      "label":"format.function",
-      "kind":"Snippet",
-      "detail":"Table",
-      "sortText":"C",
-      "insertText":"[format.function]"
+      "label": "format.function",
+      "kind": "Snippet",
+      "detail": "Table",
+      "sortText": "C",
+      "insertText": "[format.function]"
     },
     {
-      "label":"format.import",
-      "kind":"Snippet",
-      "detail":"Table",
-      "sortText":"C",
-      "insertText":"[format.import]"
+      "label": "format.import",
+      "kind": "Snippet",
+      "detail": "Table",
+      "sortText": "C",
+      "insertText": "[format.import]"
     },
     {
-      "label":"format.block",
-      "kind":"Snippet",
-      "detail":"Table",
-      "sortText":"C",
-      "insertText":"[format.block]"
+      "label": "format.block",
+      "kind": "Snippet",
+      "detail": "Table",
+      "sortText": "C",
+      "insertText": "[format.block]"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/toml/ballerina_toml/completion/config/table_context/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/toml/ballerina_toml/completion/config/table_context/config1.json
@@ -115,32 +115,32 @@
       "insertText": "template=${1:false}"
     },
     {
-      "label":"format",
-      "kind":"Snippet",
-      "detail":"Table",
-      "sortText":"C",
-      "insertText":"[format]"
+      "label": "format",
+      "kind": "Snippet",
+      "detail": "Table",
+      "sortText": "C",
+      "insertText": "[format]"
     },
     {
-      "label":"format.function",
-      "kind":"Snippet",
-      "detail":"Table",
-      "sortText":"C",
-      "insertText":"[format.function]"
+      "label": "format.function",
+      "kind": "Snippet",
+      "detail": "Table",
+      "sortText": "C",
+      "insertText": "[format.function]"
     },
     {
-      "label":"format.import",
-      "kind":"Snippet",
-      "detail":"Table",
-      "sortText":"C",
-      "insertText":"[format.import]"
+      "label": "format.import",
+      "kind": "Snippet",
+      "detail": "Table",
+      "sortText": "C",
+      "insertText": "[format.import]"
     },
     {
-      "label":"format.block",
-      "kind":"Snippet",
-      "detail":"Table",
-      "sortText":"C",
-      "insertText":"[format.block]"
+      "label": "format.block",
+      "kind": "Snippet",
+      "detail": "Table",
+      "sortText": "C",
+      "insertText": "[format.block]"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/toml/ballerina_toml/completion/config/table_context/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/toml/ballerina_toml/completion/config/table_context/config1.json
@@ -113,6 +113,34 @@
       "detail": "Boolean",
       "sortText": "A",
       "insertText": "template=${1:false}"
+    },
+    {
+      "label":"format",
+      "kind":"Snippet",
+      "detail":"Table",
+      "sortText":"C",
+      "insertText":"[format]"
+    },
+    {
+      "label":"format.function",
+      "kind":"Snippet",
+      "detail":"Table",
+      "sortText":"C",
+      "insertText":"[format.function]"
+    },
+    {
+      "label":"format.import",
+      "kind":"Snippet",
+      "detail":"Table",
+      "sortText":"C",
+      "insertText":"[format.import]"
+    },
+    {
+      "label":"format.block",
+      "kind":"Snippet",
+      "detail":"Table",
+      "sortText":"C",
+      "insertText":"[format.block]"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/toml/ballerina_toml/completion/config/table_context/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/toml/ballerina_toml/completion/config/table_context/config2.json
@@ -113,6 +113,35 @@
       "detail": "Boolean",
       "sortText": "A",
       "insertText": "template=${1:false}"
+    },
+    {
+      "label":"format",
+      "kind":"Snippet",
+      "detail":"Table",
+      "sortText":"C",
+      "insertText":"[format]"
+    },
+    {
+      "label":"format.function",
+      "kind":"Snippet",
+      "detail":"Table",
+      "sortText":"C",
+      "insertText":"[format.function]"
+    },
+    {
+      "label":"format.import",
+      "kind":"Snippet",
+      "detail":"Table",
+      "sortText":"C",
+      "insertText":"[format.import]"
+    },
+    {
+      "label":"format.block",
+      "kind":"Snippet",
+      "detail":"Table",
+      "sortText":"C",
+      "insertText":"[format.block]"
     }
+
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/toml/ballerina_toml/completion/config/table_context/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/toml/ballerina_toml/completion/config/table_context/config2.json
@@ -115,33 +115,32 @@
       "insertText": "template=${1:false}"
     },
     {
-      "label":"format",
-      "kind":"Snippet",
-      "detail":"Table",
-      "sortText":"C",
-      "insertText":"[format]"
+      "label": "format",
+      "kind": "Snippet",
+      "detail": "Table",
+      "sortText": "C",
+      "insertText": "[format]"
     },
     {
-      "label":"format.function",
-      "kind":"Snippet",
-      "detail":"Table",
-      "sortText":"C",
-      "insertText":"[format.function]"
+      "label": "format.function",
+      "kind": "Snippet",
+      "detail": "Table",
+      "sortText": "C",
+      "insertText": "[format.function]"
     },
     {
-      "label":"format.import",
-      "kind":"Snippet",
-      "detail":"Table",
-      "sortText":"C",
-      "insertText":"[format.import]"
+      "label": "format.import",
+      "kind": "Snippet",
+      "detail": "Table",
+      "sortText": "C",
+      "insertText": "[format.import]"
     },
     {
-      "label":"format.block",
-      "kind":"Snippet",
-      "detail":"Table",
-      "sortText":"C",
-      "insertText":"[format.block]"
+      "label": "format.block",
+      "kind": "Snippet",
+      "detail": "Table",
+      "sortText": "C",
+      "insertText": "[format.block]"
     }
-
   ]
 }

--- a/misc/formatter/modules/formatter-cli/src/main/java/org/ballerinalang/formatter/cli/FormatUtil.java
+++ b/misc/formatter/modules/formatter-cli/src/main/java/org/ballerinalang/formatter/cli/FormatUtil.java
@@ -29,7 +29,6 @@ import org.ballerinalang.formatter.core.Formatter;
 import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormattingOptions;
 
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/misc/formatter/modules/formatter-cli/src/main/java/org/ballerinalang/formatter/cli/FormatUtil.java
+++ b/misc/formatter/modules/formatter-cli/src/main/java/org/ballerinalang/formatter/cli/FormatUtil.java
@@ -43,7 +43,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Util class for compilation and format execution for formatting CLI tool.
@@ -129,7 +128,8 @@ class FormatUtil {
 
                     try {
                         project = BuildProject.load(projectPath, constructBuildOptions());
-                        options = constructFormattingOptions(project.currentPackage().manifest().getValue("format"));
+                        options = FormattingOptions.builder()
+                                .build(project.currentPackage().manifest().getValue("format"));
                     } catch (ProjectException e) {
                         throw LauncherUtils.createLauncherException(e.getMessage());
                     }
@@ -196,7 +196,7 @@ class FormatUtil {
                 FormattingOptions options;
                 try {
                     project = BuildProject.load(sourceRootPath, constructBuildOptions());
-                    options = constructFormattingOptions(project.currentPackage().manifest().getValue("format"));
+                    options = FormattingOptions.builder().build(project.currentPackage().manifest().getValue("format"));
                 } catch (ProjectException e) {
                     throw LauncherUtils.createLauncherException(e.getMessage());
                 }
@@ -338,13 +338,6 @@ class FormatUtil {
                 .setTestReport(false)
                 .setObservabilityIncluded(false)
                 .build();
-    }
-
-    private static FormattingOptions constructFormattingOptions(Object configurations) {
-        if (configurations instanceof Map) {
-            return FormattingOptions.builder().build((Map<String, Object>) configurations);
-        }
-        return FormattingOptions.builder().build();
     }
 
     /**

--- a/misc/formatter/modules/formatter-cli/src/test/java/org/ballerinalang/formatter/cli/FormatCmdTest.java
+++ b/misc/formatter/modules/formatter-cli/src/test/java/org/ballerinalang/formatter/cli/FormatCmdTest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.formatter.cli;
 import io.ballerina.cli.launcher.BLauncherException;
 import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -29,8 +30,6 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-
 
 /**
  * Format CLI tool test suit for testing tool's exceptions.
@@ -53,9 +52,6 @@ public class FormatCmdTest {
             RES_DIR.resolve("BallerinaProject/source/ProjectTemp");
     private static final Path BALLERINA_PROJECT_ASSERT =
             RES_DIR.resolve("BallerinaProject/assert/Project");
-    private static final Path[] BALLERINA_CONFIGURATION_DIRS =
-            {RES_DIR.resolve("configurations/general/source"), RES_DIR.resolve("configurations/functions/source"),
-                    RES_DIR.resolve("configurations/blocks/source"), RES_DIR.resolve("configurations/imports/source")};
 
     @Test(description = "Test single file project formatting")
     public void formatCLIOnASingleFileProject() {
@@ -87,28 +83,44 @@ public class FormatCmdTest {
         }
     }
 
-    @Test(description = "Test ballerina project formatting")
-    public void formatCLIOnBallerinaProjectWithConfigurations() {
+    @Test(description = "Test ballerina project formatting with configurations",
+            dataProvider = "provideConfigurationProjects")
+    public void formatCLIOnBallerinaProjectWithConfigurations(String testCase, List<Path> dirs) {
         List<String> argList = new ArrayList<>();
-        for (Path dir : BALLERINA_CONFIGURATION_DIRS) {
-            try {
-                List<Path> subDirs = Files.list(dir)
-                        .filter(Files::isDirectory)
-                        .filter(d -> !d.getFileName().toString().endsWith("Temp"))
-                        .collect(Collectors.toList());
-                for (Path subDir : subDirs) {
-                    Path tempDir = subDir.resolveSibling(subDir.getFileName() + "Temp");
-                    Path assertDir = Paths.get(subDir.toString().replace("/source/", "/assert/"));
+        try {
+            for (Path dir : dirs) {
+                Path tempDir = dir.resolveSibling(dir.getFileName() + "Temp");
+                Path assertDir = Paths.get(dir.toString().replace("/source/", "/assert/"));
 
-                    FormatUtil.execute(argList, false, null, null, false, subDir);
-                    Assert.assertEquals(Files.readString(subDir.resolve("main.bal")),
-                            Files.readString(assertDir.resolve("main.bal")));
-                    FileUtils.copyDirectory(tempDir.toFile(), subDir.toFile());
-                }
-            } catch (IOException e) {
-                Assert.fail("Failed to update the source file.");
+                FormatUtil.execute(argList, false, null, null, false, dir);
+                Assert.assertEquals(Files.readString(dir.resolve("main.bal")),
+                        Files.readString(assertDir.resolve("main.bal")));
+                FileUtils.copyDirectory(tempDir.toFile(), dir.toFile());
             }
+        } catch (IOException e) {
+            Assert.fail(testCase + " test failed to update the source file.");
         }
+    }
+
+    @DataProvider(name = "provideConfigurationProjects")
+    private Object[][] provideConfigurationProjects() {
+        return new Object[][]{
+                {"general", List.of(
+                        RES_DIR.resolve("configurations/general/source/project")
+                )},
+                {"function", List.of(
+                        RES_DIR.resolve("configurations/functions/source/oneArg"),
+                        RES_DIR.resolve("configurations/functions/source/paranAlign"),
+                        RES_DIR.resolve("configurations/functions/source/paranAlignOneArg")
+                )},
+                {"blocks", List.of(
+                        RES_DIR.resolve("configurations/blocks/source/ifelse"),
+                        RES_DIR.resolve("configurations/blocks/source/short")
+                )},
+                {"import", List.of(
+                        RES_DIR.resolve("configurations/imports/source/project")
+                )}
+        };
     }
 
     @Test(description = "Test ballerina project formatting with dot op",

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/assert/ifelse/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/assert/ifelse/main.bal
@@ -1,0 +1,12 @@
+function getGrades(int score) returns string {
+    int i = 0;
+    if 0 < score && score < 55 {
+        return "F";
+    }
+    else if 55 <= score && score < 65 {
+        return "C";
+    }
+    else {
+        return "Invalid grade";
+    }
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/assert/short/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/assert/short/main.bal
@@ -1,0 +1,28 @@
+import ballerina/io;
+
+function loop(int times) {
+    int count = 1;
+    while (count <= times) { count += 1; }
+}
+
+function getSign(int number) returns string {
+    if number <= 0 { return "+"; }
+    else { return "-"; }
+}
+
+function btoi(boolean? b) returns int {
+    match b {
+        true => { return 1; }
+        false => { return 0; }
+    }
+    return 0;
+}
+
+function printFalse() {
+    boolean b = false;
+    if b {
+        io:println(1);
+    } else {
+        io:println(0);
+    }
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/ifelse/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/ifelse/Ballerina.toml
@@ -1,0 +1,2 @@
+[format.block]
+elseBlockOnANewLine = true

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/ifelse/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/ifelse/main.bal
@@ -1,0 +1,10 @@
+function getGrades(int score) returns string  {
+    int i = 0;
+    if 0 <  score && score < 55 {
+        return "F";
+    } else   if 55 <= score  && score < 65  {
+        return "C"  ;
+    } else  {
+        return "Invalid grade";
+    }
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/ifelseTemp/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/ifelseTemp/Ballerina.toml
@@ -1,0 +1,2 @@
+[format.block]
+elseBlockOnANewLine = true

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/ifelseTemp/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/ifelseTemp/main.bal
@@ -1,0 +1,10 @@
+function getGrades(int score) returns string  {
+    int i = 0;
+    if 0 <  score && score < 55 {
+        return "F";
+    } else   if 55 <= score  && score < 65  {
+        return "C"  ;
+    } else  {
+        return "Invalid grade";
+    }
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/short/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/short/Ballerina.toml
@@ -1,0 +1,2 @@
+[format.block]
+allowShortBlocksOnASingleLine = true

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/short/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/short/main.bal
@@ -1,0 +1,28 @@
+import ballerina/io;
+
+function loop(int times) {
+    int count = 1;
+    while (count <= times) {count+= 1;}
+}
+
+function getSign(int number) returns string {
+    if number <= 0 { return "+"; }
+    else { return "-"; }
+}
+
+function btoi(boolean? b) returns int {
+    match b {
+        true => { return 1; }
+        false => { return 0; }
+    }
+    return 0;
+}
+
+function printFalse() {
+    boolean b = false;
+    if b {
+        io:println(1);
+    } else {
+        io:println(0);
+    }
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/shortTemp/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/shortTemp/Ballerina.toml
@@ -1,0 +1,2 @@
+[format.block]
+allowShortBlocksOnASingleLine = true

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/shortTemp/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/blocks/source/shortTemp/main.bal
@@ -1,0 +1,28 @@
+import ballerina/io;
+
+function loop(int times) {
+    int count = 1;
+    while (count <= times) {count+= 1;}
+}
+
+function getSign(int number) returns string {
+    if number <= 0 { return "+"; }
+    else { return "-"; }
+}
+
+function btoi(boolean? b) returns int {
+    match b {
+        true => { return 1; }
+        false => { return 0; }
+    }
+    return 0;
+}
+
+function printFalse() {
+    boolean b = false;
+    if b {
+        io:println(1);
+    } else {
+        io:println(0);
+    }
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/assert/oneArg/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/assert/oneArg/main.bal
@@ -1,0 +1,12 @@
+function add(int first,
+        int second,
+        int third,
+        int fourth,
+        int fifth,
+        int sixth,
+        int seventh,
+        int eighth,
+        int ninth,
+        int tenth) returns int {
+    return first + second + third + fourth + fifth + sixth + seventh + eighth + ninth + tenth;
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/assert/paranAlign/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/assert/paranAlign/main.bal
@@ -1,0 +1,5 @@
+function add(int first, int second, int third, int fourth, int fifth, int sixth, 
+             int seventh, int eighth, int ninth, int tenth) returns int {
+    return first + second + third + fourth + fifth + sixth + seventh + eighth + 
+    ninth + tenth;
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/assert/paranAlignOneArg/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/assert/paranAlignOneArg/main.bal
@@ -1,0 +1,12 @@
+function add(int first,
+             int second,
+             int third,
+             int fourth,
+             int fifth,
+             int sixth,
+             int seventh,
+             int eighth,
+             int ninth,
+             int tenth) returns int {
+    return first + second + third + fourth + fifth + sixth + seventh + eighth + ninth + tenth;
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/oneArg/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/oneArg/Ballerina.toml
@@ -1,0 +1,6 @@
+[format]
+columnLimit = 120
+
+[format.function]
+oneArgPerLine = true
+paranAlign = false

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/oneArg/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/oneArg/main.bal
@@ -1,0 +1,3 @@
+function add ( int first, int  second,int  third,int fourth, int   fifth, int   sixth, int   seventh, int  eighth,   int  ninth,int tenth)   returns int {
+    return first+  second + third   + fourth +   fifth +  sixth + seventh+eighth + ninth+ tenth ;
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/oneArgTemp/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/oneArgTemp/Ballerina.toml
@@ -1,0 +1,6 @@
+[format]
+columnLimit = 120
+
+[format.function]
+oneArgPerLine = true
+paranAlign = false

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/oneArgTemp/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/oneArgTemp/main.bal
@@ -1,0 +1,3 @@
+function add ( int first, int  second,int  third,int fourth, int   fifth, int   sixth, int   seventh, int  eighth,   int  ninth,int tenth)   returns int {
+    return first+  second + third   + fourth +   fifth +  sixth + seventh+eighth + ninth+ tenth ;
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlign/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlign/Ballerina.toml
@@ -1,0 +1,6 @@
+[format]
+columnLimit = 80
+
+[format.function]
+oneArgPerLine = false
+paranAlign = true

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlign/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlign/main.bal
@@ -1,0 +1,3 @@
+function add ( int first, int  second,int  third,int fourth, int   fifth, int   sixth, int   seventh, int  eighth,   int  ninth,int tenth)   returns int {
+    return first+  second + third   + fourth +   fifth +  sixth + seventh+eighth + ninth+ tenth ;
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlignOneArg/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlignOneArg/Ballerina.toml
@@ -1,0 +1,6 @@
+[format]
+columnLimit = 120
+
+[format.function]
+oneArgPerLine = true
+paranAlign = true

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlignOneArg/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlignOneArg/main.bal
@@ -1,0 +1,3 @@
+function add ( int first, int  second,int  third,int fourth, int   fifth, int   sixth, int   seventh, int  eighth,   int  ninth,int tenth)   returns int {
+    return first+  second + third   + fourth +   fifth +  sixth + seventh+eighth + ninth+ tenth ;
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlignOneArgTemp/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlignOneArgTemp/Ballerina.toml
@@ -1,0 +1,6 @@
+[format]
+columnLimit = 120
+
+[format.function]
+oneArgPerLine = true
+paranAlign = true

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlignOneArgTemp/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlignOneArgTemp/main.bal
@@ -1,0 +1,3 @@
+function add ( int first, int  second,int  third,int fourth, int   fifth, int   sixth, int   seventh, int  eighth,   int  ninth,int tenth)   returns int {
+    return first+  second + third   + fourth +   fifth +  sixth + seventh+eighth + ninth+ tenth ;
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlignTemp/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlignTemp/Ballerina.toml
@@ -1,0 +1,6 @@
+[format]
+columnLimit = 80
+
+[format.function]
+oneArgPerLine = false
+paranAlign = true

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlignTemp/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/functions/source/paranAlignTemp/main.bal
@@ -1,0 +1,3 @@
+function add ( int first, int  second,int  third,int fourth, int   fifth, int   sixth, int   seventh, int  eighth,   int  ninth,int tenth)   returns int {
+    return first+  second + third   + fourth +   fifth +  sixth + seventh+eighth + ninth+ tenth ;
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/general/assert/project/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/general/assert/project/main.bal
@@ -1,0 +1,30 @@
+const int MAX_STUDENTS       = 100;
+const string WELCOME_MESSAGE = "Welcome";
+const int MAX_AGE            = 20;
+
+type Student record {
+  string name;
+  int age;
+};
+
+function registerStudent(Student[] students, string name, int age, 
+    int numStudents) returns boolean {
+  if numStudents < MAX_STUDENTS {
+    students.push({ name, age });
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function queryTest() {
+  int[] nums = [1, 2, 3, 4];
+  int[] numsTimes10 = from var i in nums
+                      select i * 10;
+  int[] evenNums = from int i in nums
+                   where i % 2 == 0
+                   select i;
+  int[] numsReversed = from int i in nums
+                       order by i descending
+                       select i;
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/general/source/project/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/general/source/project/Ballerina.toml
@@ -1,0 +1,6 @@
+[format]
+tabWidth = 2
+recordBraceSpacing = true
+columnLimit = 80
+alignMultiLineQueries = true
+alignConsecutiveDefinitions = true

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/general/source/project/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/general/source/project/main.bal
@@ -1,0 +1,28 @@
+const int MAX_STUDENTS = 100;
+const string WELCOME_MESSAGE = "Welcome";
+const int MAX_AGE = 20;
+
+type Student record {
+    string name;
+    int age;
+};
+
+function registerStudent(Student[] students, string name, int age, int numStudents) returns boolean {
+    if numStudents  <  MAX_STUDENTS {
+        students.push({name, age});
+        return true;
+    } else   {
+    return false;
+    }
+}
+
+function queryTest() {
+    int[] nums  =  [1 , 2,3,  4];
+    int[] numsTimes10 = from var i in nums select i * 10;
+    int[] evenNums = from int i in nums
+        where i  % 2  == 0
+        select i;
+    int[] numsReversed = from int  i in nums
+        order  by i   descending
+    select i;
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/general/source/projectTemp/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/general/source/projectTemp/Ballerina.toml
@@ -1,0 +1,6 @@
+[format]
+tabWidth = 2
+recordBraceSpacing = true
+columnLimit = 80
+alignMultiLineQueries = true
+alignConsecutiveDefinitions = true

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/general/source/projectTemp/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/general/source/projectTemp/main.bal
@@ -1,0 +1,28 @@
+const int MAX_STUDENTS = 100;
+const string WELCOME_MESSAGE = "Welcome";
+const int MAX_AGE = 20;
+
+type Student record {
+    string name;
+    int age;
+};
+
+function registerStudent(Student[] students, string name, int age, int numStudents) returns boolean {
+    if numStudents  <  MAX_STUDENTS {
+        students.push({name, age});
+        return true;
+    } else   {
+    return false;
+    }
+}
+
+function queryTest() {
+    int[] nums  =  [1 , 2,3,  4];
+    int[] numsTimes10 = from var i in nums select i * 10;
+    int[] evenNums = from int i in nums
+        where i  % 2  == 0
+        select i;
+    int[] numsReversed = from int  i in nums
+        order  by i   descending
+    select i;
+}

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/imports/assert/project/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/imports/assert/project/main.bal
@@ -1,0 +1,10 @@
+import cal.add;
+import cal.err;
+import cal.sub;
+
+import ballerina/file;
+import ballerina/http;
+import ballerina/io;
+import ballerina/log;
+import ballerinax/googleapis.gmail as gmail;
+

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/imports/source/project/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/imports/source/project/Ballerina.toml
@@ -1,0 +1,3 @@
+[format.import]
+groupImports = true
+sortImports = true

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/imports/source/project/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/imports/source/project/main.bal
@@ -1,0 +1,8 @@
+import ballerinax/googleapis.gmail as gmail;
+import ballerina/http;
+import cal.add;
+import ballerina/log;
+import ballerina/file;
+import ballerina/io;
+import cal.sub;
+import cal.err;

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/imports/source/projectTemp/Ballerina.toml
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/imports/source/projectTemp/Ballerina.toml
@@ -1,0 +1,3 @@
+[format.import]
+groupImports = true
+sortImports = true

--- a/misc/formatter/modules/formatter-cli/src/test/resources/configurations/imports/source/projectTemp/main.bal
+++ b/misc/formatter/modules/formatter-cli/src/test/resources/configurations/imports/source/projectTemp/main.bal
@@ -1,0 +1,8 @@
+import ballerinax/googleapis.gmail as gmail;
+import ballerina/http;
+import cal.add;
+import ballerina/log;
+import ballerina/file;
+import ballerina/io;
+import cal.sub;
+import cal.err;

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/BlockFormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/BlockFormattingOptions.java
@@ -22,15 +22,11 @@ package org.ballerinalang.formatter.core;
  */
 public class BlockFormattingOptions {
 
-    private boolean allowShortBlocksOnASingleLine;
-
-    private boolean allowShortMatchLabelsOnASingleLine;
-
-    private boolean allowShortIfStatementsOnASingleLine;
-
-    private boolean allowShortLoopsOnASingleLine;
-
-    private boolean elseBlockOnANewLine;
+    private final boolean allowShortBlocksOnASingleLine;
+    private final boolean allowShortMatchLabelsOnASingleLine;
+    private final boolean allowShortIfStatementsOnASingleLine;
+    private final boolean allowShortLoopsOnASingleLine;
+    private final boolean elseBlockOnANewLine;
 
     public BlockFormattingOptions(boolean allowShortBlocksOnASingleLine, boolean allowShortMatchLabelsOnASingleLine,
                                   boolean allowShortIfStatementsOnASingleLine, boolean allowShortLoopsOnASingleLine,
@@ -72,13 +68,9 @@ public class BlockFormattingOptions {
     public static class BlockFormattingOptionsBuilder {
 
         private boolean allowShortBlocksOnASingleLine = false;
-
         private boolean allowShortMatchLabelsOnASingleLine = false;
-
         private boolean allowShortIfStatementsOnASingleLine = false;
-
         private boolean allowShortLoopsOnASingleLine = false;
-
         private boolean elseBlockOnANewLine = false;
 
         public BlockFormattingOptions.BlockFormattingOptionsBuilder setAllowShortBlocksOnASingleLine(

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/BlockFormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/BlockFormattingOptions.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.formatter.core;
+
+/**
+ * A model for formatting of functions by the API user, that could be passed onto the formatter.
+ *
+ * @since 2201.8.0
+ */
+public class BlockFormattingOptions {
+
+    private boolean allowShortBlocksOnASingleLine;
+
+    private boolean allowShortMatchLabelsOnASingleLine;
+
+    private boolean allowShortIfStatementsOnASingleLine;
+
+    private boolean allowShortLoopsOnASingleLine;
+
+    private boolean elseBlockOnANewLine;
+
+    public BlockFormattingOptions(boolean allowShortBlocksOnASingleLine, boolean allowShortMatchLabelsOnASingleLine,
+                                  boolean allowShortIfStatementsOnASingleLine, boolean allowShortLoopsOnASingleLine,
+                                  boolean elseBlockOnANewLine) {
+        this.allowShortBlocksOnASingleLine = allowShortBlocksOnASingleLine;
+        this.allowShortMatchLabelsOnASingleLine = allowShortMatchLabelsOnASingleLine;
+        this.allowShortIfStatementsOnASingleLine = allowShortIfStatementsOnASingleLine;
+        this.allowShortLoopsOnASingleLine = allowShortLoopsOnASingleLine;
+        this.elseBlockOnANewLine = elseBlockOnANewLine;
+    }
+
+    public boolean allowShortBlocksOnASingleLine() {
+        return allowShortBlocksOnASingleLine;
+    }
+
+    public boolean allowShortMatchLabelsOnASingleLine() {
+        return allowShortMatchLabelsOnASingleLine;
+    }
+
+    public boolean allowShortIfStatementsOnASingleLine() {
+        return allowShortIfStatementsOnASingleLine;
+    }
+
+    public boolean allowShortLoopsOnASingleLine() {
+        return allowShortLoopsOnASingleLine;
+    }
+
+    public boolean elseBlockOnANewLine() {
+        return elseBlockOnANewLine;
+    }
+
+    public static BlockFormattingOptions.BlockFormattingOptionsBuilder builder() {
+        return new BlockFormattingOptions.BlockFormattingOptionsBuilder();
+    }
+
+    /**
+     * A builder for the {@code BlockFormattingOptions}.
+     */
+    public static class BlockFormattingOptionsBuilder {
+
+        private boolean allowShortBlocksOnASingleLine = false;
+
+        private boolean allowShortMatchLabelsOnASingleLine = false;
+
+        private boolean allowShortIfStatementsOnASingleLine = false;
+
+        private boolean allowShortLoopsOnASingleLine = false;
+
+        private boolean elseBlockOnANewLine = false;
+
+        public BlockFormattingOptions.BlockFormattingOptionsBuilder setAllowShortBlocksOnASingleLine(
+                boolean allowShortBlocksOnASingleLine) {
+            this.allowShortBlocksOnASingleLine = allowShortBlocksOnASingleLine;
+            return this;
+        }
+
+        public BlockFormattingOptions.BlockFormattingOptionsBuilder setAllowShortMatchLabelsOnASingleLine(
+                boolean allowShortMatchLabelsOnASingleLine) {
+            this.allowShortMatchLabelsOnASingleLine = allowShortMatchLabelsOnASingleLine;
+            return this;
+        }
+
+        public BlockFormattingOptions.BlockFormattingOptionsBuilder setAllowShortIfStatementsOnASingleLine(
+                boolean allowShortIfStatementsOnASingleLine) {
+            this.allowShortIfStatementsOnASingleLine = allowShortIfStatementsOnASingleLine;
+            return this;
+        }
+
+        public BlockFormattingOptions.BlockFormattingOptionsBuilder setAllowShortLoopsOnASingleLine(
+                boolean allowShortLoopsOnASingleLine) {
+            this.allowShortLoopsOnASingleLine = allowShortLoopsOnASingleLine;
+            return this;
+        }
+
+        public BlockFormattingOptions.BlockFormattingOptionsBuilder setElseBlockOnANewLine(
+                boolean elseBlockOnANewLine) {
+            this.elseBlockOnANewLine = elseBlockOnANewLine;
+            return this;
+        }
+
+        public BlockFormattingOptions build() {
+            return new BlockFormattingOptions(allowShortBlocksOnASingleLine, allowShortMatchLabelsOnASingleLine,
+                    allowShortIfStatementsOnASingleLine, allowShortLoopsOnASingleLine, elseBlockOnANewLine);
+        }
+    }
+}

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterUtils.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterUtils.java
@@ -15,8 +15,11 @@
  */
 package org.ballerinalang.formatter.core;
 
+import io.ballerina.compiler.syntax.tree.BlockStatementNode;
+import io.ballerina.compiler.syntax.tree.ConstantDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.tools.text.LineRange;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 
@@ -78,5 +81,27 @@ class FormatterUtils {
                 .append(node1.moduleName().stream().map(node -> node.toString().trim()).collect(Collectors.joining()),
                         node2.moduleName().stream().map(node -> node.toString().trim()).collect(Collectors.joining()))
                 .toComparison());
+    }
+
+    static boolean isBlockOnASingleLine(FormattingOptions options, BlockStatementNode node) {
+        if (node.lineRange().startLine().line() != node.lineRange().endLine().line()) {
+            return false;
+        }
+
+        if (options.allowShortBlocksOnASingleLine()) {
+            return true;
+        }
+
+        SyntaxKind parentKind = node.parent().kind();
+        return (options.allowShortIfStatementsOnASingleLine() && parentKind == SyntaxKind.IF_ELSE_STATEMENT) ||
+                (options.allowShortLoopsOnASingleLine() && parentKind == SyntaxKind.WHILE_STATEMENT) ||
+                (options.allowShortMatchLabelsOnASingleLine() && parentKind == SyntaxKind.MATCH_CLAUSE);
+    }
+
+    static int getConstDefLength(ConstantDeclarationNode node) {
+        int size = node.visibilityQualifier().isPresent() ? node.visibilityQualifier().get().text().length() : 0;
+        size += node.constKeyword().text().length();
+        size += node.variableName().text().length();
+        return size;
     }
 }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterUtils.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterUtils.java
@@ -83,7 +83,7 @@ class FormatterUtils {
                 .toComparison());
     }
 
-    static boolean isBlockOnASingleLine(FormattingOptions options, BlockStatementNode node) {
+    static boolean isBlockOnASingleLine(BlockFormattingOptions options, BlockStatementNode node) {
         if (node.lineRange().startLine().line() != node.lineRange().endLine().line()) {
             return false;
         }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterUtils.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterUtils.java
@@ -101,6 +101,7 @@ class FormatterUtils {
     static int getConstDefLength(ConstantDeclarationNode node) {
         int size = node.visibilityQualifier().isPresent() ? node.visibilityQualifier().get().text().length() : 0;
         size += node.constKeyword().text().length();
+        size += node.typeDescriptor().isPresent() ? node.typeDescriptor().get().toSourceCode().length() : 0;
         size += node.variableName().text().length();
         return size;
     }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterUtils.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterUtils.java
@@ -83,22 +83,22 @@ class FormatterUtils {
                 .toComparison());
     }
 
-    static boolean isBlockOnASingleLine(BlockFormattingOptions options, BlockStatementNode node) {
+    static int openBraceTrailingNLs(BlockFormattingOptions options, BlockStatementNode node) {
         if (node.lineRange().startLine().line() != node.lineRange().endLine().line()) {
-            return false;
+            return 1;
         }
 
         if (options.allowShortBlocksOnASingleLine()) {
-            return true;
+            return 0;
         }
 
         SyntaxKind parentKind = node.parent().kind();
-        return (options.allowShortIfStatementsOnASingleLine() && parentKind == SyntaxKind.IF_ELSE_STATEMENT) ||
+        return  (options.allowShortIfStatementsOnASingleLine() && parentKind == SyntaxKind.IF_ELSE_STATEMENT) ||
                 (options.allowShortLoopsOnASingleLine() && parentKind == SyntaxKind.WHILE_STATEMENT) ||
-                (options.allowShortMatchLabelsOnASingleLine() && parentKind == SyntaxKind.MATCH_CLAUSE);
+                (options.allowShortMatchLabelsOnASingleLine() && parentKind == SyntaxKind.MATCH_CLAUSE) ? 0 : 1;
     }
 
-    static int getConstDefLength(ConstantDeclarationNode node) {
+    static int getConstDefWidth(ConstantDeclarationNode node) {
         int size = node.visibilityQualifier().isPresent() ? node.visibilityQualifier().get().text().length() : 0;
         size += node.constKeyword().text().length();
         size += node.typeDescriptor().isPresent() ? node.typeDescriptor().get().toSourceCode().length() : 0;

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingEnv.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingEnv.java
@@ -32,6 +32,11 @@ public class FormattingEnv {
     int currentIndentation = 0;
 
     /**
+     * Number of whitespaces to be used as the indentation for the current context used when aligning statements.
+     */
+    int preservedIndentation = 0;
+
+    /**
      * Number of leading newlines to be added to the currently processing node.
      */
     int leadingNL = 0;
@@ -75,6 +80,11 @@ public class FormattingEnv {
      * Previous token's trailing new lines.
      */
     int prevTokensTrailingNL = 0;
+
+    /**
+     * Maximum length of the consecutive constant definitions.
+     */
+    int maxConstDefWidth = 1;
 
     /**
      * Flag indicating whether the token that is currently being formatted should preserve its user defined indentation.

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
@@ -262,10 +262,15 @@ public class FormattingOptions {
 
         public FormattingOptions build() {
             return new FormattingOptions(tabSize, wsCharacter, columnLimit, lineWrapping, forceFormattingOptions,
-                    importFormattingOptions);
+                    recordBraceSpacing, alignConsecutiveDefinitions, alignMultiLineQueries, importFormattingOptions,
+                    functionBuilder.build(), blockBuilder.build());
         }
 
-        public FormattingOptions build(Map<String, Object> configurations) {
+        public FormattingOptions build(Object data) {
+            if (!(data instanceof Map)) {
+                return build();
+            }
+            Map<String, Object> configurations = (Map<String, Object>) data;
             for (Map.Entry<String, Object> entry : configurations.entrySet()) {
                 String key = entry.getKey();
                 Object value = entry.getValue();
@@ -356,8 +361,7 @@ public class FormattingOptions {
                 }
             }
             return new FormattingOptions(tabSize, wsCharacter, columnLimit, lineWrapping, forceFormattingOptions,
-                    recordBraceSpacing,
-                    alignConsecutiveDefinitions, alignMultiLineQueries, importBuilder.build(),
+                    recordBraceSpacing, alignConsecutiveDefinitions, alignMultiLineQueries, importBuilder.build(),
                     functionBuilder.build(), blockBuilder.build());
         }
     }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
@@ -15,6 +15,8 @@
  */
 package org.ballerinalang.formatter.core;
 
+import java.util.Map;
+
 /**
  * A model for formatting options that could be passed onto the formatter.
  */
@@ -30,6 +32,26 @@ public class FormattingOptions {
 
     private boolean lineWrapping;
 
+    private boolean paranAlignedIndentation;
+
+    private boolean oneArgPerLine;
+
+    private boolean recordBraceSpacing;
+
+    private boolean allowShortBlocksOnASingleLine;
+
+    private boolean allowShortMatchLabelsOnASingleLine;
+
+    private boolean allowShortIfStatementsOnASingleLine;
+
+    private boolean allowShortLoopsOnASingleLine;
+
+    private boolean elseBlockOnANewLine;
+
+    private boolean sortImports;
+
+    private boolean alignConsecutiveDefinitions;
+
     private ForceFormattingOptions forceFormattingOptions;
 
     private ImportFormattingOptions importFormattingOptions;
@@ -43,6 +65,29 @@ public class FormattingOptions {
         this.lineWrapping = lineWrapping;
         this.forceFormattingOptions = forceFormattingOptions;
         this.importFormattingOptions = importFormattingOptions;
+    }
+
+    FormattingOptions(int tabSize, String wsCharacter, int columnLimit, boolean lineWrapping,
+                      ForceFormattingOptions forceFormattingOptions, boolean paranAlignedIndentation,
+                      boolean oneArgPerLine, boolean allowShortBlocksOnASingleLine, boolean recordBraceSpacing,
+                      boolean elseBlockOnANewLine, boolean sortImports, boolean alignConsecutiveDefinitions,
+                      boolean allowShortIfStatementsOnASingleLine, boolean allowShortLoopsOnASingleLine,
+                      boolean allowShortMatchLabelsOnASingleLine) {
+        this.tabSize = tabSize;
+        this.wsCharacter = wsCharacter;
+        this.columnLimit = columnLimit;
+        this.lineWrapping = lineWrapping;
+        this.forceFormattingOptions = forceFormattingOptions;
+        this.paranAlignedIndentation = paranAlignedIndentation;
+        this.oneArgPerLine = oneArgPerLine;
+        this.recordBraceSpacing = recordBraceSpacing;
+        this.elseBlockOnANewLine = elseBlockOnANewLine;
+        this.sortImports = sortImports;
+        this.alignConsecutiveDefinitions = alignConsecutiveDefinitions;
+        this.allowShortBlocksOnASingleLine = allowShortBlocksOnASingleLine;
+        this.allowShortIfStatementsOnASingleLine = allowShortIfStatementsOnASingleLine;
+        this.allowShortLoopsOnASingleLine = allowShortLoopsOnASingleLine;
+        this.allowShortMatchLabelsOnASingleLine = allowShortMatchLabelsOnASingleLine;
     }
 
     /**
@@ -148,6 +193,46 @@ public class FormattingOptions {
         return importFormattingOptions;
     }
 
+    public boolean isElseBlockOnANewLine() {
+        return elseBlockOnANewLine;
+    }
+
+    public boolean isParanAlignedIndentation() {
+        return paranAlignedIndentation;
+    }
+
+    public boolean isOneArgPerLine() {
+        return oneArgPerLine;
+    }
+
+    public boolean allowShortBlocksOnASingleLine() {
+        return allowShortBlocksOnASingleLine;
+    }
+
+    public boolean allowShortMatchLabelsOnASingleLine() {
+        return allowShortMatchLabelsOnASingleLine;
+    }
+
+    public boolean allowShortIfStatementsOnASingleLine() {
+        return allowShortIfStatementsOnASingleLine;
+    }
+
+    public boolean allowShortLoopsOnASingleLine() {
+        return allowShortLoopsOnASingleLine;
+    }
+
+    public boolean isRecordBraceSpacing() {
+        return recordBraceSpacing;
+    }
+
+    public boolean sortImports() {
+        return sortImports;
+    }
+
+    public boolean alignConsecutiveDefinitions() {
+        return alignConsecutiveDefinitions;
+    }
+
     public static FormattingOptionsBuilder builder() {
         return new FormattingOptionsBuilder();
     }
@@ -162,6 +247,16 @@ public class FormattingOptions {
         private String wsCharacter = " ";
         private int columnLimit = 120;
         private boolean lineWrapping = false;
+        private boolean paranAlignedIndentation = false;
+        private boolean oneArgPerLine = false;
+        private boolean recordBraceSpacing = false;
+        private boolean elseBlockOnANewLine = false;
+        private Boolean sortImports = false;
+        private Boolean alignConsecutiveDefinitions = false;
+        private boolean allowShortBlocksOnASingleLine = false;
+        private Boolean allowShortMatchLabelsOnASingleLine = false;
+        private Boolean allowShortLoopsOnASingleLine = false;
+        private Boolean allowShortIfStatementsOnASingleLine = false;
         private ForceFormattingOptions forceFormattingOptions = ForceFormattingOptions.builder().build();
         private ImportFormattingOptions importFormattingOptions = ImportFormattingOptions.builder().build();
 
@@ -200,6 +295,69 @@ public class FormattingOptions {
         public FormattingOptions build() {
             return new FormattingOptions(tabSize, wsCharacter, columnLimit, lineWrapping, forceFormattingOptions,
                     importFormattingOptions);
+        }
+
+        public FormattingOptions build(Map<String, Object> configurations) {
+            for (Map.Entry<String, Object> entry : configurations.entrySet()) {
+                String key = entry.getKey();
+                Object value = entry.getValue();
+                switch (key) {
+                    case "columnLimit":
+                        this.columnLimit = ((Number) value).intValue();
+                        this.lineWrapping = true;
+                        break;
+                    case "tabWidth":
+                        this.tabSize = ((Number) value).intValue();
+                        break;
+                    case "sortImports":
+                        this.sortImports = ((Boolean) value);
+                        break;
+                    case "alignConsecutiveDefinitions":
+                        this.alignConsecutiveDefinitions = ((Boolean) value);
+                        break;
+                    case "allowShortMatchLabelsOnASingleLine":
+                        this.allowShortMatchLabelsOnASingleLine = ((Boolean) value);
+                        break;
+                    case "allowShortIfStatementsOnASingleLine":
+                        this.allowShortIfStatementsOnASingleLine = ((Boolean) value);
+                        break;
+                    case "allowShortLoopsOnASingleLine":
+                        this.allowShortLoopsOnASingleLine = ((Boolean) value);
+                        break;
+                    case "allowShortBlocksOnASingleLine":
+                        this.allowShortBlocksOnASingleLine = ((Boolean) value);
+                        break;
+                    case "recordBraceSpacing":
+                        this.recordBraceSpacing = ((Boolean) value);
+                        break;
+                    case "elseBlockOnANewLine":
+                        this.elseBlockOnANewLine = ((Boolean) value);
+                        break;
+                    case "function":
+                        Map<String, Object> funcConfigurations = (Map<String, Object>) value;
+                        for (Map.Entry<String, Object> funcEntry : funcConfigurations.entrySet()) {
+                            String funcKey = funcEntry.getKey();
+                            Object funcValue = funcEntry.getValue();
+                            switch (funcKey) {
+                                case "paranAlign":
+                                    this.paranAlignedIndentation = ((Boolean) funcValue);
+                                    break;
+                                case "oneArgPerLine":
+                                    this.oneArgPerLine = ((Boolean) funcValue);
+                                    break;
+                                default:
+                                    break;
+                            }
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+            return new FormattingOptions(tabSize, wsCharacter, columnLimit, lineWrapping, forceFormattingOptions,
+                    paranAlignedIndentation, oneArgPerLine, allowShortBlocksOnASingleLine, recordBraceSpacing,
+                    elseBlockOnANewLine, sortImports, alignConsecutiveDefinitions, allowShortIfStatementsOnASingleLine,
+                    allowShortLoopsOnASingleLine, allowShortMatchLabelsOnASingleLine);
         }
     }
 }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
@@ -32,29 +32,19 @@ public class FormattingOptions {
 
     private boolean lineWrapping;
 
-    private boolean paranAlignedIndentation;
-
-    private boolean oneArgPerLine;
-
     private boolean recordBraceSpacing;
 
-    private boolean allowShortBlocksOnASingleLine;
-
-    private boolean allowShortMatchLabelsOnASingleLine;
-
-    private boolean allowShortIfStatementsOnASingleLine;
-
-    private boolean allowShortLoopsOnASingleLine;
-
-    private boolean elseBlockOnANewLine;
-
-    private boolean sortImports;
-
     private boolean alignConsecutiveDefinitions;
+
+    private boolean alignMultiLineQueries;
 
     private ForceFormattingOptions forceFormattingOptions;
 
     private ImportFormattingOptions importFormattingOptions;
+
+    private FunctionFormattingOptions functionFormattingOptions;
+
+    private BlockFormattingOptions blockFormattingOptions;
 
     private FormattingOptions(int tabSize, String wsCharacter, int columnLimit, boolean lineWrapping,
                               ForceFormattingOptions forceFormattingOptions,
@@ -68,26 +58,25 @@ public class FormattingOptions {
     }
 
     FormattingOptions(int tabSize, String wsCharacter, int columnLimit, boolean lineWrapping,
-                      ForceFormattingOptions forceFormattingOptions, boolean paranAlignedIndentation,
-                      boolean oneArgPerLine, boolean allowShortBlocksOnASingleLine, boolean recordBraceSpacing,
-                      boolean elseBlockOnANewLine, boolean sortImports, boolean alignConsecutiveDefinitions,
-                      boolean allowShortIfStatementsOnASingleLine, boolean allowShortLoopsOnASingleLine,
-                      boolean allowShortMatchLabelsOnASingleLine) {
+                      ForceFormattingOptions forceFormattingOptions,
+                      boolean recordBraceSpacing,
+                      boolean alignConsecutiveDefinitions,
+                      boolean alignMultiLineQueries,
+                      ImportFormattingOptions importFormattingOptions,
+                      FunctionFormattingOptions functionFormattingOptions,
+                      BlockFormattingOptions blockFormattingOptions) {
         this.tabSize = tabSize;
         this.wsCharacter = wsCharacter;
         this.columnLimit = columnLimit;
         this.lineWrapping = lineWrapping;
         this.forceFormattingOptions = forceFormattingOptions;
-        this.paranAlignedIndentation = paranAlignedIndentation;
-        this.oneArgPerLine = oneArgPerLine;
         this.recordBraceSpacing = recordBraceSpacing;
-        this.elseBlockOnANewLine = elseBlockOnANewLine;
-        this.sortImports = sortImports;
         this.alignConsecutiveDefinitions = alignConsecutiveDefinitions;
-        this.allowShortBlocksOnASingleLine = allowShortBlocksOnASingleLine;
-        this.allowShortIfStatementsOnASingleLine = allowShortIfStatementsOnASingleLine;
-        this.allowShortLoopsOnASingleLine = allowShortLoopsOnASingleLine;
-        this.allowShortMatchLabelsOnASingleLine = allowShortMatchLabelsOnASingleLine;
+        this.alignMultiLineQueries = alignMultiLineQueries;
+        this.importFormattingOptions = importFormattingOptions;
+        this.functionFormattingOptions = functionFormattingOptions;
+        this.blockFormattingOptions = blockFormattingOptions;
+
     }
 
     /**
@@ -193,44 +182,24 @@ public class FormattingOptions {
         return importFormattingOptions;
     }
 
-    public boolean isElseBlockOnANewLine() {
-        return elseBlockOnANewLine;
+    public FunctionFormattingOptions getFunctionFormattingOptions() {
+        return functionFormattingOptions;
     }
 
-    public boolean isParanAlignedIndentation() {
-        return paranAlignedIndentation;
-    }
-
-    public boolean isOneArgPerLine() {
-        return oneArgPerLine;
-    }
-
-    public boolean allowShortBlocksOnASingleLine() {
-        return allowShortBlocksOnASingleLine;
-    }
-
-    public boolean allowShortMatchLabelsOnASingleLine() {
-        return allowShortMatchLabelsOnASingleLine;
-    }
-
-    public boolean allowShortIfStatementsOnASingleLine() {
-        return allowShortIfStatementsOnASingleLine;
-    }
-
-    public boolean allowShortLoopsOnASingleLine() {
-        return allowShortLoopsOnASingleLine;
+    public BlockFormattingOptions getBlockFormattingOptions() {
+        return blockFormattingOptions;
     }
 
     public boolean isRecordBraceSpacing() {
         return recordBraceSpacing;
     }
 
-    public boolean sortImports() {
-        return sortImports;
-    }
-
     public boolean alignConsecutiveDefinitions() {
         return alignConsecutiveDefinitions;
+    }
+
+    public boolean alignMultiLineQueries() {
+        return alignMultiLineQueries;
     }
 
     public static FormattingOptionsBuilder builder() {
@@ -247,18 +216,17 @@ public class FormattingOptions {
         private String wsCharacter = " ";
         private int columnLimit = 120;
         private boolean lineWrapping = false;
-        private boolean paranAlignedIndentation = false;
-        private boolean oneArgPerLine = false;
         private boolean recordBraceSpacing = false;
-        private boolean elseBlockOnANewLine = false;
-        private Boolean sortImports = false;
-        private Boolean alignConsecutiveDefinitions = false;
-        private boolean allowShortBlocksOnASingleLine = false;
-        private Boolean allowShortMatchLabelsOnASingleLine = false;
-        private Boolean allowShortLoopsOnASingleLine = false;
-        private Boolean allowShortIfStatementsOnASingleLine = false;
+        private boolean alignConsecutiveDefinitions = false;
+        private boolean alignMultiLineQueries = false;
         private ForceFormattingOptions forceFormattingOptions = ForceFormattingOptions.builder().build();
-        private ImportFormattingOptions importFormattingOptions = ImportFormattingOptions.builder().build();
+        private ImportFormattingOptions.ImportFormattingOptionsBuilder importBuilder =
+                ImportFormattingOptions.builder();
+        private FunctionFormattingOptions.FunctionFormattingOptionsBuilder functionBuilder =
+                FunctionFormattingOptions.builder();
+        private BlockFormattingOptions.BlockFormattingOptionsBuilder blockBuilder =
+                BlockFormattingOptions.builder();
+        private ImportFormattingOptions importFormattingOptions = importBuilder.build();
 
         public FormattingOptions.FormattingOptionsBuilder setTabSize(int tabSize) {
             this.tabSize = tabSize;
@@ -309,41 +277,74 @@ public class FormattingOptions {
                     case "tabWidth":
                         this.tabSize = ((Number) value).intValue();
                         break;
-                    case "sortImports":
-                        this.sortImports = ((Boolean) value);
-                        break;
                     case "alignConsecutiveDefinitions":
                         this.alignConsecutiveDefinitions = ((Boolean) value);
-                        break;
-                    case "allowShortMatchLabelsOnASingleLine":
-                        this.allowShortMatchLabelsOnASingleLine = ((Boolean) value);
-                        break;
-                    case "allowShortIfStatementsOnASingleLine":
-                        this.allowShortIfStatementsOnASingleLine = ((Boolean) value);
-                        break;
-                    case "allowShortLoopsOnASingleLine":
-                        this.allowShortLoopsOnASingleLine = ((Boolean) value);
-                        break;
-                    case "allowShortBlocksOnASingleLine":
-                        this.allowShortBlocksOnASingleLine = ((Boolean) value);
                         break;
                     case "recordBraceSpacing":
                         this.recordBraceSpacing = ((Boolean) value);
                         break;
-                    case "elseBlockOnANewLine":
-                        this.elseBlockOnANewLine = ((Boolean) value);
+                    case "alignMultiLineQueries":
+                        this.alignMultiLineQueries = ((Boolean) value);
+                        break;
+                    case "block":
+                        Map<String, Object> blockConfigurations = (Map<String, Object>) value;
+                        for (Map.Entry<String, Object> funcEntry : blockConfigurations.entrySet()) {
+                            String blockKey = funcEntry.getKey();
+                            boolean blockValue = (Boolean) funcEntry.getValue();
+                            switch (blockKey) {
+                                case "elseBlockOnANewLine":
+                                    this.blockBuilder.setElseBlockOnANewLine(blockValue);
+                                    break;
+                                case "allowShortMatchLabelsOnASingleLine":
+                                    this.blockBuilder.setAllowShortMatchLabelsOnASingleLine(
+                                            blockValue);
+                                    break;
+                                case "allowShortIfStatementsOnASingleLine":
+                                    this.blockBuilder.setAllowShortIfStatementsOnASingleLine(
+                                            blockValue);
+                                    break;
+                                case "allowShortLoopsOnASingleLine":
+                                    this.blockBuilder.setAllowShortLoopsOnASingleLine(blockValue);
+                                    break;
+                                case "allowShortBlocksOnASingleLine":
+                                    this.blockBuilder.setAllowShortBlocksOnASingleLine(blockValue);
+                                    break;
+                                default:
+                                    break;
+                            }
+                        }
                         break;
                     case "function":
                         Map<String, Object> funcConfigurations = (Map<String, Object>) value;
                         for (Map.Entry<String, Object> funcEntry : funcConfigurations.entrySet()) {
                             String funcKey = funcEntry.getKey();
-                            Object funcValue = funcEntry.getValue();
+                            boolean funcValue = (Boolean) funcEntry.getValue();
                             switch (funcKey) {
                                 case "paranAlign":
-                                    this.paranAlignedIndentation = ((Boolean) funcValue);
+                                    this.functionBuilder.setParanAlign(funcValue);
                                     break;
                                 case "oneArgPerLine":
-                                    this.oneArgPerLine = ((Boolean) funcValue);
+                                    this.functionBuilder.setOneArgPerLine(funcValue);
+                                    break;
+                                default:
+                                    break;
+                            }
+                        }
+                        break;
+                    case "import":
+                        Map<String, Object> importConfigurations = (Map<String, Object>) value;
+                        for (Map.Entry<String, Object> funcEntry : importConfigurations.entrySet()) {
+                            String funcKey = funcEntry.getKey();
+                            boolean importValue = (Boolean) funcEntry.getValue();
+                            switch (funcKey) {
+                                case "groupImports":
+                                    this.importBuilder.setGroupImports(importValue);
+                                    break;
+                                case "sortImports":
+                                    this.importBuilder.setSortImports(importValue);
+                                    break;
+                                case "removeUnusedImports":
+                                    this.importBuilder.setRemoveUnusedImports(importValue);
                                     break;
                                 default:
                                     break;
@@ -355,9 +356,9 @@ public class FormattingOptions {
                 }
             }
             return new FormattingOptions(tabSize, wsCharacter, columnLimit, lineWrapping, forceFormattingOptions,
-                    paranAlignedIndentation, oneArgPerLine, allowShortBlocksOnASingleLine, recordBraceSpacing,
-                    elseBlockOnANewLine, sortImports, alignConsecutiveDefinitions, allowShortIfStatementsOnASingleLine,
-                    allowShortLoopsOnASingleLine, allowShortMatchLabelsOnASingleLine);
+                    recordBraceSpacing,
+                    alignConsecutiveDefinitions, alignMultiLineQueries, importBuilder.build(),
+                    functionBuilder.build(), blockBuilder.build());
         }
     }
 }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -366,10 +366,10 @@ public class FormattingTreeModifier extends TreeModifier {
         }
         Token openPara = formatToken(functionSignatureNode.openParenToken(), 0, parenTrailingNL);
 
-        boolean paranAlign = options.getFunctionFormattingOptions().paranAlign();
+        boolean paranAlign = options.getFunctionFormattingOptions().getParanAlign();
         // Start a new indentation of two tabs for the parameters.
         alignOrIndent(paranAlign, 2);
-        boolean oneArgPerLine = options.getFunctionFormattingOptions().oneArgPerLine();
+        boolean oneArgPerLine = options.getFunctionFormattingOptions().getOneArgPerLine();
         SeparatedNodeList<ParameterNode> parameters =
                 formatSeparatedNodeList(functionSignatureNode.parameters(), 0, 0, oneArgPerLine ? 0 : 1,
                         oneArgPerLine ? 1 : 0, 0, 0, true);

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -255,8 +255,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.ballerinalang.formatter.core.FormatterUtils.isInlineRange;
-import static org.ballerinalang.formatter.core.FormatterUtils.isBlockOnASingleLine;
-import static org.ballerinalang.formatter.core.FormatterUtils.getConstDefLength;
+import static org.ballerinalang.formatter.core.FormatterUtils.openBraceTrailingNLs;
+import static org.ballerinalang.formatter.core.FormatterUtils.getConstDefWidth;
 import static org.ballerinalang.formatter.core.FormatterUtils.sortImportDeclarations;
 
 /**
@@ -368,21 +368,12 @@ public class FormattingTreeModifier extends TreeModifier {
 
         boolean paranAlign = options.getFunctionFormattingOptions().paranAlign();
         // Start a new indentation of two tabs for the parameters.
-        if (paranAlign) {
-            align();
-        } else {
-            indent(2);
-        }
+        alignOrIndent(paranAlign, 2);
         boolean oneArgPerLine = options.getFunctionFormattingOptions().oneArgPerLine();
         SeparatedNodeList<ParameterNode> parameters =
                 formatSeparatedNodeList(functionSignatureNode.parameters(), 0, 0, oneArgPerLine ? 0 : 1,
                         oneArgPerLine ? 1 : 0, 0, 0, true);
-
-        if (paranAlign) {
-            unalign();
-        } else {
-            unindent(2);
-        }
+        unalignOrUnindent(paranAlign, 2);
 
         Token closePara;
         ReturnTypeDescriptorNode returnTypeDesc = null;
@@ -566,7 +557,7 @@ public class FormattingTreeModifier extends TreeModifier {
     public BlockStatementNode transform(BlockStatementNode blockStatementNode) {
         boolean preserveIndent = env.preserveIndentation;
         preserveIndentation(blockStatementNode.openBraceToken().isMissing() && preserveIndent);
-        int trailingNL = isBlockOnASingleLine(options.getBlockFormattingOptions(), blockStatementNode) ? 0 : 1;
+        int trailingNL = openBraceTrailingNLs(options.getBlockFormattingOptions(), blockStatementNode);
         int trailingWS = 1 - trailingNL;
         Token openBrace = formatToken(blockStatementNode.openBraceToken(), trailingWS, trailingNL);
         preserveIndentation(preserveIndent);
@@ -574,11 +565,9 @@ public class FormattingTreeModifier extends TreeModifier {
         NodeList<StatementNode> statements =
                 formatNodeList(blockStatementNode.statements(), 0, 1, trailingWS, trailingNL);
         unindent(); // end the indentation
-        int closingNewLine =
-                (options.getBlockFormattingOptions().elseBlockOnANewLine() &&
-                        blockStatementNode.parent().kind() == SyntaxKind.IF_ELSE_STATEMENT) ? 1 :
-                        env.trailingNL;
-        Token closeBrace = formatToken(blockStatementNode.closeBraceToken(), env.trailingWS, closingNewLine);
+        int closingNL = (options.getBlockFormattingOptions().elseBlockOnANewLine() &&
+                blockStatementNode.parent().kind() == SyntaxKind.IF_ELSE_STATEMENT) ? 1 : env.trailingNL;
+        Token closeBrace = formatToken(blockStatementNode.closeBraceToken(), env.trailingWS, closingNL);
 
         return blockStatementNode.modify()
                 .withOpenBraceToken(openBrace)
@@ -1150,7 +1139,7 @@ public class FormattingTreeModifier extends TreeModifier {
         Token constKeyword = formatToken(constantDeclarationNode.constKeyword(), 1, 0);
         TypeDescriptorNode typeDescriptorNode = formatNode(constantDeclarationNode.typeDescriptor().orElse(null), 1, 0);
         int wSBeforeEqual = !options.alignConsecutiveDefinitions() ? 1 :
-                env.maxConstDefWidth - getConstDefLength(constantDeclarationNode) + 1;
+                env.maxConstDefWidth - getConstDefWidth(constantDeclarationNode) + 1;
         Token variableName = formatToken(constantDeclarationNode.variableName(), wSBeforeEqual, 0);
         Token equalsToken = formatToken(constantDeclarationNode.equalsToken(), 1, 0);
         Node initializer = formatNode(constantDeclarationNode.initializer(), 0, 0);
@@ -2851,11 +2840,7 @@ public class FormattingTreeModifier extends TreeModifier {
     public QueryExpressionNode transform(QueryExpressionNode queryExpressionNode) {
         int length = options.alignMultiLineQueries() ? env.currentIndentation : env.lineLength;
         if (length != 0) {
-            if (options.alignMultiLineQueries()) {
-                align();
-            } else {
-                indent();
-            }
+            alignOrIndent(options.alignMultiLineQueries());
         }
 
         QueryConstructTypeNode queryConstructType =
@@ -2872,11 +2857,7 @@ public class FormattingTreeModifier extends TreeModifier {
         OnConflictClauseNode onConflictClause = formatNode(queryExpressionNode.onConflictClause().orElse(null),
                 env.trailingWS, env.trailingNL);
         if (length != 0) {
-            if (options.alignMultiLineQueries()) {
-                unalign();
-            } else {
-                unindent();
-            }
+            unalignOrUnindent(options.alignMultiLineQueries());
         }
 
         return queryExpressionNode.modify()
@@ -3871,7 +3852,7 @@ public class FormattingTreeModifier extends TreeModifier {
         if (options.alignConsecutiveDefinitions()) {
             env.maxConstDefWidth = members.stream()
                     .filter(member -> member.kind() == SyntaxKind.CONST_DECLARATION)
-                    .mapToInt(member -> getConstDefLength((ConstantDeclarationNode) member))
+                    .mapToInt(member -> getConstDefWidth((ConstantDeclarationNode) member))
                     .max()
                     .orElse(1);
         }
@@ -4101,16 +4082,9 @@ public class FormattingTreeModifier extends TreeModifier {
             }
 
             Token oldSeparator = nodeList.getSeparator(index);
-            if (allowInAndMultiLine) {
+            if (allowInAndMultiLine && hasNonWSMinutiae(oldSeparator.trailingMinutiae())) {
+                separatorTrailingNL = separatorTrailingNL > 0 ? separatorTrailingNL : 1;
                 separatorTrailingWS = 0;
-                separatorTrailingNL = 0;
-                if (hasNonWSMinutiae(oldSeparator.trailingMinutiae()) ||
-                        (options.getFunctionFormattingOptions().oneArgPerLine() &&
-                                oldNode.parent().kind() == SyntaxKind.FUNCTION_SIGNATURE)) {
-                    separatorTrailingNL++;
-                } else {
-                    separatorTrailingWS++;
-                }
             }
             Token newSeparator = formatToken(oldSeparator, separatorTrailingWS, separatorTrailingNL);
             newNodes[(2 * index) + 1] = newSeparator;
@@ -4464,6 +4438,9 @@ public class FormattingTreeModifier extends TreeModifier {
         env.currentIndentation += (options.getTabSize() * step);
     }
 
+    /**
+     * Align the code with the previous line.
+     */
     private void align() {
         env.preservedIndentation = env.currentIndentation;
         env.currentIndentation = env.lineLength;
@@ -4490,8 +4467,43 @@ public class FormattingTreeModifier extends TreeModifier {
         env.currentIndentation -= (options.getTabSize() * step);
     }
 
+    /**
+     * Undo the alignment with the previous line.
+     */
     private void unalign() {
         env.currentIndentation = env.preservedIndentation;
+    }
+
+    private void alignOrIndent(boolean shouldAlign) {
+        if (shouldAlign) {
+            align();
+        } else {
+            indent();
+        }
+    }
+
+    private void alignOrIndent(boolean shouldAlign, int step) {
+        if (shouldAlign) {
+            align();
+        } else {
+            indent(step);
+        }
+    }
+
+    private void unalignOrUnindent(boolean shouldAlign) {
+        if (shouldAlign) {
+            unalign();
+        } else {
+            unindent();
+        }
+    }
+
+    private void unalignOrUnindent(boolean shouldAlign, int step) {
+        if (shouldAlign) {
+            unalign();
+        } else {
+            unindent(step);
+        }
     }
 
     /**

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -255,6 +255,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.ballerinalang.formatter.core.FormatterUtils.isInlineRange;
+import static org.ballerinalang.formatter.core.FormatterUtils.isBlockOnASingleLine;
+import static org.ballerinalang.formatter.core.FormatterUtils.getConstDefLength;
 import static org.ballerinalang.formatter.core.FormatterUtils.sortImportDeclarations;
 
 /**
@@ -365,10 +367,16 @@ public class FormattingTreeModifier extends TreeModifier {
         Token openPara = formatToken(functionSignatureNode.openParenToken(), 0, parenTrailingNL);
 
         // Start a new indentation of two tabs for the parameters.
-        indent(2);
+        if (options.isParanAlignedIndentation()) {
+            align();
+        } else {
+            indent(2);
+        }
+        boolean oneArgPerLine = options.isOneArgPerLine();
         SeparatedNodeList<ParameterNode> parameters =
-                formatSeparatedNodeList(functionSignatureNode.parameters(), 0, 0, 0, 0, 0, 0, true);
-        unindent(2);
+                formatSeparatedNodeList(functionSignatureNode.parameters(), 0, 0, oneArgPerLine ? 0 : 1,
+                        oneArgPerLine ? 1 : 0,
+                        0, 0);
 
         Token closePara;
         ReturnTypeDescriptorNode returnTypeDesc = null;
@@ -378,6 +386,12 @@ public class FormattingTreeModifier extends TreeModifier {
                     formatNode(functionSignatureNode.returnTypeDesc().get(), env.trailingWS, env.trailingNL);
         } else {
             closePara = formatToken(functionSignatureNode.closeParenToken(), env.trailingWS, env.trailingNL);
+        }
+
+        if (options.isParanAlignedIndentation()) {
+            unalign();
+        } else {
+            unindent(2);
         }
 
         return functionSignatureNode.modify()
@@ -417,7 +431,7 @@ public class FormattingTreeModifier extends TreeModifier {
         if (includedRecordParameterNode.paramName().isPresent()) {
             typeName = formatNode(includedRecordParameterNode.typeName(), 1, 0);
             Token paramName = formatToken(includedRecordParameterNode.paramName().orElse(null),
-                                          env.trailingWS, env.trailingNL);
+                    env.trailingWS, env.trailingNL);
             return includedRecordParameterNode.modify()
                     .withAsteriskToken(asterisk)
                     .withAnnotations(annotations)
@@ -520,7 +534,9 @@ public class FormattingTreeModifier extends TreeModifier {
         BlockStatementNode ifBody;
         Node elseBody = null;
         if (ifElseStatementNode.elseBody().isPresent()) {
-            ifBody = formatNode(ifElseStatementNode.ifBody(), 1, 0);
+            boolean needNL = options.isElseBlockOnANewLine();
+            ifBody = formatNode(ifElseStatementNode.ifBody(), needNL ? 0 : 1,
+                    needNL ? 1 : 0);
             preserveIndentation(!hasTrailingNL(ifElseStatementNode.ifBody().closeBraceToken()));
             elseBody = formatNode(ifElseStatementNode.elseBody().orElse(null), env.trailingWS, env.trailingNL);
             preserveIndentation(prevPreservedNewLine);
@@ -550,12 +566,19 @@ public class FormattingTreeModifier extends TreeModifier {
     public BlockStatementNode transform(BlockStatementNode blockStatementNode) {
         boolean preserveIndent = env.preserveIndentation;
         preserveIndentation(blockStatementNode.openBraceToken().isMissing() && preserveIndent);
-        Token openBrace = formatToken(blockStatementNode.openBraceToken(), 0, 1);
+        int trailingNL = isBlockOnASingleLine(options, blockStatementNode) ? 0 : 1;
+        int trailingWS = 1 - trailingNL;
+        Token openBrace = formatToken(blockStatementNode.openBraceToken(), trailingWS, trailingNL);
         preserveIndentation(preserveIndent);
         indent(); // start an indentation
-        NodeList<StatementNode> statements = formatNodeList(blockStatementNode.statements(), 0, 1, 0, 1);
+        NodeList<StatementNode> statements =
+                formatNodeList(blockStatementNode.statements(), 0, 1, trailingWS, trailingNL);
         unindent(); // end the indentation
-        Token closeBrace = formatToken(blockStatementNode.closeBraceToken(), env.trailingWS, env.trailingNL);
+        int closingNewLine =
+                (options.isElseBlockOnANewLine() &&
+                        blockStatementNode.parent().kind() == SyntaxKind.IF_ELSE_STATEMENT) ? 1 :
+                        env.trailingNL;
+        Token closeBrace = formatToken(blockStatementNode.closeBraceToken(), env.trailingWS, closingNewLine);
 
         return blockStatementNode.modify()
                 .withOpenBraceToken(openBrace)
@@ -1062,11 +1085,12 @@ public class FormattingTreeModifier extends TreeModifier {
     public FunctionCallExpressionNode transform(FunctionCallExpressionNode functionCallExpressionNode) {
         NameReferenceNode functionName = formatNode(functionCallExpressionNode.functionName(), 0, 0);
         Token functionCallOpenPara = formatToken(functionCallExpressionNode.openParenToken(), 0, 0);
+        indent(2);
         SeparatedNodeList<FunctionArgumentNode> arguments = formatSeparatedNodeList(functionCallExpressionNode
                 .arguments(), 0, 0, 0, 0);
         Token functionCallClosePara = formatToken(functionCallExpressionNode.closeParenToken(),
                 env.trailingWS, env.trailingNL);
-
+        unindent(2);
         return functionCallExpressionNode.modify()
                 .withFunctionName(functionName)
                 .withOpenParenToken(functionCallOpenPara)
@@ -1127,7 +1151,9 @@ public class FormattingTreeModifier extends TreeModifier {
         Token visibilityQualifier = formatToken(constantDeclarationNode.visibilityQualifier().orElse(null), 1, 0);
         Token constKeyword = formatToken(constantDeclarationNode.constKeyword(), 1, 0);
         TypeDescriptorNode typeDescriptorNode = formatNode(constantDeclarationNode.typeDescriptor().orElse(null), 1, 0);
-        Token variableName = formatToken(constantDeclarationNode.variableName(), 1, 0);
+        int wSBeforeEqual = !options.alignConsecutiveDefinitions() ? 1 :
+                env.maxConstDefWidth - getConstDefLength(constantDeclarationNode) + 1;
+        Token variableName = formatToken(constantDeclarationNode.variableName(), wSBeforeEqual, 0);
         Token equalsToken = formatToken(constantDeclarationNode.equalsToken(), 1, 0);
         Node initializer = formatNode(constantDeclarationNode.initializer(), 0, 0);
         Token semicolonToken = formatToken(constantDeclarationNode.semicolonToken(), env.trailingWS, env.trailingNL);
@@ -1177,7 +1203,7 @@ public class FormattingTreeModifier extends TreeModifier {
             functionKeyword = formatToken(functionTypeDescriptorNode.functionKeyword(), env.trailingWS, env.trailingNL);
         }
         FunctionSignatureNode functionSignature = formatNode(functionTypeDescriptorNode.functionSignature().
-                                                             orElse(null), env.trailingWS, env.trailingNL);
+                orElse(null), env.trailingWS, env.trailingNL);
         return functionTypeDescriptorNode.modify()
                 .withQualifierList(qualifierList)
                 .withFunctionKeyword(functionKeyword)
@@ -1241,11 +1267,12 @@ public class FormattingTreeModifier extends TreeModifier {
         } else {
             fieldTrailingWS++;
         }
-
-        Token openBrace = formatToken(mappingConstructorExpressionNode.openBrace(), 0, fieldTrailingNL);
+        int innerWS = options.isRecordBraceSpacing() ? 1 : 0;
+        Token openBrace = formatToken(mappingConstructorExpressionNode.openBrace(), innerWS, fieldTrailingNL);
         indent();
         SeparatedNodeList<MappingFieldNode> fields = formatSeparatedNodeList(
-                mappingConstructorExpressionNode.fields(), 0, 0, fieldTrailingWS, fieldTrailingNL, 0, fieldTrailingNL);
+                mappingConstructorExpressionNode.fields(), 0, 0, fieldTrailingWS, fieldTrailingNL, innerWS,
+                fieldTrailingNL);
         unindent();
         Token closeBrace = formatToken(mappingConstructorExpressionNode.closeBrace(), env.trailingWS, env.trailingNL);
 
@@ -2824,9 +2851,9 @@ public class FormattingTreeModifier extends TreeModifier {
 
     @Override
     public QueryExpressionNode transform(QueryExpressionNode queryExpressionNode) {
-        int lineLength = env.lineLength;
-        if (lineLength != 0) {
-            indent();
+        int indentation = env.currentIndentation;
+        if (indentation != 0) {
+            align();
         }
 
         QueryConstructTypeNode queryConstructType =
@@ -2842,8 +2869,8 @@ public class FormattingTreeModifier extends TreeModifier {
 
         OnConflictClauseNode onConflictClause = formatNode(queryExpressionNode.onConflictClause().orElse(null),
                 env.trailingWS, env.trailingNL);
-        if (lineLength != 0) {
-            unindent();
+        if (indentation != 0) {
+            unalign();
         }
 
         return queryExpressionNode.modify()
@@ -3519,14 +3546,14 @@ public class FormattingTreeModifier extends TreeModifier {
     @Override
     public ArrayTypeDescriptorNode transform(ArrayTypeDescriptorNode arrayTypeDescriptorNode) {
         TypeDescriptorNode memberTypeDesc = formatNode(arrayTypeDescriptorNode.memberTypeDesc(), 0, 0);
-        NodeList<ArrayDimensionNode> dimensions = formatNodeList(arrayTypeDescriptorNode.dimensions(), 0, 
+        NodeList<ArrayDimensionNode> dimensions = formatNodeList(arrayTypeDescriptorNode.dimensions(), 0,
                 0, env.trailingWS, env.trailingNL);
         return arrayTypeDescriptorNode.modify()
                 .withMemberTypeDesc(memberTypeDesc)
                 .withDimensions(dimensions)
                 .apply();
     }
-    
+
     @Override
     public ArrayDimensionNode transform(ArrayDimensionNode arrayDimensionNode) {
         Token openBracket = formatToken(arrayDimensionNode.openBracket(), 0, 0);
@@ -3834,6 +3861,15 @@ public class FormattingTreeModifier extends TreeModifier {
 
         boolean nodeModified = false;
         int size = members.size();
+
+        if (options.alignConsecutiveDefinitions()) {
+            env.maxConstDefWidth = members.stream()
+                    .filter(member -> member.kind() == SyntaxKind.CONST_DECLARATION)
+                    .mapToInt(member -> getConstDefLength((ConstantDeclarationNode) member))
+                    .max()
+                    .orElse(1);
+        }
+
         Node[] newNodes = new Node[size];
         for (int index = 0; index < size; index++) {
             T currentMember = members.get(index);
@@ -4420,6 +4456,11 @@ public class FormattingTreeModifier extends TreeModifier {
         env.currentIndentation += (options.getTabSize() * step);
     }
 
+    private void align() {
+        env.preservedIndentation = env.currentIndentation;
+        env.currentIndentation = env.lineLength;
+    }
+
     /**
      * Undo the indentation of the code by the number of white-spaces defined by tab-size.
      */
@@ -4439,6 +4480,10 @@ public class FormattingTreeModifier extends TreeModifier {
         }
 
         env.currentIndentation -= (options.getTabSize() * step);
+    }
+
+    private void unalign() {
+        env.currentIndentation = env.preservedIndentation;
     }
 
     /**

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FunctionFormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FunctionFormattingOptions.java
@@ -61,7 +61,7 @@ public class FunctionFormattingOptions {
         }
 
         public FunctionFormattingOptions build() {
-            return new FunctionFormattingOptions(oneArgPerLine, paranAlign);
+            return new FunctionFormattingOptions(paranAlign, oneArgPerLine);
         }
     }
 }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FunctionFormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FunctionFormattingOptions.java
@@ -22,19 +22,19 @@ package org.ballerinalang.formatter.core;
  */
 public class FunctionFormattingOptions {
 
-    private boolean paranAlign;
-    private boolean oneArgPerLine;
+    private final boolean paranAlign;
+    private final boolean oneArgPerLine;
 
     private FunctionFormattingOptions(boolean paranAlign, boolean oneArgPerLine) {
         this.paranAlign = paranAlign;
         this.oneArgPerLine = oneArgPerLine;
     }
 
-    public boolean paranAlign() {
+    public boolean getParanAlign() {
         return paranAlign;
     }
 
-    public boolean oneArgPerLine() {
+    public boolean getOneArgPerLine() {
         return oneArgPerLine;
     }
 

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FunctionFormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FunctionFormattingOptions.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.formatter.core;
+
+/**
+ * A model for formatting of functions by the API user, that could be passed onto the formatter.
+ *
+ * @since 2201.8.0
+ */
+public class FunctionFormattingOptions {
+
+    private boolean paranAlign;
+    private boolean oneArgPerLine;
+
+    private FunctionFormattingOptions(boolean paranAlign, boolean oneArgPerLine) {
+        this.paranAlign = paranAlign;
+        this.oneArgPerLine = oneArgPerLine;
+    }
+
+    public boolean paranAlign() {
+        return paranAlign;
+    }
+
+    public boolean oneArgPerLine() {
+        return oneArgPerLine;
+    }
+
+    public static FunctionFormattingOptions.FunctionFormattingOptionsBuilder builder() {
+        return new FunctionFormattingOptions.FunctionFormattingOptionsBuilder();
+    }
+
+    /**
+     * A builder for the {@code FunctionFormattingOptions}.
+     */
+    public static class FunctionFormattingOptionsBuilder {
+
+        private boolean paranAlign = false;
+        private boolean oneArgPerLine = false;
+
+        public FunctionFormattingOptions.FunctionFormattingOptionsBuilder setParanAlign(boolean paranAlign) {
+            this.paranAlign = paranAlign;
+            return this;
+        }
+
+        public FunctionFormattingOptions.FunctionFormattingOptionsBuilder setOneArgPerLine(boolean oneArgPerLine) {
+            this.oneArgPerLine = oneArgPerLine;
+            return this;
+        }
+
+        public FunctionFormattingOptions build() {
+            return new FunctionFormattingOptions(oneArgPerLine, paranAlign);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #41280 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.


This feature can be tested by adding a `format` section to the `Ballerina.toml` file in a Ballerina project and by using the `bal format` command to format the file. The set of parameters that can be be put under the `format` section is given [here](https://github.com/ballerina-platform/ballerina-lang/issues/41280#issuecomment-1698353386).  Given below is a sample `Ballerina.toml` file

```
[format]
columnLimit = 80
tabWidth = 2
alignConsecutiveDefinitions=true
recordBraceSpacing = true

[format.function]
oneArgPerLine = false
paranAlign = true

[format.block]
allowShortIfStatementsOnASingleLine = true
elseBlocksOnANewLine = true

[format.import]
groupImports = true
sortImports = true
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
