### PR TITLE
Fix removal of whitespace between invalid tokens in formatter

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -4371,6 +4371,7 @@ public class FormattingTreeModifier extends TreeModifier {
                         continue;
                     }
 
+                    // If last minutiae, use env.trailingWS; otherwise, add a single space after the invalid node
                     if (i == size - 1) {
                         addWhitespace(env.trailingWS, trailingMinutiae);
                     } else {

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -4371,7 +4371,7 @@ public class FormattingTreeModifier extends TreeModifier {
                         continue;
                     }
 
-                    // If last minutiae, use env.trailingWS; otherwise, add a single space after the invalid node
+                    // We reach here when the prevMinutiae is an invalid node/token
                     if (i == size - 1) {
                         addWhitespace(env.trailingWS, trailingMinutiae);
                     } else {

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
@@ -89,11 +89,6 @@ public class ParserTestFormatter extends FormatterTest {
                 "service_decl_source_02.bal", "service_decl_source_05.bal", "service_decl_source_17.bal",
                 "service_decl_source_20.bal",
 
-                // The following tests are disabled due to tokens merging together after formatting. issue #35240
-                "query_expr_source_121.bal", "query_expr_source_123.bal", "query_expr_source_124.bal",
-                "query_expr_source_126.bal", "match_stmt_source_21.bal",
-                "func_params_source_27.bal",
-
                 "separated_node_list_import_decl.bal", "node_location_test_03.bal",
 
                 // parser tests with syntax errors that cannot be handled by the formatter

--- a/misc/formatter/modules/formatter-core/src/test/resources/actions/query/assert/query_action_4.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/actions/query/assert/query_action_4.bal
@@ -1,0 +1,5 @@
+public function main() {
+    var c = from var i in 0 ... 5
+        select i
+        where i %2 != 0;
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/actions/query/source/query_action_4.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/actions/query/source/query_action_4.bal
@@ -1,0 +1,5 @@
+public function main() {
+    var c = from var i in 0 ... 5
+        select i
+     where  i  %2  !=  0 ;
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #35240 

## Approach
> Describe how you are implementing the solutions along with the design details.

In the case of invalid tokens this indents the code as necessary and preserves the formatting done by the user and stops removal of whitespaces.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
