### PR TITLE
[2201.7.x] Update syntax tree JSON generation for new regex statements

### DIFF
--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -194,8 +194,17 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
         if (syntaxDiagnostics != null) {
             nodeJson.add("syntaxDiagnostics", SyntaxTreeDiagnosticsUtil.getDiagnostics(syntaxDiagnostics));
         }
-        nodeJson.add("leadingMinutiae", evaluateMinutiae(node.leadingMinutiae()));
-        nodeJson.add("trailingMinutiae", evaluateMinutiae(node.trailingMinutiae()));
+        // Some kinds are not supported trailing and leading minutiae. (eg: ReTag)
+        try {
+            nodeJson.add("trailingMinutiae", evaluateMinutiae(node.trailingMinutiae()));
+        } catch (Exception e){
+            nodeJson.add("trailingMinutiae", new JsonObject());
+        }
+        try {
+            nodeJson.add("leadingMinutiae", evaluateMinutiae(node.leadingMinutiae()));
+        } catch (Exception e){
+            nodeJson.add("leadingMinutiae", new JsonObject());
+        }
 
         if (node.lineRange() != null) {
             LineRange lineRange = node.lineRange();
@@ -624,8 +633,17 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
                 nodeInfo.add(memberEntry.getKey(), memberEntry.getValue());
             });
         }
-        nodeInfo.add("leadingMinutiae", evaluateMinutiae(node.leadingMinutiae()));
-        nodeInfo.add("trailingMinutiae", evaluateMinutiae(node.trailingMinutiae()));
+//        Some kinds are not supported trailing and leading minutiae. (eg: ReTag)
+        try {
+            nodeInfo.add("trailingMinutiae", evaluateMinutiae(node.trailingMinutiae()));
+        } catch (Exception e){
+            nodeInfo.add("trailingMinutiae", new JsonObject());
+        }
+        try {
+            nodeInfo.add("leadingMinutiae", evaluateMinutiae(node.leadingMinutiae()));
+        } catch (Exception e){
+            nodeInfo.add("leadingMinutiae", new JsonObject());
+        }
         return nodeInfo;
     }
 

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -194,15 +194,16 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
         if (syntaxDiagnostics != null) {
             nodeJson.add("syntaxDiagnostics", SyntaxTreeDiagnosticsUtil.getDiagnostics(syntaxDiagnostics));
         }
-        // Some kinds are not supported trailing and leading minutiae. (eg: ReTag)
+        // Skip trailing minutiae if node doesn't have trailing minutiae (eg: ReTag)
         try {
             nodeJson.add("trailingMinutiae", evaluateMinutiae(node.trailingMinutiae()));
-        } catch (Exception e){
+        } catch (Exception e) {
             nodeJson.add("trailingMinutiae", new JsonObject());
         }
+        // Skip leading minutiae if node doesn't have leading minutiae (eg: ReTag)
         try {
             nodeJson.add("leadingMinutiae", evaluateMinutiae(node.leadingMinutiae()));
-        } catch (Exception e){
+        } catch (Exception e) {
             nodeJson.add("leadingMinutiae", new JsonObject());
         }
 
@@ -633,15 +634,16 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
                 nodeInfo.add(memberEntry.getKey(), memberEntry.getValue());
             });
         }
-//        Some kinds are not supported trailing and leading minutiae. (eg: ReTag)
+        // Skip trailing minutiae if node doesn't have trailing minutiae (eg: ReTag)
         try {
             nodeInfo.add("trailingMinutiae", evaluateMinutiae(node.trailingMinutiae()));
-        } catch (Exception e){
+        } catch (Exception e) {
             nodeInfo.add("trailingMinutiae", new JsonObject());
         }
+        // Skip leading minutiae if node doesn't have leading minutiae
         try {
             nodeInfo.add("leadingMinutiae", evaluateMinutiae(node.leadingMinutiae()));
-        } catch (Exception e){
+        } catch (Exception e) {
             nodeInfo.add("leadingMinutiae", new JsonObject());
         }
         return nodeInfo;

--- a/misc/diagram-util/src/test/java/org/ballerinalang/diagramutil/SyntaxTreeGenTest.java
+++ b/misc/diagram-util/src/test/java/org/ballerinalang/diagramutil/SyntaxTreeGenTest.java
@@ -381,11 +381,11 @@ public class SyntaxTreeGenTest {
         // Verify main function visible endpoints
         JsonObject exEp0 = mainFunctionVEp.get(0).getAsJsonObject();
         checkClientVisibleEndpoints(exEp0, "exEp0", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 14, 14, true,  true);
+                "testEps", "0.1.0", 14, 14, true, true);
 
         JsonObject exEp1 = mainFunctionVEp.get(1).getAsJsonObject();
         checkClientVisibleEndpoints(exEp1, "exEp1", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 17, 17, false,  false);
+                "testEps", "0.1.0", 17, 17, false, false);
 
         // Verify main function if block
         Assert.assertEquals(mainFunctionBody.get("statements").getAsJsonArray().get(3).getAsJsonObject().get("ifBody")
@@ -402,7 +402,7 @@ public class SyntaxTreeGenTest {
 
         JsonObject exEp2 = mainFunctionIfBodyVEp.get(2).getAsJsonObject();
         checkClientVisibleEndpoints(exEp2, "exEp2", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 22, 22, false,  false);
+                "testEps", "0.1.0", 22, 22, false, false);
 
         // Verify main function anonymous function block
         Assert.assertEquals(mainFunctionBody.get("statements").getAsJsonArray().get(4).getAsJsonObject()
@@ -420,7 +420,7 @@ public class SyntaxTreeGenTest {
 
         JsonObject exEp3 = mainFunctionAnonVEp.get(2).getAsJsonObject();
         checkClientVisibleEndpoints(exEp3, "exEp3", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 26, 26, false,  false);
+                "testEps", "0.1.0", 26, 26, false, false);
 
         // Verify secondFunc function
         Assert.assertEquals(members.get(3).getAsJsonObject().get("kind").getAsString(), "FunctionDefinition");
@@ -436,11 +436,11 @@ public class SyntaxTreeGenTest {
 
         JsonObject exEpP1 = secondFunctionVEp.get(1).getAsJsonObject();
         checkClientVisibleEndpoints(exEpP1, "exEpP1", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 31, 31, false,  true);
+                "testEps", "0.1.0", 31, 31, false, true);
 
         JsonObject exEp6 = secondFunctionVEp.get(2).getAsJsonObject();
         checkClientVisibleEndpoints(exEp6, "exEp6", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 41, 41, false,  false);
+                "testEps", "0.1.0", 41, 41, false, false);
 
         // Verify secondFunc function while block
         Assert.assertEquals(secondFunctionBody.get("statements").getAsJsonArray().get(1).getAsJsonObject()
@@ -457,7 +457,7 @@ public class SyntaxTreeGenTest {
 
         JsonObject exEp4 = secondFunctionWhileBodyVEp.get(2).getAsJsonObject();
         checkClientVisibleEndpoints(exEp4, "exEp4", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 34, 34, false,  false);
+                "testEps", "0.1.0", 34, 34, false, false);
 
         // Verify secondFunc function do block
         Assert.assertEquals(secondFunctionBody.get("statements").getAsJsonArray().get(2).getAsJsonObject()
@@ -474,7 +474,7 @@ public class SyntaxTreeGenTest {
 
         JsonObject exEp5 = secondFunctionDoBodyVEp.get(2).getAsJsonObject();
         checkClientVisibleEndpoints(exEp5, "exEp5", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 38, 38, false,  false);
+                "testEps", "0.1.0", 38, 38, false, false);
 
         // Verify secondFunc function else block
         Assert.assertEquals(secondFunctionBody.get("statements").getAsJsonArray().get(4).getAsJsonObject()
@@ -494,7 +494,7 @@ public class SyntaxTreeGenTest {
 
         JsonObject exEp7 = secondFunctionElseBodyVEp.get(3).getAsJsonObject();
         checkClientVisibleEndpoints(exEp7, "exEp7", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 46, 46, false,  false);
+                "testEps", "0.1.0", 46, 46, false, false);
 
         // Verify thirdFunc function
         Assert.assertEquals(members.get(4).getAsJsonObject().get("kind").getAsString(), "FunctionDefinition");
@@ -510,11 +510,11 @@ public class SyntaxTreeGenTest {
 
         JsonObject exEp8 = thirdFunctionVEp.get(1).getAsJsonObject();
         checkClientVisibleEndpoints(exEp8, "exEp8", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 53, 53, false,  false);
+                "testEps", "0.1.0", 53, 53, false, false);
 
         JsonObject exEp62 = thirdFunctionVEp.get(2).getAsJsonObject();
         checkClientVisibleEndpoints(exEp62, "exEp6", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 57, 57, false,  false);
+                "testEps", "0.1.0", 57, 57, false, false);
 
         // Verify fourthFunc function
         Assert.assertEquals(members.get(5).getAsJsonObject().get("kind").getAsString(), "FunctionDefinition");
@@ -530,24 +530,24 @@ public class SyntaxTreeGenTest {
 
         JsonObject exEpOut = fourthFunctionVEp.get(1).getAsJsonObject();
         checkClientVisibleEndpoints(exEpOut, "exEpOut", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 72, 72, false,  true);
+                "testEps", "0.1.0", 72, 72, false, true);
 
         JsonObject exEpP2 = fourthFunctionVEp.get(2).getAsJsonObject();
         checkClientVisibleEndpoints(exEpP2, "exEpP2", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 62, 62, false,  true, false, true);
+                "testEps", "0.1.0", 62, 62, false, true, false, true);
 
         JsonObject tempVar = fourthFunctionVEp.get(3).getAsJsonObject();
         checkClientVisibleEndpoints(tempVar, "temp", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 63, 63, false,  false);
+                "testEps", "0.1.0", 63, 63, false, false);
 
 
         JsonObject exEp10 = fourthFunctionVEp.get(4).getAsJsonObject();
         checkClientVisibleEndpoints(exEp10, "exEp10", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 64, 64, false,  false);
+                "testEps", "0.1.0", 64, 64, false, false);
 
         JsonObject inEp1 = fourthFunctionVEp.get(5).getAsJsonObject();
         checkClientVisibleEndpoints(inEp1, "inEp1", "InternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 70, 70, false,  false);
+                "testEps", "0.1.0", 70, 70, false, false);
 
         // Verify service declaration
         Assert.assertEquals(members.get(6).getAsJsonObject().get("kind").getAsString(), "ServiceDeclaration");
@@ -585,7 +585,7 @@ public class SyntaxTreeGenTest {
 
         JsonObject exEp11 = postResourceVEps.get(3).getAsJsonObject();
         checkClientVisibleEndpoints(exEp11, "exEp11", "ExternalClient", "gayanOrg", "testEps",
-                "testEps", "0.1.0", 90, 90, false,  false);
+                "testEps", "0.1.0", 90, 90, false, false);
 
         // Verify /abc service declaration
         Assert.assertEquals(members.get(9).getAsJsonObject().get("kind").getAsString(), "ServiceDeclaration");
@@ -718,7 +718,8 @@ public class SyntaxTreeGenTest {
         Assert.assertEquals(stJson.getAsJsonObject().get("kind").getAsString(), "ModulePart");
         JsonArray members = stJson.getAsJsonObject().get("members").getAsJsonArray();
         JsonObject mainFunction = members.get(0).getAsJsonObject();
-        JsonObject regexStmt = mainFunction.get("functionBody").getAsJsonObject().get("statements").getAsJsonArray().get(0).getAsJsonObject();
+        JsonObject regexStmt = mainFunction.get("functionBody").getAsJsonObject().get("statements").getAsJsonArray()
+                .get(0).getAsJsonObject();
         String kind = regexStmt.get("initializer").getAsJsonObject().get("kind").getAsString();
         Assert.assertEquals(kind, "RegexTemplateExpression");
     }

--- a/misc/diagram-util/src/test/resources/regexTest/main.bal
+++ b/misc/diagram-util/src/test/resources/regexTest/main.bal
@@ -1,0 +1,7 @@
+import ballerina/io;
+
+public function main() {
+    var regexr = re `^test all\s*(?:resources?|endpoints?|paths?)?\.?$`;
+    string str1 = "test all resource";
+    io:println(str1.matches(regexr)); // true
+}


### PR DESCRIPTION
## Purpose
Update syntax tree JSON generation for new `regex` statements.

Fixes https://github.com/wso2-enterprise/internal-support-ballerina/issues/445

## Approach
The previous implementation added trailing and leading minutiae to every node. But some node kinds don't have them. This PR will skip those node kinds to prevent breaking syntax tree JSON generation.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
