### PR TITLE
[2201.8.x] Add support to visible endpoint generation for annotated endpoints

### DIFF
--- a/misc/diagram-util/src/test/resources/annotatedEndpoint/Ballerina.toml
+++ b/misc/diagram-util/src/test/resources/annotatedEndpoint/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "gayanOrg"
+name = "EndpintOrder"
+version = "0.1.0"

--- a/misc/diagram-util/src/test/resources/annotatedEndpoint/main.bal
+++ b/misc/diagram-util/src/test/resources/annotatedEndpoint/main.bal
@@ -1,0 +1,50 @@
+import ballerina/http;
+
+service /user on new http:Listener(9090) {
+
+    http:Client httpEp;
+
+    private http:Client httpEpPvt;
+
+    @display {
+        label: "Annotated Http Endpoint"
+    }
+    http:Client httpEpAnt;
+
+    @display {
+        label: "Annotated Private Http Endpoint"
+    }
+    private http:Client httpEpAntPvt;
+
+    @display {
+        label: "Annotated Internal Client Endpoint",
+        id: "InternalClient-b704fd5e-06b8-47df-89fe-6c462b5cdf4e"
+    }
+    public InternalClient internalEpAnt;
+
+    function init() returns error? {
+        self.httpEp = check new (url = "");
+        self.httpEpPvt = check new (url = "");
+        self.httpEpAnt = check new (url = "");
+        self.httpEpAntPvt = check new (url = "");
+
+        self.internalEpAnt = check new InternalClient("");
+    }
+
+    resource function post .() returns error? {
+
+    }
+}
+
+// Internal client ( connector )
+public client class InternalClient {
+    public string url;
+
+    isolated function init(string url) returns error? {
+        self.url = url;
+    }
+
+    remote isolated function getAll(@untainted string path) returns string|error? {
+        return "Hello";
+    }
+}


### PR DESCRIPTION
## Purpose

This PR has updated the logic for generating visible endpoints to support those with annotations and access modifiers.

Here is the supporting endpoint declaration syntax.

```ballerina
   @display {
        label: "Annotated Private Internal Client Endpoint"
    }
    private InternalClient httpEpAntPvt;
```

Fixes https://github.com/wso2-enterprise/internal-support-ballerina/issues/452

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
