### PR TITLE
Add quartz vulnerability to the ignore list

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -8,5 +8,5 @@ GMS-2022-7
 # com.github.docker-java:docker-java:3.1.5
 CVE-2020-13956
 
-# quartz-2.3.2
+# quartz:2.3.2
 CVE-2023-39017

--- a/.trivyignore
+++ b/.trivyignore
@@ -7,3 +7,6 @@ GMS-2022-7
 
 # com.github.docker-java:docker-java:3.1.5
 CVE-2020-13956
+
+# quartz-2.3.2
+CVE-2023-39017


### PR DESCRIPTION
## Purpose
$Subject

Since the task package is in the language, we can't remove the quartz usage from the repo.
So, this PR ignores this quartz vulnerability.

Related to https://github.com/wso2-enterprise/internal-support-ballerina/issues/454
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/41471