### PR TITLE
Fix creating wrong type of error for runtime API with type reference type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/creators/JvmErrorCreatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/creators/JvmErrorCreatorGen.java
@@ -145,7 +145,7 @@ public class JvmErrorCreatorGen {
             mv.visitLabel(targetLabel);
             mv.visitTypeInsn(NEW, ERROR_VALUE);
             mv.visitInsn(DUP);
-            this.jvmTypeGen.loadType(mv, errorDefinition.type);
+            this.jvmTypeGen.loadType(mv, errorDefinition.referenceType);
             mv.visitVarInsn(ALOAD, messageIndex);
             mv.visitVarInsn(ALOAD, causeIndex);
             mv.visitVarInsn(ALOAD, detailsIndex);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -500,10 +500,7 @@ public class Values {
         BString errorMsg = StringUtils.fromString("error message!");
         BError bError = ErrorCreator.createError(errorModule, errorTypeName.getValue(), errorTypeName,
                 ErrorCreator.createError(errorMsg), ValueCreator.createMapValue());
-        // TODO: fix https://github.com/ballerina-platform/ballerina-lang/issues/41025
-        String typeName = errorTypeName.getValue().equals("ResourceDispatchingError") ?
-                "RequestDispatchingError" : errorTypeName.getValue();
-        assert bError.getType().getName().equals(typeName);
+        assert bError.getType().getName().equals(errorTypeName.getValue());
         return bError;
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/errors/errors.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/errors/errors.bal
@@ -34,6 +34,12 @@ public function validateAPI() {
 
     errorVar = getErrorValue("ResourceNotFoundError");
     test:assertTrue(errorVar is ResourceNotFoundError);
+
+    errorVar = getErrorValue("RequestDispatchingError");
+    test:assertTrue(errorVar is RequestDispatchingError);
+
+    errorVar = getErrorValue("StatusCodeError");
+    test:assertTrue(errorVar is StatusCodeError);
 }
 
 function getErrorValue(string errorTypeName) returns error = @java:Method {


### PR DESCRIPTION
## Purpose
$subject

Fixes #41025 

## Approach
Use the `referenceType` field for generating error creator methods instead of the `type` field.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
