### PR TITLE
Search Package Algorithm using Hashmap in EnvironmentPackageCache.java

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/EnvironmentPackageCache.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/EnvironmentPackageCache.java
@@ -1,19 +1,19 @@
 package io.ballerina.projects.internal.environment;
 
 import io.ballerina.projects.Package;
-import io.ballerina.projects.PackageDescriptor;
 import io.ballerina.projects.PackageId;
-import io.ballerina.projects.PackageManifest;
 import io.ballerina.projects.PackageName;
 import io.ballerina.projects.PackageOrg;
 import io.ballerina.projects.PackageVersion;
 import io.ballerina.projects.Project;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Environment-level Package cache.
@@ -66,6 +66,7 @@ public class EnvironmentPackageCache implements WritablePackageCache {
 
     @Override
     public List<Package> getPackages(PackageOrg packageOrg, PackageName packageName) {
+        // Improved logic: Use streams to simplify the code
         return projectCache
                 .getOrDefault(packageOrg, Collections.emptyMap())
                 .getOrDefault(packageName, Collections.emptyMap())
@@ -77,6 +78,13 @@ public class EnvironmentPackageCache implements WritablePackageCache {
 
     @Override
     public void removePackage(PackageId packageId) {
-        projects.remove(packageId);
+        Project project = projects.remove(packageId);
+        if (project != null) {
+            Package pkg = project.currentPackage();
+            projectCache
+                .getOrDefault(pkg.packageOrg(), Collections.emptyMap())
+                .getOrDefault(pkg.packageName(), Collections.emptyMap())
+                .remove(pkg.packageVersion());
+        }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/EnvironmentPackageCache.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/EnvironmentPackageCache.java
@@ -66,17 +66,13 @@ public class EnvironmentPackageCache implements WritablePackageCache {
 
     @Override
     public List<Package> getPackages(PackageOrg packageOrg, PackageName packageName) {
-        // Do we have a need to improve this logic?
-        // TODO Optimize this logic
-        List<Package> foundList = new ArrayList<>();
-        for (Project project : projects.values()) {
-            PackageManifest pkgDesc = project.currentPackage().manifest();
-            if (pkgDesc.org().equals(packageOrg) &&
-                    pkgDesc.name().equals(packageName)) {
-                foundList.add(project.currentPackage());
-            }
-        }
-        return foundList;
+        return projectCache
+                .getOrDefault(packageOrg, Collections.emptyMap())
+                .getOrDefault(packageName, Collections.emptyMap())
+                .values()
+                .stream()
+                .map(Project::currentPackage)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/EnvironmentPackageCache.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/EnvironmentPackageCache.java
@@ -1,18 +1,20 @@
 package io.ballerina.projects.internal.environment;
 
 import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageDescriptor;
 import io.ballerina.projects.PackageId;
+import io.ballerina.projects.PackageManifest;
 import io.ballerina.projects.PackageName;
 import io.ballerina.projects.PackageOrg;
 import io.ballerina.projects.PackageVersion;
 import io.ballerina.projects.Project;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/EnvironmentPackageCache.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/EnvironmentPackageCache.java
@@ -23,14 +23,14 @@ import java.util.Optional;
 public class EnvironmentPackageCache implements WritablePackageCache {
 
     private final Map<PackageId, Project> projects = new HashMap<>();
-    private final Map<PackageOrg, Map<PackageName, Map<PackageVersion, Package>>> projectCache = new HashMap<>();
+    private final Map<PackageOrg, Map<PackageName, Map<PackageVersion, Project>>> projectCache = new HashMap<>();
 
     public void cache(Package pkg) {
         projects.put(pkg.packageId(), pkg.project());
         projectCache
             .computeIfAbsent(pkg.packageOrg(), org -> new HashMap<>())
             .computeIfAbsent(pkg.packageName(), name -> new HashMap<>())
-            .put(pkg.packageVersion(), pkg);
+            .put(pkg.packageVersion(), pkg.project());
     }
 
     @Override
@@ -60,8 +60,8 @@ public class EnvironmentPackageCache implements WritablePackageCache {
             projectCache
                 .getOrDefault(packageOrg, Collections.emptyMap())
                 .getOrDefault(packageName, Collections.emptyMap())
-                .get(version)
-        );
+                .getOrDefault(version, Collections.emptyMap())
+        ).map(Project::currentPackage);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/EnvironmentPackageCache.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/EnvironmentPackageCache.java
@@ -23,11 +23,11 @@ import java.util.Optional;
 public class EnvironmentPackageCache implements WritablePackageCache {
 
     private final Map<PackageId, Project> projects = new HashMap<>();
-    private final Map<PackageOrg, Map<PackageName, Map<PackageVersion, Package>>> packageCache = new HashMap<>();
+    private final Map<PackageOrg, Map<PackageName, Map<PackageVersion, Package>>> projectCache = new HashMap<>();
 
     public void cache(Package pkg) {
         projects.put(pkg.packageId(), pkg.project());
-        packageCache
+        projectCache
             .computeIfAbsent(pkg.packageOrg(), org -> new HashMap<>())
             .computeIfAbsent(pkg.packageName(), name -> new HashMap<>())
             .put(pkg.packageVersion(), pkg);


### PR DESCRIPTION
## Purpose
Previous algorithm searches linearly through all orgs, packages, versions while new algorithm uses a nested hashmap.
Time complexity:
    Prev -> O(len(orgs) * len(packages) * len(versions))
    New -> O(1)
Space Complexity: Previous algorithm uses a previously created map while the new algorithm uses a new nested hashmap.

Fixes #36790

## Approach
Created nested hashmap to convert linear time searching to constant time searching.

## Remarks
Hashmap in this file named as projects can be removed completely from this file. All methods in this file can be created with new nested Hashmap.