### PR TITLE
Fix invalid completions for a precise resource parameter type

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ClientResourceAccessActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ClientResourceAccessActionNodeContext.java
@@ -346,8 +346,7 @@ public class ClientResourceAccessActionNodeContext
                 }
                 if (node.kind() == SyntaxKind.COMPUTED_RESOURCE_ACCESS_SEGMENT) {
                     ExpressionNode exprNode = ((ComputedResourceAccessSegmentNode) node).expression();
-                    Optional<TypeSymbol> exprType =
-                            semanticModel.get().typeOf(exprNode);
+                    Optional<TypeSymbol> exprType = semanticModel.get().typeOf(exprNode);
                     if (exprType.isEmpty() || !checkSubtype(typeSymbol, exprType.get(), exprNode.toString())) {
                         return Pair.of(Collections.emptyList(), false);
                     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config38.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config38.json
@@ -4,7 +4,7 @@
     "character": 9
   },
   "source": "action_node_context/source/client_resource_access_action_source31.bal",
-  "description": "",
+  "description": "Test completions in singleton resource param",
   "items": [
     {
       "label": "/[\"name\" a].accessor",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config38.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config38.json
@@ -1,0 +1,40 @@
+{
+  "position": {
+    "line": 8,
+    "character": 9
+  },
+  "source": "action_node_context/source/client_resource_access_action_source31.bal",
+  "description": "",
+  "items": [
+    {
+      "label": "/[\"name\" a].accessor",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `\"name\"` a"
+        }
+      },
+      "sortText": "CC",
+      "filterText": "|accessor",
+      "insertText": "/[\"name\"].accessor;",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "/name.accessor",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `\"name\"` a"
+        }
+      },
+      "sortText": "CC",
+      "filterText": "|accessor",
+      "insertText": "/name.accessor;",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config38.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config38.json
@@ -16,7 +16,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `\"name\"` a"
         }
       },
-      "sortText": "CC",
+      "sortText": "CD",
       "filterText": "|accessor",
       "insertText": "/[\"name\"].accessor;",
       "insertTextFormat": "Snippet"
@@ -31,7 +31,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `\"name\"` a"
         }
       },
-      "sortText": "CC",
+      "sortText": "CE",
       "filterText": "|accessor",
       "insertText": "/name.accessor;",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config39.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config39.json
@@ -16,13 +16,13 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `\"A1\"|\"A2\"` a"
         }
       },
-      "sortText": "CC",
+      "sortText": "CD",
       "filterText": "|accessor",
       "insertText": "/[${1:\"path\"}].accessor;",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "/<path>.accessor",
+      "label": "/<a>.accessor",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -31,7 +31,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `\"A1\"|\"A2\"` a"
         }
       },
-      "sortText": "CC",
+      "sortText": "CE",
       "filterText": "|accessor",
       "insertText": "/${1:path}.accessor;",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config39.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config39.json
@@ -4,7 +4,7 @@
     "character": 9
   },
   "source": "action_node_context/source/client_resource_access_action_source32.bal",
-  "description": "",
+  "description": "Test completions in union of singleton resource params",
   "items": [
     {
       "label": "/[\"A1\"|\"A2\" a].accessor",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config39.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config39.json
@@ -1,0 +1,40 @@
+{
+  "position": {
+    "line": 8,
+    "character": 9
+  },
+  "source": "action_node_context/source/client_resource_access_action_source32.bal",
+  "description": "",
+  "items": [
+    {
+      "label": "/[\"A1\"|\"A2\" a].accessor",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `\"A1\"|\"A2\"` a"
+        }
+      },
+      "sortText": "CC",
+      "filterText": "|accessor",
+      "insertText": "/[${1:\"path\"}].accessor;",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "/<path>.accessor",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `\"A1\"|\"A2\"` a"
+        }
+      },
+      "sortText": "CC",
+      "filterText": "|accessor",
+      "insertText": "/${1:path}.accessor;",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config40.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config40.json
@@ -16,13 +16,13 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int|string:Char` a"
         }
       },
-      "sortText": "CC",
+      "sortText": "CD",
       "filterText": "|accessor",
       "insertText": "/[${1:\"path\"}].accessor;",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "/<path>.accessor",
+      "label": "/<a>.accessor",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -31,7 +31,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int|string:Char` a"
         }
       },
-      "sortText": "CC",
+      "sortText": "CE",
       "filterText": "|accessor",
       "insertText": "/${1:path}.accessor;",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config40.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config40.json
@@ -4,7 +4,7 @@
     "character": 9
   },
   "source": "action_node_context/source/client_resource_access_action_source33.bal",
-  "description": "",
+  "description": "Test completions in resource param with a subtype of expression",
   "items": [
     {
       "label": "/[int|string:Char a].accessor",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config40.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config40.json
@@ -1,0 +1,40 @@
+{
+  "position": {
+    "line": 8,
+    "character": 9
+  },
+  "source": "action_node_context/source/client_resource_access_action_source33.bal",
+  "description": "",
+  "items": [
+    {
+      "label": "/[int|string:Char a].accessor",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int|string:Char` a"
+        }
+      },
+      "sortText": "CC",
+      "filterText": "|accessor",
+      "insertText": "/[${1:\"path\"}].accessor;",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "/<path>.accessor",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int|string:Char` a"
+        }
+      },
+      "sortText": "CC",
+      "filterText": "|accessor",
+      "insertText": "/${1:path}.accessor;",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config41.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config41.json
@@ -1,0 +1,70 @@
+{
+  "position": {
+    "line": 16,
+    "character": 18
+  },
+  "source": "action_node_context/source/client_resource_access_action_source34.bal",
+  "description": "",
+  "items": [
+    {
+      "label": ".accessor",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `\"A31\"` a"
+        }
+      },
+      "sortText": "C",
+      "filterText": "accessor",
+      "insertText": ".accessor",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 16,
+              "character": 17
+            },
+            "end": {
+              "line": 16,
+              "character": 18
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": ".put",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `\"A31\"|\"A32\"` a"
+        }
+      },
+      "sortText": "C",
+      "filterText": "put",
+      "insertText": ".put",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 16,
+              "character": 17
+            },
+            "end": {
+              "line": 16,
+              "character": 18
+            }
+          },
+          "newText": ""
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config41.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config41.json
@@ -4,7 +4,7 @@
     "character": 18
   },
   "source": "action_node_context/source/client_resource_access_action_source34.bal",
-  "description": "",
+  "description": "Test completions in multiple singleton resource access functions, and accessing with a field value",
   "items": [
     {
       "label": ".accessor",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config42.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config42.json
@@ -4,7 +4,7 @@
     "character": 14
   },
   "source": "action_node_context/source/client_resource_access_action_source35.bal",
-  "description": "",
+  "description": "Test completions in multiple singleton resource access functions, and accessing with a label",
   "items": [
     {
       "label": ".accessor",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config42.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config42.json
@@ -1,0 +1,70 @@
+{
+  "position": {
+    "line": 16,
+    "character": 14
+  },
+  "source": "action_node_context/source/client_resource_access_action_source35.bal",
+  "description": "",
+  "items": [
+    {
+      "label": ".accessor",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `\"A31\"` a"
+        }
+      },
+      "sortText": "C",
+      "filterText": "accessor",
+      "insertText": ".accessor",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 16,
+              "character": 13
+            },
+            "end": {
+              "line": 16,
+              "character": 14
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": ".put",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `\"A31\"|\"A32\"` a"
+        }
+      },
+      "sortText": "C",
+      "filterText": "put",
+      "insertText": ".put",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 16,
+              "character": 13
+            },
+            "end": {
+              "line": 16,
+              "character": 14
+            }
+          },
+          "newText": ""
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config43.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config43.json
@@ -1,0 +1,70 @@
+{
+  "position": {
+    "line": 16,
+    "character": 12
+  },
+  "source": "action_node_context/source/client_resource_access_action_source36.bal",
+  "description": "",
+  "items": [
+    {
+      "label": ".accessor",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string:Char` a"
+        }
+      },
+      "sortText": "C",
+      "filterText": "accessor",
+      "insertText": ".accessor",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 16,
+              "character": 11
+            },
+            "end": {
+              "line": 16,
+              "character": 12
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": ".put",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string:Char|int` a"
+        }
+      },
+      "sortText": "C",
+      "filterText": "put",
+      "insertText": ".put",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 16,
+              "character": 11
+            },
+            "end": {
+              "line": 16,
+              "character": 12
+            }
+          },
+          "newText": ""
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config43.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config43.json
@@ -4,7 +4,7 @@
     "character": 12
   },
   "source": "action_node_context/source/client_resource_access_action_source36.bal",
-  "description": "",
+  "description": "Test completions in multiple resource access functions with subtypes of the expression",
   "items": [
     {
       "label": ".accessor",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source31.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source31.bal
@@ -1,0 +1,10 @@
+client class MyClient {
+    resource function accessor ["name" a]() {
+        
+    }
+}
+
+public function main() {
+    var cl = new MyClient();
+    cl ->
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source32.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source32.bal
@@ -1,0 +1,10 @@
+client class MyClient {
+    resource function accessor ["A1"|"A2" a]() {
+
+    }
+}
+
+public function main() {
+    var cl = new MyClient();
+    cl ->
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source33.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source33.bal
@@ -1,0 +1,10 @@
+client class MyClient {
+    resource function accessor [int|string:Char a]() {
+
+    }
+}
+
+public function main() {
+    var cl = new MyClient();
+    cl ->
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source34.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source34.bal
@@ -1,0 +1,18 @@
+client class MyClient {
+    resource function accessor ["A31" a]() {
+
+    }
+
+    resource function put ["A31"|"A32" a]() {
+
+    }
+
+    resource function post ["A32" a]() {
+
+    }
+}
+
+public function main() {
+    var cl = new MyClient();
+    cl ->/["A31"].
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source35.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source35.bal
@@ -1,0 +1,18 @@
+client class MyClient {
+    resource function accessor ["A31" a]() {
+
+    }
+
+    resource function put ["A31"|"A32" a]() {
+
+    }
+
+    resource function post ["A32" a]() {
+
+    }
+}
+
+public function main() {
+    var cl = new MyClient();
+    cl ->/A31.
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source36.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source36.bal
@@ -1,0 +1,18 @@
+client class MyClient {
+    resource function accessor [string:Char a]() {
+
+    }
+
+    resource function put [string:Char|int a]() {
+
+    }
+
+    resource function post [int a]() {
+
+    }
+}
+
+public function main() {
+    var cl = new MyClient();
+    cl ->/A.
+}


### PR DESCRIPTION
## Purpose

The LS server does not provide all applicable completions when the resource parameter type is a subtype of the expression type. For instance, for the resource parameters `singleton` and `string:Char`, completions are not shown since the expression type is `string`, which is a broader type than the former. The PR addresses this problem by providing completions for these cases as well.

Fixes #37668 

## Approach
Since the semantic model assigns the broader type for a node, the expression type will **not always** be a subtype of the resource parameter type, which contradicts our existing implementation. Hence, this PR appends an additional check for those edge cases where the expression type is broader than the resource parameter type.

## Samples
For the below client source code with a singleton resource parameter, we can obtain the following code completions as continuing.

```ballerina
client class MyClient {
    resource function accessor ["A31" a]() {
    }
}
```
<img width="320" height="150" alt="image" src="https://github.com/ballerina-platform/ballerina-lang/assets/59343084/21981bcf-8b0e-4810-bfdf-4e1c5d11f293">
<img width="320" height="150" alt="image" src="https://github.com/ballerina-platform/ballerina-lang/assets/59343084/52d36f5a-8eb2-44a6-945c-c7cc5d7a47d6">

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
