### PR TITLE
[2201.7.x] Fix TypeCastError in concurrent transactions

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionLocalContext.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionLocalContext.java
@@ -64,8 +64,14 @@ public class TransactionLocalContext {
         this.rollbackOnlyError = null;
         this.isTransactional = true;
         this.transactionId = ValueCreator.createArrayValue(globalTransactionId.getBytes());
-        transactionResourceManager.transactionInfoMap.put(ByteBuffer.wrap(transactionId.getBytes().clone()),
-                infoRecord);
+        validateAndPutTransactionInfo(ByteBuffer.wrap(transactionId.getBytes().clone()), infoRecord);
+    }
+
+    private void validateAndPutTransactionInfo(ByteBuffer transactionIdBytes, Object infoRecord) {
+        if (infoRecord == null) {
+            return;
+        }
+        transactionResourceManager.transactionInfoMap.put(transactionIdBytes, infoRecord);
     }
 
     public static TransactionLocalContext createTransactionParticipantLocalCtx(String globalTransactionId,
@@ -228,7 +234,7 @@ public class TransactionLocalContext {
     }
 
     public Object getInfoRecord() {
-        return transactionResourceManager.transactionInfoMap.get(ByteBuffer.wrap(transactionId.getBytes()));
+        return transactionResourceManager.getTransactionRecord(transactionId);
     }
 
     public boolean isTransactional() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
@@ -606,6 +606,11 @@ public class TransactionResourceManager {
     }
 
     public Object getTransactionRecord(BArray xid) {
-        return transactionInfoMap.get(ByteBuffer.wrap(xid.getBytes()));
+        synchronized (transactionInfoMap) {
+            if (transactionInfoMap.containsKey(ByteBuffer.wrap(xid.getBytes()))) {
+                return transactionInfoMap.get(ByteBuffer.wrap(xid.getBytes()));
+            }
+            return null;
+        }
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
@@ -106,7 +106,7 @@ public class TransactionResourceManager {
         resourceRegistry = new HashMap<>();
         committedFuncRegistry = new HashMap<>();
         abortedFuncRegistry = new HashMap<>();
-        transactionInfoMap = new HashMap<>();
+        transactionInfoMap = new ConcurrentHashMap<>();
         transactionManagerEnabled = getTransactionManagerEnabled();
         if (transactionManagerEnabled) {
             trxRegistry = new HashMap<>();


### PR DESCRIPTION
## Purpose
> Fixes the TypeCastError when running multiple transactions concurrently.

Fixes #41281 and https://github.com/ballerina-platform/module-ballerinai-transaction/issues/524

## Approach
> Changed the `transactionInfoMap` to a ConcurrentHashMap instead of a HashMap to resolve the issue where `infoRecord` was becoming nil when accessing `transactionInfoMap` concurrently.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> [master] - https://github.com/ballerina-platform/ballerina-lang/pull/41506
> [2201.8.x] - https://github.com/ballerina-platform/ballerina-lang/pull/41504
> Related Issues - https://github.com/ballerina-platform/module-ballerinai-transaction/issues/524
> Related PR - https://github.com/ballerina-platform/module-ballerinai-transaction/pull/529
> Test Available in https://github.com/ballerina-platform/module-ballerinai-transaction

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples