### PR TITLE
Remove duplicate composite keys from tables

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -46,7 +46,6 @@ import io.ballerina.runtime.internal.types.BTableType;
 import io.ballerina.runtime.internal.types.BTupleType;
 import io.ballerina.runtime.internal.types.BTypeReferenceType;
 import io.ballerina.runtime.internal.types.BUnionType;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -97,7 +96,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
     //These are required to achieve the iterator behavior
     private LinkedHashMap<Long, Long> indexToKeyMap;
     private LinkedHashMap<Long, Long> keyToIndexMap;
-    private LinkedHashMap<Long, Pair<K, V>> keyValues;
+    private LinkedHashMap<Long, KeyValuePair<K, V>> keyValues;
     private long noOfAddedEntries = 0;
 
     private boolean nextKeySupported;
@@ -481,7 +480,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         public Object next() {
             Long hash = indexToKeyMap.get(cursor);
             if (hash != null) {
-                Pair<K, V> keyValuePair = (Pair<K, V>) keyValues.get(hash);
+                KeyValuePair<K, V> keyValuePair = (KeyValuePair<K, V>) keyValues.get(hash);
                 K key = keyValuePair.getKey();
                 V value = keyValuePair.getValue();
 
@@ -537,7 +536,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             entries.put(hash, entryList);
             updateIndexKeyMappings((K) data, hash);
             values.put(hash, newData);
-            keyValues.put(hash, Pair.of((K) data, data));
+            keyValues.put(hash, KeyValuePair.of((K) data, data));
             return data;
         }
 
@@ -591,7 +590,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
                 extEntries.add(entry);
                 List<V> extValues = values.get(hash);
                 extValues.add(data);
-                keyValues.put(hash, Pair.of(key, data));
+                keyValues.put(hash, KeyValuePair.of(key, data));
                 updateIndexKeyMappings(key, hash);
                 return;
             }
@@ -639,7 +638,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             keys.put(hash, key);
             updateIndexKeyMappings(key, hash);
             values.put(hash, data);
-            keyValues.put(hash, Pair.of(key, value));
+            keyValues.put(hash, KeyValuePair.of(key, value));
             return data.get(0);
         }
 
@@ -746,6 +745,28 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
                 }
                 return (K) arr;
             }
+        }
+    }
+
+    private static final class KeyValuePair<K, V> {
+        private K key;
+        private V value;
+
+        public KeyValuePair(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public static <K, V> KeyValuePair<K, V> of(K key, V value) {
+            return new KeyValuePair<>(key, value);
+        }
+
+        public K getKey() {
+            return key;
+        }
+
+        public V getValue() {
+            return value;
         }
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -46,6 +46,7 @@ import io.ballerina.runtime.internal.types.BTableType;
 import io.ballerina.runtime.internal.types.BTupleType;
 import io.ballerina.runtime.internal.types.BTypeReferenceType;
 import io.ballerina.runtime.internal.types.BUnionType;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -94,9 +95,9 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
     private long maxIntKey = 0;
 
     //These are required to achieve the iterator behavior
-    private LinkedHashMap<Long, K> indexToKeyMap;
+    private LinkedHashMap<Long, Long> indexToKeyMap;
     private LinkedHashMap<Long, Long> keyToIndexMap;
-    private LinkedHashMap<K, V> keyValues;
+    private LinkedHashMap<Long, Pair<K, V>> keyValues;
     private long noOfAddedEntries = 0;
 
     private boolean nextKeySupported;
@@ -478,9 +479,11 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
 
         @Override
         public Object next() {
-            K key = (K) indexToKeyMap.get(cursor);
-            if (key != null) {
-                V value = (V) keyValues.get(key);
+            Long hash = indexToKeyMap.get(cursor);
+            if (hash != null) {
+                Pair<K, V> keyValuePair = (Pair<K, V>) keyValues.get(hash);
+                K key = keyValuePair.getKey();
+                V value = keyValuePair.getValue();
 
                 List<Type> types = new ArrayList<>();
                 types.add(TypeChecker.getType(key));
@@ -534,7 +537,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             entries.put(hash, entryList);
             updateIndexKeyMappings((K) data, hash);
             values.put(hash, newData);
-            keyValues.put((K) data, data);
+            keyValues.put(hash, Pair.of((K) data, data));
             return data;
         }
 
@@ -588,7 +591,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
                 extEntries.add(entry);
                 List<V> extValues = values.get(hash);
                 extValues.add(data);
-                keyValues.put(key, data);
+                keyValues.put(hash, Pair.of(key, data));
                 updateIndexKeyMappings(key, hash);
                 return;
             }
@@ -630,14 +633,13 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         }
 
         private V putData(K key, V value, List<V> data, Map.Entry<K, V> entry, Long hash) {
-
             List<Map.Entry<K, V>> entryList = new ArrayList<>();
             entryList.add(entry);
             entries.put(hash, entryList);
             keys.put(hash, key);
             updateIndexKeyMappings(key, hash);
             values.put(hash, data);
-            keyValues.put(key, value);
+            keyValues.put(hash, Pair.of(key, value));
             return data.get(0);
         }
 
@@ -655,8 +657,8 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         }
 
         public V remove(K key) {
-            keyValues.remove(key);
             Long hash = TableUtils.hash(key, null);
+            keyValues.remove(hash);
             List<Map.Entry<K, V>> entryList = entries.get(hash);
             if (entryList != null && entryList.size() > 1) {
                 for (Map.Entry<K, V> entry: entryList) {
@@ -751,7 +753,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
     private void updateIndexKeyMappings(K key, Long hash) {
         if (!keyToIndexMap.containsKey(hash)) {
             keyToIndexMap.put(hash, noOfAddedEntries);
-            indexToKeyMap.put(noOfAddedEntries, key);
+            indexToKeyMap.put(noOfAddedEntries, hash);
             noOfAddedEntries++;
         }
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
@@ -43,7 +43,6 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.stream.IntStream;
 
@@ -91,13 +90,6 @@ public class TupleValueImpl extends AbstractArrayValue {
                 hasRestElement == that.hasRestElement &&
                 type.equals(that.type) &&
                 Arrays.equals(refValues, that.refValues);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = Objects.hash(type, tupleType);
-        result = 31 * result + Arrays.hashCode(refValues);
-        return result;
     }
 
     public TupleValueImpl(Object[] values, TupleType type) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
@@ -43,6 +43,7 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.stream.IntStream;
 
@@ -90,6 +91,13 @@ public class TupleValueImpl extends AbstractArrayValue {
                 hasRestElement == that.hasRestElement &&
                 type.equals(that.type) &&
                 Arrays.equals(refValues, that.refValues);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(type, tupleType);
+        result = 31 * result + Arrays.hashCode(refValues);
+        return result;
     }
 
     public TupleValueImpl(Object[] values, TupleType type) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableKeyFieldValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableKeyFieldValueTest.java
@@ -72,7 +72,8 @@ public class TableKeyFieldValueTest {
                 "testGroupExprAsKeyValue",
                 "testKeyCollision",
                 "testRegExpAsKeyValue",
-                "testKeyCollisionWithStringAndRegExpAsKeyValues"
+                "testKeyCollisionWithStringAndRegExpAsKeyValues",
+                "testTupleAsKeyValue"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableKeyFieldValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableKeyFieldValueTest.java
@@ -73,7 +73,8 @@ public class TableKeyFieldValueTest {
                 "testKeyCollision",
                 "testRegExpAsKeyValue",
                 "testKeyCollisionWithStringAndRegExpAsKeyValues",
-                "testTupleAsKeyValue"
+                "testTupleAsKeyValue",
+                "testStringAsKeyValue"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableKeyFieldValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableKeyFieldValueTest.java
@@ -73,8 +73,10 @@ public class TableKeyFieldValueTest {
                 "testKeyCollision",
                 "testRegExpAsKeyValue",
                 "testKeyCollisionWithStringAndRegExpAsKeyValues",
-                "testTupleAsKeyValue",
-                "testStringAsKeyValue"
+                "testStringAsKeyValue",
+                "testStringAsCompositeKeyValue",
+                "testMapAsCompositeKeyValue",
+                "testArrayAsCompositeKeyValue"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
@@ -583,54 +583,158 @@ function testKeyCollisionWithStringAndRegExpAsKeyValues() {
     assertEqual(tbl, tbl5);
 }
 
-type Employee record {|
-    readonly string orgId;
-    readonly string appId;
-    string company;
+type Row12 record {|
+    readonly string key1;
+    readonly string key2;
+    string a;
 |};
 
-function testTupleAsKeyValue() {
-    table<Employee> key(orgId, appId) tbl = table [
-        {orgId: "1", appId: "1", company: "xxx"}
+function testStringAsKeyValue() {
+    Row12 expectedRec = {key1: "k1", key2: "k2", a: "n2"};
+
+    table<Row12> key(key1) tbl = table [
+        {key1: "k1", key2: "k2", a: "n1"}
+    ];
+    table<Row12> tbl2 = table [
+        {key1: "k1", key2: "k2", a: "n2"}
     ];
 
-    tbl.put({
-        orgId: "1",
-        appId: "1",
-        company: "yyy"
-    });
+    // Test the put method of the table
+    tbl.put(expectedRec.clone());
 
-    table<Employee> tbl1 = from Employee r in tbl
-        where r.orgId == "1" && r.appId == "1"
+    table<Row12> tbl1 = from Row12 r in tbl
+        where r.key1 == "k1" && r.key2 == "k2"
         select r;
-
-    table<Employee> tbl2 = table [
-        {orgId: "1", appId: "1", company: "yyy"}
-    ];
-
     assertEqual(tbl1, tbl2);
+
+    // Test the get method of the table
+    readonly & string keyString = "k1";
+    Row12 outputRec = tbl.get(keyString);
+    assertEqual(expectedRec, outputRec);
+
+    // Test the add method of the table
+    error? err = trap tbl.add(expectedRec);
+    assertEqual(err is error, true);
+    assertEqual((<error>err).message(), "{ballerina/lang.table}KeyConstraintViolation");
+
+    // Test the remove method of the table
+    Row12 removedRec = tbl.remove(keyString);
+    assertEqual(expectedRec, removedRec);
+    assertEqual(tbl.length(), 0);
 }
 
-function testStringAsKeyValue() {
-    table<Employee> key(orgId) tbl = table [
-        {orgId: "1", appId: "1", company: "xxx"}
+function testStringAsCompositeKeyValue() {
+    Row12 expectedRec = {key1: "k1", key2: "k2", a: "n2"};
+
+    table<Row12> key(key1, key2) tbl = table [
+        {key1: "k1", key2: "k2", a: "n1"}
+    ];
+    table<Row12> tbl2 = table [
+        {key1: "k1", key2: "k2", a: "n2"}
     ];
 
-    tbl.put({
-        orgId: "1",
-        appId: "1",
-        company: "yyy"
-    });
+    // Test the put method of the table
+    tbl.put(expectedRec.clone());
 
-    table<Employee> tbl1 = from Employee r in tbl
-        where r.orgId == "1" && r.appId == "1"
+    table<Row12> tbl1 = from Row12 r in tbl
+        where r.key1 == "k1" && r.key2 == "k2"
         select r;
+    assertEqual(tbl1, tbl2);
 
-    table<Employee> tbl2 = table [
-        {orgId: "1", appId: "1", company: "yyy"}
+    // Test the get method of the table
+    [string & readonly, string & readonly] keyTuple = ["k1", "k2"];
+    Row12 outputRec = tbl.get(keyTuple);
+    assertEqual(expectedRec, outputRec);
+
+    // Test the add method of the table
+    error? err = trap tbl.add(expectedRec);
+    assertEqual(err is error, true);
+    assertEqual((<error>err).message(), "{ballerina/lang.table}KeyConstraintViolation");
+
+    // Test the remove method of the table
+    Row12 removedRec = tbl.remove(keyTuple);
+    assertEqual(expectedRec, removedRec);
+    assertEqual(tbl.length(), 0);
+}
+
+type Row13 record {|
+    readonly map<string> keys;
+    readonly map<int> values;
+    string a;
+|};
+
+function testMapAsCompositeKeyValue() {
+    Row13 expectedRec = {keys: {"k1": "v1", "k2": "v2"}, values: {"k1": 1, "k2": 2}, a: "n2"};
+
+    table<Row13> key(keys, values) tbl = table [
+        {keys: {"k1": "v1", "k2": "v2"}, values: {"k1": 1, "k2": 2}, a: "n1"}
+    ];
+    table<Row13> tbl2 = table [
+        {keys: {"k1": "v1", "k2": "v2"}, values: {"k1": 1, "k2": 2}, a: "n2"}
     ];
 
+    // Test the put method of the table
+    tbl.put(expectedRec.clone());
+
+    table<Row13> tbl1 = from Row13 r in tbl
+        where r.keys == {"k1": "v1", "k2": "v2"} && r.values == {"k1": 1, "k2": 2}
+        select r;
     assertEqual(tbl1, tbl2);
+
+    // Test the get method of the table
+    [map<string> & readonly, map<int> & readonly] keyTuple = [{"k1": "v1", "k2": "v2"}, {"k1": 1, "k2": 2}];
+    Row13 outputRec = tbl.get(keyTuple);
+    assertEqual(expectedRec, outputRec);
+
+    // Test the add method of the table
+    error? err = trap tbl.add(expectedRec);
+    assertEqual(err is error, true);
+    assertEqual((<error>err).message(), "{ballerina/lang.table}KeyConstraintViolation");
+
+    // Test the remove method of the table
+    Row13 removedRec = tbl.remove(keyTuple);
+    assertEqual(expectedRec, removedRec);
+    assertEqual(tbl.length(), 0);
+}
+
+type Row14 record {|
+    readonly string[] keys;
+    readonly int[] values;
+    string a;
+|};
+
+function testArrayAsCompositeKeyValue() {
+    Row14 expectedRec = {keys: ["k1", "k2"], values: [1, 2], a: "n2"};
+
+    table<Row14> key(keys, values) tbl = table [
+        {keys: ["k1", "k2"], values: [1, 2], a: "n1"}
+    ];
+    table<Row14> tbl2 = table [
+        {keys: ["k1", "k2"], values: [1, 2], a: "n2"}
+    ];
+
+    // Test the put method of the table
+    tbl.put(expectedRec.clone());
+
+    table<Row14> tbl1 = from Row14 r in tbl
+        where r.keys == ["k1", "k2"] && r.values == [1, 2]
+        select r;
+    assertEqual(tbl1, tbl2);
+
+    // Test the get method of the table
+    [string[] & readonly, int[] & readonly] keyTuple = [["k1", "k2"], [1, 2]];
+    Row14 outputRec = tbl.get(keyTuple);
+    assertEqual(expectedRec, outputRec);
+
+    // Test the add method of the table
+    error? err = trap tbl.add(expectedRec);
+    assertEqual(err is error, true);
+    assertEqual((<error>err).message(), "{ballerina/lang.table}KeyConstraintViolation");
+
+    // Test the remove method of the table
+    Row14 removedRec = tbl.remove(keyTuple);
+    assertEqual(expectedRec, removedRec);
+    assertEqual(tbl.length(), 0);
 }
 
 function assertEqual(any expected, any actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
@@ -611,6 +611,28 @@ function testTupleAsKeyValue() {
     assertEqual(tbl1, tbl2);
 }
 
+function testStringAsKeyValue() {
+    table<Employee> key(orgId) tbl = table [
+        {orgId: "1", appId: "1", company: "xxx"}
+    ];
+
+    tbl.put({
+        orgId: "1",
+        appId: "1",
+        company: "yyy"
+    });
+
+    table<Employee> tbl1 = from Employee r in tbl
+        where r.orgId == "1" && r.appId == "1"
+        select r;
+
+    table<Employee> tbl2 = table [
+        {orgId: "1", appId: "1", company: "yyy"}
+    ];
+
+    assertEqual(tbl1, tbl2);
+}
+
 function assertEqual(any expected, any actual) {
     if expected is anydata && actual is anydata && expected == actual {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
@@ -583,6 +583,34 @@ function testKeyCollisionWithStringAndRegExpAsKeyValues() {
     assertEqual(tbl, tbl5);
 }
 
+type Employee record {|
+    readonly string orgId;
+    readonly string appId;
+    string company;
+|};
+
+function testTupleAsKeyValue() {
+    table<Employee> key(orgId, appId) tbl = table [
+        {orgId: "1", appId: "1", company: "xxx"}
+    ];
+
+    tbl.put({
+        orgId: "1",
+        appId: "1",
+        company: "yyy"
+    });
+
+    table<Employee> tbl1 = from Employee r in tbl
+        where r.orgId == "1" && r.appId == "1"
+        select r;
+
+    table<Employee> tbl2 = table [
+        {orgId: "1", appId: "1", company: "yyy"}
+    ];
+
+    assertEqual(tbl1, tbl2);
+}
+
 function assertEqual(any expected, any actual) {
     if expected is anydata && actual is anydata && expected == actual {
         return;


### PR DESCRIPTION
## Purpose
Currently, the `TupleValueImpl` does not override the `hashCode` method, so it cannot identify two instances of the object that are of the same type and value.

Fixes #41503 

## Approach
The PR modifies the hash map used for the iterator behavior so that the key-value pair in `keyValues` is uniquely identified by its table hash.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
