### PR TITLE
[2201.6.x] Introduce configurable timeouts for CentralClient 

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
@@ -435,7 +435,8 @@ public class CommandUtil {
             CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                     initializeProxy(settings.getProxy()), settings.getProxy().username(),
                     settings.getProxy().password(),
-                    getAccessTokenOfCLI(settings));
+                    getAccessTokenOfCLI(settings), settings.getCentral().getConnectTimeout(),
+                    settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
             client.pullPackage(orgName, packageName, version, destination, supportedPlatform,
                     RepoUtils.getBallerinaVersion(), false);
         }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
@@ -436,7 +436,8 @@ public class CommandUtil {
                     initializeProxy(settings.getProxy()), settings.getProxy().username(),
                     settings.getProxy().password(),
                     getAccessTokenOfCLI(settings), settings.getCentral().getConnectTimeout(),
-                    settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
+                    settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
+                    settings.getCentral().getCallTimeout());
             client.pullPackage(orgName, packageName, version, destination, supportedPlatform,
                     RepoUtils.getBallerinaVersion(), false);
         }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/DeprecateCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/DeprecateCommand.java
@@ -171,7 +171,8 @@ public class DeprecateCommand implements BLauncherCmd {
             CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                     initializeProxy(settings.getProxy()), settings.getProxy().username(),
                     settings.getProxy().password(),
-                    getAccessTokenOfCLI(settings));
+                    getAccessTokenOfCLI(settings), settings.getCentral().getConnectTimeout(),
+                    settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
             client.deprecatePackage(packageValue, deprecationMsg,
                     JvmTarget.JAVA_11.code(),
                     RepoUtils.getBallerinaVersion(), this.undoFlag);

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/DeprecateCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/DeprecateCommand.java
@@ -172,7 +172,8 @@ public class DeprecateCommand implements BLauncherCmd {
                     initializeProxy(settings.getProxy()), settings.getProxy().username(),
                     settings.getProxy().password(),
                     getAccessTokenOfCLI(settings), settings.getCentral().getConnectTimeout(),
-                    settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
+                    settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
+                    settings.getCentral().getCallTimeout());
             client.deprecatePackage(packageValue, deprecationMsg,
                     JvmTarget.JAVA_11.code(),
                     RepoUtils.getBallerinaVersion(), this.undoFlag);

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
@@ -191,7 +191,8 @@ public class PullCommand implements BLauncherCmd {
                         initializeProxy(settings.getProxy()), settings.getProxy().username(),
                         settings.getProxy().password(), getAccessTokenOfCLI(settings),
                         settings.getCentral().getConnectTimeout(),
-                        settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
+                        settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
+                        settings.getCentral().getCallTimeout());
                 client.pullPackage(orgName, packageName, version, packagePathInBalaCache, supportedPlatform,
                                    RepoUtils.getBallerinaVersion(), false);
                 if (version.equals(Names.EMPTY.getValue())) {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
@@ -189,7 +189,9 @@ public class PullCommand implements BLauncherCmd {
                 }
                 CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                         initializeProxy(settings.getProxy()), settings.getProxy().username(),
-                        settings.getProxy().password(), getAccessTokenOfCLI(settings));
+                        settings.getProxy().password(), getAccessTokenOfCLI(settings),
+                        settings.getCentral().getConnectTimeout(),
+                        settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
                 client.pullPackage(orgName, packageName, version, packagePathInBalaCache, supportedPlatform,
                                    RepoUtils.getBallerinaVersion(), false);
                 if (version.equals(Names.EMPTY.getValue())) {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
@@ -176,7 +176,9 @@ public class PushCommand implements BLauncherCmd {
                 }
                 CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                         initializeProxy(settings.getProxy()), settings.getProxy().username(),
-                        settings.getProxy().password(), getAccessTokenOfCLI(settings));
+                        settings.getProxy().password(), getAccessTokenOfCLI(settings),
+                        settings.getCentral().getConnectTimeout(),
+                        settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
                 if (balaPath == null) {
                     pushPackage(project, client);
                 } else {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
@@ -178,7 +178,8 @@ public class PushCommand implements BLauncherCmd {
                         initializeProxy(settings.getProxy()), settings.getProxy().username(),
                         settings.getProxy().password(), getAccessTokenOfCLI(settings),
                         settings.getCentral().getConnectTimeout(),
-                        settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
+                        settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
+                        settings.getCentral().getCallTimeout());
                 if (balaPath == null) {
                     pushPackage(project, client);
                 } else {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/SearchCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/SearchCommand.java
@@ -145,7 +145,8 @@ public class SearchCommand implements BLauncherCmd {
                                                                     getAccessTokenOfCLI(settings),
                                                                     settings.getCentral().getConnectTimeout(),
                                                                     settings.getCentral().getReadTimeout(),
-                                                                    settings.getCentral().getWriteTimeout());
+                                                                    settings.getCentral().getWriteTimeout(),
+                                                                    settings.getCentral().getCallTimeout());
             PackageSearchResult packageSearchResult = client.searchPackage(query,
                                                                            JvmTarget.JAVA_11.code(),
                                                                            RepoUtils.getBallerinaVersion());

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/SearchCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/SearchCommand.java
@@ -142,7 +142,10 @@ public class SearchCommand implements BLauncherCmd {
                                                            initializeProxy(settings.getProxy()),
                                                                     settings.getProxy().username(),
                                                                     settings.getProxy().password(),
-                                                                    getAccessTokenOfCLI(settings));
+                                                                    getAccessTokenOfCLI(settings),
+                                                                    settings.getCentral().getConnectTimeout(),
+                                                                    settings.getCentral().getReadTimeout(),
+                                                                    settings.getCentral().getWriteTimeout());
             PackageSearchResult packageSearchResult = client.searchPackage(query,
                                                                            JvmTarget.JAVA_11.code(),
                                                                            RepoUtils.getBallerinaVersion());

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/ToolCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/ToolCommand.java
@@ -341,8 +341,10 @@ public class ToolCommand implements BLauncherCmd {
             settings = Settings.from();
         }
         CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
-                initializeProxy(settings.getProxy()),
-                getAccessTokenOfCLI(settings));
+                initializeProxy(settings.getProxy()), settings.getProxy().username(),
+                settings.getProxy().password(), getAccessTokenOfCLI(settings),
+                settings.getCentral().getConnectTimeout(),
+                settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
         String[] toolInfo = client.pullTool(toolId, version, balaCacheDirPath, supportedPlatform,
                 RepoUtils.getBallerinaVersion(), false);
         org = toolInfo[0];

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/ToolCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/ToolCommand.java
@@ -344,7 +344,8 @@ public class ToolCommand implements BLauncherCmd {
                 initializeProxy(settings.getProxy()), settings.getProxy().username(),
                 settings.getProxy().password(), getAccessTokenOfCLI(settings),
                 settings.getCentral().getConnectTimeout(),
-                settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
+                settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
+                settings.getCentral().getCallTimeout());
         String[] toolInfo = client.pullTool(toolId, version, balaCacheDirPath, supportedPlatform,
                 RepoUtils.getBallerinaVersion(), false);
         org = toolInfo[0];

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -134,6 +134,9 @@ public class CentralAPIClient {
     private final boolean verboseEnabled;
     private final String proxyUsername;
     private final String proxyPassword;
+    private final int connectTimeout;
+    private final int readTimeout;
+    private final int writeTimeout;
 
     public CentralAPIClient(String baseUrl, Proxy proxy, String accessToken) {
         this.outStream = System.out;
@@ -143,9 +146,12 @@ public class CentralAPIClient {
         this.verboseEnabled = Boolean.parseBoolean(System.getenv(SYS_PROP_CENTRAL_VERBOSE_ENABLED));
         this.proxyUsername = "";
         this.proxyPassword = "";
+        this.connectTimeout = 60;
+        this.readTimeout = 60;
+        this.writeTimeout = 60;
     }
     public CentralAPIClient(String baseUrl, Proxy proxy, String proxyUsername, String proxyPassword,
-                            String accessToken) {
+                            String accessToken, int connectionTimeout, int readTimeout, int writeTimeout) {
         this.outStream = System.out;
         this.baseUrl = baseUrl;
         this.proxy = proxy;
@@ -153,6 +159,9 @@ public class CentralAPIClient {
         this.verboseEnabled = Boolean.parseBoolean(System.getenv(SYS_PROP_CENTRAL_VERBOSE_ENABLED));
         this.proxyUsername = proxyUsername;
         this.proxyPassword = proxyPassword;
+        this.connectTimeout = connectionTimeout;
+        this.readTimeout = readTimeout;
+        this.writeTimeout = writeTimeout;
     }
 
     /**
@@ -1137,8 +1146,9 @@ public class CentralAPIClient {
         // TODO: update this client initiation with default timeouts after fixing central/connectors API.
         OkHttpClient client = new OkHttpClient.Builder()
                 .followRedirects(false)
-                .connectTimeout(20, TimeUnit.SECONDS)
-                .readTimeout(20, TimeUnit.SECONDS)
+                .connectTimeout(connectTimeout, TimeUnit.SECONDS)
+                .readTimeout(readTimeout, TimeUnit.SECONDS)
+                .writeTimeout(writeTimeout, TimeUnit.SECONDS)
                 .proxy(this.proxy)
                 .build();
 
@@ -1280,6 +1290,9 @@ public class CentralAPIClient {
         OkHttpClient okHttpClient = new OkHttpClient.Builder()
                 .followRedirects(false)
                 .retryOnConnectionFailure(true)
+                .connectTimeout(connectTimeout, TimeUnit.SECONDS)
+                .readTimeout(readTimeout, TimeUnit.SECONDS)
+                .writeTimeout(writeTimeout, TimeUnit.SECONDS)
                 .proxy(this.proxy)
                 .build();
 
@@ -1395,8 +1408,9 @@ public class CentralAPIClient {
         // TODO: update this client initiation with default timeouts after fixing central/triggers API.
         OkHttpClient client = new OkHttpClient.Builder()
                 .followRedirects(false)
-                .connectTimeout(20, TimeUnit.SECONDS)
-                .readTimeout(20, TimeUnit.SECONDS)
+                .connectTimeout(connectTimeout, TimeUnit.SECONDS)
+                .readTimeout(readTimeout, TimeUnit.SECONDS)
+                .writeTimeout(writeTimeout, TimeUnit.SECONDS)
                 .proxy(this.proxy)
                 .build();
 

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -137,6 +137,7 @@ public class CentralAPIClient {
     private final int connectTimeout;
     private final int readTimeout;
     private final int writeTimeout;
+    private final int callTimeout;
 
     public CentralAPIClient(String baseUrl, Proxy proxy, String accessToken) {
         this.outStream = System.out;
@@ -149,9 +150,11 @@ public class CentralAPIClient {
         this.connectTimeout = 60;
         this.readTimeout = 60;
         this.writeTimeout = 60;
+        this.callTimeout = 0;
     }
     public CentralAPIClient(String baseUrl, Proxy proxy, String proxyUsername, String proxyPassword,
-                            String accessToken, int connectionTimeout, int readTimeout, int writeTimeout) {
+                            String accessToken, int connectionTimeout, int readTimeout, int writeTimeout,
+                            int callTimeout) {
         this.outStream = System.out;
         this.baseUrl = baseUrl;
         this.proxy = proxy;
@@ -162,6 +165,7 @@ public class CentralAPIClient {
         this.connectTimeout = connectionTimeout;
         this.readTimeout = readTimeout;
         this.writeTimeout = writeTimeout;
+        this.callTimeout = callTimeout;
     }
 
     /**
@@ -1149,6 +1153,7 @@ public class CentralAPIClient {
                 .connectTimeout(connectTimeout, TimeUnit.SECONDS)
                 .readTimeout(readTimeout, TimeUnit.SECONDS)
                 .writeTimeout(writeTimeout, TimeUnit.SECONDS)
+                .callTimeout(callTimeout, TimeUnit.SECONDS)
                 .proxy(this.proxy)
                 .build();
 
@@ -1293,6 +1298,7 @@ public class CentralAPIClient {
                 .connectTimeout(connectTimeout, TimeUnit.SECONDS)
                 .readTimeout(readTimeout, TimeUnit.SECONDS)
                 .writeTimeout(writeTimeout, TimeUnit.SECONDS)
+                .callTimeout(callTimeout, TimeUnit.SECONDS)
                 .proxy(this.proxy)
                 .build();
 
@@ -1411,6 +1417,7 @@ public class CentralAPIClient {
                 .connectTimeout(connectTimeout, TimeUnit.SECONDS)
                 .readTimeout(readTimeout, TimeUnit.SECONDS)
                 .writeTimeout(writeTimeout, TimeUnit.SECONDS)
+                .callTimeout(callTimeout, TimeUnit.SECONDS)
                 .proxy(this.proxy)
                 .build();
 

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -126,6 +126,10 @@ public class CentralAPIClient {
     private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
     // System property name for enabling central verbose
     public static final String SYS_PROP_CENTRAL_VERBOSE_ENABLED = "CENTRAL_VERBOSE_ENABLED";
+    private static final int DEFAULT_CONNECT_TIMEOUT = 60;
+    private static final int DEFAULT_READ_TIMEOUT = 60;
+    private static final int DEFAULT_WRITE_TIMEOUT = 60;
+    private static final int DEFAULT_CALL_TIMEOUT = 0;
 
     private final String baseUrl;
     private final Proxy proxy;
@@ -147,10 +151,10 @@ public class CentralAPIClient {
         this.verboseEnabled = Boolean.parseBoolean(System.getenv(SYS_PROP_CENTRAL_VERBOSE_ENABLED));
         this.proxyUsername = "";
         this.proxyPassword = "";
-        this.connectTimeout = 60;
-        this.readTimeout = 60;
-        this.writeTimeout = 60;
-        this.callTimeout = 0;
+        this.connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+        this.readTimeout = DEFAULT_READ_TIMEOUT;
+        this.writeTimeout = DEFAULT_WRITE_TIMEOUT;
+        this.callTimeout = DEFAULT_CALL_TIMEOUT;
     }
     public CentralAPIClient(String baseUrl, Proxy proxy, String proxyUsername, String proxyPassword,
                             String accessToken, int connectionTimeout, int readTimeout, int writeTimeout,

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/SettingsBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/SettingsBuilder.java
@@ -45,7 +45,10 @@ import java.util.List;
  * @since 0.964
  */
 public class SettingsBuilder {
-
+    private static final int DEFAULT_CONNECT_TIMEOUT = 60;
+    private static final int DEFAULT_READ_TIMEOUT = 60;
+    private static final int DEFAULT_WRITE_TIMEOUT = 60;
+    private static final int DEFAULT_CALL_TIMEOUT = 0;
     private TomlDocument settingsToml;
     private Settings settings;
     private DiagnosticResult diagnostics;
@@ -107,10 +110,10 @@ public class SettingsBuilder {
         String username = "";
         String password = "";
         String accessToken = "";
-        int connectTimeout = 60;
-        int readTimeout = 60;
-        int writeTimeout = 60;
-        int callTimeout = 0;
+        int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+        int readTimeout = DEFAULT_READ_TIMEOUT;
+        int writeTimeout = DEFAULT_WRITE_TIMEOUT;
+        int callTimeout = DEFAULT_CALL_TIMEOUT;
 
         if (!tomlAstNode.entries().isEmpty()) {
             TomlTableNode proxyNode = (TomlTableNode) tomlAstNode.entries().get(PROXY);
@@ -124,10 +127,10 @@ public class SettingsBuilder {
             TomlTableNode centralNode = (TomlTableNode) tomlAstNode.entries().get(CENTRAL);
             if (centralNode != null && centralNode.kind() != TomlType.NONE && centralNode.kind() == TomlType.TABLE) {
                 accessToken = getStringValueFromProxyNode(centralNode, ACCESS_TOKEN, "");
-                connectTimeout = getIntValueFromProxyNode(centralNode, CONNECT_TIMEOUT, 60);
-                readTimeout = getIntValueFromProxyNode(centralNode, READ_TIMEOUT, 60);
-                writeTimeout = getIntValueFromProxyNode(centralNode, WRITE_TIMEOUT, 60);
-                callTimeout = getIntValueFromProxyNode(centralNode, CALL_TIMEOUT, 0);
+                connectTimeout = getIntValueFromProxyNode(centralNode, CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT);
+                readTimeout = getIntValueFromProxyNode(centralNode, READ_TIMEOUT, DEFAULT_CONNECT_TIMEOUT);
+                writeTimeout = getIntValueFromProxyNode(centralNode, WRITE_TIMEOUT, DEFAULT_CONNECT_TIMEOUT);
+                callTimeout = getIntValueFromProxyNode(centralNode, CALL_TIMEOUT, DEFAULT_CALL_TIMEOUT);
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/SettingsBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/SettingsBuilder.java
@@ -58,6 +58,9 @@ public class SettingsBuilder {
     private static final String USERNAME = "username";
     private static final String PASSWORD = "password";
     private static final String ACCESS_TOKEN = "accesstoken";
+    private static final String CONNECT_TIMEOUT = "connectTimeout";
+    private static final String READ_TIMEOUT = "readTimeout";
+    private static final String WRITE_TIMEOUT = "writeTimeout";
 
     private SettingsBuilder(TomlDocument settingsToml) {
         this.diagnosticList = new ArrayList<>();
@@ -103,6 +106,9 @@ public class SettingsBuilder {
         String username = "";
         String password = "";
         String accessToken = "";
+        int connectTimeout = 60;
+        int readTimeout = 60;
+        int writeTimeout = 60;
 
         if (!tomlAstNode.entries().isEmpty()) {
             TomlTableNode proxyNode = (TomlTableNode) tomlAstNode.entries().get(PROXY);
@@ -116,10 +122,14 @@ public class SettingsBuilder {
             TomlTableNode centralNode = (TomlTableNode) tomlAstNode.entries().get(CENTRAL);
             if (centralNode != null && centralNode.kind() != TomlType.NONE && centralNode.kind() == TomlType.TABLE) {
                 accessToken = getStringValueFromProxyNode(centralNode, ACCESS_TOKEN, "");
+                connectTimeout = getIntValueFromProxyNode(centralNode, CONNECT_TIMEOUT, 60);
+                readTimeout = getIntValueFromProxyNode(centralNode, READ_TIMEOUT, 60);
+                writeTimeout = getIntValueFromProxyNode(centralNode, WRITE_TIMEOUT, 60);
             }
         }
 
-        return Settings.from(Proxy.from(host, port, username, password), Central.from(accessToken), diagnostics());
+        return Settings.from(Proxy.from(host, port, username, password), Central.from(accessToken,
+                connectTimeout, readTimeout, writeTimeout), diagnostics());
     }
 
     private String getStringValueFromProxyNode(TomlTableNode pkgNode, String key, String defaultValue) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/SettingsBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/SettingsBuilder.java
@@ -61,6 +61,7 @@ public class SettingsBuilder {
     private static final String CONNECT_TIMEOUT = "connectTimeout";
     private static final String READ_TIMEOUT = "readTimeout";
     private static final String WRITE_TIMEOUT = "writeTimeout";
+    private static final String CALL_TIMEOUT = "callTimeout";
 
     private SettingsBuilder(TomlDocument settingsToml) {
         this.diagnosticList = new ArrayList<>();
@@ -109,6 +110,7 @@ public class SettingsBuilder {
         int connectTimeout = 60;
         int readTimeout = 60;
         int writeTimeout = 60;
+        int callTimeout = 0;
 
         if (!tomlAstNode.entries().isEmpty()) {
             TomlTableNode proxyNode = (TomlTableNode) tomlAstNode.entries().get(PROXY);
@@ -125,11 +127,12 @@ public class SettingsBuilder {
                 connectTimeout = getIntValueFromProxyNode(centralNode, CONNECT_TIMEOUT, 60);
                 readTimeout = getIntValueFromProxyNode(centralNode, READ_TIMEOUT, 60);
                 writeTimeout = getIntValueFromProxyNode(centralNode, WRITE_TIMEOUT, 60);
+                callTimeout = getIntValueFromProxyNode(centralNode, CALL_TIMEOUT, 0);
             }
         }
 
         return Settings.from(Proxy.from(host, port, username, password), Central.from(accessToken,
-                connectTimeout, readTimeout, writeTimeout), diagnostics());
+                connectTimeout, readTimeout, writeTimeout, callTimeout), diagnostics());
     }
 
     private String getStringValueFromProxyNode(TomlTableNode pkgNode, String key, String defaultValue) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Central.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Central.java
@@ -27,20 +27,23 @@ public class Central {
     private int connectTimeout = 60;
     private int readTimeout = 60;
     private int writeTimeout = 60;
+    private int callTimeout = 0;
 
-    private Central(String accesstoken, int connectTimeout, int readTimeout, int writeTimeout) {
+    private Central(String accesstoken, int connectTimeout, int readTimeout, int writeTimeout, int callTimeout) {
         this.accesstoken = accesstoken;
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
         this.writeTimeout = writeTimeout;
+        this.callTimeout = callTimeout;
     }
 
-    public static Central from(String accesstoken, int connectTimeout, int readTimeout, int writeTimeout) {
-        return new Central(accesstoken, connectTimeout, readTimeout, writeTimeout);
+    public static Central from(String accesstoken, int connectTimeout, int readTimeout, int writeTimeout,
+                               int callTimeout) {
+        return new Central(accesstoken, connectTimeout, readTimeout, writeTimeout, callTimeout);
     }
 
     public static Central from() {
-            return new Central("", 60, 60, 60);
+            return new Central("", 60, 60, 60, 0);
     }
 
     /**
@@ -77,6 +80,15 @@ public class Central {
      */
     public int getWriteTimeout() {
         return writeTimeout;
+    }
+
+    /**
+     * Get the call timeout.
+     *
+     * @return call timeout
+     */
+    public int getCallTimeout() {
+        return callTimeout;
     }
 
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Central.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Central.java
@@ -24,17 +24,23 @@ package io.ballerina.projects.internal.model;
  */
 public class Central {
     private String accesstoken = "";
+    private int connectTimeout = 60;
+    private int readTimeout = 60;
+    private int writeTimeout = 60;
 
-    private Central(String accesstoken) {
+    private Central(String accesstoken, int connectTimeout, int readTimeout, int writeTimeout) {
         this.accesstoken = accesstoken;
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
+        this.writeTimeout = writeTimeout;
     }
 
-    public static Central from(String accesstoken) {
-        return new Central(accesstoken);
+    public static Central from(String accesstoken, int connectTimeout, int readTimeout, int writeTimeout) {
+        return new Central(accesstoken, connectTimeout, readTimeout, writeTimeout);
     }
 
     public static Central from() {
-        return new Central("");
+            return new Central("", 60, 60, 60);
     }
 
     /**
@@ -45,6 +51,34 @@ public class Central {
     public String getAccessToken() {
         return accesstoken;
     }
+
+    /**
+     * Get the connection timeout.
+     *
+     * @return connection timeout
+     */
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    /**
+     * Get the read timeout.
+     *
+     * @return read timeout
+     */
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    /**
+     * Get the write timeout.
+     *
+     * @return write timeout
+     */
+    public int getWriteTimeout() {
+        return writeTimeout;
+    }
+
 
     /**
      * Sets the value of the access token.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Central.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Central.java
@@ -91,7 +91,6 @@ public class Central {
         return callTimeout;
     }
 
-
     /**
      * Sets the value of the access token.
      *

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
@@ -75,7 +75,10 @@ public class RemotePackageRepository implements PackageRepository {
                 environment, cacheDirectory, ballerinaShortVersion);
         Proxy proxy = initializeProxy(settings.getProxy());
         CentralAPIClient client = new CentralAPIClient(repoUrl, proxy, settings.getProxy().username(),
-                settings.getProxy().password(), getAccessTokenOfCLI(settings));
+                settings.getProxy().password(), getAccessTokenOfCLI(settings),
+                settings.getCentral().getConnectTimeout(),
+                settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
+                settings.getCentral().getCallTimeout());
 
         return new RemotePackageRepository(fileSystemRepository, client);
     }

--- a/compiler/ballerina-lang/src/main/resources/settings-toml-schema.json
+++ b/compiler/ballerina-lang/src/main/resources/settings-toml-schema.json
@@ -38,6 +38,9 @@
         },
         "writeTimeout": {
           "type": "integer"
+        },
+        "callTimeout": {
+          "type": "integer"
         }
       }
     }

--- a/compiler/ballerina-lang/src/main/resources/settings-toml-schema.json
+++ b/compiler/ballerina-lang/src/main/resources/settings-toml-schema.json
@@ -29,6 +29,15 @@
       "properties": {
         "accesstoken": {
           "type": "string"
+        },
+        "connectTimeout": {
+          "type": "integer"
+        },
+        "readTimeout": {
+          "type": "integer"
+        },
+        "writeTimeout": {
+          "type": "integer"
         }
       }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorService.java
@@ -109,7 +109,9 @@ public class BallerinaConnectorService implements ExtendedLanguageServerService 
                 Settings settings = RepoUtils.readSettings();
                 CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                         initializeProxy(settings.getProxy()), settings.getProxy().username(),
-                        settings.getProxy().password(), getAccessTokenOfCLI(settings));
+                        settings.getProxy().password(), getAccessTokenOfCLI(settings),
+                        settings.getCentral().getConnectTimeout(),
+                        settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
 
                 JsonElement connectorSearchResult = client.getConnectors(request.getQueryMap(),
                         "any", RepoUtils.getBallerinaVersion());
@@ -193,8 +195,9 @@ public class BallerinaConnectorService implements ExtendedLanguageServerService 
             Settings settings = RepoUtils.readSettings();
             CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                     initializeProxy(settings.getProxy()), settings.getProxy().username(),
-                    settings.getProxy().password(),
-                    getAccessTokenOfCLI(settings));
+                    settings.getProxy().password(), getAccessTokenOfCLI(settings),
+                    settings.getCentral().getConnectTimeout(),
+                    settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
             if (request.getConnectorId() != null) {
                 // Fetch connector by connector Id.
                 connector = client.getConnector(request.getConnectorId(), "any", RepoUtils.getBallerinaVersion());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorService.java
@@ -111,7 +111,8 @@ public class BallerinaConnectorService implements ExtendedLanguageServerService 
                         initializeProxy(settings.getProxy()), settings.getProxy().username(),
                         settings.getProxy().password(), getAccessTokenOfCLI(settings),
                         settings.getCentral().getConnectTimeout(),
-                        settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
+                        settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
+                        settings.getCentral().getCallTimeout());
 
                 JsonElement connectorSearchResult = client.getConnectors(request.getQueryMap(),
                         "any", RepoUtils.getBallerinaVersion());
@@ -197,7 +198,8 @@ public class BallerinaConnectorService implements ExtendedLanguageServerService 
                     initializeProxy(settings.getProxy()), settings.getProxy().username(),
                     settings.getProxy().password(), getAccessTokenOfCLI(settings),
                     settings.getCentral().getConnectTimeout(),
-                    settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
+                    settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
+                    settings.getCentral().getCallTimeout());
             if (request.getConnectorId() != null) {
                 // Fetch connector by connector Id.
                 connector = client.getConnector(request.getConnectorId(), "any", RepoUtils.getBallerinaVersion());

--- a/misc/ls-extensions/modules/trigger-service/src/main/java/io/ballerina/trigger/BallerinaTriggerService.java
+++ b/misc/ls-extensions/modules/trigger-service/src/main/java/io/ballerina/trigger/BallerinaTriggerService.java
@@ -75,7 +75,9 @@ public class BallerinaTriggerService implements ExtendedLanguageServerService {
                 Settings settings = RepoUtils.readSettings();
                 CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                         initializeProxy(settings.getProxy()), settings.getProxy().username(),
-                        settings.getProxy().password(), getAccessTokenOfCLI(settings));
+                        settings.getProxy().password(), getAccessTokenOfCLI(settings),
+                        settings.getCentral().getConnectTimeout(),
+                        settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
                 JsonElement triggerSearchResult = client.getTriggers(request.getQueryMap(),
                         "any", RepoUtils.getBallerinaVersion());
                 CentralTriggerListResult centralTriggerListResult = new Gson().fromJson(
@@ -105,7 +107,9 @@ public class BallerinaTriggerService implements ExtendedLanguageServerService {
             CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                     initializeProxy(settings.getProxy()), settings.getProxy().username(),
                     settings.getProxy().password(),
-                    getAccessTokenOfCLI(settings));
+                    getAccessTokenOfCLI(settings),
+                    settings.getCentral().getConnectTimeout(),
+                    settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
             if (request.getTriggerId() != null) {
                 trigger = client.getTrigger(request.getTriggerId(), "any", RepoUtils.getBallerinaVersion());
                 return Optional.of(trigger);

--- a/misc/ls-extensions/modules/trigger-service/src/main/java/io/ballerina/trigger/BallerinaTriggerService.java
+++ b/misc/ls-extensions/modules/trigger-service/src/main/java/io/ballerina/trigger/BallerinaTriggerService.java
@@ -77,7 +77,8 @@ public class BallerinaTriggerService implements ExtendedLanguageServerService {
                         initializeProxy(settings.getProxy()), settings.getProxy().username(),
                         settings.getProxy().password(), getAccessTokenOfCLI(settings),
                         settings.getCentral().getConnectTimeout(),
-                        settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
+                        settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
+                        settings.getCentral().getCallTimeout());
                 JsonElement triggerSearchResult = client.getTriggers(request.getQueryMap(),
                         "any", RepoUtils.getBallerinaVersion());
                 CentralTriggerListResult centralTriggerListResult = new Gson().fromJson(
@@ -109,7 +110,8 @@ public class BallerinaTriggerService implements ExtendedLanguageServerService {
                     settings.getProxy().password(),
                     getAccessTokenOfCLI(settings),
                     settings.getCentral().getConnectTimeout(),
-                    settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
+                    settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
+                    settings.getCentral().getCallTimeout());
             if (request.getTriggerId() != null) {
                 trigger = client.getTrigger(request.getTriggerId(), "any", RepoUtils.getBallerinaVersion());
                 return Optional.of(trigger);

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/BallerinaPackageResolver.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/BallerinaPackageResolver.java
@@ -180,7 +180,8 @@ class BallerinaPackageResolver {
                 initializeProxy(settings.getProxy()), settings.getProxy().username(),
                 settings.getProxy().password(), getAccessTokenOfCLI(settings),
                 settings.getCentral().getConnectTimeout(),
-                settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
+                settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout(),
+                settings.getCentral().getCallTimeout());
     }
 
     private Path resolveBalaPath(String org, String pkgName, String version) throws SemverToolException {

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/BallerinaPackageResolver.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/BallerinaPackageResolver.java
@@ -178,7 +178,9 @@ class BallerinaPackageResolver {
         }
         this.centralClient = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                 initializeProxy(settings.getProxy()), settings.getProxy().username(),
-                settings.getProxy().password(), getAccessTokenOfCLI(settings));
+                settings.getProxy().password(), getAccessTokenOfCLI(settings),
+                settings.getCentral().getConnectTimeout(),
+                settings.getCentral().getReadTimeout(), settings.getCentral().getWriteTimeout());
     }
 
     private Path resolveBalaPath(String org, String pkgName, String version) throws SemverToolException {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Related to https://github.com/wso2-enterprise/internal-support-ballerina/issues/411
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/41588

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

Settings.toml needs to be configured as follows to configure timouts
```
[central]
readTimeout = 10 #seconds
writeTimeout = 20 #seconds
connectTimeout = 30 #seconds
callTimeout = 80 #seconds
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
