### PR TITLE
Support invoking actions directly in Ballerina shell

### DIFF
--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/DiagnosticReporter.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/DiagnosticReporter.java
@@ -86,7 +86,7 @@ public abstract class DiagnosticReporter {
      *
      * @return All the collected diagnostics.
      */
-    public Collection<Diagnostic> diagnostics() {
+    public List<Diagnostic> diagnostics() {
         return this.diagnostics;
     }
 

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/ParserConstants.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/ParserConstants.java
@@ -26,6 +26,7 @@ import java.util.Set;
  * @since 2.0.0
  */
 public class ParserConstants {
+    public static final String WRAPPER_PREFIX = "__shell_wrapper__";
 
     public static final Set<String> RESTRICTED_FUNCTION_NAMES = Set.of("main", "init", "__java_recall",
             "__java_memorize", "__recall_any", "__recall_any_error", "__memorize", "__stmts", "__run");

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/ParserConstants.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/ParserConstants.java
@@ -26,10 +26,21 @@ import java.util.Set;
  * @since 2.0.0
  */
 public class ParserConstants {
+
     public static final String WRAPPER_PREFIX = "__shell_wrapper__";
 
     public static final Set<String> RESTRICTED_FUNCTION_NAMES = Set.of("main", "init", "__java_recall",
             "__java_memorize", "__recall_any", "__recall_any_error", "__memorize", "__stmts", "__run");
+
+    /**
+     * Checks if the given function name is restricted.
+     *
+     * @param functionName Function name to check.
+     * @return True if the function name is restricted.
+     */
+    public static boolean isFunctionNameRestricted(String functionName) {
+        return RESTRICTED_FUNCTION_NAMES.contains(functionName) || functionName.startsWith(WRAPPER_PREFIX);
+    }
 
     private ParserConstants() {}
 }

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/ParserConstants.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/ParserConstants.java
@@ -35,8 +35,8 @@ public class ParserConstants {
     /**
      * Checks if the given function name is restricted.
      *
-     * @param functionName Function name to check.
-     * @return True if the function name is restricted.
+     * @param functionName function name to check
+     * @return <code>true</code> if the function name is restricted. <code>false</code> otherwise
      */
     public static boolean isFunctionNameRestricted(String functionName) {
         return RESTRICTED_FUNCTION_NAMES.contains(functionName) || functionName.startsWith(WRAPPER_PREFIX);

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/SerialTreeParser.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/SerialTreeParser.java
@@ -123,8 +123,7 @@ public class SerialTreeParser extends TrialTreeParser {
     private boolean isModuleDeclarationAllowed(ModuleMemberDeclarationNode declarationNode) {
         if (declarationNode instanceof FunctionDefinitionNode) {
             String functionName = ((FunctionDefinitionNode) declarationNode).functionName().text();
-            if (RESTRICTED_FUNCTION_NAMES.contains(functionName) ||
-                    functionName.startsWith(ParserConstants.WRAPPER_PREFIX)) {
+            if (ParserConstants.isFunctionNameRestricted(functionName)) {
                 addWarnDiagnostic("Found '" + functionName + "' function in the declarations.\n" +
                         "Discarded '" + functionName + "' function without loading.");
                 return false;

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/SerialTreeParser.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/SerialTreeParser.java
@@ -123,7 +123,8 @@ public class SerialTreeParser extends TrialTreeParser {
     private boolean isModuleDeclarationAllowed(ModuleMemberDeclarationNode declarationNode) {
         if (declarationNode instanceof FunctionDefinitionNode) {
             String functionName = ((FunctionDefinitionNode) declarationNode).functionName().text();
-            if (RESTRICTED_FUNCTION_NAMES.contains(functionName)) {
+            if (RESTRICTED_FUNCTION_NAMES.contains(functionName) ||
+                    functionName.startsWith(ParserConstants.WRAPPER_PREFIX)) {
                 addWarnDiagnostic("Found '" + functionName + "' function in the declarations.\n" +
                         "Discarded '" + functionName + "' function without loading.");
                 return false;

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/SerialTreeParser.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/SerialTreeParser.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Parses the source code line using a trial based method.
@@ -50,7 +49,7 @@ import java.util.Set;
  * @since 2.0.0
  */
 public class SerialTreeParser extends TrialTreeParser {
-    private static final Set<String> RESTRICTED_FUNCTION_NAMES = ParserConstants.RESTRICTED_FUNCTION_NAMES;
+
     private static final String COMMAND_PREFIX = "/";
     private final List<TreeParserTrial> nodeParserTrials;
 
@@ -103,7 +102,7 @@ public class SerialTreeParser extends TrialTreeParser {
             ModulePartTrial modulePartTrial = new ModulePartTrial(this);
             Collection<Node> nodes = modulePartTrial.parse(source);
             List<Node> declarationNodes = new ArrayList<>();
-            for (Node node:nodes) {
+            for (Node node : nodes) {
                 ModulePartNode modulePartNode = (ModulePartNode) node;
                 modulePartNode.imports().forEach(declarationNodes::add);
                 modulePartNode.members().stream().filter(this::isModuleDeclarationAllowed)

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ModuleMemberTrial.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ModuleMemberTrial.java
@@ -80,8 +80,7 @@ public class ModuleMemberTrial extends TreeParserTrial {
     private void validateModuleDeclaration(ModuleMemberDeclarationNode declarationNode) {
         if (declarationNode instanceof FunctionDefinitionNode) {
             String functionName = ((FunctionDefinitionNode) declarationNode).functionName().text();
-            if (RESTRICTED_FUNCTION_NAMES.contains(functionName) ||
-                    functionName.startsWith(ParserConstants.WRAPPER_PREFIX)) {
+            if (ParserConstants.isFunctionNameRestricted(functionName)) {
                 String message = "Function name " + "'" + functionName + "'" + " not allowed in Ballerina Shell.\n";
                 throw new InvalidMethodException(message);
             }

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ModuleMemberTrial.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ModuleMemberTrial.java
@@ -80,7 +80,8 @@ public class ModuleMemberTrial extends TreeParserTrial {
     private void validateModuleDeclaration(ModuleMemberDeclarationNode declarationNode) {
         if (declarationNode instanceof FunctionDefinitionNode) {
             String functionName = ((FunctionDefinitionNode) declarationNode).functionName().text();
-            if (RESTRICTED_FUNCTION_NAMES.contains(functionName)) {
+            if (RESTRICTED_FUNCTION_NAMES.contains(functionName) ||
+                    functionName.startsWith(ParserConstants.WRAPPER_PREFIX)) {
                 String message = "Function name " + "'" + functionName + "'" + " not allowed in Ballerina Shell.\n";
                 throw new InvalidMethodException(message);
             }

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ModuleMemberTrial.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ModuleMemberTrial.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Attempts to capture a module member declaration.
@@ -44,8 +43,6 @@ import java.util.Set;
  * @since 2.0.0
  */
 public class ModuleMemberTrial extends TreeParserTrial {
-
-    private static final Set<String> RESTRICTED_FUNCTION_NAMES = ParserConstants.RESTRICTED_FUNCTION_NAMES;
 
     public ModuleMemberTrial(TrialTreeParser parentParser) {
         super(parentParser);

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/snippet/factory/BasicSnippetFactory.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/snippet/factory/BasicSnippetFactory.java
@@ -155,12 +155,15 @@ public class BasicSnippetFactory extends SnippetFactory {
                 qualifiers = NodeFactory.createNodeList(varNode.finalKeyword().get());
             }
 
-            Optional<ExpressionNode> varInitNode = varNode.initializer();
-            if (varInitNode.isEmpty()) {
+            Optional<ExpressionNode> optVarInitNode = varNode.initializer();
+            if (optVarInitNode.isEmpty()) {
+                assert false : "This line is unreachable as the error is captured before.";
+                addErrorDiagnostic("Variable declaration without an initializer is not allowed");
                 return null;
             }
 
-            SyntaxKind nodeKind = varInitNode.get().kind();
+            ExpressionNode varInitNode = optVarInitNode.get();
+            SyntaxKind nodeKind = varInitNode.kind();
             if (isSupportedAction(nodeKind)) {
                 TypedBindingPatternNode typedBindingPatternNode = varNode.typedBindingPattern();
                 TypeDescriptorNode typeDescriptorNode = typedBindingPatternNode.typeDescriptor();
@@ -168,12 +171,12 @@ public class BasicSnippetFactory extends SnippetFactory {
 
                 // Check if the type descriptor of the variable is 'var' as it is not yet supported.
                 if (typeDescriptorNode.kind() == SyntaxKind.VAR_TYPE_DESC) {
-                    addErrorDiagnostic("Actions not allowed with a 'var' TypeDescriptor.");
+                    addErrorDiagnostic("Actions not allowed with a 'var' TypeDescriptor");
                     return null;
                 }
 
                 boolean hasCheck = nodeKind == SyntaxKind.CHECK_ACTION;
-                String functionBody = varInitNode.get().toString();
+                String functionBody = varInitNode.toSourceCode();
                 String functionDefinition = (hasCheck ? "function() returns error|" :
                         "function() returns ") + typeDescriptorNode;
                 String functionName = ParserConstants.WRAPPER_PREFIX + varFunctionCount;

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/snippet/factory/BasicSnippetFactory.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/snippet/factory/BasicSnippetFactory.java
@@ -171,22 +171,22 @@ public class BasicSnippetFactory extends SnippetFactory {
 
                 // Check if the type descriptor of the variable is 'var' as it is not yet supported.
                 if (typeDescriptorNode.kind() == SyntaxKind.VAR_TYPE_DESC) {
-                    addErrorDiagnostic("Actions not allowed with a 'var' TypeDescriptor");
+                    addErrorDiagnostic("'var' type is not yet supported for actions. Please specify the exact type.");
                     return null;
                 }
 
-                boolean hasCheck = nodeKind == SyntaxKind.CHECK_ACTION;
-                String functionBody = varInitNode.toSourceCode();
-                String functionDefinition = (hasCheck ? "function() returns error|" :
+                boolean isCheckAction = nodeKind == SyntaxKind.CHECK_ACTION;
+                String initAction = varInitNode.toSourceCode();
+                String functionTypeDesc = (isCheckAction ? "function() returns error|" :
                         "function() returns ") + typeDescriptorNode;
                 String functionName = ParserConstants.WRAPPER_PREFIX + varFunctionCount;
-                String functionString = String.format("%s %s = %s {%s %s = %s; return %s;};", functionDefinition,
-                        functionName, functionDefinition, typeDescriptorNode, bindingPatternNode, functionBody,
+                String functionVarDecl = String.format("%s %s = %s {%s %s = %s; return %s;};", functionTypeDesc,
+                        functionName, functionTypeDesc, typeDescriptorNode, bindingPatternNode, initAction,
                         bindingPatternNode);
-                varNode = (VariableDeclarationNode) NodeParser.parseStatement(functionString);
+                varNode = (VariableDeclarationNode) NodeParser.parseStatement(functionVarDecl);
                 newNode = (VariableDeclarationNode) NodeParser.parseStatement(
                         String.format("%s %s = %s %s();", typeDescriptorNode, bindingPatternNode,
-                                (hasCheck ? "check " : ""), functionName));
+                                (isCheckAction ? "check " : ""), functionName));
             }
 
             varFunctionCount += 1;

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/AbstractEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/AbstractEvaluatorTest.java
@@ -84,7 +84,7 @@ public abstract class AbstractEvaluatorTest {
                 ShellCompilation shellCompilation = evaluator.getCompilation(testCase.getCode());
                 Optional<PackageCompilation> compilation = shellCompilation.getPackageCompilation();
 
-                if (compilation.isEmpty() && testCase.getStderr().size() > 0) {
+                if (compilation.isEmpty() && !testCase.getStderr().isEmpty()) {
                     for (int i = 0; i < testCase.getStderr().size(); i++) {
                         Assert.assertEquals(evaluator.diagnostics().get(i).toString(), testCase.getStderr().get(i));
                     }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/AbstractEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/AbstractEvaluatorTest.java
@@ -83,6 +83,14 @@ public abstract class AbstractEvaluatorTest {
 
                 ShellCompilation shellCompilation = evaluator.getCompilation(testCase.getCode());
                 Optional<PackageCompilation> compilation = shellCompilation.getPackageCompilation();
+
+                if (compilation.isEmpty() && testCase.getStderr().size() > 0) {
+                    for (int i = 0; i < testCase.getStderr().size(); i++) {
+                        Assert.assertEquals(evaluator.diagnostics().get(i).toString(), testCase.getStderr().get(i));
+                    }
+                    continue;
+                }
+
                 String expr = evaluator.getValue(compilation).get().getResult();
                 Assert.assertEquals(invoker.getStdOut(), testCase.getStdout(), testCase.getDescription());
                 Assert.assertEquals(expr, testCase.getExpr(), testCase.getDescription());

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ActionEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ActionEvaluatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ActionEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ActionEvaluatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://wso2.com) All Rights Reserved.
+ * Copyright (c) 2024, WSO2 LLC. (http://wso2.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ActionEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ActionEvaluatorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.shell.test.evaluator;
+
+import io.ballerina.shell.exceptions.BallerinaShellException;
+import org.testng.annotations.Test;
+
+/**
+ * Test simple snippets with action invocations.
+ *
+ * @since 2201.9.0
+ */
+public class ActionEvaluatorTest extends AbstractEvaluatorTest {
+    private static final String START_EVALUATOR_TESTCASE = "testcases/evaluator/actions.start.json";
+    private static final String REMOTE_EVALUATOR_TESTCASE = "testcases/evaluator/actions.remote.json";
+    private static final String RESOURCE_EVALUATOR_TESTCASE = "testcases/evaluator/actions.resource.json";
+    private static final String VAR_EVALUATOR_TESTCASE = "testcases/evaluator/actions.var.json";
+
+    @Test
+    public void testEvaluateStart() throws BallerinaShellException {
+        testEvaluate(START_EVALUATOR_TESTCASE);
+    }
+
+    @Test
+    public void testEvaluateRemote() throws BallerinaShellException {
+        testEvaluate(REMOTE_EVALUATOR_TESTCASE);
+    }
+
+    @Test
+    public void testEvaluateResource() throws BallerinaShellException {
+        testEvaluate(RESOURCE_EVALUATOR_TESTCASE);
+    }
+
+    @Test
+    public void testEvaluateVar() throws BallerinaShellException {
+        testEvaluate(VAR_EVALUATOR_TESTCASE);
+    }
+}

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/base/TestCase.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/base/TestCase.java
@@ -18,6 +18,9 @@
 
 package io.ballerina.shell.test.evaluator.base;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * One statement in a evaluator test case.
  *
@@ -29,6 +32,7 @@ public class TestCase {
     private String expr;
     private String stdout = "";
     private String error;
+    private List<String> stderr = new ArrayList<>();
 
     public String getDescription() {
         return description;
@@ -68,5 +72,13 @@ public class TestCase {
 
     public void setError(String error) {
         this.error = error;
+    }
+
+    public List<String> getStderr() {
+        return stderr;
+    }
+
+    public void setStderr(List<String> stderr) {
+        this.stderr = stderr;
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/actions.remote.json
+++ b/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/actions.remote.json
@@ -1,0 +1,24 @@
+[
+  {
+    "description": "Define a client class",
+    "code": "client class MyClient { remote function invoke(string param) returns string { return string `remote method invoked with ${param}`; } }"
+  },
+  {
+    "description": "Initialize a client class",
+    "code": "MyClient myClient = new;"
+  },
+  {
+    "description": "Invoke a client remote method as an expression",
+    "code": "myClient->invoke(\"input\");",
+    "expr": "\"remote method invoked with input\""
+  },
+  {
+    "description": "Invoke a client remote method with a variable",
+    "code": "string returnValue = myClient->invoke(\"input\");"
+  },
+  {
+    "description": "Check the return value",
+    "code": "returnValue",
+    "expr": "\"remote method invoked with input\""
+  }
+]

--- a/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/actions.resource.json
+++ b/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/actions.resource.json
@@ -1,0 +1,24 @@
+[
+  {
+    "description": "Define a client class",
+    "code": "client class MyClient { resource function get root/[string path](string param) returns string { return string `${path} -> ${param}`; } }"
+  },
+  {
+    "description": "Initialize a client class",
+    "code": "MyClient myClient = new;"
+  },
+  {
+    "description": "Invoke a client resource method as an expression",
+    "code": "myClient ->/root/name(\"input\");",
+    "expr": "\"name -> input\""
+  },
+  {
+    "description": "Invoke a client resource method with a variable",
+    "code": "string returnValue = myClient ->/root/name(\"input\");"
+  },
+  {
+    "description": "Check the return value",
+    "code": "returnValue",
+    "expr": "\"name -> input\""
+  }
+]

--- a/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/actions.start.json
+++ b/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/actions.start.json
@@ -1,0 +1,20 @@
+[
+  {
+    "description": "Initialize the function",
+    "code": "function name() returns int { int x = 3; x += 3 * 2; return x; }"
+  },
+  {
+    "description": "Execute the function with start as an expression",
+    "code": "start name()",
+    "expr": "future {isDone:true,result:9}"
+  },
+  {
+    "description": "Execute the function with start with a variable assignment",
+    "code": "future<int> futureResult = start name()"
+  },
+  {
+    "description": "Check the return value",
+    "code": "futureResult",
+    "expr": "future {isDone:true,result:9}"
+  }
+]

--- a/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/actions.var.json
+++ b/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/actions.var.json
@@ -1,0 +1,14 @@
+[
+  {
+    "description": "Initialize the function",
+    "code": "function name() returns int { int x = 3; x += 3 * 2; return x; }"
+  },
+  {
+    "description": "Execute the function with start with a variable assignment",
+    "code": "var futureResult = start name()",
+    "stderr": [
+      "Actions not allowed with a 'var' TypeDescriptor.",
+      "Compilation aborted due to invalid input."
+    ]
+  }
+]

--- a/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/actions.var.json
+++ b/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/actions.var.json
@@ -7,7 +7,7 @@
     "description": "Execute the function with start with a variable assignment",
     "code": "var futureResult = start name()",
     "stderr": [
-      "Actions not allowed with a 'var' TypeDescriptor.",
+      "Actions not allowed with a 'var' TypeDescriptor",
       "Compilation aborted due to invalid input."
     ]
   }

--- a/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/actions.var.json
+++ b/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/actions.var.json
@@ -7,7 +7,7 @@
     "description": "Execute the function with start with a variable assignment",
     "code": "var futureResult = start name()",
     "stderr": [
-      "Actions not allowed with a 'var' TypeDescriptor",
+      "'var' type is not yet supported for actions. Please specify the exact type.",
       "Compilation aborted due to invalid input."
     ]
   }


### PR DESCRIPTION
## Purpose

Since Ballerina does not allow actions to be invoked at the module level, the current implementation has the limitation of invoking an action. As a workaround, this PR wraps the action in a function and returns the value to the module-level declared variable.

Fixes #39960
Fixes  #39893

## Approach

The new implementation wraps the action inside a function and returns the value to a module-level variable. Considering the user's input `http:Response response  = check clientEndpoint->get("/entries");`, the shell generates the following snippet as a workaround for the issue.

```ballerina
function () returns error|http:Response __shell_wrapper__0 = function() returns error|http:Response {
    http:Response response = check clientEndpoint->get("/entries");
    return response;
};
http:Response response = check __shell_wrapper__0();
```

## Samples
The following types of actions are now supported in Ballerina shell with this PR.

```ballerina
$= string returnValue = myClient->invoke("input");

$= string returnValue = myClient ->/root/name("input");

$= future<int> futureResult = start name();
```

## Remarks
Still, the user cannot assign the output of an action to a `var` variable. This requires additional implementation since we have to intact the semantic model to determine the return type of the action and then generate the custom function.

Additionally, since the shell generates a function for each action, those function names are now disallowed for the user.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
