### PR TITLE
[2201.8.x] Fix xml `toString()` error for modified name space attributes 

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BallerinaXmlSerializer.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BallerinaXmlSerializer.java
@@ -287,7 +287,7 @@ public class BallerinaXmlSerializer extends OutputStream {
     }
 
     private void writeAttributes(HashSet<String> curNSSet, Map<String, String> attributeMap) throws XMLStreamException {
-        String defaultNS = xmlStreamWriter.getNamespaceContext().getNamespaceURI(XMLNS);
+        String defaultNS = xmlStreamWriter.getNamespaceContext().getNamespaceURI("");
         for (Map.Entry<String, String> attributeEntry : attributeMap.entrySet()) {
             String key = attributeEntry.getKey();
             int closingCurlyPos = key.lastIndexOf('}');

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
@@ -382,9 +382,9 @@ public final class XmlItem extends XmlValue implements BXmlItem {
     }
 
     private void mergeAdjoiningTextNodesIntoList(List leftList, List<BXml> appendingList) {
-        XmlPi lastChild = (XmlPi) leftList.get(leftList.size() - 1);
-        String firstChildContent = ((XmlPi) appendingList.get(0)).getData();
-        String mergedTextContent = lastChild.getData() + firstChildContent;
+        XmlText lastChild = (XmlText) leftList.get(leftList.size() - 1);
+        String firstChildContent = appendingList.get(0).getTextValue();
+        String mergedTextContent = lastChild.getTextValue() + firstChildContent;
         XmlText text = new XmlText(mergedTextContent);
         leftList.set(leftList.size() - 1, text);
         for (int i = 1; i < appendingList.size(); i++) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/record/ClosedRecordTypeInclusionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/record/ClosedRecordTypeInclusionTest.java
@@ -51,7 +51,7 @@ public class ClosedRecordTypeInclusionTest {
         compileResult = BCompileUtil.compile("test-src/record/closed_record_type_inclusion.bal");
     }
 
-    @Test(description = "Negative tests" , groups = {"disableOnOldParser"})
+    @Test(description = "Negative tests")
     public void negativeTests() {
         CompileResult negative = BCompileUtil.compile("test-src/record/closed_record_type_inclusion_negative.bal");
         int index = 0;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/record/OpenRecordTypeInclusionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/record/OpenRecordTypeInclusionTest.java
@@ -51,7 +51,7 @@ public class OpenRecordTypeInclusionTest {
         compileResult = BCompileUtil.compile("test-src/record/open_record_type_inclusion.bal");
     }
 
-    @Test(description = "Negative tests" , groups = {"disableOnOldParser"})
+    @Test(description = "Negative tests")
     public void negativeTests() {
         CompileResult negative = BCompileUtil.compile("test-src/record/open_record_type_inclusion_negative.bal");
         int index = 0;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersNegativeTest.java
@@ -67,7 +67,7 @@ public class FunctionPointersNegativeTest {
         BAssertUtil.validateError(result, 0, "incompatible types: expected 'string', found 'Person'", 32, 30);
     }
 
-    @Test(groups = { "disableOnOldParser" })
+    @Test()
     public void testFPWithNoImport() {
         CompileResult result =
                 BCompileUtil.compile("test-src/expressions/lambda/negative/fp-with-import-negative.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersWithOptionalArgsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersWithOptionalArgsTest.java
@@ -41,7 +41,7 @@ public class FunctionPointersWithOptionalArgsTest {
         result = BCompileUtil.compile("test-src/expressions/lambda/function-pointers-with-optional-args.bal");
     }
 
-    @Test(groups = { "disableOnOldParser" })
+    @Test()
     public void testFunctionPointersWithNamedArgs() {
         CompileResult result =
                 BCompileUtil.compile("test-src/expressions/lambda/function-pointers-with-named-args-negative.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -327,7 +327,7 @@ public class MappingConstructorExprTest {
         };
     }
 
-    @Test(groups = "disableOnOldParser")
+    @Test()
     public void testReadOnlyFieldsSemanticNegative() {
         CompileResult compileResult =
                 BCompileUtil.compile("test-src/expressions/mappingconstructor/readonly_field_negative.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectDocumentationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectDocumentationTest.java
@@ -66,7 +66,7 @@ public class ObjectDocumentationTest {
         Assert.assertNotNull(docNode);
     }
 
-    @Test(description = "Test doc struct.", groups = { "disableOnOldParser" })
+    @Test(description = "Test doc struct.")
     public void testDocStruct() {
         CompileResult compileResult = BCompileUtil.compile("test-src/object/object_doc_annotation.bal");
         Assert.assertEquals(compileResult.getWarnCount(), 0);
@@ -88,7 +88,7 @@ public class ObjectDocumentationTest {
                 EMPTY_STRING), "struct `field c` documentation");
     }
 
-    @Test(description = "Test doc negative cases.", groups = { "disableOnOldParser" })
+    @Test(description = "Test doc negative cases.")
     public void testDocumentationNegative() {
         CompileResult compileResult = BCompileUtil.compile("test-src/object/object_documentation_negative.bal");
         Assert.assertEquals(compileResult.getErrorCount(), 0, getErrorString(compileResult.getDiagnostics()));

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/LimitClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/LimitClauseTest.java
@@ -152,7 +152,7 @@ public class LimitClauseTest {
         Assert.assertTrue((Boolean) values);
     }
 
-    @Test(description = "Test limit clause with incompatible types", groups = {"disableOnOldParser"})
+    @Test(description = "Test limit clause with incompatible types")
     public void testNegativeScenarios() {
         negativeResult = BCompileUtil.compile("test-src/query/limit-clause-negative.bal");
         Assert.assertEquals(negativeResult.getErrorCount(), 3);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/OrderByClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/OrderByClauseTest.java
@@ -35,7 +35,7 @@ import static org.ballerinalang.test.BAssertUtil.validateError;
  *
  * @since Swan Lake
  */
-@Test(groups = {"disableOnOldParser"})
+@Test()
 public class OrderByClauseTest {
 
     private CompileResult result;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/XMLQueryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/XMLQueryExpressionTest.java
@@ -522,6 +522,11 @@ public class XMLQueryExpressionTest {
         BRunUtil.invoke(result, "testQueryExpressionIteratingOverStreamReturningXMLWithReadonly");
     }
 
+    @Test(description = "Test XML template with query expression iterating over xml starting with whitespace")
+    public void testQueryExpressionXmlStartWithWhiteSpace() {
+        BRunUtil.invoke(result, "testQueryExpressionXmlStartWithWhiteSpace");
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/XMLQueryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/XMLQueryExpressionTest.java
@@ -50,7 +50,7 @@ public class XMLQueryExpressionTest {
         validateError(negativeResult, index++, "incompatible types: expected " +
                         "'xml<((xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text) & readonly)> & readonly'," +
                         " found 'xml'", 21, 16);
-        validateError(negativeResult, index++, "incompatible types: expected 'xml:Element & readonly', " + "" +
+        validateError(negativeResult, index++, "incompatible types: expected 'xml:Element & readonly', " +
                 "found 'xml:Element'", 25, 16);
         validateError(negativeResult, index++,
                 "incompatible types: expected 'xml<(xml:Element & readonly)> & readonly', found 'xml:Element'",
@@ -89,7 +89,7 @@ public class XMLQueryExpressionTest {
                 "<name>Sherlock Holmes</name><name>The Da Vinci Code</name>");
     }
 
-    @Test(groups = {"disableOnOldParser"}, description = "Test simple query expression for XMLs - #2")
+    @Test(description = "Test simple query expression for XMLs - #2")
     public void testSimpleQueryExprForXML2() {
         Object returnValues = BRunUtil.invoke(result, "testSimpleQueryExprForXML2");
         Assert.assertNotNull(returnValues);
@@ -149,7 +149,7 @@ public class XMLQueryExpressionTest {
                 "<name>Sherlock Holmes</name><name>The Da Vinci Code</name>");
     }
 
-    @Test(groups = {"disableOnOldParser"}, description = "Test simple query expression for xml? - #2")
+    @Test(description = "Test simple query expression for xml? - #2")
     public void testSimpleQueryExprForXMLOrNilResult2() {
         Object returnValues = BRunUtil.invoke(result, "testSimpleQueryExprForXMLOrNilResult2");
         Assert.assertNotNull(returnValues);
@@ -355,8 +355,7 @@ public class XMLQueryExpressionTest {
         BRunUtil.invoke(result, "testSimpleQueryExprForXMLWithReadonly1");
     }
 
-    @Test(groups = {"disableOnOldParser"},
-            description = "Test simple query expression for XMLs with readonly intersection - #2")
+    @Test(description = "Test simple query expression for XMLs with readonly intersection - #2")
     public void testSimpleQueryExprForXMLWithReadonly2() {
         BRunUtil.invoke(result, "testSimpleQueryExprForXMLWithReadonly2");
     }
@@ -386,8 +385,7 @@ public class XMLQueryExpressionTest {
         BRunUtil.invoke(result, "testSimpleQueryExprForXMLOrNilResultWithReadonly1");
     }
 
-    @Test(groups = {"disableOnOldParser"},
-            description = "Test simple query expression for xml? with readonly intersection - #2")
+    @Test(description = "Test simple query expression for xml? with readonly intersection - #2")
     public void testSimpleQueryExprForXMLOrNilResultWithReadonly2() {
        BRunUtil.invoke(result, "testSimpleQueryExprForXMLOrNilResultWithReadonly2");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordOptionalFieldsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordOptionalFieldsTest.java
@@ -47,7 +47,7 @@ public class ClosedRecordOptionalFieldsTest {
         compileResult = BCompileUtil.compile("test-src/record/closed_record_optional_fields.bal");
     }
 
-    @Test(description = "Test for the compile errors", groups = {"disableOnOldParser"})
+    @Test(description = "Test for the compile errors")
     public void testNegatives() {
         CompileResult negativeResult = BCompileUtil.compile(
                 "test-src/record/closed_record_optional_fields_negatives.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordNegativeTest.java
@@ -71,8 +71,7 @@ public class OpenRecordNegativeTest {
                 " anydata...; |} j; anydata...; |}', found 'int'", 4, 9);
     }
 
-    @Test(description = "Test white space between the type name and ellipsis in rest descriptor",
-            groups = {"disableOnOldParser"})
+    @Test(description = "Test white space between the type name and ellipsis in rest descriptor")
     public void testRestDescriptorSyntax() {
         CompileResult result = BCompileUtil.compile("test-src/record/open_record_invalid_rest_desc.bal");
         assertEquals(result.getErrorCount(), 0);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordDocumentationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordDocumentationTest.java
@@ -40,7 +40,7 @@ public class RecordDocumentationTest {
     public void setup() {
     }
 
-    @Test(description = "Test doc annotation.", groups = {"disableOnOldParser"})
+    @Test(description = "Test doc annotation.")
     public void testDocAnnotation() {
         CompileResult compileResult = BCompileUtil.compile("test-src/record/record_annotation.bal");
         Assert.assertEquals(compileResult.getWarnCount(), 3);
@@ -88,7 +88,7 @@ public class RecordDocumentationTest {
                 EMPTY_STRING), "struct `field c` documentation");
     }
 
-    @Test(description = "Test doc negative cases.", groups = {"disableOnOldParser"})
+    @Test(description = "Test doc negative cases.")
     public void testDocumentationNegative() {
         CompileResult compileResult = BCompileUtil.compile("test-src/record/record_documentation_negative.bal");
         Assert.assertEquals(compileResult.getErrorCount(), 0,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
@@ -455,7 +455,7 @@ public class SealedArrayTest {
         BRunUtil.invoke(compileResult, "testSealedArrayConstrainedMapInvalidIndex", args);
     }
 
-    @Test(groups = { "disableOnOldParser" })
+    @Test()
     public void testArrayWithConstantSizeReferenceFill() {
         BRunUtil.invoke(compileResult, "testArrayWithConstantSizeReferenceFill");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
@@ -77,7 +77,7 @@ public class BByteValueNegativeTest {
         BAssertUtil.validateError(result, 22, msg4, 40, 87);
     }
 
-    @Test(description = "Test byte shift operators negative", groups = { "disableOnOldParser" })
+    @Test(description = "Test byte shift operators negative")
     public void invalidByteShiftOperators() {
         CompileResult result = BCompileUtil.compile("test-src/types/byte/byte-shift-operators-negative.bal");
         Assert.assertEquals(result.getErrorCount(), 13);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/integer/BIntegerValueNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/integer/BIntegerValueNegativeTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 /**
  * Test class for negative integer tests.
  */
-@Test(groups = { "disableOnOldParser" })
+@Test()
 public class BIntegerValueNegativeTest {
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapAccessExprTest.java
@@ -147,7 +147,7 @@ public class MapAccessExprTest {
         Assert.assertEquals(returns.get(1).toString(), "Colombo");
     }
 
-    @Test(description = "Map access negative scenarios", groups = {"disableOnOldParser"})
+    @Test(description = "Map access negative scenarios")
     public void testNegativeSemantics() {
         Assert.assertEquals(resultSemanticsNegative.getDiagnostics().length, 4);
         int index = 0;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/VarDeclaredAssignmentStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/VarDeclaredAssignmentStmtTest.java
@@ -153,7 +153,7 @@ public class VarDeclaredAssignmentStmtTest {
         BRunUtil.invoke(result, "testObjectToVarAssignment2");
     }
 
-    @Test(description = "Test var in variable def.", groups = {"disableOnOldParser"})
+    @Test(description = "Test var in variable def.")
     public void testVarTypeInVariableDefStatement() {
         //var type is not not allowed in variable def statements
         CompileResult res = BCompileUtil.compile("test-src/types/var/var-type-variable-def-negative.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAttributesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAttributesTest.java
@@ -72,8 +72,7 @@ public class XMLAttributesTest {
                         "xmlns:ns3=\"http://sample.com/wso2/f\" foo1=\"bar\"/>");
     }
 
-    // ToDo: enable after fixing #40373
-    @Test(enabled = false)
+    @Test()
     public void testAddNamespaceAsAttribute1() {
         BArray returns = (BArray) BRunUtil.invoke(xmlAttrProgFile, "testAddNamespaceAsAttribute");
         Assert.assertTrue(returns.get(0) instanceof BXml);
@@ -132,8 +131,7 @@ public class XMLAttributesTest {
                         "xmlns:ns5=\"http://sample.com/wso2/f/\" ns5:diff=\"yes\" ns5:foo1=\"bar1\"/>");
     }
 
-    // ToDo: enable after fixing #40373
-    @Test(enabled = false)
+    @Test()
     public void testAddAttributeWithQName_5() {
         Object returns = BRunUtil.invoke(xmlAttrProgFile, "testAddAttributeWithDiffQName_5");
         Assert.assertTrue(returns instanceof BXml);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
@@ -181,8 +181,7 @@ public class XMLIterationTest {
         Assert.assertEquals(((BXmlSequence) resArray.getRefValue(1)).getTextValue().toString(), authors[1][0]);
     }
 
-    @Test(groups = {"disableOnOldParser"},
-            description = "Test iterating over xml elements where some elements are characters")
+    @Test(description = "Test iterating over xml elements where some elements are characters")
     public void testXMLCompoundCharacterSequenceIteration() {
         Object results = BRunUtil.invoke(result, "xmlSequenceIter");
         Assert.assertEquals(result.getDiagnostics().length, 0);
@@ -190,8 +189,7 @@ public class XMLIterationTest {
         Assert.assertEquals(str, "<book>the book</book>\nbit of text\\u2702\\u2705\n");
     }
 
-    @Test(groups = {"disableOnOldParser"},
-            description = "Test iterating over xml sequence where all elements are character items")
+    @Test(description = "Test iterating over xml sequence where all elements are character items")
     public void testXMLCharacterSequenceIteration() {
         Object results = BRunUtil.invoke(result, "xmlCharItemIter");
         Assert.assertEquals(result.getDiagnostics().length, 0);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralWithNamespacesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralWithNamespacesTest.java
@@ -31,6 +31,7 @@ import org.ballerinalang.test.util.BFileUtil;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -178,7 +179,7 @@ public class XMLLiteralWithNamespacesTest {
     public void xmlWithDefaultNamespaceToString() {
         Object returns = BRunUtil.invoke(literalWithNamespacesResult, "XMLWithDefaultNamespaceToString");
         Assert.assertEquals(returns.toString(),
-                "<Order xmlns=\"http://acme.company\" xmlns:acme=\"http://acme.company\">\n" +
+                "<Order xmlns=\"http://acme.company\" xmlns:acme=\"http://acme.company.nondefault\">\n" +
                         "        <OrderLines>\n" +
                         "            <OrderLine acme:lineNo=\"334\" itemCode=\"334-2\"/>\n" +
                         "        </OrderLines>\n" +
@@ -200,20 +201,24 @@ public class XMLLiteralWithNamespacesTest {
     }
 
     @Test
-    public void testXmlLiteralUsingXmlNamespacePrefix() {
-        BRunUtil.invoke(literalWithNamespacesResult, "testXmlLiteralUsingXmlNamespacePrefix");
-    }
-
-    @Test
     public void testXMLToString() {
         BXml xml = XmlFactory.parse("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                 "<!DOCTYPE foo [<!ELEMENT foo ANY ><!ENTITY data \"Example\" >]><foo>&data;</foo>");
         Assert.assertEquals(xml.toString(), "<foo>Example</foo>");
     }
 
-    @Test
-    public void testXmlInterpolationWithQuery() {
-        BRunUtil.invoke(literalWithNamespacesResult, "testXmlInterpolationWithQuery");
+    @Test (dataProvider = "xmlValueFunctions")
+    public void testXmlStrings(String functionName) {
+        BRunUtil.invoke(literalWithNamespacesResult, functionName);
+    }
+
+    @DataProvider(name = "xmlValueFunctions")
+    private String[] xmlValueFunctions() {
+        return new String[]{
+                "testXmlLiteralUsingXmlNamespacePrefix",
+                "testXmlInterpolationWithQuery",
+                "testAddAttributeToDefaultNS"
+        };
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/xml-query-expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/xml-query-expression.bal
@@ -1536,7 +1536,7 @@ function testQueryExpressionXmlStartWithWhiteSpace() {
             </body>
         </html>
     `;
-    assertEquality(xmlValue.toString(), string `
+    xml expected = xml `
         <html>
             <head>
                 <title>Dynamic Table</title>
@@ -1557,7 +1557,8 @@ function testQueryExpressionXmlStartWithWhiteSpace() {
                 </table>
             </body>
         </html>
-    `);
+    `;
+    assertEquality(xmlValue, expected);
 }
 
 function assertEquality(any|error actual, any|error expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/xml-query-expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/xml-query-expression.bal
@@ -1514,6 +1514,52 @@ function testQueryExpressionIteratingOverStreamReturningXMLWithReadonly() {
     assertEquality(res.toString(), (xml `<person country="Russia">John</person><person country="Germany">Mike</person>`).toString());
 }
 
+function testQueryExpressionXmlStartWithWhiteSpace() {
+    Person[] personList = [{name: "John", country: "Australia"}, {name: "Mike", country : "Canada"}];
+    xml xmlValue = xml `
+        <html>
+            <head>
+                <title>Dynamic Table</title>
+            </head>
+            <body>
+                <table border="1">
+                    <tr>
+                        <th>Name</th>
+                        <th>Country</th>
+                    </tr>
+                    ${from var {name, country} in personList
+    select xml ` <tr>
+                     <th>${name}</th>
+                     <th>${country}</th>
+                </tr>`}
+                </table>
+            </body>
+        </html>
+    `;
+    assertEquality(xmlValue.toString(), string `
+        <html>
+            <head>
+                <title>Dynamic Table</title>
+            </head>
+            <body>
+                <table border="1">
+                    <tr>
+                        <th>Name</th>
+                        <th>Country</th>
+                    </tr>
+                     <tr>
+                     <th>John</th>
+                     <th>Australia</th>
+                </tr> <tr>
+                     <th>Mike</th>
+                     <th>Canada</th>
+                </tr>
+                </table>
+            </body>
+        </html>
+    `);
+}
+
 function assertEquality(any|error actual, any|error expected) {
     if expected is anydata && actual is anydata && expected == actual {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals-with-namespaces.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals-with-namespaces.bal
@@ -1,3 +1,5 @@
+import ballerina/test;
+
 xmlns "http://ballerina.com/b" as ns1; 
 
 function testElementLiteralWithNamespaces() returns [xml, xml] {
@@ -162,9 +164,7 @@ function testXmlLiteralUsingXmlNamespacePrefix() {
     xml x1 = xml `<entry xml:base="https://namespace.servicebus.windows.net/$Resources/Eventhubs"></entry>`;
     string s = x1.toString();
     string expectedStr = "<entry xml:base=\"https://namespace.servicebus.windows.net/$Resources/Eventhubs\"/>";
-    if (s != expectedStr) {
-        panic error("Assertion error", expected = expectedStr, found=s);
-    }
+    test:assertEquals(s, expectedStr, "XML literal with xml namespace prefix failed");
 }
 
 xmlns "http://www.so2w.org" as globalNS;
@@ -177,9 +177,7 @@ function testXmlInterpolationWithQuery() returns error? {
     xml x2 = x1/<empRecord>[0];
     string s1 = x2.toString();
     string expectedStr1 = "<empRecord employeeId=\"1\"><inlineNS:id xmlns:inlineNS=\"http://www.so2w.org\">1</inlineNS:id></empRecord>";
-    if (s1 != expectedStr1) {
-        panic error("Assertion error", expected = expectedStr1, found = s1);
-    }
+    test:assertEquals(s1, expectedStr1, "XML interpolation with query failed");
 
     xmlns "http://www.so2w.org" as localNS;
     xml x3 = xml `<empRecords>
@@ -189,17 +187,13 @@ function testXmlInterpolationWithQuery() returns error? {
     xml x4 = x3/<empRecord>[0]/<localNS:id>;
     string s2 = x4.toString();
     string expectedStr2 = "<localNS:id xmlns:localNS=\"http://www.so2w.org\">1</localNS:id>";
-    if (s2 != expectedStr2) {
-        panic error("Assertion error", expected = expectedStr2, found = s2);
-    }
+    test:assertEquals(s2, expectedStr2, "XML interpolation with query failed");
 
     xml x5 = from int i in [1]
         select xml `<empRecord employeeId="${i}"><localNS:id>${i}</localNS:id></empRecord>`;
     string s3 = x5.toString();
     string expectedStr3 = "<empRecord employeeId=\"1\"><localNS:id xmlns:localNS=\"http://www.so2w.org\">1</localNS:id></empRecord>";
-    if (s3 != expectedStr3) {
-        panic error("Assertion error", expected = expectedStr3, found = s3);
-    }
+    test:assertEquals(s3, expectedStr3, "XML interpolation with query failed");
 
     xml x6 = xml `<empRecords>
          ${from int i in 1 ... 3
@@ -208,9 +202,7 @@ function testXmlInterpolationWithQuery() returns error? {
     xml x7 = x6/<empRecord>[0]/<globalNS:id>;
     string s4 = x7.toString();
     string expectedStr4 = "<globalNS:id xmlns:globalNS=\"http://www.so2w.org\">1</globalNS:id>";
-    if (s4 != expectedStr4) {
-        panic error("Assertion error", expected = expectedStr4, found = s4);
-    }
+    test:assertEquals(s4, expectedStr4, "XML interpolation with query failed");
 
     xml x8 = xml ``;
     from int i in [1]
@@ -218,9 +210,7 @@ function testXmlInterpolationWithQuery() returns error? {
         x8 = xml `<empRecord employeeId="${i}"><localNS:id>${i}</localNS:id></empRecord>`;
     };
     string s5 = x8.toString();
-    if (s5 != expectedStr3) {
-        panic error("Assertion error", expected = expectedStr3, found = s5);
-    }
+    test:assertEquals(s5, expectedStr3, "XML interpolation with query failed");
 
     xml x9 = xml ``;
     from int i in [1]
@@ -231,26 +221,20 @@ function testXmlInterpolationWithQuery() returns error? {
         };
     };
     string s6 = x9.toString();
-    if (s6 != expectedStr3) {
-        panic error("Assertion error", expected = expectedStr3, found = s6);
-    }
+    test:assertEquals(s6, expectedStr3, "XML interpolation with query failed");
 
     xml x10 = from int i in [1]
         let xml y = xml `<empRecord employeeId="${i}"><localNS:id>${i}</localNS:id></empRecord>`
         select xml `<record>${y}</record>`;
     string s7 = x10.toString();
     string expectedStr5 = "<record><empRecord employeeId=\"1\"><localNS:id xmlns:localNS=\"http://www.so2w.org\">1</localNS:id></empRecord></record>";
-    if (s7 != expectedStr5) {
-        panic error("Assertion error", expected = expectedStr3, found = s7);
-    }
+    test:assertEquals(s7, expectedStr5, "XML interpolation with query failed");
 
     xml x11 = from xml x in (from int j in [1]
             select xml `<empRecord employeeId="${j}"><localNS:id>${j}</localNS:id></empRecord>`)
         select xml `<record>${x}</record>`;
     string s8 = x11.toString();
-    if (s8 != expectedStr5) {
-        panic error("Assertion error", expected = expectedStr3, found = s7);
-    }
+    test:assertEquals(s8, expectedStr5, "XML interpolation with query failed");
 
     xml x12 = from int i in [1]
         join int j in [1]
@@ -259,18 +243,14 @@ function testXmlInterpolationWithQuery() returns error? {
         select xml `<record>${i}</record>`;
     string s9 = x12.toString();
     string expectedStr6 = "<record>1</record>";
-    if (s9 != expectedStr6) {
-        panic error("Assertion error", expected = expectedStr3, found = s7);
-    }
+    test:assertEquals(s9, expectedStr6, "XML interpolation with query failed");
 
     xml expectedXml = xml `<empRecord employeeId="1"><localNS:id>1</localNS:id></empRecord>`;
     xml x13 = from int i in [1]
         where xml `<empRecord employeeId="${i}"><localNS:id>${i}</localNS:id></empRecord>` == expectedXml
         select xml `<record>${expectedXml}</record>`;
     string s10 = x13.toString();
-    if (s10 != expectedStr5) {
-        panic error("Assertion error", expected = expectedStr5, found = s10);
-    }
+    test:assertEquals(s10, expectedStr5, "XML interpolation with query failed");
 
     do {
         xmlns "http://www.so2w1.org" as doNS;
@@ -278,9 +258,7 @@ function testXmlInterpolationWithQuery() returns error? {
             select xml `<localNS:empRecord employeeId="${i}"><doNS:id>${i}</doNS:id></localNS:empRecord>`;
         string s11 = x14.toString();
         string expectedStr7 = "<localNS:empRecord xmlns:localNS=\"http://www.so2w.org\" employeeId=\"1\"><doNS:id xmlns:doNS=\"http://www.so2w1.org\">1</doNS:id></localNS:empRecord>";
-        if (s11 != expectedStr7) {
-            panic error("Assertion error", expected = expectedStr7, found = s11);
-        }
+        test:assertEquals(s11, expectedStr7, "XML interpolation with query failed");
     }
 
     do {
@@ -289,9 +267,7 @@ function testXmlInterpolationWithQuery() returns error? {
             select xml `<localNS:empRecord employeeId="${i}"><doNS:id>${i}</doNS:id></localNS:empRecord>`;
         string s12 = x15.toString();
         string expectedStr8 = "<localNS:empRecord xmlns:localNS=\"http://www.so2w.org\" employeeId=\"1\"><doNS:id xmlns:doNS=\"http://www.so2w2.org\">1</doNS:id></localNS:empRecord>";
-        if (s12 != expectedStr8) {
-            panic error("Assertion error", expected = expectedStr8, found = s12);
-        }
+        test:assertEquals(s12, expectedStr8, "XML interpolation with query failed");
     }
 }
 
@@ -301,14 +277,10 @@ function testAddAttributeToDefaultNS() {
     //adding attribute with default namespace
     xAttr["{http://sample.com/wso2/c1}foo1"] = "bar1";
     string s = x1.toString();
-    string expectedStr = "<root xmlns=\"http://sample.com/wso2/c1\" xmlns:ns3=\"http://sample.com/wso2/f\" foo1=\"bar1\"/>";
-    if (s != expectedStr) {
-        panic error("Assertion error", expected = expectedStr, found=s);
-    }
+    string expectedStr = string `<root xmlns="http://sample.com/wso2/c1" xmlns:ns3="http://sample.com/wso2/f" foo1="bar1"/>`;
+    test:assertEquals(s, expectedStr, "XML add attribute with default namespace failed");
+    
     s = xAttr.toString();
-    expectedStr = "{\"{http://www.w3.org/2000/xmlns/}xmlns\":\"http://sample.com/wso2/c1\"," +
-    "\"{http://www.w3.org/2000/xmlns/}ns3\":\"http://sample.com/wso2/f\",\"{http://sample.com/wso2/c1}foo1\":\"bar1\"}";
-        if (s != expectedStr) {
-        panic error("Assertion error", expected = expectedStr, found=s);
-    }
+    expectedStr = string `{"{http://www.w3.org/2000/xmlns/}xmlns":"http://sample.com/wso2/c1","{http://www.w3.org/2000/xmlns/}ns3":"http://sample.com/wso2/f","{http://sample.com/wso2/c1}foo1":"bar1"}`;
+    test:assertEquals(s, expectedStr, "XML add attribute with default namespace failed");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals-with-namespaces.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals-with-namespaces.bal
@@ -147,7 +147,7 @@ function getXML() returns xml {
 }
 
 function XMLWithDefaultNamespaceToString() returns string {
-    xml x = xml `<Order xmlns="http://acme.company" xmlns:acme="http://acme.company">
+    xml x = xml `<Order xmlns="http://acme.company" xmlns:acme="http://acme.company.nondefault">
         <OrderLines>
             <OrderLine acme:lineNo="334" itemCode="334-2"></OrderLine>
         </OrderLines>
@@ -292,5 +292,23 @@ function testXmlInterpolationWithQuery() returns error? {
         if (s12 != expectedStr8) {
             panic error("Assertion error", expected = expectedStr8, found = s12);
         }
+    }
+}
+
+function testAddAttributeToDefaultNS() {
+    xml x1 = xml `<root xmlns="http://sample.com/wso2/c1" xmlns:ns3="http://sample.com/wso2/f"></root>`;
+    var xAttr = let var x2 = <'xml:Element>x1 in x2.getAttributes();
+    //adding attribute with default namespace
+    xAttr["{http://sample.com/wso2/c1}foo1"] = "bar1";
+    string s = x1.toString();
+    string expectedStr = "<root xmlns=\"http://sample.com/wso2/c1\" xmlns:ns3=\"http://sample.com/wso2/f\" foo1=\"bar1\"/>";
+    if (s != expectedStr) {
+        panic error("Assertion error", expected = expectedStr, found=s);
+    }
+    s = xAttr.toString();
+    expectedStr = "{\"{http://www.w3.org/2000/xmlns/}xmlns\":\"http://sample.com/wso2/c1\"," +
+    "\"{http://www.w3.org/2000/xmlns/}ns3\":\"http://sample.com/wso2/f\",\"{http://sample.com/wso2/c1}foo1\":\"bar1\"}";
+        if (s != expectedStr) {
+        panic error("Assertion error", expected = expectedStr, found=s);
     }
 }


### PR DESCRIPTION
## Purpose
$subject

Fixes #40373
Fixes #41521 

## Approach
- Fix checking 'xmlns` as the default NS key when writing XML value with default namespace attributes.
- Fixed wrong class casting for whitespace values at the start of the XML query
- Removed `disableOnOldParser` test group as it is no-longer used

## Samples
```ballerina
import ballerina/io;

xmlns "http://sample.com/wso2/c1";

public function main() {
    xml x1 = xml `<root xmlns:ns3="http://sample.com/wso2/f"></root>`;
    var xAttr = let var x2 = <'xml:Element>x1 in x2.getAttributes();
    //adding attribute with default namespace
    xAttr["{http://sample.com/wso2/c1}foo1"] = "bar1";
    io:println(x1);
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
