### PR TITLE
Provide completions after a variable resource path parameter in a resource access action

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3823,6 +3823,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         }
 
         if (resourceFunctions.size() == 0) {
+            checkExpr(resourceAccessInvocation.resourceAccessPathSegments, data);
             dlog.error(resourceAccessInvocation.resourceAccessPathSegments.pos, DiagnosticErrorCode.UNDEFINED_RESOURCE,
                     lhsExprType);
             data.resultType = symTable.semanticError;
@@ -3833,10 +3834,12 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         resourceFunctions.removeIf(func -> !func.accessor.value.equals(resourceAccessInvocation.name.value));
         int targetResourceFuncCount = resourceFunctions.size();
         if (targetResourceFuncCount == 0) {
+            checkExpr(resourceAccessInvocation.resourceAccessPathSegments, data);
             dlog.error(resourceAccessInvocation.name.pos,
                     DiagnosticErrorCode.UNDEFINED_RESOURCE_METHOD, resourceAccessInvocation.name, lhsExprType);
             data.resultType = symTable.semanticError;
         } else if (targetResourceFuncCount > 1) {
+            checkExpr(resourceAccessInvocation.resourceAccessPathSegments, data);
             dlog.error(resourceAccessInvocation.pos, DiagnosticErrorCode.AMBIGUOUS_RESOURCE_ACCESS_NOT_YET_SUPPORTED);
             data.resultType = symTable.semanticError;
         } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3823,10 +3823,9 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         }
 
         if (resourceFunctions.size() == 0) {
-            checkExpr(resourceAccessInvocation.resourceAccessPathSegments, data);
-            dlog.error(resourceAccessInvocation.resourceAccessPathSegments.pos, DiagnosticErrorCode.UNDEFINED_RESOURCE,
-                    lhsExprType);
-            data.resultType = symTable.semanticError;
+            handleResourceAccessError(resourceAccessInvocation.resourceAccessPathSegments,
+                    resourceAccessInvocation.resourceAccessPathSegments.pos, DiagnosticErrorCode.UNDEFINED_RESOURCE,
+                    data, lhsExprType);
             return;
         }
 
@@ -3834,14 +3833,12 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         resourceFunctions.removeIf(func -> !func.accessor.value.equals(resourceAccessInvocation.name.value));
         int targetResourceFuncCount = resourceFunctions.size();
         if (targetResourceFuncCount == 0) {
-            checkExpr(resourceAccessInvocation.resourceAccessPathSegments, data);
-            dlog.error(resourceAccessInvocation.name.pos,
-                    DiagnosticErrorCode.UNDEFINED_RESOURCE_METHOD, resourceAccessInvocation.name, lhsExprType);
-            data.resultType = symTable.semanticError;
+            handleResourceAccessError(resourceAccessInvocation.resourceAccessPathSegments,
+                    resourceAccessInvocation.name.pos, DiagnosticErrorCode.UNDEFINED_RESOURCE_METHOD, data,
+                    resourceAccessInvocation.name, lhsExprType);
         } else if (targetResourceFuncCount > 1) {
-            checkExpr(resourceAccessInvocation.resourceAccessPathSegments, data);
-            dlog.error(resourceAccessInvocation.pos, DiagnosticErrorCode.AMBIGUOUS_RESOURCE_ACCESS_NOT_YET_SUPPORTED);
-            data.resultType = symTable.semanticError;
+            handleResourceAccessError(resourceAccessInvocation.resourceAccessPathSegments, resourceAccessInvocation.pos,
+                    DiagnosticErrorCode.AMBIGUOUS_RESOURCE_ACCESS_NOT_YET_SUPPORTED, data, lhsExprType);
         } else {
             BResourceFunction targetResourceFunc = resourceFunctions.get(0);
             checkExpr(resourceAccessInvocation.resourceAccessPathSegments,
@@ -3850,6 +3847,14 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             resourceAccessInvocation.targetResourceFunc = targetResourceFunc;
             checkResourceAccessParamAndReturnType(resourceAccessInvocation, targetResourceFunc, data);
         }
+    }
+
+    private void handleResourceAccessError(BLangListConstructorExpr resourceAccessPathSegments,
+                                           Location diagnosticLocation, DiagnosticErrorCode errorCode,
+                                           AnalyzerData data, Object... dlogArgs) {
+        checkExpr(resourceAccessPathSegments, data);
+        dlog.error(diagnosticLocation, errorCode, dlogArgs);
+        data.resultType = symTable.semanticError;
     }
 
     private BTupleType getResourcePathType(List<BResourcePathSegmentSymbol> pathSegmentSymbols) {

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config44.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config44.json
@@ -1,0 +1,40 @@
+{
+  "position": {
+    "line": 7,
+    "character": 25
+  },
+  "source": "action_node_context/source/client_resource_access_action_source37.bal",
+  "description": "",
+  "items": [
+    {
+      "label": "/third",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` second"
+        }
+      },
+      "sortText": "C",
+      "filterText": "third|get",
+      "insertText": "/third;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 24
+            },
+            "end": {
+              "line": 7,
+              "character": 25
+            }
+          },
+          "newText": ""
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config44.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config44.json
@@ -4,7 +4,7 @@
     "character": 25
   },
   "source": "action_node_context/source/client_resource_access_action_source37.bal",
-  "description": "",
+  "description": "Test completions after a variable resource path",
   "items": [
     {
       "label": "/third",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source37.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/source/client_resource_access_action_source37.bal
@@ -1,0 +1,9 @@
+client class MyClient {
+    resource function get first/[string second]/third() {}
+}
+
+public function main() {
+    string someVar = "check";
+    MyClient cl = new;
+    cl->/first/[someVar]/;
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfInResourceAccessActionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfInResourceAccessActionTest.java
@@ -30,6 +30,8 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
 import static org.testng.Assert.assertEquals;
@@ -60,6 +62,14 @@ public class TypeOfInResourceAccessActionTest {
         return new Object[][]{
                 {42, 23, 42, 54, UNION},
                 {42, 23, 42, 32, TYPE_REFERENCE},
+                {110, 9, 110, 12, STRING},
+                {111, 9, 111, 14, STRING},
+                {111, 17, 111, 25, STRING},
+                {112, 17, 111, 19, STRING},
+                {113, 15, 113, 19, INT},
+                {114, 15, 114, 16, INT},
+                {115, 9, 115, 14, STRING},
+                {115, 17, 115, 24, STRING},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/actions/resource_access_action.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/actions/resource_access_action.bal
@@ -91,3 +91,27 @@ public function testPathSegmentOfAmbiguousResourceFunction() {
    Bam bam = new;
    bam->/path1/path2.post();
 }
+
+client class Resc {
+    resource function post user() {}
+
+    resource function post [string name]() {}
+
+    resource function get sports/[string name]() {}
+
+    resource function get pets/[int id]() {}
+
+    resource function get sports/[string name]/info () {}
+}
+
+function testTypeOfResourceSegments() {
+    Resc cl = new;
+    string myString = "";
+    int myInt = 0;
+    cl->/user.post();
+    cl->/sports/[myString]();
+    cl->/sports/["A"]();
+    cl->/pets/[myInt]();
+    cl->/pets/[1]();
+    cl->/sports/[myString]/
+}


### PR DESCRIPTION
## Purpose
$title.

Fixes #41623

## Approach
The current implementation of the type checker does not resolve the variable types of the path parameters if it encounters an error. The PR resolves the variable types despite the error conditions.

## Samples

Completions are now shown after a resource path parameter with a variable, as shown below.

<img width="381" alt="image" src="https://github.com/ballerina-platform/ballerina-lang/assets/59343084/2094796f-60fd-49c8-a003-b92492448756">


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
