### PR TITLE
[2201.8.x] Fix value conversion error for inline record creation with special characters

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -34,6 +34,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
@@ -42,6 +43,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
+import org.wso2.ballerinalang.util.Flags;
 import org.wso2.ballerinalang.util.Lists;
 
 import java.util.ArrayList;
@@ -190,6 +192,9 @@ public class JvmDesugarPhase {
     private static void encodeTypeDefIdentifiers(List<BIRTypeDefinition> typeDefs,
                                                  HashMap<String, String> encodedVsInitialIds) {
         for (BIRTypeDefinition typeDefinition : typeDefs) {
+            if (Symbols.isFlagOn(typeDefinition.type.flags, Flags.ANONYMOUS)) {
+                typeDefinition.name = Names.fromString(Utils.unescapeBallerina(typeDefinition.name.value));
+            }
             typeDefinition.type.tsymbol.name = Names.fromString(encodeNonFunctionIdentifier(
                     typeDefinition.type.tsymbol.name.value, encodedVsInitialIds));
             typeDefinition.internalName =

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -379,7 +379,7 @@ public class LangLibValueTest {
                 "testConvertToUnionWithAmbiguousMemberTypes", "testConvertingToReferenceTypes",
                 "testCloneWithTypeTableToAnydata", "testUnionNestedTypeConversionErrors",
                 "testCloneWithTypeToUnionOfTypeReference", "testCloneWithTypeToTableNegative",
-                "testCloneWithTypeToRecordWithIntersectingUnionMembers"
+                "testCloneWithTypeToRecordWithIntersectingUnionMembers", "testCloneWithTypeToRecordWithSpecialChars"
         };
     }
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -4646,6 +4646,40 @@ function testLast() {
     assertTrue([] == value:last(ar1, ar));
 }
 
+
+public type Copybook record {
+    DFHCOMMAREA DFHCOMMAREA?;
+};
+
+public type DFHCOMMAREA record {
+    record {
+        string MI\-HDR\-VERSION?;
+        string MI\-HDR\-MSGID?;
+        string MI\-HDR\-LOGGINGID?;
+        record {
+            string MI\-HDR\-REPLYQMGR?;
+        }[2] MI\-HDR\-REPLYSTACK?;
+    } BROKER\-MESSAGE\-AREA?;
+};
+
+function testCloneWithTypeToRecordWithSpecialChars() {
+    string s = string `{
+    "DFHCOMMAREA": {
+        "BROKER-MESSAGE-AREA": {
+            "MI-HDR-VERSION": "2",
+            "MI-HDR-MSGID":"3238763233323598798798712321187612",
+            "MI-HDR-LOGGINGID": "Z5118761-Z"
+        }
+    }
+    }`;
+    json rec = checkpanic value:fromJsonString(s);
+    map<json> mapJson = checkpanic rec.ensureType();
+    Copybook|error dfhcommarea = mapJson.cloneWithType();
+    assertTrue(dfhcommarea is Copybook);
+    Copybook cb =  checkpanic dfhcommarea.ensureType();
+    assertEquality(cb.DFHCOMMAREA?.BROKER\-MESSAGE\-AREA.toString(), string `{"MI-HDR-VERSION":"2","MI-HDR-MSGID":"3238763233323598798798712321187612","MI-HDR-LOGGINGID":"Z5118761-Z"}`);
+}
+
 type AssertionError distinct error;
 
 const ASSERTION_ERROR_REASON = "AssertionError";


### PR DESCRIPTION
## Purpose
$subject

Fixes #41633 

## Approach
As we use the decoded identifiers in the value conversions, the generated record value creators should have the same representation in the switch cases. This PR fixes it by using the `Utils.unescapeBallerina()` API.

## Samples
```ballerina
import ballerina/io;

public type Copybook record {
    DFHCOMMAREA DFHCOMMAREA?;
};

public type DFHCOMMAREA record {
    record {
        string MI\-HDR\-VERSION?;
        string MI\-HDR\-MSGID?;
        string MI\-HDR\-LOGGINGID?;
        record {
            string MI\-HDR\-REPLYQMGR?;
        }[2] MI\-HDR\-REPLYSTACK?;
    } BROKER\-MESSAGE\-AREA?;
};

public function main() returns error? {
    string s = string `{
    "DFHCOMMAREA": {
        "BROKER-MESSAGE-AREA": {
            "MI-HDR-VERSION": "2",
            "MI-HDR-MSGID":"3238763233323598798798712321187612",
            "MI-HDR-LOGGINGID": "Z5118761-Z"
        }
    }
    }`;
    json rec = checkpanic value:fromJsonString(s);
    map<json> mapJson = check rec.ensureType();
    Copybook dfhcommarea = check mapJson.cloneWithType();
    io:println(dfhcommarea.DFHCOMMAREA?.BROKER\-MESSAGE\-AREA);
}
```
## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
