### PR TITLE
[2201.8.x] Inlcude service name suffix via env variable in observability

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObservabilityConstants.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObservabilityConstants.java
@@ -28,7 +28,7 @@ public class ObservabilityConstants {
 
     private ObservabilityConstants() {
     }
-    public static final String BAL_OBSERVE_SERVICE_NAME_SUFFIX = "BAL_OBSERVE_SERVICE_NAME_SUFFIX";
+    static final String BAL_OBSERVE_SERVICE_NAME_SUFFIX = "BAL_OBSERVE_SERVICE_NAME_SUFFIX";
 
     public static final String KEY_OBSERVER_CONTEXT = "__observer_context__";
     public static final String DEFAULT_SERVICE_NAME = "Ballerina";

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObservabilityConstants.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObservabilityConstants.java
@@ -28,6 +28,7 @@ public class ObservabilityConstants {
 
     private ObservabilityConstants() {
     }
+    public static final String BAL_OBSERVE_SERVICE_NAME_SUFFIX = "BAL_OBSERVE_SERVICE_NAME_SUFFIX";
 
     public static final String KEY_OBSERVER_CONTEXT = "__observer_context__";
     public static final String DEFAULT_SERVICE_NAME = "Ballerina";

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -38,7 +38,26 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BALLERINA_BUILTIN_PKG_PREFIX;
-import static io.ballerina.runtime.observability.ObservabilityConstants.*;
+import static io.ballerina.runtime.observability.ObservabilityConstants.BAL_OBSERVE_SERVICE_NAME_SUFFIX;
+import static io.ballerina.runtime.observability.ObservabilityConstants.CHECKPOINT_EVENT_NAME;
+import static io.ballerina.runtime.observability.ObservabilityConstants.DEFAULT_SERVICE_NAME;
+import static io.ballerina.runtime.observability.ObservabilityConstants.KEY_OBSERVER_CONTEXT;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_ENTRYPOINT_FUNCTION_MODULE;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_ENTRYPOINT_FUNCTION_NAME;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_ENTRYPOINT_RESOURCE_ACCESSOR;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_ENTRYPOINT_SERVICE_NAME;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_IS_SRC_CLIENT_REMOTE;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_IS_SRC_MAIN_FUNCTION;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_IS_SRC_SERVICE_REMOTE;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_IS_SRC_SERVICE_RESOURCE;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_IS_SRC_WORKER;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_SRC_FUNCTION_NAME;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_SRC_MODULE;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_SRC_OBJECT_NAME;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_SRC_POSITION;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_SRC_RESOURCE_ACCESSOR;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_SRC_RESOURCE_PATH;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_TRUE_VALUE;
 
 /**
  * Util class used for observability.

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -38,25 +38,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BALLERINA_BUILTIN_PKG_PREFIX;
-import static io.ballerina.runtime.observability.ObservabilityConstants.CHECKPOINT_EVENT_NAME;
-import static io.ballerina.runtime.observability.ObservabilityConstants.DEFAULT_SERVICE_NAME;
-import static io.ballerina.runtime.observability.ObservabilityConstants.KEY_OBSERVER_CONTEXT;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_ENTRYPOINT_FUNCTION_MODULE;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_ENTRYPOINT_FUNCTION_NAME;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_ENTRYPOINT_RESOURCE_ACCESSOR;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_ENTRYPOINT_SERVICE_NAME;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_IS_SRC_CLIENT_REMOTE;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_IS_SRC_MAIN_FUNCTION;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_IS_SRC_SERVICE_REMOTE;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_IS_SRC_SERVICE_RESOURCE;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_IS_SRC_WORKER;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_SRC_FUNCTION_NAME;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_SRC_MODULE;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_SRC_OBJECT_NAME;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_SRC_POSITION;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_SRC_RESOURCE_ACCESSOR;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_SRC_RESOURCE_PATH;
-import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_TRUE_VALUE;
+import static io.ballerina.runtime.observability.ObservabilityConstants.*;
 
 /**
  * Util class used for observability.
@@ -189,7 +171,7 @@ public class ObserveUtils {
         }
 
         String serviceNameValue = serviceName.getValue();
-        String serviceNameSuffix = System.getenv("SERVICE_NAME_SUFFIX");
+        String serviceNameSuffix = System.getenv(BAL_OBSERVE_SERVICE_NAME_SUFFIX);
         if (serviceNameSuffix != null && !serviceNameSuffix.isEmpty()) {
             observerContext.setServiceName(serviceNameValue + "-" + serviceNameSuffix);
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -187,7 +187,14 @@ public class ObserveUtils {
                 observerContext.setEntrypointResourceAccessor(resourceAccessor.getValue());
             }
         }
-        observerContext.setServiceName(serviceName.getValue());
+
+        String serviceNameValue = serviceName.getValue();
+        String serviceNameSuffix = System.getenv("SERVICE_NAME_SUFFIX");
+        if (serviceNameSuffix != null && !serviceNameSuffix.isEmpty()) {
+            observerContext.setServiceName(serviceNameValue + "-" + serviceNameSuffix);
+        }
+
+        observerContext.setServiceName(serviceNameValue);
 
         if (isResource) {
             observerContext.setOperationName(resourceAccessor.getValue() + " " + resourcePathOrFunction.getValue());


### PR DESCRIPTION
## Purpose
As a user requirement, we need to differentiate traces from different instances with same services (service names) when we observe them in a tracer provider such as Jaeger, Zipkin & New Relic. 

Fixes #41621

## Approach
Add a suffix to the service name in observability via an environment variable. 

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
