### PR TITLE
Improved the order of completions provided for resource access paths

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ResourcePathCompletionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ResourcePathCompletionUtil.java
@@ -216,7 +216,8 @@ public class ResourcePathCompletionUtil {
                 new ResourceAccessPathPart(computedInsertText, computedSignature);
         if (context.currentSemanticModel().isPresent() &&
                 context.currentSemanticModel().get().types().STRING.subtypeOf(typeSymbol)) {
-            resourceAccessPathPart.namedPathSignature = "<path>";
+            resourceAccessPathPart.namedPathSignature =  pathParameterSymbol.getName().isPresent() ?
+                    "<" + pathParameterSymbol.getName().get() + ">" : "<path>";;
             resourceAccessPathPart.namedPathInsertText = "${" + placeHolderIndex + ":" + "path" + "}";
             resourceAccessPathPart.computedPathInsertText = "[${" + placeHolderIndex + ":" + "\"path\"" + "}]";
             resourceAccessPathPart.isStringPathPram = true;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ResourcePathCompletionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ResourcePathCompletionUtil.java
@@ -216,8 +216,8 @@ public class ResourcePathCompletionUtil {
                 new ResourceAccessPathPart(computedInsertText, computedSignature);
         if (context.currentSemanticModel().isPresent() &&
                 context.currentSemanticModel().get().types().STRING.subtypeOf(typeSymbol)) {
-            resourceAccessPathPart.namedPathSignature =  pathParameterSymbol.getName().isPresent() ?
-                    "<" + pathParameterSymbol.getName().get() + ">" : "<path>";;
+            resourceAccessPathPart.namedPathSignature = "<" +
+                    (pathParameterSymbol.getName().isPresent() ? pathParameterSymbol.getName().get() : "path") + ">";
             resourceAccessPathPart.namedPathInsertText = "${" + placeHolderIndex + ":" + "path" + "}";
             resourceAccessPathPart.computedPathInsertText = "[${" + placeHolderIndex + ":" + "\"path\"" + "}]";
             resourceAccessPathPart.isStringPathPram = true;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -90,6 +90,7 @@ import org.wso2.ballerinalang.compiler.util.Names;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -543,6 +544,7 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
         Predicate<Symbol> symbolFilter = getExpressionContextSymbolFilter();
         List<Symbol> filteredList = visibleSymbols.stream()
                 .filter(symbolFilter)
+                .sorted(Comparator.comparing(symbol -> symbol.getName().get()))
                 .collect(Collectors.toList());
         completionItems.addAll(this.getCompletionItemList(filteredList, context));
         completionItems.addAll(this.getBasicAndOtherTypeCompletions(context));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AsyncSendActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AsyncSendActionNodeContext.java
@@ -48,8 +48,10 @@ public class AsyncSendActionNodeContext extends RightArrowActionNodeContext<Asyn
     @Override
     public void sort(BallerinaCompletionContext context, AsyncSendActionNode node, 
                      List<LSCompletionItem> completionItems) {
+        int rankOffset = 1;
         for (LSCompletionItem completionItem : completionItems) {
-            sortByAssignability(context, completionItem, SortingUtil.toRank(context, completionItem));
+            sortByAssignability(context, completionItem, SortingUtil.toRank(context, completionItem, rankOffset));
+            rankOffset++;
         }
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AsyncSendActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AsyncSendActionNodeContext.java
@@ -48,10 +48,9 @@ public class AsyncSendActionNodeContext extends RightArrowActionNodeContext<Asyn
     @Override
     public void sort(BallerinaCompletionContext context, AsyncSendActionNode node, 
                      List<LSCompletionItem> completionItems) {
-        int rankOffset = 1;
-        for (LSCompletionItem completionItem : completionItems) {
-            sortByAssignability(context, completionItem, SortingUtil.toRank(context, completionItem, rankOffset));
-            rankOffset++;
+        for (int i = 0; i < completionItems.size(); i++) {
+            LSCompletionItem completionItem = completionItems.get(i);
+            sortByAssignability(context, completionItem, SortingUtil.toRank(context, completionItem, i + 1));
         }
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ClientResourceAccessActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ClientResourceAccessActionNodeContext.java
@@ -212,8 +212,8 @@ public class ClientResourceAccessActionNodeContext
         }
 
         Optional<TypeSymbol> parameterSymbol = getParameterTypeSymbol(context);
-        int rankOffset = 1;
-        for (LSCompletionItem completionItem : completionItems) {
+        for (int i = 0; i < completionItems.size(); i++) {
+            LSCompletionItem completionItem = completionItems.get(i);
             if (completionItem.getType() == LSCompletionItem.CompletionItemType.NAMED_ARG) {
                 sortNamedArgCompletionItem(context, completionItem);
             } else if (parameterSymbol.isEmpty()) {
@@ -224,10 +224,9 @@ public class ClientResourceAccessActionNodeContext
                         symbolCompletionItem.getSymbol().get().kind() == SymbolKind.RESOURCE_METHOD) {
                     completionItem.getCompletionItem().setSortText(
                             SortingUtil.genSortTextByAssignability(context, completionItem, parameterSymbol.get()) +
-                                    SortingUtil.genSortText(rankOffset));
+                                    SortingUtil.genSortText(i + 1));
                 }
                 sortDefaultCompletionItem(context, parameterSymbol.get(), completionItem);
-                rankOffset++;
             } else {
                 sortDefaultCompletionItem(context, parameterSymbol.get(), completionItem);
             }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/InvocationNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/InvocationNodeContextProvider.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.api.symbols.ParameterKind;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
-import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
@@ -41,7 +40,6 @@ import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.NamedArgCompletionItem;
-import org.ballerinalang.langserver.completions.SymbolCompletionItem;
 import org.ballerinalang.langserver.completions.builder.NamedArgCompletionItemBuilder;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.SortingUtil;
@@ -74,63 +72,69 @@ public class InvocationNodeContextProvider<T extends Node> extends AbstractCompl
 
     @Override
     public void sort(BallerinaCompletionContext context, T node, List<LSCompletionItem> completionItems) {
-        if ((node.kind() == SyntaxKind.EXPLICIT_NEW_EXPRESSION && 
-                !TypeResolverUtil.isInNewExpressionParameterContext((ExplicitNewExpressionNode) node, 
-                        context.getCursorPositionInTree())) 
+        if ((node.kind() == SyntaxKind.EXPLICIT_NEW_EXPRESSION &&
+                !TypeResolverUtil.isInNewExpressionParameterContext((ExplicitNewExpressionNode) node,
+                        context.getCursorPositionInTree()))
                 || (node.kind() == SyntaxKind.IMPLICIT_NEW_EXPRESSION &&
-                        !TypeResolverUtil.isInNewExpressionParameterContext(
-                                (ImplicitNewExpressionNode) node, context.getCursorPositionInTree()))) {
+                !TypeResolverUtil.isInNewExpressionParameterContext(
+                        (ImplicitNewExpressionNode) node, context.getCursorPositionInTree()))) {
             super.sort(context, node, completionItems);
             return;
         }
 
+        Optional<TypeSymbol> parameterSymbol = getParameterTypeSymbol(context);
+        for (LSCompletionItem completionItem : completionItems) {
+            if (completionItem.getType() == LSCompletionItem.CompletionItemType.NAMED_ARG) {
+                sortNamedArgCompletionItem(context, completionItem);
+            } else if (parameterSymbol.isEmpty()) {
+                sortParameterlessCompletionItem(context, completionItem);
+            } else {
+                sortDefaultCompletionItem(context, parameterSymbol.get(), completionItem);
+            }
+        }
+    }
+
+    protected static Optional<TypeSymbol> getParameterTypeSymbol(BallerinaCompletionContext context) {
         Optional<TypeSymbol> parameterSymbol = Optional.empty();
         if (context.currentSemanticModel().isPresent() && context.currentDocument().isPresent()) {
             parameterSymbol = context.currentSemanticModel().get().expectedType(context.currentDocument().get(),
                     LinePosition.from(context.getCursorPosition().getLine(),
                             context.getCursorPosition().getCharacter()));
         }
+        return parameterSymbol;
+    }
 
-        int rankOffset = 1;
-        for (LSCompletionItem completionItem : completionItems) {
-            if (completionItem.getType() == LSCompletionItem.CompletionItemType.NAMED_ARG) {
-                NamedArgCompletionItem argCompletionItem = (NamedArgCompletionItem) completionItem;
-                Either<ParameterSymbol, RecordFieldSymbol> symbol = argCompletionItem.getParameterSymbol();
-                String sortText;
-                if (symbol.isRight()) {
-                    RecordFieldSymbol right = symbol.getRight();
-                    if (right.isOptional()) {
-                        sortText = SortingUtil.genSortText(1) + SortingUtil.genSortText(3);
-                    } else if (right.hasDefaultValue()) {
-                        sortText = SortingUtil.genSortText(1) + SortingUtil.genSortText(2);
-                    } else {
-                        sortText = SortingUtil.genSortText(1) + SortingUtil.genSortText(1);
-                    }
-                } else {
-                    sortText = SortingUtil.genSortText(1) +
-                            SortingUtil.genSortText(SortingUtil.toRank(context, completionItem));
-                }
-                completionItem.getCompletionItem().setSortText(sortText);
-            } else if (parameterSymbol.isEmpty()) {
-                completionItem.getCompletionItem().setSortText(SortingUtil.genSortText(
-                        SortingUtil.toRank(context, completionItem)));
-            } else if (completionItem.getType() == LSCompletionItem.CompletionItemType.SYMBOL) {
-                SymbolCompletionItem symbolCompletionItem = (SymbolCompletionItem) completionItem;
-                if (symbolCompletionItem.getSymbol().isPresent() &&
-                        symbolCompletionItem.getSymbol().get().kind() == SymbolKind.RESOURCE_METHOD) {
-                    completionItem.getCompletionItem().setSortText(
-                            SortingUtil.genSortTextByAssignability(context, completionItem, parameterSymbol.get()) +
-                                    SortingUtil.genSortText(rankOffset));
-                }
-                completionItem.getCompletionItem().setSortText(
-                        SortingUtil.genSortTextByAssignability(context, completionItem, parameterSymbol.get()));
+    protected static void sortNamedArgCompletionItem(BallerinaCompletionContext context,
+                                                     LSCompletionItem completionItem) {
+        NamedArgCompletionItem argCompletionItem = (NamedArgCompletionItem) completionItem;
+        Either<ParameterSymbol, RecordFieldSymbol> symbol = argCompletionItem.getParameterSymbol();
+        String sortText;
+        if (symbol.isRight()) {
+            RecordFieldSymbol right = symbol.getRight();
+            if (right.isOptional()) {
+                sortText = SortingUtil.genSortText(1) + SortingUtil.genSortText(3);
+            } else if (right.hasDefaultValue()) {
+                sortText = SortingUtil.genSortText(1) + SortingUtil.genSortText(2);
             } else {
-                completionItem.getCompletionItem().setSortText(
-                        SortingUtil.genSortTextByAssignability(context, completionItem, parameterSymbol.get()));
+                sortText = SortingUtil.genSortText(1) + SortingUtil.genSortText(1);
             }
-            rankOffset++;
+        } else {
+            sortText = SortingUtil.genSortText(1) +
+                    SortingUtil.genSortText(SortingUtil.toRank(context, completionItem));
         }
+        completionItem.getCompletionItem().setSortText(sortText);
+    }
 
+    protected static void sortParameterlessCompletionItem(BallerinaCompletionContext context,
+                                                          LSCompletionItem completionItem) {
+        completionItem.getCompletionItem().setSortText(SortingUtil.genSortText(
+                SortingUtil.toRank(context, completionItem)));
+    }
+
+    protected static void sortDefaultCompletionItem(BallerinaCompletionContext context, TypeSymbol parameterSymbol,
+                                                    LSCompletionItem completionItem) {
+        completionItem.getCompletionItem().setSortText(
+                SortingUtil.genSortTextByAssignability(context, completionItem, parameterSymbol));
     }
 
     protected List<LSCompletionItem> getNamedArgCompletionItems(BallerinaCompletionContext context,

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config1.json
@@ -16,7 +16,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CD",
       "filterText": "remote1",
       "insertText": "remote1()",
       "insertTextFormat": "Snippet"
@@ -31,7 +31,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `string`   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CE",
       "filterText": "path1|get",
       "insertText": "/path1;",
       "insertTextFormat": "Snippet"
@@ -46,7 +46,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` a  \n- `int` b"
         }
       },
-      "sortText": "CC",
+      "sortText": "CF",
       "filterText": "post",
       "insertText": "/.post(${1});",
       "insertTextFormat": "Snippet",
@@ -65,13 +65,13 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string[]` ids"
         }
       },
-      "sortText": "CC",
+      "sortText": "CG",
       "filterText": "get",
       "insertText": "/[${1:\"path\"}];",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "/<path>",
+      "label": "/<ids>",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -80,7 +80,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string[]` ids"
         }
       },
-      "sortText": "CC",
+      "sortText": "CH",
       "filterText": "get",
       "insertText": "/${1:path};",
       "insertTextFormat": "Snippet"
@@ -95,13 +95,13 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` id1"
         }
       },
-      "sortText": "CC",
+      "sortText": "CI",
       "filterText": "path1|get",
       "insertText": "/path1/[${1:\"path\"}];",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "/path1/<path>",
+      "label": "/path1/<id1>",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -110,7 +110,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` id1"
         }
       },
-      "sortText": "CC",
+      "sortText": "CJ",
       "filterText": "path1|get",
       "insertText": "/path1/${1:path};",
       "insertTextFormat": "Snippet"
@@ -125,13 +125,13 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` id1  \n  \n**Return** `int`   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CK",
       "filterText": "path1|path2|get",
       "insertText": "/path1/[${1:\"path\"}]/path2;",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "/path1/<path>/path2",
+      "label": "/path1/<id1>/path2",
       "kind": "Function",
       "detail": "int",
       "documentation": {
@@ -140,7 +140,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` id1  \n  \n**Return** `int`   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CL",
       "filterText": "path1|path2|get",
       "insertText": "/path1/${1:path}/path2;",
       "insertTextFormat": "Snippet"
@@ -155,7 +155,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` id1  \n- `string[]` ids  \n- `string` b  \n- `string[]` ids2"
         }
       },
-      "sortText": "CC",
+      "sortText": "CM",
       "filterText": "path1|path2|post",
       "insertText": "/path1/[${1:\"path\"}]/path2/[${2:\"path\"}].post(${3});",
       "insertTextFormat": "Snippet",
@@ -165,7 +165,7 @@
       }
     },
     {
-      "label": "/path1/<path>/path2/<path>.post(string b, string... ids2)",
+      "label": "/path1/<id1>/path2/<ids>.post(string b, string... ids2)",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -174,7 +174,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` id1  \n- `string[]` ids  \n- `string` b  \n- `string[]` ids2"
         }
       },
-      "sortText": "CC",
+      "sortText": "CN",
       "filterText": "path1|path2|post",
       "insertText": "/path1/${1:path}/path2/${2:path}.post(${3});",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config10.json
@@ -37,7 +37,7 @@
       ]
     },
     {
-      "label": "/<path>",
+      "label": "/<ids>",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -131,7 +131,7 @@
       }
     },
     {
-      "label": "/path2/<path>.post(string b, string... ids2)",
+      "label": "/path2/<ids>.post(string b, string... ids2)",
       "kind": "Function",
       "detail": "()",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config11.json
@@ -37,7 +37,7 @@
       ]
     },
     {
-      "label": "/<path>",
+      "label": "/<ids>",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -131,7 +131,7 @@
       }
     },
     {
-      "label": "/path2/<path>.post(string b, string... ids2)",
+      "label": "/path2/<ids>.post(string b, string... ids2)",
       "kind": "Function",
       "detail": "()",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config12.json
@@ -37,7 +37,7 @@
       ]
     },
     {
-      "label": "/<path>",
+      "label": "/<ids>",
       "kind": "Function",
       "detail": "()",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config13.json
@@ -101,7 +101,7 @@
       ]
     },
     {
-      "label": "/<path>",
+      "label": "/<ids>",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -161,7 +161,7 @@
       ]
     },
     {
-      "label": "/path1/<path>",
+      "label": "/path1/<id1>",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -221,7 +221,7 @@
       ]
     },
     {
-      "label": "/path1/<path>/path2",
+      "label": "/path1/<id1>/path2",
       "kind": "Function",
       "detail": "int",
       "documentation": {
@@ -285,7 +285,7 @@
       }
     },
     {
-      "label": "/path1/<path>/path2/<path>.post(string b, string... ids2)",
+      "label": "/path1/<id1>/path2/<ids>.post(string b, string... ids2)",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -353,7 +353,7 @@
       }
     },
     {
-      "label": "/path1/<path>/path3.post(string b, string... ids2)",
+      "label": "/path1/<id1>/path3.post(string b, string... ids2)",
       "kind": "Function",
       "detail": "()",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config15.json
@@ -22,7 +22,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "/<path>",
+      "label": "/<ids>",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -56,7 +56,7 @@
       }
     },
     {
-      "label": "/<path>.post(string b, string... ids2)",
+      "label": "/<ids>.post(string b, string... ids2)",
       "kind": "Function",
       "detail": "()",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config16.json
@@ -37,7 +37,7 @@
       ]
     },
     {
-      "label": "/<path>",
+      "label": "/<ids>",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -101,7 +101,7 @@
       }
     },
     {
-      "label": "/<path>.post(string b, string... ids2)",
+      "label": "/<ids>.post(string b, string... ids2)",
       "kind": "Function",
       "detail": "()",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config21.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config21.json
@@ -41,7 +41,7 @@
       }
     },
     {
-      "label": "/path1/<path>/path2/<path>.post(string str, string... ids2)",
+      "label": "/path1/<id1>/path2/<ids>.post(string str, string... ids2)",
       "kind": "Function",
       "detail": "module1:Response",
       "documentation": {
@@ -143,7 +143,7 @@
       }
     },
     {
-      "label": "/path4/<path>(module1:TargetType targetType)",
+      "label": "/path4/<pathParam>(module1:TargetType targetType)",
       "kind": "Function",
       "detail": "targetType|module1:ClientError|error",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config22.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config22.json
@@ -37,7 +37,7 @@
       ]
     },
     {
-      "label": "/<path>",
+      "label": "/<ids>",
       "kind": "Function",
       "detail": "()",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config6.json
@@ -67,7 +67,7 @@
       ]
     },
     {
-      "label": "/<path>",
+      "label": "/<ids>",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -127,7 +127,7 @@
       ]
     },
     {
-      "label": "/path1/<path>",
+      "label": "/path1/<id1>",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -187,7 +187,7 @@
       ]
     },
     {
-      "label": "/path1/<path>/path2",
+      "label": "/path1/<id1>/path2",
       "kind": "Function",
       "detail": "int",
       "documentation": {
@@ -251,7 +251,7 @@
       }
     },
     {
-      "label": "/path1/<path>/path2/<path>.post(string b, string... ids2)",
+      "label": "/path1/<id1>/path2/<ids>.post(string b, string... ids2)",
       "kind": "Function",
       "detail": "()",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config7.json
@@ -37,7 +37,7 @@
       ]
     },
     {
-      "label": "/<path>",
+      "label": "/<ids>",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -97,7 +97,7 @@
       ]
     },
     {
-      "label": "/<path>",
+      "label": "/<id1>",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -157,7 +157,7 @@
       ]
     },
     {
-      "label": "/<path>/path2",
+      "label": "/<id1>/path2",
       "kind": "Function",
       "detail": "int",
       "documentation": {
@@ -221,7 +221,7 @@
       }
     },
     {
-      "label": "/<path>/path2/<path>.post(string b, string... ids2)",
+      "label": "/<id1>/path2/<ids>.post(string b, string... ids2)",
       "kind": "Function",
       "detail": "()",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config8.json
@@ -16,7 +16,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `module1:RequestMessage` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Return** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CD",
       "filterText": "post",
       "insertText": "post(${1})",
       "insertTextFormat": "Snippet",
@@ -35,7 +35,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample remote method with java interoperability\n  \n**Params**  \n- `string` path: Resource path  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CG",
       "filterText": "get",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
@@ -54,7 +54,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample remote method with java interoperability\n  \n**Params**  \n- `string` path: Resource path  \n- `handle` request: Request need to be forward  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType`   \n- Response  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CH",
       "filterText": "forward",
       "insertText": "forward(${1})",
       "insertTextFormat": "Snippet",
@@ -73,7 +73,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample remote method with java interoperability\n  \n**Params**  \n- `module1:TargetType2` targetType: `any`type which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType`   \n- Type any  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CI",
       "filterText": "delete",
       "insertText": "delete(${1})",
       "insertTextFormat": "Snippet",
@@ -92,7 +92,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource method.\n  \n**Params**  \n- `string` id1: Path parameter  \n- `string[]` ids: Rest path parameter  \n- `string` str: Argument  \n- `string[]` ids2: Rest argument  \n  \n**Return** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CE",
       "filterText": "path1|path2|post",
       "insertText": "/path1/[${1:\"path\"}]/path2/[${2:\"path\"}].post(${3});",
       "insertTextFormat": "Snippet",
@@ -102,7 +102,7 @@
       }
     },
     {
-      "label": "/path1/<path>/path2/<path>.post(string str, string... ids2)",
+      "label": "/path1/<id1>/path2/<ids>.post(string str, string... ids2)",
       "kind": "Function",
       "detail": "module1:Response",
       "documentation": {
@@ -111,7 +111,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource method.\n  \n**Params**  \n- `string` id1: Path parameter  \n- `string[]` ids: Rest path parameter  \n- `string` str: Argument  \n- `string[]` ids2: Rest argument  \n  \n**Return** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CF",
       "filterText": "path1|path2|post",
       "insertText": "/path1/${1:path}/path2/${2:path}.post(${3});",
       "insertTextFormat": "Snippet",
@@ -130,7 +130,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with java interoperability\n  \n**Params**  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CJ",
       "filterText": "path3|get",
       "insertText": "/path3(${1});",
       "insertTextFormat": "Snippet",
@@ -149,7 +149,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with multiple target types with java interoperability\n  \n**Params**  \n- `string` pathParam  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError|error`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CK",
       "filterText": "path4|get",
       "insertText": "/path4/[${1:\"path\"}](${2});",
       "insertTextFormat": "Snippet",
@@ -159,7 +159,7 @@
       }
     },
     {
-      "label": "/path4/<path>(module1:TargetType targetType)",
+      "label": "/path4/<pathParam>(module1:TargetType targetType)",
       "kind": "Function",
       "detail": "targetType|module1:ClientError|error",
       "documentation": {
@@ -168,7 +168,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with multiple target types with java interoperability\n  \n**Params**  \n- `string` pathParam  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError|error`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CL",
       "filterText": "path4|get",
       "insertText": "/path4/${1:path}(${2});",
       "insertTextFormat": "Snippet",
@@ -187,7 +187,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with rest path praram with multiple target types with java interoperability\n  \n**Params**  \n- `string[]` path: Request path  \n- `module1:RequestMessage` message: An HTTP outbound request or any allowed payload  \n- `map<string|string[]>?` headers: The entity headers(Defaultable)  \n- `string?` mediaType: The MIME type header of the request entity(Defaultable)  \n- `module1:TargetType` targetType: HTTP response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to  \nestablish the communication with the upstream server or a data binding failure  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CM",
       "filterText": "post",
       "insertText": "/[${1:\"path\"}].post(${2});",
       "insertTextFormat": "Snippet",
@@ -206,7 +206,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with rest path praram with multiple target types with java interoperability\n  \n**Params**  \n- `string[]` path: Request path  \n- `module1:RequestMessage` message: An HTTP outbound request or any allowed payload  \n- `map<string|string[]>?` headers: The entity headers(Defaultable)  \n- `string?` mediaType: The MIME type header of the request entity(Defaultable)  \n- `module1:TargetType` targetType: HTTP response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to  \nestablish the communication with the upstream server or a data binding failure  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CN",
       "filterText": "post",
       "insertText": "/${1:path}.post(${2});",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config8.json
@@ -225,7 +225,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function to return a stream of objects\n  \n**Params**  \n- `module1:TargetType2` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `stream<targetType, module1:ClientError?>`   \n- A stream of targetType and/or ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CO",
       "filterText": "responses|get",
       "insertText": "/responses(${1});",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config9.json
@@ -37,7 +37,7 @@
       ]
     },
     {
-      "label": "/<path>",
+      "label": "/<ids>",
       "kind": "Function",
       "detail": "()",
       "documentation": {
@@ -131,7 +131,7 @@
       }
     },
     {
-      "label": "/path2/<path>.post(string b, string... ids2)",
+      "label": "/path2/<ids>.post(string b, string... ids2)",
       "kind": "Function",
       "detail": "()",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action__with_check_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action__with_check_config1.json
@@ -15,7 +15,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` name  \n  \n**Return** `Product|ProductError`   \n  \n"
         }
       },
-      "sortText": "BC",
+      "sortText": "BD",
       "filterText": "findByName",
       "insertText": "findByName(${1})",
       "insertTextFormat": "Snippet",
@@ -34,7 +34,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `Product[]`   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CE",
       "filterText": "listAll",
       "insertText": "listAll()",
       "insertTextFormat": "Snippet"
@@ -49,7 +49,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` name  \n  \n**Return** `int`   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CF",
       "filterText": "countByName",
       "insertText": "countByName(${1})",
       "insertTextFormat": "Snippet",
@@ -68,7 +68,7 @@
           "value": "**Package:** _._  \n  \nCount the products by given criteria.\nCriteria can be optional\n  \n**Params**  \n- `string` name: Name to search  \n- `string` id: id to be searched  \n- `int` page: Page number    \n- `int` offset: Offset number  \n  \n**Return** `int`   \n- Count   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CG",
       "filterText": "countBy",
       "insertText": "countBy(${1})",
       "insertTextFormat": "Snippet",
@@ -87,7 +87,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `string`   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CH",
       "filterText": "geVersion",
       "insertText": "geVersion()",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action__with_check_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action__with_check_config2.json
@@ -15,7 +15,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` name  \n  \n**Return** `Product|ProductError`   \n  \n"
         }
       },
-      "sortText": "BC",
+      "sortText": "BD",
       "filterText": "findByName",
       "insertText": "findByName(${1})",
       "insertTextFormat": "Snippet",
@@ -34,7 +34,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `Product[]`   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CE",
       "filterText": "listAll",
       "insertText": "listAll()",
       "insertTextFormat": "Snippet"
@@ -49,7 +49,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` name  \n  \n**Return** `int`   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CF",
       "filterText": "countByName",
       "insertText": "countByName(${1})",
       "insertTextFormat": "Snippet",
@@ -68,7 +68,7 @@
           "value": "**Package:** _._  \n  \nCount the products by given criteria.\nCriteria can be optional\n  \n**Params**  \n- `string` name: Name to search  \n- `string` id: id to be searched  \n- `int` page: Page number    \n- `int` offset: Offset number  \n  \n**Return** `int`   \n- Count   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CG",
       "filterText": "countBy",
       "insertText": "countBy(${1})",
       "insertTextFormat": "Snippet",
@@ -87,7 +87,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `string`   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CH",
       "filterText": "geVersion",
       "insertText": "geVersion()",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config1.json
@@ -16,7 +16,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `module1:RequestMessage` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Return** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CD",
       "filterText": "post",
       "insertText": "post(${1})",
       "insertTextFormat": "Snippet",
@@ -35,7 +35,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample remote method with java interoperability\n  \n**Params**  \n- `string` path: Resource path  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CG",
       "filterText": "get",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
@@ -54,7 +54,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample remote method with java interoperability\n  \n**Params**  \n- `string` path: Resource path  \n- `handle` request: Request need to be forward  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType`   \n- Response  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CH",
       "filterText": "forward",
       "insertText": "forward(${1})",
       "insertTextFormat": "Snippet",
@@ -73,7 +73,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample remote method with java interoperability\n  \n**Params**  \n- `module1:TargetType2` targetType: `any`type which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType`   \n- Type any  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CI",
       "filterText": "delete",
       "insertText": "delete(${1})",
       "insertTextFormat": "Snippet",
@@ -92,7 +92,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource method.\n  \n**Params**  \n- `string` id1: Path parameter  \n- `string[]` ids: Rest path parameter  \n- `string` str: Argument  \n- `string[]` ids2: Rest argument  \n  \n**Return** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CE",
       "filterText": "path1|path2|post",
       "insertText": "/path1/[${1:\"path\"}]/path2/[${2:\"path\"}].post(${3});",
       "insertTextFormat": "Snippet",
@@ -102,7 +102,7 @@
       }
     },
     {
-      "label": "/path1/<path>/path2/<path>.post(string str, string... ids2)",
+      "label": "/path1/<id1>/path2/<ids>.post(string str, string... ids2)",
       "kind": "Function",
       "detail": "module1:Response",
       "documentation": {
@@ -111,7 +111,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource method.\n  \n**Params**  \n- `string` id1: Path parameter  \n- `string[]` ids: Rest path parameter  \n- `string` str: Argument  \n- `string[]` ids2: Rest argument  \n  \n**Return** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CF",
       "filterText": "path1|path2|post",
       "insertText": "/path1/${1:path}/path2/${2:path}.post(${3});",
       "insertTextFormat": "Snippet",
@@ -130,7 +130,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with java interoperability\n  \n**Params**  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CJ",
       "filterText": "path3|get",
       "insertText": "/path3(${1});",
       "insertTextFormat": "Snippet",
@@ -149,7 +149,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with multiple target types with java interoperability\n  \n**Params**  \n- `string` pathParam  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError|error`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CK",
       "filterText": "path4|get",
       "insertText": "/path4/[${1:\"path\"}](${2});",
       "insertTextFormat": "Snippet",
@@ -159,7 +159,7 @@
       }
     },
     {
-      "label": "/path4/<path>(module1:TargetType targetType)",
+      "label": "/path4/<pathParam>(module1:TargetType targetType)",
       "kind": "Function",
       "detail": "targetType|module1:ClientError|error",
       "documentation": {
@@ -168,7 +168,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with multiple target types with java interoperability\n  \n**Params**  \n- `string` pathParam  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError|error`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CL",
       "filterText": "path4|get",
       "insertText": "/path4/${1:path}(${2});",
       "insertTextFormat": "Snippet",
@@ -187,7 +187,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with rest path praram with multiple target types with java interoperability\n  \n**Params**  \n- `string[]` path: Request path  \n- `module1:RequestMessage` message: An HTTP outbound request or any allowed payload  \n- `map<string|string[]>?` headers: The entity headers(Defaultable)  \n- `string?` mediaType: The MIME type header of the request entity(Defaultable)  \n- `module1:TargetType` targetType: HTTP response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to  \nestablish the communication with the upstream server or a data binding failure  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CM",
       "filterText": "post",
       "insertText": "/[${1:\"path\"}].post(${2});",
       "insertTextFormat": "Snippet",
@@ -206,7 +206,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with rest path praram with multiple target types with java interoperability\n  \n**Params**  \n- `string[]` path: Request path  \n- `module1:RequestMessage` message: An HTTP outbound request or any allowed payload  \n- `map<string|string[]>?` headers: The entity headers(Defaultable)  \n- `string?` mediaType: The MIME type header of the request entity(Defaultable)  \n- `module1:TargetType` targetType: HTTP response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to  \nestablish the communication with the upstream server or a data binding failure  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CN",
       "filterText": "post",
       "insertText": "/${1:path}.post(${2});",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config1.json
@@ -225,7 +225,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function to return a stream of objects\n  \n**Params**  \n- `module1:TargetType2` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `stream<targetType, module1:ClientError?>`   \n- A stream of targetType and/or ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CO",
       "filterText": "responses|get",
       "insertText": "/responses(${1});",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config2.json
@@ -16,7 +16,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `module1:RequestMessage` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Return** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CD",
       "filterText": "post",
       "insertText": "post(${1})",
       "insertTextFormat": "Snippet",
@@ -35,7 +35,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample remote method with java interoperability\n  \n**Params**  \n- `string` path: Resource path  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CG",
       "filterText": "get",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
@@ -54,7 +54,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample remote method with java interoperability\n  \n**Params**  \n- `string` path: Resource path  \n- `handle` request: Request need to be forward  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType`   \n- Response  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CH",
       "filterText": "forward",
       "insertText": "forward(${1})",
       "insertTextFormat": "Snippet",
@@ -73,7 +73,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample remote method with java interoperability\n  \n**Params**  \n- `module1:TargetType2` targetType: `any`type which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType`   \n- Type any  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CI",
       "filterText": "delete",
       "insertText": "delete(${1})",
       "insertTextFormat": "Snippet",
@@ -92,7 +92,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource method.\n  \n**Params**  \n- `string` id1: Path parameter  \n- `string[]` ids: Rest path parameter  \n- `string` str: Argument  \n- `string[]` ids2: Rest argument  \n  \n**Return** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CE",
       "filterText": "path1|path2|post",
       "insertText": "/path1/[${1:\"path\"}]/path2/[${2:\"path\"}].post(${3});",
       "insertTextFormat": "Snippet",
@@ -102,7 +102,7 @@
       }
     },
     {
-      "label": "/path1/<path>/path2/<path>.post(string str, string... ids2)",
+      "label": "/path1/<id1>/path2/<ids>.post(string str, string... ids2)",
       "kind": "Function",
       "detail": "module1:Response",
       "documentation": {
@@ -111,7 +111,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource method.\n  \n**Params**  \n- `string` id1: Path parameter  \n- `string[]` ids: Rest path parameter  \n- `string` str: Argument  \n- `string[]` ids2: Rest argument  \n  \n**Return** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CF",
       "filterText": "path1|path2|post",
       "insertText": "/path1/${1:path}/path2/${2:path}.post(${3});",
       "insertTextFormat": "Snippet",
@@ -130,7 +130,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with java interoperability\n  \n**Params**  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CJ",
       "filterText": "path3|get",
       "insertText": "/path3(${1});",
       "insertTextFormat": "Snippet",
@@ -149,7 +149,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with multiple target types with java interoperability\n  \n**Params**  \n- `string` pathParam  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError|error`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CK",
       "filterText": "path4|get",
       "insertText": "/path4/[${1:\"path\"}](${2});",
       "insertTextFormat": "Snippet",
@@ -159,7 +159,7 @@
       }
     },
     {
-      "label": "/path4/<path>(module1:TargetType targetType)",
+      "label": "/path4/<pathParam>(module1:TargetType targetType)",
       "kind": "Function",
       "detail": "targetType|module1:ClientError|error",
       "documentation": {
@@ -168,7 +168,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with multiple target types with java interoperability\n  \n**Params**  \n- `string` pathParam  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError|error`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CL",
       "filterText": "path4|get",
       "insertText": "/path4/${1:path}(${2});",
       "insertTextFormat": "Snippet",
@@ -187,7 +187,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with rest path praram with multiple target types with java interoperability\n  \n**Params**  \n- `string[]` path: Request path  \n- `module1:RequestMessage` message: An HTTP outbound request or any allowed payload  \n- `map<string|string[]>?` headers: The entity headers(Defaultable)  \n- `string?` mediaType: The MIME type header of the request entity(Defaultable)  \n- `module1:TargetType` targetType: HTTP response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to  \nestablish the communication with the upstream server or a data binding failure  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CM",
       "filterText": "post",
       "insertText": "/[${1:\"path\"}].post(${2});",
       "insertTextFormat": "Snippet",
@@ -206,7 +206,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with rest path praram with multiple target types with java interoperability\n  \n**Params**  \n- `string[]` path: Request path  \n- `module1:RequestMessage` message: An HTTP outbound request or any allowed payload  \n- `map<string|string[]>?` headers: The entity headers(Defaultable)  \n- `string?` mediaType: The MIME type header of the request entity(Defaultable)  \n- `module1:TargetType` targetType: HTTP response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to  \nestablish the communication with the upstream server or a data binding failure  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CN",
       "filterText": "post",
       "insertText": "/${1:path}.post(${2});",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config2.json
@@ -225,7 +225,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function to return a stream of objects\n  \n**Params**  \n- `module1:TargetType2` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `stream<targetType, module1:ClientError?>`   \n- A stream of targetType and/or ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CO",
       "filterText": "responses|get",
       "insertText": "/responses(${1});",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config4.json
@@ -102,7 +102,7 @@
       }
     },
     {
-      "label": "/path1/<path>/path2/<path>.post(string str, string... ids2)",
+      "label": "/path1/<id1>/path2/<ids>.post(string str, string... ids2)",
       "kind": "Function",
       "detail": "mod:Response",
       "documentation": {
@@ -159,7 +159,7 @@
       }
     },
     {
-      "label": "/path4/<path>(mod:TargetType targetType)",
+      "label": "/path4/<pathParam>(mod:TargetType targetType)",
       "kind": "Function",
       "detail": "targetType|mod:ClientError|error",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config5.json
@@ -225,7 +225,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function to return a stream of objects\n  \n**Params**  \n- `module1:TargetType2` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `stream<targetType, module1:ClientError?>`   \n- A stream of targetType and/or ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CO",
       "filterText": "responses|get",
       "insertText": "/responses(${1});",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config5.json
@@ -16,7 +16,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `module1:RequestMessage` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Return** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
-      "sortText": "AC",
+      "sortText": "AD",
       "filterText": "post",
       "insertText": "post(${1})",
       "insertTextFormat": "Snippet",
@@ -35,7 +35,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample remote method with java interoperability\n  \n**Params**  \n- `string` path: Resource path  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "AC",
+      "sortText": "AG",
       "filterText": "get",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
@@ -54,7 +54,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample remote method with java interoperability\n  \n**Params**  \n- `string` path: Resource path  \n- `handle` request: Request need to be forward  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType`   \n- Response  \n  \n"
         }
       },
-      "sortText": "AC",
+      "sortText": "AH",
       "filterText": "forward",
       "insertText": "forward(${1})",
       "insertTextFormat": "Snippet",
@@ -73,7 +73,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample remote method with java interoperability\n  \n**Params**  \n- `module1:TargetType2` targetType: `any`type which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType`   \n- Type any  \n  \n"
         }
       },
-      "sortText": "AC",
+      "sortText": "AI",
       "filterText": "delete",
       "insertText": "delete(${1})",
       "insertTextFormat": "Snippet",
@@ -92,7 +92,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource method.\n  \n**Params**  \n- `string` id1: Path parameter  \n- `string[]` ids: Rest path parameter  \n- `string` str: Argument  \n- `string[]` ids2: Rest argument  \n  \n**Return** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CE",
       "filterText": "path1|path2|post",
       "insertText": "/path1/[${1:\"path\"}]/path2/[${2:\"path\"}].post(${3});",
       "insertTextFormat": "Snippet",
@@ -102,7 +102,7 @@
       }
     },
     {
-      "label": "/path1/<path>/path2/<path>.post(string str, string... ids2)",
+      "label": "/path1/<id1>/path2/<ids>.post(string str, string... ids2)",
       "kind": "Function",
       "detail": "module1:Response",
       "documentation": {
@@ -111,7 +111,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource method.\n  \n**Params**  \n- `string` id1: Path parameter  \n- `string[]` ids: Rest path parameter  \n- `string` str: Argument  \n- `string[]` ids2: Rest argument  \n  \n**Return** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CF",
       "filterText": "path1|path2|post",
       "insertText": "/path1/${1:path}/path2/${2:path}.post(${3});",
       "insertTextFormat": "Snippet",
@@ -130,7 +130,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with java interoperability\n  \n**Params**  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CJ",
       "filterText": "path3|get",
       "insertText": "/path3(${1});",
       "insertTextFormat": "Snippet",
@@ -149,7 +149,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with multiple target types with java interoperability\n  \n**Params**  \n- `string` pathParam  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError|error`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CK",
       "filterText": "path4|get",
       "insertText": "/path4/[${1:\"path\"}](${2});",
       "insertTextFormat": "Snippet",
@@ -159,7 +159,7 @@
       }
     },
     {
-      "label": "/path4/<path>(module1:TargetType targetType)",
+      "label": "/path4/<pathParam>(module1:TargetType targetType)",
       "kind": "Function",
       "detail": "targetType|module1:ClientError|error",
       "documentation": {
@@ -168,7 +168,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with multiple target types with java interoperability\n  \n**Params**  \n- `string` pathParam  \n- `module1:TargetType` targetType: Response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError|error`   \n- The Response or the ClientError  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CL",
       "filterText": "path4|get",
       "insertText": "/path4/${1:path}(${2});",
       "insertTextFormat": "Snippet",
@@ -187,7 +187,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with rest path praram with multiple target types with java interoperability\n  \n**Params**  \n- `string[]` path: Request path  \n- `module1:RequestMessage` message: An HTTP outbound request or any allowed payload  \n- `map<string|string[]>?` headers: The entity headers(Defaultable)  \n- `string?` mediaType: The MIME type header of the request entity(Defaultable)  \n- `module1:TargetType` targetType: HTTP response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to  \nestablish the communication with the upstream server or a data binding failure  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CM",
       "filterText": "post",
       "insertText": "/[${1:\"path\"}].post(${2});",
       "insertTextFormat": "Snippet",
@@ -206,7 +206,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nSample resource function with rest path praram with multiple target types with java interoperability\n  \n**Params**  \n- `string[]` path: Request path  \n- `module1:RequestMessage` message: An HTTP outbound request or any allowed payload  \n- `map<string|string[]>?` headers: The entity headers(Defaultable)  \n- `string?` mediaType: The MIME type header of the request entity(Defaultable)  \n- `module1:TargetType` targetType: HTTP response or `anydata`, which is expected to be returned after data binding(Defaultable)  \n  \n**Return** `targetType|module1:ClientError`   \n- The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to  \nestablish the communication with the upstream server or a data binding failure  \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CN",
       "filterText": "post",
       "insertText": "/${1:path}.post(${2});",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config6.json
@@ -15,7 +15,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` name  \n  \n**Return** `Product`   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CD",
       "filterText": "findByName",
       "insertText": "findByName(${1})",
       "insertTextFormat": "Snippet",
@@ -34,7 +34,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `Product[]`   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CE",
       "filterText": "listAll",
       "insertText": "listAll()",
       "insertTextFormat": "Snippet"
@@ -49,7 +49,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` name  \n  \n**Return** `int`   \n  \n"
         }
       },
-      "sortText": "CC",
+      "sortText": "CF",
       "filterText": "countByName",
       "insertText": "countByName(${1})",
       "insertTextFormat": "Snippet",
@@ -68,7 +68,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `string`   \n  \n"
         }
       },
-      "sortText": "AC",
+      "sortText": "AG",
       "filterText": "getVersion",
       "insertText": "getVersion()",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/async_send_action_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/async_send_action_ctx_config1.json
@@ -9,7 +9,7 @@
       "label": "w3",
       "kind": "Variable",
       "detail": "worker",
-      "sortText": "CB",
+      "sortText": "CC",
       "insertText": "w3",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "CQ",
+      "sortText": "CS",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/async_send_action_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/async_send_action_ctx_config2.json
@@ -9,7 +9,7 @@
       "label": "w3",
       "kind": "Variable",
       "detail": "worker",
-      "sortText": "CB",
+      "sortText": "CC",
       "insertText": "w3",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "CQ",
+      "sortText": "CS",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"


### PR DESCRIPTION
## Purpose
When multiple resource access methods share the same `sortText`, the VS Code plugin sorts them alphabetically, thus dividing completions with named and computed resource segments into two sets. This arrangement reduces the developer experience, with computed resource segments moved to the bottom.

Fixes #41636

## Approach
The current approach assigns a unique `sortText` to each completion item based on the position generated by the LS, ensuring that the order is not disrupted by the VS Code plugin.

## Samples
Grouped completions with both named resource segments and computed resource segments are now as shown below.

<img width="746" alt="image" src="https://github.com/ballerina-platform/ballerina-lang/assets/59343084/7bbd6d09-ef3d-4339-8b17-9850f476caf0">

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
