### PR TITLE
Fix invalid behavior in `TableIterator` with hash-collided keys

### DIFF
--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTableTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTableTest.java
@@ -123,6 +123,11 @@ public class LangLibTableTest {
     }
 
     @Test
+    public void testHashCollisionInQuery() {
+        BRunUtil.invoke(compileResult, "testHashCollisionInQuery");
+    }
+
+    @Test
     public void testGetKeyList() {
         Object result = BRunUtil.invoke(compileResult, "testGetKeyList");
         BArray returns = (BArray) result;

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTableTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTableTest.java
@@ -128,6 +128,11 @@ public class LangLibTableTest {
     }
 
     @Test
+    public void testGetKeysOfHashCollidedKeys() {
+        BRunUtil.invoke(compileResult, "testGetKeysOfHashCollidedKeys");
+    }
+
+    @Test
     public void testGetKeyList() {
         Object result = BRunUtil.invoke(compileResult, "testGetKeyList");
         BArray returns = (BArray) result;

--- a/langlib/langlib-test/src/test/resources/test-src/tablelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/tablelib_test.bal
@@ -355,6 +355,31 @@ function testHashCollisionHandlingScenarios() {
 
 }
 
+function testHashCollisionInQuery() {
+    table<record {readonly int|string|float? k;}> key(k) tbl1 = table [];
+    table<record {readonly int|string|float? k;}> tbl2 = table [{k: 0}];
+
+    tbl1.add({k: 0});
+    tbl1.add({k: 5});
+    tbl1.add({k: -31});
+    tbl1.add({k: "10"});
+    tbl1.add({k: 100.05});
+    tbl1.add({k: ()});
+    tbl1.add({k: 30});
+    table<record {|readonly int|string|float? k; anydata...;|}> tbl3 =
+        from var tid in tbl1
+            where tid["k"] == 0
+            select tid;
+    assertEquals(tbl2, tbl3);
+
+    _ = tbl1.remove(());
+    table<record {|readonly int|string|float? k; anydata...;|}> tbl4 =
+        from var tid in tbl1
+            where tid["k"] == 0
+            select tid;
+    assertEquals(tbl2, tbl4);
+}
+
 function testGetKeyList() returns any[] {
     return tab.keys();
 }

--- a/langlib/langlib-test/src/test/resources/test-src/tablelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/tablelib_test.bal
@@ -356,15 +356,14 @@ function testHashCollisionHandlingScenarios() {
 }
 
 function testHashCollisionInQuery() {
-    table<record {readonly int|string|float? k;}> key(k) tbl1 = table [];
+    table<record {readonly int|string|float? k;}> key(k) tbl1 = table [{k: "10"}];
     table<record {readonly int|string|float? k;}> tbl2 = table [{k: 0}];
 
-    tbl1.add({k: 0});
     tbl1.add({k: 5});
-    tbl1.add({k: -31});
-    tbl1.add({k: "10"});
-    tbl1.add({k: 100.05});
     tbl1.add({k: ()});
+    tbl1.add({k: -31});
+    tbl1.add({k: 0});
+    tbl1.add({k: 100.05});
     tbl1.add({k: 30});
     table<record {|readonly int|string|float? k; anydata...;|}> tbl3 =
         from var tid in tbl1
@@ -378,6 +377,14 @@ function testHashCollisionInQuery() {
             where tid["k"] == 0
             select tid;
     assertEquals(tbl2, tbl4);
+}
+
+public function testGetKeysOfHashCollidedKeys() {
+    table<record {readonly int? k;}> key(k) tbl1 = table [
+        {k: 5}, {k: 0}, {k: ()}, {k: 2}
+    ];
+
+    assertEquals(tbl1.keys(), [5, 0, (), 2]);
 }
 
 function testGetKeyList() returns any[] {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
@@ -605,7 +605,7 @@ function testStringAsKeyValue() {
     table<Row12> tbl1 = from Row12 r in tbl
         where r.key1 == "k1" && r.key2 == "k2"
         select r;
-    assertEqual(tbl1, tbl2);
+    assertEqual(tbl2, tbl1);
 
     // Test the get method of the table
     readonly & string keyString = "k1";
@@ -639,7 +639,7 @@ function testStringAsCompositeKeyValue() {
     table<Row12> tbl1 = from Row12 r in tbl
         where r.key1 == "k1" && r.key2 == "k2"
         select r;
-    assertEqual(tbl1, tbl2);
+    assertEqual(tbl2, tbl1);
 
     // Test the get method of the table
     [string & readonly, string & readonly] keyTuple = ["k1", "k2"];
@@ -679,7 +679,7 @@ function testMapAsCompositeKeyValue() {
     table<Row13> tbl1 = from Row13 r in tbl
         where r.keys == {"k1": "v1", "k2": "v2"} && r.values == {"k1": 1, "k2": 2}
         select r;
-    assertEqual(tbl1, tbl2);
+    assertEqual(tbl2, tbl1);
 
     // Test the get method of the table
     [map<string> & readonly, map<int> & readonly] keyTuple = [{"k1": "v1", "k2": "v2"}, {"k1": 1, "k2": 2}];
@@ -719,7 +719,7 @@ function testArrayAsCompositeKeyValue() {
     table<Row14> tbl1 = from Row14 r in tbl
         where r.keys == ["k1", "k2"] && r.values == [1, 2]
         select r;
-    assertEqual(tbl1, tbl2);
+    assertEqual(tbl2, tbl1);
 
     // Test the get method of the table
     [string[] & readonly, int[] & readonly] keyTuple = [["k1", "k2"], [1, 2]];


### PR DESCRIPTION
## Purpose
The current implementation of the TableIterator does not consider hash collisions, as it treats its map implementations to have a one-to-one mapping. Hence, when there are hash-collided keys, the behavior produces invalid error messages.

Fixes #41717
Fixes #41719
Fixes #41721
Fixes #41819

## Approach
The PR modifies the map implementation of the `TableValue` class to handle hash collisions in the iterator behavior.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
