### PR TITLE
Look up closure symbols with the original symbol

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
@@ -1243,7 +1243,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
         if (!varSymbol.closure && isClosure) {
             SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
             BSymbol resolvedSymbol =
-                            symResolver.lookupClosureVarSymbol(encInvokableEnv, varSymbol.name, SymTag.VARIABLE);
+                    symResolver.lookupClosureVarSymbol(encInvokableEnv, varSymbol, varSymbol.name, SymTag.VARIABLE);
             if (resolvedSymbol != symTable.notFoundSymbol) {
                 varSymbol.closure = true;
                 ((BLangFunction) encInvokable).closureVarSymbols.add(new ClosureVarSymbol(varSymbol, pos));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
@@ -1242,8 +1242,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
                             !flagSet.contains(Flag.ATTACHED) && varSymbol.owner.tag != SymTag.PACKAGE;
         if (!varSymbol.closure && isClosure) {
             SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
-            BSymbol resolvedSymbol =
-                    symResolver.lookupClosureVarSymbol(encInvokableEnv, varSymbol, varSymbol.name, SymTag.VARIABLE);
+            BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, varSymbol, varSymbol.name);
             if (resolvedSymbol != symTable.notFoundSymbol) {
                 varSymbol.closure = true;
                 ((BLangFunction) encInvokable).closureVarSymbols.add(new ClosureVarSymbol(varSymbol, pos));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
@@ -1242,7 +1242,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
                             !flagSet.contains(Flag.ATTACHED) && varSymbol.owner.tag != SymTag.PACKAGE;
         if (!varSymbol.closure && isClosure) {
             SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
-            BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, varSymbol, varSymbol.name);
+            BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, varSymbol);
             if (resolvedSymbol != symTable.notFoundSymbol) {
                 varSymbol.closure = true;
                 ((BLangFunction) encInvokable).closureVarSymbols.add(new ClosureVarSymbol(varSymbol, pos));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -5877,7 +5877,7 @@ public class Desugar extends BLangNodeVisitor {
         if (!varSymbol.closure) {
             SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
             BSymbol resolvedSymbol =
-                    symResolver.lookupClosureVarSymbol(encInvokableEnv, varSymbol.name, SymTag.VARIABLE);
+                    symResolver.lookupClosureVarSymbol(encInvokableEnv, varSymbol);
             if (resolvedSymbol != symTable.notFoundSymbol) {
                 varSymbol.closure = true;
                 ((BLangFunction) encInvokable).closureVarSymbols.add(new ClosureVarSymbol(varSymbol, pos));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -5876,8 +5876,7 @@ public class Desugar extends BLangNodeVisitor {
     private void updateClosureVariable(BVarSymbol varSymbol, BLangInvokableNode encInvokable, Location pos) {
         if (!varSymbol.closure) {
             SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
-            BSymbol resolvedSymbol =
-                    symResolver.lookupClosureVarSymbol(encInvokableEnv, varSymbol);
+            BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, varSymbol);
             if (resolvedSymbol != symTable.notFoundSymbol) {
                 varSymbol.closure = true;
                 ((BLangFunction) encInvokable).closureVarSymbols.add(new ClosureVarSymbol(varSymbol, pos));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -1905,17 +1905,18 @@ public class QueryDesugar extends BLangNodeVisitor {
         BSymbol symbol = bLangSimpleVarRef.symbol;
         String identifier = bLangSimpleVarRef.variableName == null ? String.valueOf(bLangSimpleVarRef.varSymbol.name) :
                 String.valueOf(bLangSimpleVarRef.variableName);
-        BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(env,
-                Names.fromString(identifier), SymTag.VARIABLE);
+        if (symbol instanceof BVarSymbol) {
+            BVarSymbol originalSymbol = ((BVarSymbol) symbol).originalSymbol;
+            if (originalSymbol != null) {
+                symbol = originalSymbol;
+            }
+        }
+        BSymbol resolvedSymbol =
+                symResolver.lookupClosureVarSymbol(env, symbol, Names.fromString(identifier), SymTag.VARIABLE);
+
         // check whether the symbol and resolved symbol are the same.
         // because, lookup using name produce unexpected results if there's variable shadowing.
         if (symbol != null && symbol != resolvedSymbol && !FRAME_PARAMETER_NAME.equals(identifier)) {
-            if (symbol instanceof BVarSymbol) {
-                BVarSymbol originalSymbol = ((BVarSymbol) symbol).originalSymbol;
-                if (originalSymbol != null) {
-                    symbol = originalSymbol;
-                }
-            }
             if ((withinLambdaOrArrowFunc || queryEnv == null || !queryEnv.scope.entries.containsKey(symbol.name))
                     && !identifiers.containsKey(identifier)) {
                 Location pos = currentQueryLambdaBody.pos;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -1965,7 +1965,7 @@ public class QueryDesugar extends BLangNodeVisitor {
             resolvedSymbol.closure = true;
             // When there's a type guard, there can be a enclSymbol before type narrowing.
             // So, we have to mark that as a closure as well.
-            BSymbol enclSymbol = symResolver.lookupClosureVarSymbol(env.enclEnv,
+            BSymbol enclSymbol = symResolver.lookupClosureVarSymbol(env.enclEnv, symbol,
                     Names.fromString(identifier), SymTag.VARIABLE);
             if (enclSymbol != null && enclSymbol != symTable.notFoundSymbol) {
                 enclSymbol.closure = true;
@@ -2592,8 +2592,8 @@ public class QueryDesugar extends BLangNodeVisitor {
 
     void updateIdentifiers(SymbolEnv env) {
         for (Map.Entry<String, BSymbol> identifier : identifiers.entrySet()) {
-            BSymbol symbol = symResolver.lookupClosureVarSymbol(env, Names.fromString(identifier.getKey()),
-                    SymTag.SEQUENCE);
+            BSymbol symbol =
+                    symResolver.lookupSymbolInGivenScope(env, Names.fromString(identifier.getKey()), SymTag.SEQUENCE);
             if (symbol != symTable.notFoundSymbol && !identifier.getValue().closure) {
                     identifiers.put(identifier.getKey(), symbol);
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -20,6 +20,7 @@ import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.clauses.OrderKeyNode;
 import org.ballerinalang.model.elements.Flag;
+import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.tree.IdentifierNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.OperatorKind;
@@ -1904,9 +1905,10 @@ public class QueryDesugar extends BLangNodeVisitor {
     public void visit(BLangSimpleVarRef bLangSimpleVarRef) {
         BSymbol symbol = bLangSimpleVarRef.symbol;
         if (symbol == null) {
+            result = bLangSimpleVarRef;
             return;
         }
-        if (symbol instanceof BVarSymbol) {
+        if (symbol.kind == SymbolKind.VARIABLE) {
             BVarSymbol originalSymbol = ((BVarSymbol) symbol).originalSymbol;
             if (originalSymbol != null) {
                 symbol = originalSymbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -1903,15 +1903,18 @@ public class QueryDesugar extends BLangNodeVisitor {
     @Override
     public void visit(BLangSimpleVarRef bLangSimpleVarRef) {
         BSymbol symbol = bLangSimpleVarRef.symbol;
-        String identifier = bLangSimpleVarRef.variableName == null ? String.valueOf(bLangSimpleVarRef.varSymbol.name) :
-                String.valueOf(bLangSimpleVarRef.variableName);
+        if (symbol == null) {
+            return;
+        }
         if (symbol instanceof BVarSymbol) {
             BVarSymbol originalSymbol = ((BVarSymbol) symbol).originalSymbol;
             if (originalSymbol != null) {
                 symbol = originalSymbol;
             }
         }
-        BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(env, symbol, Names.fromString(identifier));
+        BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(env, symbol);
+        String identifier = bLangSimpleVarRef.variableName == null ? String.valueOf(bLangSimpleVarRef.varSymbol.name) :
+                String.valueOf(bLangSimpleVarRef.variableName);
 
         // check whether the symbol and resolved symbol are the same.
         // because, lookup using name produce unexpected results if there's variable shadowing.
@@ -1964,7 +1967,7 @@ public class QueryDesugar extends BLangNodeVisitor {
             resolvedSymbol.closure = true;
             // When there's a type guard, there can be a enclSymbol before type narrowing.
             // So, we have to mark that as a closure as well.
-            BSymbol enclSymbol = symResolver.lookupClosureVarSymbol(env.enclEnv, symbol, Names.fromString(identifier));
+            BSymbol enclSymbol = symResolver.lookupClosureVarSymbol(env.enclEnv, symbol);
             if (enclSymbol != null && enclSymbol != symTable.notFoundSymbol) {
                 enclSymbol.closure = true;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -1920,7 +1920,7 @@ public class QueryDesugar extends BLangNodeVisitor {
 
         // check whether the symbol and resolved symbol are the same.
         // because, lookup using name produce unexpected results if there's variable shadowing.
-        if (symbol != null && symbol != resolvedSymbol && !FRAME_PARAMETER_NAME.equals(identifier)) {
+        if (symbol != resolvedSymbol && !FRAME_PARAMETER_NAME.equals(identifier)) {
             if ((withinLambdaOrArrowFunc || queryEnv == null || !queryEnv.scope.entries.containsKey(symbol.name))
                     && !identifiers.containsKey(identifier)) {
                 Location pos = currentQueryLambdaBody.pos;
@@ -1965,7 +1965,7 @@ public class QueryDesugar extends BLangNodeVisitor {
                 bLangSimpleVarRef.symbol = symbol;
                 bLangSimpleVarRef.varSymbol = symbol;
             }
-        } else if (resolvedSymbol != symTable.notFoundSymbol && symbol != null) {
+        } else if (resolvedSymbol != symTable.notFoundSymbol) {
             resolvedSymbol.closure = true;
             // When there's a type guard, there can be a enclSymbol before type narrowing.
             // So, we have to mark that as a closure as well.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -1908,7 +1908,7 @@ public class QueryDesugar extends BLangNodeVisitor {
             result = bLangSimpleVarRef;
             return;
         }
-        if (symbol.kind == SymbolKind.VARIABLE) {
+        if (symbol.kind == SymbolKind.VARIABLE || symbol.kind == SymbolKind.FUNCTION) {
             BVarSymbol originalSymbol = ((BVarSymbol) symbol).originalSymbol;
             if (originalSymbol != null) {
                 symbol = originalSymbol;
@@ -1965,14 +1965,8 @@ public class QueryDesugar extends BLangNodeVisitor {
                 bLangSimpleVarRef.symbol = symbol;
                 bLangSimpleVarRef.varSymbol = symbol;
             }
-        } else if (resolvedSymbol != symTable.notFoundSymbol) {
+        } else if (!resolvedSymbol.closure && resolvedSymbol != symTable.notFoundSymbol) {
             resolvedSymbol.closure = true;
-            // When there's a type guard, there can be a enclSymbol before type narrowing.
-            // So, we have to mark that as a closure as well.
-            BSymbol enclSymbol = symResolver.lookupClosureVarSymbol(env.enclEnv, symbol);
-            if (enclSymbol != null && enclSymbol != symTable.notFoundSymbol) {
-                enclSymbol.closure = true;
-            }
         }
         result = bLangSimpleVarRef;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -1911,8 +1911,7 @@ public class QueryDesugar extends BLangNodeVisitor {
                 symbol = originalSymbol;
             }
         }
-        BSymbol resolvedSymbol =
-                symResolver.lookupClosureVarSymbol(env, symbol, Names.fromString(identifier), SymTag.VARIABLE);
+        BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(env, symbol, Names.fromString(identifier));
 
         // check whether the symbol and resolved symbol are the same.
         // because, lookup using name produce unexpected results if there's variable shadowing.
@@ -1965,8 +1964,7 @@ public class QueryDesugar extends BLangNodeVisitor {
             resolvedSymbol.closure = true;
             // When there's a type guard, there can be a enclSymbol before type narrowing.
             // So, we have to mark that as a closure as well.
-            BSymbol enclSymbol = symResolver.lookupClosureVarSymbol(env.enclEnv, symbol,
-                    Names.fromString(identifier), SymTag.VARIABLE);
+            BSymbol enclSymbol = symResolver.lookupClosureVarSymbol(env.enclEnv, symbol, Names.fromString(identifier));
             if (enclSymbol != null && enclSymbol != symTable.notFoundSymbol) {
                 enclSymbol.closure = true;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -818,10 +818,9 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
      * @param env       symbol env to analyse and find the closure variable.
      * @param symbol    symbol to lookup
      * @param name      name of the symbol to lookup
-     * @param expSymTag symbol tag
      * @return closure symbol wrapper along with the resolved count
      */
-    public BSymbol lookupClosureVarSymbol(SymbolEnv env, Symbol symbol, Name name, long expSymTag) {
+    public BSymbol lookupClosureVarSymbol(SymbolEnv env, Symbol symbol, Name name) {
         ScopeEntry entry = env.scope.lookup(name);
         while (entry != NOT_FOUND_ENTRY) {
             if (entry.symbol != symbol) {
@@ -832,7 +831,8 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                     (entry.symbol.tag & SymTag.VARIABLE_NAME) == SymTag.VARIABLE_NAME) {
                 return entry.symbol;
             }
-            if ((entry.symbol.tag & expSymTag) == expSymTag && !isFieldRefFromWithinARecord(entry.symbol, env)) {
+            if ((entry.symbol.tag & SymTag.VARIABLE) == SymTag.VARIABLE &&
+                    !isFieldRefFromWithinARecord(entry.symbol, env)) {
                 return entry.symbol;
             }
             entry = entry.next;
@@ -842,7 +842,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
             return symTable.notFoundSymbol;
         }
 
-        return lookupClosureVarSymbol(env.enclEnv, symbol, name, expSymTag);
+        return lookupClosureVarSymbol(env.enclEnv, symbol, name);
     }
 
     public BSymbol lookupMainSpaceSymbolInPackage(Location pos,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -816,30 +816,11 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
      * Recursively analyse the symbol env to find the closure variable symbol that is being resolved.
      *
      * @param env       symbol env to analyse and find the closure variable.
+     * @param symbol    symbol to lookup
      * @param name      name of the symbol to lookup
      * @param expSymTag symbol tag
      * @return closure symbol wrapper along with the resolved count
      */
-    public BSymbol lookupClosureVarSymbol(SymbolEnv env, Name name, long expSymTag) {
-        ScopeEntry entry = env.scope.lookup(name);
-        while (entry != NOT_FOUND_ENTRY) {
-            if (symTable.rootPkgSymbol.pkgID.equals(entry.symbol.pkgID) &&
-                    (entry.symbol.tag & SymTag.VARIABLE_NAME) == SymTag.VARIABLE_NAME) {
-                return entry.symbol;
-            }
-            if ((entry.symbol.tag & expSymTag) == expSymTag && !isFieldRefFromWithinARecord(entry.symbol, env)) {
-                return entry.symbol;
-            }
-            entry = entry.next;
-        }
-
-        if (env.enclEnv == null || env.enclEnv.node == null) {
-            return symTable.notFoundSymbol;
-        }
-
-        return lookupClosureVarSymbol(env.enclEnv, name, expSymTag);
-    }
-
     public BSymbol lookupClosureVarSymbol(SymbolEnv env, Symbol symbol, Name name, long expSymTag) {
         ScopeEntry entry = env.scope.lookup(name);
         while (entry != NOT_FOUND_ENTRY) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -820,8 +820,8 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
      * @param name      name of the symbol to lookup
      * @return closure symbol wrapper along with the resolved count
      */
-    public BSymbol lookupClosureVarSymbol(SymbolEnv env, Symbol symbol, Name name) {
-        ScopeEntry entry = env.scope.lookup(name);
+    public BSymbol lookupClosureVarSymbol(SymbolEnv env, BSymbol symbol) {
+        ScopeEntry entry = env.scope.lookup(symbol.name);
         while (entry != NOT_FOUND_ENTRY) {
             if (entry.symbol != symbol) {
                 entry = entry.next;
@@ -842,7 +842,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
             return symTable.notFoundSymbol;
         }
 
-        return lookupClosureVarSymbol(env.enclEnv, symbol, name);
+        return lookupClosureVarSymbol(env.enclEnv, symbol);
     }
 
     public BSymbol lookupMainSpaceSymbolInPackage(Location pos,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -823,16 +823,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
     public BSymbol lookupClosureVarSymbol(SymbolEnv env, BSymbol symbol) {
         ScopeEntry entry = env.scope.lookup(symbol.name);
         while (entry != NOT_FOUND_ENTRY) {
-            if (entry.symbol != symbol) {
-                entry = entry.next;
-                continue;
-            }
-            if (symTable.rootPkgSymbol.pkgID.equals(entry.symbol.pkgID) &&
-                    (entry.symbol.tag & SymTag.VARIABLE_NAME) == SymTag.VARIABLE_NAME) {
-                return entry.symbol;
-            }
-            if ((entry.symbol.tag & SymTag.VARIABLE) == SymTag.VARIABLE &&
-                    !isFieldRefFromWithinARecord(entry.symbol, env)) {
+            if (entry.symbol == symbol) {
                 return entry.symbol;
             }
             entry = entry.next;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -23,7 +23,6 @@ import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.AttachPoint;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.elements.PackageID;
-import org.ballerinalang.model.symbols.Symbol;
 import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.tree.IdentifierNode;
 import org.ballerinalang.model.tree.NodeKind;
@@ -817,7 +816,6 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
      *
      * @param env       symbol env to analyse and find the closure variable.
      * @param symbol    symbol to lookup
-     * @param name      name of the symbol to lookup
      * @return closure symbol wrapper along with the resolved count
      */
     public BSymbol lookupClosureVarSymbol(SymbolEnv env, BSymbol symbol) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6616,8 +6616,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             if ((currentFunc != null) && !currentFunc.attachedFunction &&
                     !(currentFunc.symbol.receiverSymbol == symbol)) {
                 BSymbol resolvedSymbol =
-                        symResolver.lookupClosureVarSymbol(oceData.capturedClosureEnv, symbol, symbol.name,
-                                SymTag.VARIABLE);
+                        symResolver.lookupClosureVarSymbol(oceData.capturedClosureEnv, symbol, symbol.name);
                 if (resolvedSymbol != symTable.notFoundSymbol && !resolvedSymbol.closure) {
                     if (resolvedSymbol.owner.getKind() != SymbolKind.PACKAGE) {
                         updateObjectCtorClosureSymbols(pos, currentFunc, resolvedSymbol, classDef, data);
@@ -6648,8 +6647,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     return;
                 }
                 SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
-                BSymbol resolvedSymbol =
-                        symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol, symbol.name, SymTag.VARIABLE);
+                BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol, symbol.name);
                 BLangClassDefinition classDef = (BLangClassDefinition) node;
                 if (resolvedSymbol != symTable.notFoundSymbol) {
                     if (resolvedSymbol.owner.getKind() == SymbolKind.PACKAGE) {
@@ -6680,7 +6678,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 && !isFunctionArgument(symbol, encInvokable.requiredParams)) {
             SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
             BSymbol resolvedSymbol =
-                    symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol, symbol.name, SymTag.VARIABLE);
+                    symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol, symbol.name);
             if (resolvedSymbol != symTable.notFoundSymbol && !encInvokable.flagSet.contains(Flag.ATTACHED)) {
                 resolvedSymbol.closure = true;
                 ((BLangFunction) encInvokable).closureVarSymbols.add(new ClosureVarSymbol(resolvedSymbol, pos));
@@ -6692,7 +6690,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 && !isFunctionArgument(symbol, ((BLangArrowFunction) bLangNode).params)) {
             SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
             BSymbol resolvedSymbol =
-                    symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol, symbol.name, SymTag.VARIABLE);
+                    symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol, symbol.name);
             if (resolvedSymbol != symTable.notFoundSymbol) {
                 resolvedSymbol.closure = true;
                 ((BLangArrowFunction) bLangNode).closureVarSymbols.add(new ClosureVarSymbol(resolvedSymbol, pos));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6615,8 +6615,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             BLangFunction currentFunc = (BLangFunction) encInvokable;
             if ((currentFunc != null) && !currentFunc.attachedFunction &&
                     !(currentFunc.symbol.receiverSymbol == symbol)) {
-                BSymbol resolvedSymbol =
-                        symResolver.lookupClosureVarSymbol(oceData.capturedClosureEnv, symbol, symbol.name);
+                BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(oceData.capturedClosureEnv, symbol);
                 if (resolvedSymbol != symTable.notFoundSymbol && !resolvedSymbol.closure) {
                     if (resolvedSymbol.owner.getKind() != SymbolKind.PACKAGE) {
                         updateObjectCtorClosureSymbols(pos, currentFunc, resolvedSymbol, classDef, data);
@@ -6647,7 +6646,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     return;
                 }
                 SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
-                BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol, symbol.name);
+                BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol);
                 BLangClassDefinition classDef = (BLangClassDefinition) node;
                 if (resolvedSymbol != symTable.notFoundSymbol) {
                     if (resolvedSymbol.owner.getKind() == SymbolKind.PACKAGE) {
@@ -6677,8 +6676,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         if (encInvokable != null && encInvokable.flagSet.contains(Flag.LAMBDA)
                 && !isFunctionArgument(symbol, encInvokable.requiredParams)) {
             SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
-            BSymbol resolvedSymbol =
-                    symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol, symbol.name);
+            BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol);
             if (resolvedSymbol != symTable.notFoundSymbol && !encInvokable.flagSet.contains(Flag.ATTACHED)) {
                 resolvedSymbol.closure = true;
                 ((BLangFunction) encInvokable).closureVarSymbols.add(new ClosureVarSymbol(resolvedSymbol, pos));
@@ -6689,11 +6687,21 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         if (bLangNode.getKind() == NodeKind.ARROW_EXPR
                 && !isFunctionArgument(symbol, ((BLangArrowFunction) bLangNode).params)) {
             SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
-            BSymbol resolvedSymbol =
-                    symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol, symbol.name);
+            BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol);
             if (resolvedSymbol != symTable.notFoundSymbol) {
                 resolvedSymbol.closure = true;
                 ((BLangArrowFunction) bLangNode).closureVarSymbols.add(new ClosureVarSymbol(resolvedSymbol, pos));
+                return true;
+            }
+        }
+
+        if (env.enclType != null && env.enclType.getKind() == NodeKind.RECORD_TYPE) {
+            SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, (BLangRecordTypeNode) env.enclType);
+            BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol);
+            if (resolvedSymbol != symTable.notFoundSymbol && encInvokable != null &&
+                    !encInvokable.flagSet.contains(Flag.ATTACHED)) {
+                resolvedSymbol.closure = true;
+                ((BLangFunction) encInvokable).closureVarSymbols.add(new ClosureVarSymbol(resolvedSymbol, pos));
                 return true;
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6694,17 +6694,6 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 return true;
             }
         }
-
-        if (env.enclType != null && env.enclType.getKind() == NodeKind.RECORD_TYPE) {
-            SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, (BLangRecordTypeNode) env.enclType);
-            BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol);
-            if (resolvedSymbol != symTable.notFoundSymbol && encInvokable != null &&
-                    !encInvokable.flagSet.contains(Flag.ATTACHED)) {
-                resolvedSymbol.closure = true;
-                ((BLangFunction) encInvokable).closureVarSymbols.add(new ClosureVarSymbol(resolvedSymbol, pos));
-                return true;
-            }
-        }
         return false;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6615,8 +6615,9 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             BLangFunction currentFunc = (BLangFunction) encInvokable;
             if ((currentFunc != null) && !currentFunc.attachedFunction &&
                     !(currentFunc.symbol.receiverSymbol == symbol)) {
-                BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(oceData.capturedClosureEnv, symbol.name,
-                        SymTag.VARIABLE);
+                BSymbol resolvedSymbol =
+                        symResolver.lookupClosureVarSymbol(oceData.capturedClosureEnv, symbol, symbol.name,
+                                SymTag.VARIABLE);
                 if (resolvedSymbol != symTable.notFoundSymbol && !resolvedSymbol.closure) {
                     if (resolvedSymbol.owner.getKind() != SymbolKind.PACKAGE) {
                         updateObjectCtorClosureSymbols(pos, currentFunc, resolvedSymbol, classDef, data);
@@ -6647,8 +6648,8 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     return;
                 }
                 SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
-                BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol.name,
-                        SymTag.VARIABLE);
+                BSymbol resolvedSymbol =
+                        symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol, symbol.name, SymTag.VARIABLE);
                 BLangClassDefinition classDef = (BLangClassDefinition) node;
                 if (resolvedSymbol != symTable.notFoundSymbol) {
                     if (resolvedSymbol.owner.getKind() == SymbolKind.PACKAGE) {
@@ -6679,7 +6680,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 && !isFunctionArgument(symbol, encInvokable.requiredParams)) {
             SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
             BSymbol resolvedSymbol =
-                    symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol.name, SymTag.VARIABLE);
+                    symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol, symbol.name, SymTag.VARIABLE);
             if (resolvedSymbol != symTable.notFoundSymbol && !encInvokable.flagSet.contains(Flag.ATTACHED)) {
                 resolvedSymbol.closure = true;
                 ((BLangFunction) encInvokable).closureVarSymbols.add(new ClosureVarSymbol(resolvedSymbol, pos));
@@ -6691,7 +6692,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 && !isFunctionArgument(symbol, ((BLangArrowFunction) bLangNode).params)) {
             SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
             BSymbol resolvedSymbol =
-                    symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol.name, SymTag.VARIABLE);
+                    symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol, symbol.name, SymTag.VARIABLE);
             if (resolvedSymbol != symTable.notFoundSymbol) {
                 resolvedSymbol.closure = true;
                 ((BLangArrowFunction) bLangNode).closureVarSymbols.add(new ClosureVarSymbol(resolvedSymbol, pos));

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/UnionTypeBalaTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/UnionTypeBalaTest.java
@@ -49,11 +49,12 @@ public class UnionTypeBalaTest {
     }
 
     @DataProvider(name = "unionTestFunctions")
-    public Object[][] unionTestFunctions() {
-        return new Object[][]{
-                {"testUnionPositive"},
-                {"testUnionNegative"},
-                {"testUnionRuntimeToString"}
+    public Object[] unionTestFunctions() {
+        return new Object[]{
+                "testUnionPositive",
+                "testUnionNegative",
+                "testUnionRuntimeToString",
+                "testTernaryWithQueryForModuleImportedVariable"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureNegativeTest.java
@@ -73,6 +73,10 @@ public class ClosureNegativeTest {
                 30, 25);
         BAssertUtil.validateError(compileResult, index++, "operator '+' not defined for '(int|string)' and 'int'",
                 31, 17);
+        BAssertUtil.validateError(compileResult, index++, "incompatible types: expected 'int', found '(int|string)'",
+                44, 17);
+        BAssertUtil.validateError(compileResult, index++,
+                "operator '+' not defined for '(int|string)' and '(int|boolean|error)'", 56, 21);
         Assert.assertEquals(compileResult.getErrorCount(), index);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BinaryExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BinaryExprTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -143,15 +144,17 @@ public class BinaryExprTest {
         Assert.assertEquals(((Byte) returns.get(3)).longValue(), b & d);
     }
 
-    @Test(description = "Test binary expression with query")
-    public void binaryExpressionWithQuery() {
-        Object resultAnd = BRunUtil.invoke(result, "binaryANDWithQuery", new Object[]{});
-        Assert.assertSame(resultAnd.getClass(), Boolean.class);
-        Assert.assertTrue((boolean) resultAnd);
+    @Test(description = "Test binary expression with query", dataProvider = "binaryExpressionWithQueryDataProvider")
+    public void binaryExpressionWithQuery(String fnName) {
+        BRunUtil.invoke(result, fnName, new Object[]{});
+    }
 
-        Object resultOr = BRunUtil.invoke(result, "binaryORWithQuery", new Object[]{});
-        Assert.assertSame(resultOr.getClass(), Boolean.class);
-        Assert.assertTrue((boolean) resultOr);
+    @DataProvider(name = "binaryExpressionWithQueryDataProvider")
+    public Object[] binaryExpressionWithQueryData() {
+        return new Object[] {
+                "binaryAndWithQuery",
+                "binaryOrWithQuery"
+        };
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BinaryExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BinaryExprTest.java
@@ -143,6 +143,17 @@ public class BinaryExprTest {
         Assert.assertEquals(((Byte) returns.get(3)).longValue(), b & d);
     }
 
+    @Test(description = "Test binary expression with query")
+    public void binaryExpressionWithQuery() {
+        Object resultAnd = BRunUtil.invoke(result, "binaryANDWithQuery", new Object[]{});
+        Assert.assertSame(resultAnd.getClass(), Boolean.class);
+        Assert.assertTrue((boolean) resultAnd);
+
+        Object resultOr = BRunUtil.invoke(result, "binaryORWithQuery", new Object[]{});
+        Assert.assertSame(resultOr.getClass(), Boolean.class);
+        Assert.assertTrue((boolean) resultOr);
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
@@ -262,6 +262,11 @@ public class ElvisExpressionTest {
         BRunUtil.invoke(compileResult, "testElvisExprWithUnionWithFiniteTypeContainingNull");
     }
 
+    @Test
+    public void testElvisExprWithQuery() {
+        BRunUtil.invoke(compileResult, "testElvisExprWithQuery");
+    }
+
     @Test(description = "Negative test cases.")
     public void testElvisOperatorNegative() {
         int index = 0;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
@@ -393,6 +393,21 @@ public class TernaryExpressionTest {
         BRunUtil.invoke(compileResult, "testTernaryInModuleLevel");
     }
 
+    @Test
+    public void testTernaryWithQueryWithLocalVariable() {
+        BRunUtil.invoke(compileResult, "testTernaryWithQueryWithLocalVariable");
+    }
+
+    @Test
+    public void testTernaryWithQueryWithFunctionParameter() {
+        BRunUtil.invoke(compileResult, "testTernaryWithQueryWithFunctionParameter");
+    }
+
+    @Test
+    public void testTernaryWithQueryWithModuleVariable() {
+        BRunUtil.invoke(compileResult, "testTernaryWithQueryWithModuleVariable");
+    }
+
     @Test(description = "Test type narrowing for ternary expression")
     public void testTernaryTypeNarrow() {
         CompileResult compileResult = BCompileUtil.compile("test-src/expressions/ternary/ternary_expr_type_narrow.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
@@ -418,6 +418,16 @@ public class TernaryExpressionTest {
         BRunUtil.invoke(compileResult, "testTernaryWithQueryForTwoVariables");
     }
 
+    @Test
+    public void testTernaryWithQueryWithFunctionPointers() {
+        BRunUtil.invoke(compileResult, "testTernaryWithQueryWithFunctionPointers");
+    }
+
+    @Test
+    public void testTernaryWithQueryWithFunctionAsClosure() {
+        BRunUtil.invoke(compileResult, "testTernaryWithQueryWithFunctionAsClosure");
+    }
+
     @Test(description = "Test type narrowing for ternary expression")
     public void testTernaryTypeNarrow() {
         CompileResult compileResult = BCompileUtil.compile("test-src/expressions/ternary/ternary_expr_type_narrow.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
@@ -404,8 +404,18 @@ public class TernaryExpressionTest {
     }
 
     @Test
+    public void testTernaryWithQueryWithTypeDef() {
+        BRunUtil.invoke(compileResult, "testTernaryWithQueryWithTypeDef");
+    }
+
+    @Test
     public void testTernaryWithQueryWithModuleVariable() {
         BRunUtil.invoke(compileResult, "testTernaryWithQueryWithModuleVariable");
+    }
+
+    @Test
+    public void testTernaryWithQueryForTwoVariables() {
+        BRunUtil.invoke(compileResult, "testTernaryWithQueryForTwoVariables");
     }
 
     @Test(description = "Test type narrowing for ternary expression")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtTypeNarrowingTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtTypeNarrowingTest.java
@@ -67,6 +67,11 @@ public class MatchStmtTypeNarrowingTest {
         BRunUtil.invoke(result, "testNarrowTypeInListBindingPattern3");
     }
 
+    @Test
+    public void testMatchClauseWithQuery() {
+        BRunUtil.invoke(result, "testMatchClauseWithQuery");
+    }
+
     @Test(dataProvider = "dataToTestMatchClauseWithTypeGuard", description = "Test match clause with type guard")
     public void testMatchClauseWithTypeGuard(String functionName) {
         BRunUtil.invoke(result, functionName);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
@@ -352,9 +352,7 @@ public class WorkerTest {
 
     @Test
     public void testWorkerWithQuery() {
-        Object returns = BRunUtil.invoke(result, "testWorkerWithQuery", new Object[0]);
-        long ret = (long) returns;
-        Assert.assertEquals(ret, 4);
+        BRunUtil.invoke(result, "testWorkerWithQuery", new Object[0]);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
@@ -350,6 +350,13 @@ public class WorkerTest {
         BAssertUtil.validateError(result, 0, "multiple receive action not yet supported", 23, 25);
     }
 
+    @Test
+    public void testWorkerWithQuery() {
+        Object returns = BRunUtil.invoke(result, "testWorkerWithQuery", new Object[0]);
+        long ret = (long) returns;
+        Assert.assertEquals(ret, 4);
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/test_union_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/test_union_type.bal
@@ -69,6 +69,20 @@ function testUnionRuntimeToString() {
                  <string> checkpanic err.detail()["message"]);
 }
 
+function testTernaryWithQueryForModuleImportedVariable() {
+    int|int[] thenResult = foo:IntOrNull is int ?
+        from var _ in [1, 2]
+        where foo:IntOrNull + 2 == 5
+        select 2 : 2;
+    assertEquals([2,2], thenResult);
+
+    int|int[] elseResult = foo:IntOrNull is () ? 2 :
+        from var _ in [1, 2]
+        where foo:IntOrNull + 2 == 5
+        select 2;
+    assertEquals([2,2], elseResult);
+}
+
 function assertTrue(anydata actual) {
     return assertEquals(true, actual);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/union_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/union_type.bal
@@ -25,3 +25,5 @@ public enum BazQux {
     BAZ,
     QUX
 }
+
+public int? IntOrNull = 3;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/closures/closure_negative_02.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/closures/closure_negative_02.bal
@@ -35,3 +35,26 @@ function testTypeNarrowingWithClosure2() returns int|string {
     };
     return x;
 }
+
+function testBasicClosureWithInvalidTypeNarrowing() {
+    int|string a = "32";
+    var fn = function () {
+        int b;
+        if a is int {
+            b = a;
+        }
+    };
+}
+
+function testMultiLevelClosureWithInvalidTypeNarrowing() {
+    int|string a = "32";
+    var fn1 = function() {
+        int|boolean|error b = 32;
+        var fn2 = function(int|string|boolean c) {
+            int d;
+            if a is int && b is int && c is int {
+                d = a + b + c;
+            }
+        };
+    };
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary-expr.bal
@@ -38,16 +38,25 @@ function bitwiseAnd(int a, int b, byte c, byte d) returns [int, byte, byte, byte
     return res;
 }
 
-function binaryANDWithQuery() returns boolean {
+function binaryAndWithQuery() {
     int? i = 3;
-    return i is int && (from var _ in [1, 2]
+    boolean result = i is int && (from var _ in [1, 2]
         where i + 2 == 5
         select 2) == [2, 2];
+    assertTrue(result);
 }
 
-function binaryORWithQuery() returns boolean {
+function binaryOrWithQuery() {
     int? i = 3;
-    return i is () || (from var _ in [1, 2]
+    boolean result = i is () || (from var _ in [1, 2]
         where i + 2 == 5
         select 2) == [2, 2];
+    assertTrue(result);
+}
+
+function assertTrue(boolean actual) {
+    if actual {
+        return;
+    }
+    panic error(string `expected 'true', found '${actual.toString()}'`);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary-expr.bal
@@ -37,3 +37,17 @@ function bitwiseAnd(int a, int b, byte c, byte d) returns [int, byte, byte, byte
     res [3] = b & d;
     return res;
 }
+
+function binaryANDWithQuery() returns boolean {
+    int? i = 3;
+    return i is int && (from var _ in [1, 2]
+        where i + 2 == 5
+        select 2) == [2, 2];
+}
+
+function binaryORWithQuery() returns boolean {
+    int? i = 3;
+    return i is () || (from var _ in [1, 2]
+        where i + 2 == 5
+        select 2) == [2, 2];
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
@@ -537,6 +537,15 @@ function testElvisExprWithUnionWithFiniteTypeContainingNull() {
     assertEquals(23, f);
 }
 
+function testElvisExprWithQuery() {
+    int? i = ();
+    int|int[] res = i ?:
+        from var _ in [1, 2]
+        where i == ()
+        select 2;
+    assertEquals([2,2], res);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
@@ -384,6 +384,39 @@ function testTernaryWithQueryWithModuleVariable() {
     assertEquals([2,2], elseResult);
 }
 
+type A int?;
+A a = 3;
+function testTernaryWithQueryWithTypeDef() {
+    int|int[] thenResult = a is int ?
+        from var _ in [1, 2]
+        where a + 2 == 5
+        select 2 : 2;
+    assertEquals([2,2], thenResult);
+
+    int|int[] elseResult = a is () ? 2 :
+        from var _ in [1, 2]
+        where a + 2 == 5
+        select 2;
+    assertEquals([2,2], elseResult);
+}
+
+function testTernaryWithQueryForTwoVariables() {
+    int? a = 3;
+    int? b = ();
+
+    int|int[] thenResult = a != b ?
+        from var _ in [1, 2]
+        where a + 2 == 5
+        select 2 : 2;
+    assertEquals([2, 2], thenResult);
+
+    int|int[] elseResult = a == b ? 2 :
+        from var _ in [1, 2]
+        where a + 2 == 5
+        select 2;
+    assertEquals([2, 2], elseResult);
+}
+
 boolean cond2 = true;
 int i1 =10;
 byte j1 = 100;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
@@ -334,6 +334,56 @@ function testTernaryWithLangValueMethodCalls() {
     assertEquals("a", b48);
 }
 
+function testTernaryWithQueryWithLocalVariable() {
+    int? i = 3;
+
+    int|int[] thenResult = i is int ?
+        from var _ in [1, 2]
+        where i + 2 == 5
+        select 2 : 2;
+    assertEquals([2,2], thenResult);
+
+    int|int[] elseResult = i is () ? 2 :
+        from var _ in [1, 2]
+        where i + 2 == 5
+        select 2;
+    assertEquals([2,2], elseResult);
+}
+
+function testTernaryWithQueryWithFunctionParameter() {
+    int? x = 3;
+    ternaryWithQueryWithFunctionParameter(x);
+}
+
+function ternaryWithQueryWithFunctionParameter(int? i) {
+    int|int[] thenResult = i is int ?
+        from var _ in [1, 2]
+        where i + 2 == 5
+        select 2 : 2;
+    assertEquals([2,2], thenResult);
+
+    int|int[] elseResult = i is () ? 2 :
+        from var _ in [1, 2]
+        where i + 2 == 5
+        select 2;
+    assertEquals([2,2], elseResult);
+}
+
+int? i = 3;
+function testTernaryWithQueryWithModuleVariable() {
+    int|int[] thenResult = i is int ?
+        from var _ in [1, 2]
+        where i + 2 == 5
+        select 2 : 2;
+    assertEquals([2,2], thenResult);
+
+    int|int[] elseResult = i is () ? 2 :
+        from var _ in [1, 2]
+        where i + 2 == 5
+        select 2;
+    assertEquals([2,2], elseResult);
+}
+
 boolean cond2 = true;
 int i1 =10;
 byte j1 = 100;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
@@ -417,6 +417,42 @@ function testTernaryWithQueryForTwoVariables() {
     assertEquals([2, 2], elseResult);
 }
 
+function testTernaryWithQueryWithFunctionPointers() {
+    int? i = 3;
+    var k = function() returns int? {
+        return i;
+    };
+
+    int|int[] thenResult = i is int ?
+        from var _ in [1, 2]
+        where k() + 2 == 5
+        select 2 : 2;
+    assertEquals([2,2], thenResult);
+
+    int|int[] elseResult = i is () ? 2 :
+        from var _ in [1, 2]
+        where k() + 2 == 5
+        select 2;
+    assertEquals([2,2], elseResult);
+}
+
+function testTernaryWithQueryWithFunctionAsClosure() {
+    ()|function() returns int fn = function() returns int {
+        return 3;
+    };
+    int|int[] thenResult = fn !is () ?
+        from var _ in [1, 2]
+        where fn() + 2 == 5
+        select 2 : 2;
+    assertEquals([2,2], thenResult);
+
+    int|int[] elseResult = fn is () ? 2 :
+        from var _ in [1, 2]
+        where fn() + 2 == 5
+        select 2;
+    assertEquals([2,2], elseResult);
+}
+
 boolean cond2 = true;
 int i1 =10;
 byte j1 = 100;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/match-stmt-type-narrow.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/match-stmt-type-narrow.bal
@@ -410,6 +410,24 @@ function testMatchClauseWithTypeGuard12() {
     assertEquals("Pattern1 Pattern4 with error retry count:5 Pattern5 with reason:Connection failure", matched);
 }
 
+function testMatchClauseWithQuery() {
+    int|string i = 3;
+    int|int[] result;
+
+    match i {
+        var _ if i is int => {
+            result = from var _ in [1, 2]
+                where i + 2 == 5
+                select 2;
+        }
+        _ => {
+            result = 2;
+        }
+    }
+
+    assertEquals([2, 2], result);
+}
+
 function assertEquals(anydata expected, anydata actual) {
     if expected == actual {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
@@ -652,7 +652,7 @@ function testWorkerInteractionsAfterCheck() {
     validateError(e, "Error");
 }
 
-public function testWorkerWithQuery() returns int {
+public function testWorkerWithQuery() {
     worker A {
         int? i = 3;
         i is int ? from var _ in [1, 2]
@@ -664,7 +664,7 @@ public function testWorkerWithQuery() returns int {
     foreach var item in x {
         sum += item;
     }
-    return sum;
+    assertEquals(4, sum);
 }
 
 public function sleep(int millis) = @java:Method {
@@ -679,4 +679,12 @@ function validateError(any|error value, string message) {
         panic error("Expected error message: " + message + ", found: " + value.message());
     }
     panic error("Expected error, found: " + (typeof value).toString());
+}
+
+function assertEquals(anydata expected, anydata actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error(string `expected [${expected.toString()}], found [${actual.toString()}]`);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
@@ -652,6 +652,21 @@ function testWorkerInteractionsAfterCheck() {
     validateError(e, "Error");
 }
 
+public function testWorkerWithQuery() returns int {
+    worker A {
+        int? i = 3;
+        i is int ? from var _ in [1, 2]
+                where i + 2 == 5
+                select 2 : [2] -> function;
+    }
+    int[] x = <- A;
+    int sum = 0;
+    foreach var item in x {
+        sum += item;
+    }
+    return sum;
+}
+
 public function sleep(int millis) = @java:Method {
     'class: "org.ballerinalang.test.utils.interop.Utils"
 } external;


### PR DESCRIPTION
## Purpose
For expressions like ternary and binary, the if and else bodies are generated in the desugar phase. As a result, the `TypeNarrower` is unable to set the narrowed scopes for the if and else bodies generated for these expressions since they are not available in the type checker phase. However, the current implementation of the query desugar implementation relies on this narrowed scope to determine if the variable is captured, as it uses the symbol resolver looks for the narrowed symbol in the environment. Although this approach works for user-written if-else bodies (as they are available in the type checker), it cannot identify captured variables for desugared bodies. 

Fixes #41642

## Approach

The proposed approach modifies the query desugar implementation to check the original symbol rather than the narrowed symbol to determine captured variables.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
