### PR TITLE
[2201.8.x] Fix value conversion error for record creation with special characters

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -364,11 +364,11 @@ public class BIRGen extends BLangNodeVisitor {
         BType type = getDefinedType(astTypeDefinition);
         BType referredType = Types.getImpliedType(type);
         BSymbol symbol = astTypeDefinition.symbol;
-        Name displayName = symbol.name;
+        String displayName = symbol.name.value;
         if (referredType.tag == TypeTags.RECORD) {
             BRecordType recordType = (BRecordType) referredType;
             if (recordType.shouldPrintShape()) {
-                displayName = new Name(Utils.unescapeBallerina(recordType.toString()));
+                displayName = recordType.toString();
             }
         }
 
@@ -379,7 +379,7 @@ public class BIRGen extends BLangNodeVisitor {
                                                           type,
                                                           new ArrayList<>(),
                                                           symbol.origin.toBIROrigin(),
-                                                          displayName,
+                                                          new Name(Utils.unescapeBallerina(displayName)),
                                                           symbol.originalName);
         if (symbol.tag == SymTag.TYPE_DEF) {
             BTypeReferenceType referenceType = ((BTypeDefinitionSymbol) symbol).referenceType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -18,6 +18,7 @@
 
 package org.wso2.ballerinalang.compiler.bir;
 
+import io.ballerina.identifier.Utils;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.LineRange;
@@ -367,7 +368,7 @@ public class BIRGen extends BLangNodeVisitor {
         if (referredType.tag == TypeTags.RECORD) {
             BRecordType recordType = (BRecordType) referredType;
             if (recordType.shouldPrintShape()) {
-                displayName = new Name(recordType.toString());
+                displayName = new Name(Utils.unescapeBallerina(recordType.toString()));
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -34,7 +34,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
-import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
@@ -43,7 +42,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
-import org.wso2.ballerinalang.util.Flags;
 import org.wso2.ballerinalang.util.Lists;
 
 import java.util.ArrayList;
@@ -192,9 +190,6 @@ public class JvmDesugarPhase {
     private static void encodeTypeDefIdentifiers(List<BIRTypeDefinition> typeDefs,
                                                  HashMap<String, String> encodedVsInitialIds) {
         for (BIRTypeDefinition typeDefinition : typeDefs) {
-            if (Symbols.isFlagOn(typeDefinition.type.flags, Flags.ANONYMOUS)) {
-                typeDefinition.name = Names.fromString(Utils.unescapeBallerina(typeDefinition.name.value));
-            }
             typeDefinition.type.tsymbol.name = Names.fromString(encodeNonFunctionIdentifier(
                     typeDefinition.type.tsymbol.name.value, encodedVsInitialIds));
             typeDefinition.internalName =

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -4646,12 +4646,11 @@ function testLast() {
     assertTrue([] == value:last(ar1, ar));
 }
 
-
 public type Copybook record {
-    DFHCOMMAREA DFHCOMMAREA?;
+    DFH\-COMMAREA DFH\-COMMAREA?;
 };
 
-public type DFHCOMMAREA record {
+public type DFH\-COMMAREA record {
     record {
         string MI\-HDR\-VERSION?;
         string MI\-HDR\-MSGID?;
@@ -4664,7 +4663,7 @@ public type DFHCOMMAREA record {
 
 function testCloneWithTypeToRecordWithSpecialChars() {
     string s = string `{
-    "DFHCOMMAREA": {
+    "DFH-COMMAREA": {
         "BROKER-MESSAGE-AREA": {
             "MI-HDR-VERSION": "2",
             "MI-HDR-MSGID":"3238763233323598798798712321187612",
@@ -4674,10 +4673,10 @@ function testCloneWithTypeToRecordWithSpecialChars() {
     }`;
     json rec = checkpanic value:fromJsonString(s);
     map<json> mapJson = checkpanic rec.ensureType();
-    Copybook|error dfhcommarea = mapJson.cloneWithType();
-    assertTrue(dfhcommarea is Copybook);
-    Copybook cb =  checkpanic dfhcommarea.ensureType();
-    assertEquality(cb.DFHCOMMAREA?.BROKER\-MESSAGE\-AREA.toString(), string `{"MI-HDR-VERSION":"2","MI-HDR-MSGID":"3238763233323598798798712321187612","MI-HDR-LOGGINGID":"Z5118761-Z"}`);
+    Copybook|error dfh\-commarea = mapJson.cloneWithType();
+    assertTrue(dfh\-commarea is Copybook);
+    Copybook cb =  checkpanic dfh\-commarea.ensureType();
+    assertEquality(cb.DFH\-COMMAREA?.BROKER\-MESSAGE\-AREA.toString(), string `{"MI-HDR-VERSION":"2","MI-HDR-MSGID":"3238763233323598798798712321187612","MI-HDR-LOGGINGID":"Z5118761-Z"}`);
 }
 
 type AssertionError distinct error;


### PR DESCRIPTION
## Purpose
$subject 

Fixes #41633

## Approach
As we use the decoded identifiers in the value conversions, the generated record value creators should have the same representation in the switch cases. This PR fixes it by using the Utils.unescapeBallerina() API. The issue happens for typedef name as well. 

## Samples
```ballerina
import ballerina/io;

public type Copybook record {
    DFH\-COMMAREA DFH\-COMMAREA?;
};

public type DFH\-COMMAREA record {
    record {
        string MI\-HDR\-VERSION?;
        string MI\-HDR\-MSGID?;
        string MI\-HDR\-LOGGINGID?;
        record {
            string MI\-HDR\-REPLYQMGR?;
        }[2] MI\-HDR\-REPLYSTACK?;
    } BROKER\-MESSAGE\-AREA?;
};

public function main() returns error? {
    string s = string `{
    "DFH-COMMAREA": {
        "BROKER-MESSAGE-AREA": {
            "MI-HDR-VERSION": "2",
            "MI-HDR-MSGID":"3238763233323598798798712321187612",
            "MI-HDR-LOGGINGID": "Z5118761-Z"
        }
    }
    }`;
    json rec = checkpanic value:fromJsonString(s);
    map<json> mapJson = check rec.ensureType();
    Copybook dfhcommarea = check mapJson.cloneWithType();
    io:println(dfhcommarea.DFH\-COMMAREA?.BROKER\-MESSAGE\-AREA);
}
```

## Remarks
Related to #41633

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
