### PR TITLE
Fix using of the spread field with an open record to construct a closed record 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -174,8 +174,10 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     CANNOT_SPECIFY_NAMED_ARG_FOR_FIELD_OF_INCLUDED_RECORD_WHEN_ARG_SPECIFIED_FOR_INCLUDED_RECORD("BCE2137",
             "cannot.specify.named.argument.for.field.of.included.record.when.arg.specified.for.included.record"),
     CYCLIC_TYPE_REFERENCE_NOT_YET_SUPPORTED("BCE2138", "cyclic.type.reference.not.yet.supported"),
-    INVALID_SPREAD_OP_TO_CREATE_CLOSED_RECORD_FROM_OPEN_RECORD("BCE2139",
-            "invalid.spread.operator.to.create.closed.record.from.open.record"),
+    INVALID_SPREAD_FIELD_TO_CREATE_CLOSED_RECORD_FROM_OPEN_RECORD("BCE2139",
+            "invalid.spread.field.to.create.closed.record.from.open.record"),
+    MISMATCHING_REST_TYPE_DESCRIPTOR_IN_SPREAD_FIELD("BCE2140",
+            "mismatching.rest.fields.in.spread.field"),
 
     //Transaction related error codes
     ROLLBACK_CANNOT_BE_OUTSIDE_TRANSACTION_BLOCK("BCE2300", "rollback.cannot.be.outside.transaction.block"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -176,8 +176,7 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     CYCLIC_TYPE_REFERENCE_NOT_YET_SUPPORTED("BCE2138", "cyclic.type.reference.not.yet.supported"),
     INVALID_SPREAD_FIELD_TO_CREATE_CLOSED_RECORD_FROM_OPEN_RECORD("BCE2139",
             "invalid.spread.field.to.create.closed.record.from.open.record"),
-    INVALID_SPREAD_FIELD_REST_FIELD_MISMATCH("BCE2140",
-            "invalid.spread.field.rest.field.mismatch"),
+    INVALID_SPREAD_FIELD_REST_FIELD_MISMATCH("BCE2140", "invalid.spread.field.rest.field.mismatch"),
 
     //Transaction related error codes
     ROLLBACK_CANNOT_BE_OUTSIDE_TRANSACTION_BLOCK("BCE2300", "rollback.cannot.be.outside.transaction.block"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -174,6 +174,8 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     CANNOT_SPECIFY_NAMED_ARG_FOR_FIELD_OF_INCLUDED_RECORD_WHEN_ARG_SPECIFIED_FOR_INCLUDED_RECORD("BCE2137",
             "cannot.specify.named.argument.for.field.of.included.record.when.arg.specified.for.included.record"),
     CYCLIC_TYPE_REFERENCE_NOT_YET_SUPPORTED("BCE2138", "cyclic.type.reference.not.yet.supported"),
+    INVALID_SPREAD_OP_TO_CREATE_CLOSED_RECORD_FROM_OPEN_RECORD("BCE2139",
+            "invalid.spread.operator.to.create.closed.record.from.open.record"),
 
     //Transaction related error codes
     ROLLBACK_CANNOT_BE_OUTSIDE_TRANSACTION_BLOCK("BCE2300", "rollback.cannot.be.outside.transaction.block"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -176,8 +176,8 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     CYCLIC_TYPE_REFERENCE_NOT_YET_SUPPORTED("BCE2138", "cyclic.type.reference.not.yet.supported"),
     INVALID_SPREAD_FIELD_TO_CREATE_CLOSED_RECORD_FROM_OPEN_RECORD("BCE2139",
             "invalid.spread.field.to.create.closed.record.from.open.record"),
-    MISMATCHING_REST_TYPE_DESCRIPTOR_IN_SPREAD_FIELD("BCE2140",
-            "mismatching.rest.fields.in.spread.field"),
+    INVALID_SPREAD_FIELD_REST_FIELD_MISMATCH("BCE2140",
+            "invalid.spread.field.rest.field.mismatch"),
 
     //Transaction related error codes
     ROLLBACK_CANNOT_BE_OUTSIDE_TRANSACTION_BLOCK("BCE2300", "rollback.cannot.be.outside.transaction.block"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -7656,12 +7656,20 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                             }
                         }
                     }
-                    if (!spreadRecordType.sealed && (mappingRecordType.sealed ||
-                            !types.isAssignable(spreadRecordType.restFieldType, mappingRecordType.restFieldType))) {
-                        dlog.error(spreadExpr.pos,
-                                DiagnosticErrorCode.INVALID_SPREAD_OP_TO_CREATE_CLOSED_RECORD_FROM_OPEN_RECORD,
-                                spreadExprType);
-                        errored = true;
+                    if (!spreadRecordType.sealed) {
+                         if (mappingRecordType.sealed) {
+                             dlog.error(spreadExpr.pos,
+                                     DiagnosticErrorCode.INVALID_SPREAD_FIELD_TO_CREATE_CLOSED_RECORD_FROM_OPEN_RECORD,
+                                     spreadRecordType);
+                             errored = true;
+                         } else if (!types.isAssignable(spreadRecordType.restFieldType,
+                                 mappingRecordType.restFieldType)) {
+                             dlog.error(spreadExpr.pos,
+                                     DiagnosticErrorCode.MISMATCHING_REST_TYPE_DESCRIPTOR_IN_SPREAD_FIELD,
+                                     mappingRecordType, mappingRecordType.restFieldType,
+                                     spreadRecordType.restFieldType);
+                             errored = true;
+                         }
                     }
                     return errored ? symTable.semanticError : symTable.noType;
                 } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -7666,8 +7666,8 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                                  mappingRecordType.restFieldType)) {
                              dlog.error(spreadExpr.pos,
                                      DiagnosticErrorCode.INVALID_SPREAD_FIELD_REST_FIELD_MISMATCH,
-                                     mappingRecordType, mappingRecordType.restFieldType,
-                                     spreadRecordType.restFieldType);
+                                     spreadRecordType, spreadRecordType.restFieldType,
+                                     mappingRecordType.restFieldType);
                              errored = true;
                          }
                     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -7665,7 +7665,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                          } else if (!types.isAssignable(spreadRecordType.restFieldType,
                                  mappingRecordType.restFieldType)) {
                              dlog.error(spreadExpr.pos,
-                                     DiagnosticErrorCode.MISMATCHING_REST_TYPE_DESCRIPTOR_IN_SPREAD_FIELD,
+                                     DiagnosticErrorCode.INVALID_SPREAD_FIELD_REST_FIELD_MISMATCH,
                                      mappingRecordType, mappingRecordType.restFieldType,
                                      spreadRecordType.restFieldType);
                              errored = true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -7656,11 +7656,12 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                             }
                         }
                     }
-                    if (!spreadRecordType.sealed && mappingRecordType.sealed) {
+                    if (!spreadRecordType.sealed && (mappingRecordType.sealed ||
+                            !types.isAssignable(spreadRecordType.restFieldType, mappingRecordType.restFieldType))) {
                         dlog.error(spreadExpr.pos,
                                 DiagnosticErrorCode.INVALID_SPREAD_OP_TO_CREATE_CLOSED_RECORD_FROM_OPEN_RECORD,
                                 spreadExprType);
-                        return symTable.semanticError;
+                        errored = true;
                     }
                     return errored ? symTable.semanticError : symTable.noType;
                 } else {

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1191,7 +1191,8 @@ error.invalid.spread.field.to.create.closed.record.from.open.record=\
   invalid usage of spread field with open record of type ''{0}'', that may have rest fields, to construct a closed record
 
 error.invalid.spread.field.rest.field.mismatch=\
-  invalid usage of spread field with open record of type ''{0}'', that may have rest fields of type ''{1}'', to construct a record that allows only ''{2}'' rest fields
+  invalid usage of spread field with open record of type ''{0}'', that may have rest fields of type ''{1}'', \
+  to construct a record that allows only ''{2}'' rest fields
 
 error.invalid.array.literal=\
   invalid usage of array literal with type ''{0}''

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1187,6 +1187,9 @@ error.spread.field.may.duplicate.already.specified.keys=\
 error.multiple.inclusive.types=\
   invalid usage of mapping constructor expression: multiple spread fields of inclusive mapping types are not allowed
 
+error.invalid.spread.operator.to.create.closed.record.from.open.record=\
+  invalid usage of spread operator to construct a closed record from an open record
+
 error.invalid.array.literal=\
   invalid usage of array literal with type ''{0}''
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1187,8 +1187,11 @@ error.spread.field.may.duplicate.already.specified.keys=\
 error.multiple.inclusive.types=\
   invalid usage of mapping constructor expression: multiple spread fields of inclusive mapping types are not allowed
 
-error.invalid.spread.operator.to.create.closed.record.from.open.record=\
-  invalid usage of spread operator to construct a closed record from an open record
+error.invalid.spread.field.to.create.closed.record.from.open.record=\
+  invalid usage of spread field with open record of type ''{0}'' that may have rest fields to construct a closed record
+
+error.mismatching.rest.fields.in.spread.field=\
+  invalid usage of spread field with open record of type ''{0}'' that may have rest fields of type ''{1}'' to construct a record that allows only ''{2}'' rest fields
 
 error.invalid.array.literal=\
   invalid usage of array literal with type ''{0}''

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1188,10 +1188,10 @@ error.multiple.inclusive.types=\
   invalid usage of mapping constructor expression: multiple spread fields of inclusive mapping types are not allowed
 
 error.invalid.spread.field.to.create.closed.record.from.open.record=\
-  invalid usage of spread field with open record of type ''{0}'' that may have rest fields to construct a closed record
+  invalid usage of spread field with open record of type ''{0}'', that may have rest fields, to construct a closed record
 
-error.mismatching.rest.fields.in.spread.field=\
-  invalid usage of spread field with open record of type ''{0}'' that may have rest fields of type ''{1}'' to construct a record that allows only ''{2}'' rest fields
+error.invalid.spread.field.rest.field.mismatch=\
+  invalid usage of spread field with open record of type ''{0}'', that may have rest fields of type ''{1}'', to construct a record that allows only ''{2}'' rest fields
 
 error.invalid.array.literal=\
   invalid usage of array literal with type ''{0}''

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -149,11 +149,11 @@ public class MappingConstructorExprTest {
         validateError(result, i++, "incompatible types: expected 'string' for field 's', found 'int'", 41, 17);
         validateError(result, i++, "incompatible types: expected 'int' for field 'i', found 'boolean'", 41, 29);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'record {| boolean i; anydata...; |}' that " +
-                        "may have rest fields to construct a closed record", 41, 29);
+                "invalid usage of spread field with open record of type 'record {| boolean i; anydata...; |}', that " +
+                        "may have rest fields, to construct a closed record", 41, 29);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'record {| int i; boolean x; anydata...; |}' " +
-                        "that may have rest fields to construct a closed record", 49, 29);
+                "invalid usage of spread field with open record of type 'record {| int i; boolean x; anydata...; |}'," +
+                        " that may have rest fields, to construct a closed record", 49, 29);
         validateError(result, i++, "undefined field 'x' in record 'Foo'", 49, 29);
         validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 53, 26);
         validateError(result, i++, "undefined symbol 'b'", 53, 26);
@@ -163,60 +163,56 @@ public class MappingConstructorExprTest {
         validateError(result, i++, "missing non-defaultable required record field 'i'", 67, 13);
         validateError(result, i++, "missing non-defaultable required record field 'i'", 71, 13);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'Address' that may have rest fields to " +
-                        "construct a closed record",
-                84, 39);
+                "invalid usage of spread field with open record of type 'Address', that may have rest fields, to " +
+                        "construct a closed record", 92, 39);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'Address' that may have rest fields to " +
-                        "construct a closed record",
-                87, 39);
+                "invalid usage of spread field with open record of type 'Address', that may have rest fields, to " +
+                        "construct a closed record", 95, 39);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'Address' that may have rest fields to " +
-                        "construct a closed record",
-                90, 20);
+                "invalid usage of spread field with open record of type 'Address', that may have rest fields, to " +
+                        "construct a closed record", 98, 20);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'record {| string street; anydata...; |}' " +
-                        "that may have rest fields to construct a closed record",
-                93, 20);
+                "invalid usage of spread field with open record of type 'record {| string street; anydata...; |}', " +
+                        "that may have rest fields, to construct a closed record", 101, 20);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'record {| string street; anydata...; |}' " +
-                        "that may have rest fields to construct a closed record",
-                96, 20);
+                "invalid usage of spread field with open record of type 'record {| string street; anydata...; |}', " +
+                        "that may have rest fields, to construct a closed record", 104, 20);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'record {| string s; anydata...; |}' that may" +
-                        " have rest fields to construct a closed record",
-                100, 17);
+                "invalid usage of spread field with open record of type 'record {| string s; anydata...; |}', that " +
+                        "may have rest fields, to construct a closed record", 108, 17);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'record {| int i; anydata...; |}' that may " +
-                        "have rest fields to construct a closed record",
-                100, 26);
-        validateError(result, i++, "incompatible types: expected 'string' for field 'population', found 'int'", 111,
-                21);
+                "invalid usage of spread field with open record of type 'record {| int i; anydata...; |}', that may " +
+                        "have rest fields, to construct a closed record", 108, 26);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'Country' that may have rest fields of type " +
-                        "'string' to construct a record that allows only 'anydata' rest fields",
-                111, 21);
+                "invalid usage of spread field with open record of type 'Foz', that may have rest fields of type " +
+                        "'string', to construct a record that allows only 'anydata' rest fields", 114, 36);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'Country' that may have rest fields of type " +
-                        "'string' to construct a record that allows only 'anydata' rest fields",
-                114, 21);
+                "invalid usage of spread field with open record of type 'Foz', that may have rest fields of type " +
+                        "'string', to construct a record that allows only 'anydata' rest fields", 114, 45);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'Country' that may have rest fields of type " +
-                        "'string' to construct a record that allows only 'anydata' rest fields",
-                117, 40);
-        validateError(result, i++, "incompatible types: expected a map or a record, found 'int'", 124, 28);
-        validateError(result, i++, "incompatible types: expected 'string', found '(int|float)'", 132, 25);
-        validateError(result, i++, "incompatible types: expected 'string', found 'anydata'", 132, 39);
-        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 136, 38);
-        validateError(result, i++, "undefined symbol 'b'", 136, 38);
-        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 136, 44);
-        validateError(result, i++, "undefined function 'getFoo'", 136, 44);
-        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 146, 18);
-        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 146, 30);
-        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 147, 30);
-        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 147, 36);
-        validateError(result, i++, "incompatible types: expected 'int', found 'string'", 160, 18);
-        validateError(result, i++, "incompatible types: expected '(int|float)', found 'string'", 161, 32);
+                "incompatible types: expected 'string' for field 'population', found 'int'", 125, 21);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'Country', that may have rest fields of type " +
+                        "'string', to construct a record that allows only 'anydata' rest fields", 125, 21);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'Country', that may have rest fields of type " +
+                        "'string', to construct a record that allows only 'anydata' rest fields", 128, 21);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'Country', that may have rest fields of type " +
+                        "'string', to construct a record that allows only 'anydata' rest fields", 131, 40);
+        validateError(result, i++, "incompatible types: expected a map or a record, found 'int'", 138, 28);
+        validateError(result, i++, "incompatible types: expected 'string', found '(int|float)'", 146, 25);
+        validateError(result, i++, "incompatible types: expected 'string', found 'anydata'", 146, 39);
+        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 150, 38);
+        validateError(result, i++, "undefined symbol 'b'", 150, 38);
+        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 150, 44);
+        validateError(result, i++, "undefined function 'getFoo'", 150, 44);
+        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 160, 18);
+        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 160, 30);
+        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 161, 30);
+        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 161, 36);
+        validateError(result, i++, "incompatible types: expected 'int', found 'string'", 174, 18);
+        validateError(result, i++, "incompatible types: expected '(int|float)', found 'string'", 175, 32);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -148,6 +148,10 @@ public class MappingConstructorExprTest {
         validateError(result, i++, "incompatible types: expected 'int' for field 'i', found 'float'", 41, 17);
         validateError(result, i++, "incompatible types: expected 'string' for field 's', found 'int'", 41, 17);
         validateError(result, i++, "incompatible types: expected 'int' for field 'i', found 'boolean'", 41, 29);
+        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+                41, 29);
+        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+                49, 29);
         validateError(result, i++, "undefined field 'x' in record 'Foo'", 49, 29);
         validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 53, 26);
         validateError(result, i++, "undefined symbol 'b'", 53, 26);
@@ -156,19 +160,33 @@ public class MappingConstructorExprTest {
         validateError(result, i++, "missing non-defaultable required record field 'i'", 64, 13);
         validateError(result, i++, "missing non-defaultable required record field 'i'", 67, 13);
         validateError(result, i++, "missing non-defaultable required record field 'i'", 71, 13);
-        validateError(result, i++, "incompatible types: expected a map or a record, found 'int'", 78, 28);
-        validateError(result, i++, "incompatible types: expected 'string', found '(int|float)'", 86, 25);
-        validateError(result, i++, "incompatible types: expected 'string', found 'anydata'", 86, 39);
-        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 90, 38);
-        validateError(result, i++, "undefined symbol 'b'", 90, 38);
-        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 90, 44);
-        validateError(result, i++, "undefined function 'getFoo'", 90, 44);
-        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 100, 18);
-        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 100, 30);
-        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 101, 30);
-        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 101, 36);
-        validateError(result, i++, "incompatible types: expected 'int', found 'string'", 114, 18);
-        validateError(result, i++, "incompatible types: expected '(int|float)', found 'string'", 115, 32);
+        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+                84, 39);
+        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+                87, 39);
+        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+                90, 20);
+        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+                93, 20);
+        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+                96, 20);
+        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+                100, 17);
+        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+                100, 26);
+        validateError(result, i++, "incompatible types: expected a map or a record, found 'int'", 107, 28);
+        validateError(result, i++, "incompatible types: expected 'string', found '(int|float)'", 115, 25);
+        validateError(result, i++, "incompatible types: expected 'string', found 'anydata'", 115, 39);
+        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 119, 38);
+        validateError(result, i++, "undefined symbol 'b'", 119, 38);
+        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 119, 44);
+        validateError(result, i++, "undefined function 'getFoo'", 119, 44);
+        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 129, 18);
+        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 129, 30);
+        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 130, 30);
+        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 130, 36);
+        validateError(result, i++, "incompatible types: expected 'int', found 'string'", 143, 18);
+        validateError(result, i++, "incompatible types: expected '(int|float)', found 'string'", 144, 32);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -150,12 +150,10 @@ public class MappingConstructorExprTest {
         validateError(result, i++, "incompatible types: expected 'int' for field 'i', found 'boolean'", 41, 29);
         validateError(result, i++,
                 "invalid usage of spread field with open record of type 'record {| boolean i; anydata...; |}' that " +
-                        "may have rest fields to construct a closed record",
-                41, 29);
+                        "may have rest fields to construct a closed record", 41, 29);
         validateError(result, i++,
                 "invalid usage of spread field with open record of type 'record {| int i; boolean x; anydata...; |}' " +
-                        "that may have rest fields to construct a closed record",
-                49, 29);
+                        "that may have rest fields to construct a closed record", 49, 29);
         validateError(result, i++, "undefined field 'x' in record 'Foo'", 49, 29);
         validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 53, 26);
         validateError(result, i++, "undefined symbol 'b'", 53, 26);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -148,9 +148,13 @@ public class MappingConstructorExprTest {
         validateError(result, i++, "incompatible types: expected 'int' for field 'i', found 'float'", 41, 17);
         validateError(result, i++, "incompatible types: expected 'string' for field 's', found 'int'", 41, 17);
         validateError(result, i++, "incompatible types: expected 'int' for field 'i', found 'boolean'", 41, 29);
-        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'record {| boolean i; anydata...; |}' that " +
+                        "may have rest fields to construct a closed record",
                 41, 29);
-        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'record {| int i; boolean x; anydata...; |}' " +
+                        "that may have rest fields to construct a closed record",
                 49, 29);
         validateError(result, i++, "undefined field 'x' in record 'Foo'", 49, 29);
         validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 53, 26);
@@ -160,37 +164,61 @@ public class MappingConstructorExprTest {
         validateError(result, i++, "missing non-defaultable required record field 'i'", 64, 13);
         validateError(result, i++, "missing non-defaultable required record field 'i'", 67, 13);
         validateError(result, i++, "missing non-defaultable required record field 'i'", 71, 13);
-        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                90, 39);
-        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                93, 39);
-        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'Address' that may have rest fields to " +
+                        "construct a closed record",
+                84, 39);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'Address' that may have rest fields to " +
+                        "construct a closed record",
+                87, 39);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'Address' that may have rest fields to " +
+                        "construct a closed record",
+                90, 20);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'record {| string street; anydata...; |}' " +
+                        "that may have rest fields to construct a closed record",
+                93, 20);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'record {| string street; anydata...; |}' " +
+                        "that may have rest fields to construct a closed record",
                 96, 20);
-        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                99, 20);
-        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                102, 20);
-        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                106, 17);
-        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                106, 26);
-        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                109, 21);
-        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                112, 40);
-        validateError(result, i++, "incompatible types: expected a map or a record, found 'int'", 119, 28);
-        validateError(result, i++, "incompatible types: expected 'string', found '(int|float)'", 127, 25);
-        validateError(result, i++, "incompatible types: expected 'string', found 'anydata'", 127, 39);
-        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 131, 38);
-        validateError(result, i++, "undefined symbol 'b'", 131, 38);
-        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 131, 44);
-        validateError(result, i++, "undefined function 'getFoo'", 131, 44);
-        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 141, 18);
-        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 141, 30);
-        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 142, 30);
-        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 142, 36);
-        validateError(result, i++, "incompatible types: expected 'int', found 'string'", 155, 18);
-        validateError(result, i++, "incompatible types: expected '(int|float)', found 'string'", 156, 32);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'record {| string s; anydata...; |}' that may" +
+                        " have rest fields to construct a closed record",
+                100, 17);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'record {| int i; anydata...; |}' that may " +
+                        "have rest fields to construct a closed record",
+                100, 26);
+        validateError(result, i++, "incompatible types: expected 'string' for field 'population', found 'int'", 111,
+                21);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'Country' that may have rest fields of type " +
+                        "'string' to construct a record that allows only 'anydata' rest fields",
+                111, 21);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'Country' that may have rest fields of type " +
+                        "'string' to construct a record that allows only 'anydata' rest fields",
+                114, 21);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'Country' that may have rest fields of type " +
+                        "'string' to construct a record that allows only 'anydata' rest fields",
+                117, 40);
+        validateError(result, i++, "incompatible types: expected a map or a record, found 'int'", 124, 28);
+        validateError(result, i++, "incompatible types: expected 'string', found '(int|float)'", 132, 25);
+        validateError(result, i++, "incompatible types: expected 'string', found 'anydata'", 132, 39);
+        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 136, 38);
+        validateError(result, i++, "undefined symbol 'b'", 136, 38);
+        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 136, 44);
+        validateError(result, i++, "undefined function 'getFoo'", 136, 44);
+        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 146, 18);
+        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 146, 30);
+        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 147, 30);
+        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 147, 36);
+        validateError(result, i++, "incompatible types: expected 'int', found 'string'", 160, 18);
+        validateError(result, i++, "incompatible types: expected '(int|float)', found 'string'", 161, 32);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 
@@ -271,7 +299,7 @@ public class MappingConstructorExprTest {
                 { "testSpreadOpInGlobalMap" },
                 { "testMappingConstrExprAsSpreadExpr" },
                 { "testSpreadFieldWithRecordTypeHavingNeverField" },
-                { "testSpreadFieldWithClosedRecordCreatedFromOpenRecord" }
+                { "testSpreadFieldWithRecordTypeHavingRestDescriptor" }
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -178,26 +178,31 @@ public class MappingConstructorExprTest {
                 "invalid usage of spread field with open record of type 'record {| int i; anydata...; |}', that may " +
                         "have rest fields, to construct a closed record", 102, 26);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'Foz', that may have rest fields of type " +
-                        "'string', to construct a record that allows only 'anydata' rest fields", 108, 36);
+                "invalid usage of spread field with open record of type 'record {| int j; anydata...; |}', that may " +
+                        "have rest fields of type 'anydata', to construct a record that allows only 'string' rest " +
+                        "fields", 108, 36);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'Foz', that may have rest fields of type " +
-                        "'string', to construct a record that allows only 'anydata' rest fields", 108, 45);
+                "invalid usage of spread field with open record of type 'record {| boolean b; anydata...; |}', that " +
+                        "may have rest fields of type 'anydata', to construct a record that allows only 'string' rest" +
+                        " fields", 108, 45);
         validateError(result, i++,
                 "incompatible types: expected 'string' for field 'population', found 'int'", 119, 21);
         validateError(result, i++,
-                "invalid usage of spread field with open record of type 'Country', that may have rest fields of type " +
-                        "'string', to construct a record that allows only 'anydata' rest fields", 119, 21);
-        validateError(result, i++,
-                "invalid usage of spread field with open record of type 'Country', that may have rest fields of type " +
-                        "'string', to construct a record that allows only 'anydata' rest fields", 122, 21);
-        validateError(result, i++,
-                "invalid usage of spread field with open record of type 'Country', that may have rest fields of type " +
-                        "'string', to construct a record that allows only 'anydata' rest fields", 125, 40);
-        validateError(result, i++,
                 "invalid usage of spread field with open record of type 'record {| string name; string continent; int" +
-                        "...; |}', that may have rest fields of type 'int', to construct a record that allows only " +
-                        "'string' rest fields", 128, 64);
+                        " population; anydata...; |}', that may have rest fields of type 'anydata', to construct a " +
+                        "record that allows only 'string' rest fields", 119, 21);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'record {| string name; string continent; " +
+                        "anydata...; |}', that may have rest fields of type 'anydata', to construct a record that " +
+                        "allows only 'string' rest fields", 122, 21);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'record {| string name; anydata...; |}', that" +
+                        " may have rest fields of type 'anydata', to construct a record that allows only 'string' " +
+                        "rest fields", 125, 40);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'record {| string name; string continent; " +
+                        "string...; |}', that may have rest fields of type 'string', to construct a record that " +
+                        "allows only 'int' rest fields", 128, 64);
         validateError(result, i++,
                 "invalid usage of spread field with open record of type 'record {| string name; string continent; " +
                         "error...; |}', that may have rest fields, to construct a closed record", 131, 56);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -161,32 +161,36 @@ public class MappingConstructorExprTest {
         validateError(result, i++, "missing non-defaultable required record field 'i'", 67, 13);
         validateError(result, i++, "missing non-defaultable required record field 'i'", 71, 13);
         validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                84, 39);
+                90, 39);
         validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                87, 39);
-        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                90, 20);
-        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                93, 20);
+                93, 39);
         validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
                 96, 20);
         validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                100, 17);
+                99, 20);
         validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
-                100, 26);
-        validateError(result, i++, "incompatible types: expected a map or a record, found 'int'", 107, 28);
-        validateError(result, i++, "incompatible types: expected 'string', found '(int|float)'", 115, 25);
-        validateError(result, i++, "incompatible types: expected 'string', found 'anydata'", 115, 39);
-        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 119, 38);
-        validateError(result, i++, "undefined symbol 'b'", 119, 38);
-        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 119, 44);
-        validateError(result, i++, "undefined function 'getFoo'", 119, 44);
-        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 129, 18);
-        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 129, 30);
-        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 130, 30);
-        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 130, 36);
-        validateError(result, i++, "incompatible types: expected 'int', found 'string'", 143, 18);
-        validateError(result, i++, "incompatible types: expected '(int|float)', found 'string'", 144, 32);
+                102, 20);
+        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+                106, 17);
+        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+                106, 26);
+        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+                109, 21);
+        validateError(result, i++, "invalid usage of spread operator to construct a closed record from an open record",
+                112, 40);
+        validateError(result, i++, "incompatible types: expected a map or a record, found 'int'", 119, 28);
+        validateError(result, i++, "incompatible types: expected 'string', found '(int|float)'", 127, 25);
+        validateError(result, i++, "incompatible types: expected 'string', found 'anydata'", 127, 39);
+        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 131, 38);
+        validateError(result, i++, "undefined symbol 'b'", 131, 38);
+        validateError(result, i++, "incompatible types: expected a map or a record, found 'other'", 131, 44);
+        validateError(result, i++, "undefined function 'getFoo'", 131, 44);
+        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 141, 18);
+        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 141, 30);
+        validateError(result, i++, "incompatible types: expected 'json', found 'any'", 142, 30);
+        validateError(result, i++, "incompatible types: expected 'json', found 'anydata'", 142, 36);
+        validateError(result, i++, "incompatible types: expected 'int', found 'string'", 155, 18);
+        validateError(result, i++, "incompatible types: expected '(int|float)', found 'string'", 156, 32);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 
@@ -266,7 +270,8 @@ public class MappingConstructorExprTest {
                 { "testSpreadOpInConstMap" },
                 { "testSpreadOpInGlobalMap" },
                 { "testMappingConstrExprAsSpreadExpr" },
-                { "testSpreadFieldWithRecordTypeHavingNeverField" }
+                { "testSpreadFieldWithRecordTypeHavingNeverField" },
+                { "testSpreadFieldWithClosedRecordCreatedFromOpenRecord" }
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -167,39 +167,40 @@ public class MappingConstructorExprTest {
                         "construct a closed record", 92, 39);
         validateError(result, i++,
                 "invalid usage of spread field with open record of type 'Address', that may have rest fields, to " +
-                        "construct a closed record", 95, 39);
-        validateError(result, i++,
-                "invalid usage of spread field with open record of type 'Address', that may have rest fields, to " +
-                        "construct a closed record", 98, 20);
+                        "construct a closed record", 95, 20);
         validateError(result, i++,
                 "invalid usage of spread field with open record of type 'record {| string street; anydata...; |}', " +
-                        "that may have rest fields, to construct a closed record", 101, 20);
-        validateError(result, i++,
-                "invalid usage of spread field with open record of type 'record {| string street; anydata...; |}', " +
-                        "that may have rest fields, to construct a closed record", 104, 20);
+                        "that may have rest fields, to construct a closed record", 98, 20);
         validateError(result, i++,
                 "invalid usage of spread field with open record of type 'record {| string s; anydata...; |}', that " +
-                        "may have rest fields, to construct a closed record", 108, 17);
+                        "may have rest fields, to construct a closed record", 102, 17);
         validateError(result, i++,
                 "invalid usage of spread field with open record of type 'record {| int i; anydata...; |}', that may " +
-                        "have rest fields, to construct a closed record", 108, 26);
+                        "have rest fields, to construct a closed record", 102, 26);
         validateError(result, i++,
                 "invalid usage of spread field with open record of type 'Foz', that may have rest fields of type " +
-                        "'string', to construct a record that allows only 'anydata' rest fields", 114, 36);
+                        "'string', to construct a record that allows only 'anydata' rest fields", 108, 36);
         validateError(result, i++,
                 "invalid usage of spread field with open record of type 'Foz', that may have rest fields of type " +
-                        "'string', to construct a record that allows only 'anydata' rest fields", 114, 45);
+                        "'string', to construct a record that allows only 'anydata' rest fields", 108, 45);
         validateError(result, i++,
-                "incompatible types: expected 'string' for field 'population', found 'int'", 125, 21);
-        validateError(result, i++,
-                "invalid usage of spread field with open record of type 'Country', that may have rest fields of type " +
-                        "'string', to construct a record that allows only 'anydata' rest fields", 125, 21);
+                "incompatible types: expected 'string' for field 'population', found 'int'", 119, 21);
         validateError(result, i++,
                 "invalid usage of spread field with open record of type 'Country', that may have rest fields of type " +
-                        "'string', to construct a record that allows only 'anydata' rest fields", 128, 21);
+                        "'string', to construct a record that allows only 'anydata' rest fields", 119, 21);
         validateError(result, i++,
                 "invalid usage of spread field with open record of type 'Country', that may have rest fields of type " +
-                        "'string', to construct a record that allows only 'anydata' rest fields", 131, 40);
+                        "'string', to construct a record that allows only 'anydata' rest fields", 122, 21);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'Country', that may have rest fields of type " +
+                        "'string', to construct a record that allows only 'anydata' rest fields", 125, 40);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'record {| string name; string continent; int" +
+                        "...; |}', that may have rest fields of type 'int', to construct a record that allows only " +
+                        "'string' rest fields", 128, 64);
+        validateError(result, i++,
+                "invalid usage of spread field with open record of type 'record {| string name; string continent; " +
+                        "error...; |}', that may have rest fields, to construct a closed record", 131, 56);
         validateError(result, i++, "incompatible types: expected a map or a record, found 'int'", 138, 28);
         validateError(result, i++, "incompatible types: expected 'string', found '(int|float)'", 146, 25);
         validateError(result, i++, "incompatible types: expected 'string', found 'anydata'", 146, 39);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
@@ -108,9 +108,14 @@ public class SelectivelyImmutableTypeTest {
         validateError(result, index++, "incompatible types: expected '(Department & readonly)' for field 'dept', " +
                 "found 'Department'", 113, 12);
         validateError(result, index++,
-                "invalid usage of spread operator to construct a closed record from an open record", 113, 12);
+                "invalid usage of spread field with open record of type 'record {| Department dept; anydata...; |}' " +
+                        "that may have rest fields to construct a closed record",
+                113, 12);
         validateError(result, index++,
-                "invalid usage of spread operator to construct a closed record from an open record", 133, 12);
+                "invalid usage of spread field with open record of type 'record {| readonly (Department & readonly) " +
+                        "dept; (anydata & readonly)...; |} & readonly' that may have rest fields to construct a " +
+                        "closed record",
+                133, 12);
 
         // Updates.
         validateError(result, index++, "cannot update 'readonly' record field 'details' in 'Employee'", 136, 5);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
@@ -108,14 +108,12 @@ public class SelectivelyImmutableTypeTest {
         validateError(result, index++, "incompatible types: expected '(Department & readonly)' for field 'dept', " +
                 "found 'Department'", 113, 12);
         validateError(result, index++,
-                "invalid usage of spread field with open record of type 'record {| Department dept; anydata...; |}' " +
-                        "that may have rest fields to construct a closed record",
-                113, 12);
+                "invalid usage of spread field with open record of type 'record {| Department dept; anydata...; |}', " +
+                        "that may have rest fields, to construct a closed record", 113, 12);
         validateError(result, index++,
                 "invalid usage of spread field with open record of type 'record {| readonly (Department & readonly) " +
-                        "dept; (anydata & readonly)...; |} & readonly' that may have rest fields to construct a " +
-                        "closed record",
-                133, 12);
+                        "dept; (anydata & readonly)...; |} & readonly', that may have rest fields, to construct a " +
+                        "closed record", 133, 12);
 
         // Updates.
         validateError(result, index++, "cannot update 'readonly' record field 'details' in 'Employee'", 136, 5);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
@@ -107,6 +107,10 @@ public class SelectivelyImmutableTypeTest {
                 "'PersonalDetails'", 112, 18);
         validateError(result, index++, "incompatible types: expected '(Department & readonly)' for field 'dept', " +
                 "found 'Department'", 113, 12);
+        validateError(result, index++,
+                "invalid usage of spread operator to construct a closed record from an open record", 113, 12);
+        validateError(result, index++,
+                "invalid usage of spread operator to construct a closed record from an open record", 133, 12);
 
         // Updates.
         validateError(result, index++, "cannot update 'readonly' record field 'details' in 'Employee'", 136, 5);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
@@ -288,6 +288,14 @@ function testSpreadFieldWithRecordTypeHavingRestDescriptor() {
     assertEquality("s", recA.s);
     assertEquality("m", recA.m);
     assertEquality("e", (<error>recA["e"]).message());
+
+    record {|int i; int...;|} r1 = {i: 1};
+    record {|int i; string|int...;|} r2 = {...r1};
+    assertEquality(1, r2.i);
+
+    record {|string s; never...;|} r3 = {s: "s"};
+    record {|string s; int...;|} r4 = {...r3};
+    assertEquality("s", r4.s);
 }
 
 function assertEquality(any|error expected, any|error actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
@@ -246,6 +246,37 @@ function testSpreadFieldWithRecordTypeHavingNeverField() {
     assertEquality(8, bar8.i);
 }
 
+type Vehicle record {
+    string model;
+    int year;
+};
+
+type Car record {|
+    string model;
+    int year;
+    anydata ...;
+|};
+
+type Van record {|
+    string model;
+    int year;
+    any ...;
+|};
+
+function testSpreadFieldWithClosedRecordCreatedFromOpenRecord() {
+    Vehicle vehicle1 = { model: "Tesla", year: 2023, "isElectronic": true };
+    Car car = {...vehicle1};
+    assertEquality("Tesla", car.model);
+    assertEquality(2023, car.year);
+    assertEquality(true, car["isElectronic"]);
+
+    Vehicle vehicle2 = { model: "Mercedes-Benz", year: 2023, "nPassengers": 10 };
+    Van van = {...vehicle2};
+    assertEquality("Mercedes-Benz", van.model);
+    assertEquality(2023, van.year);
+    assertEquality(10, van["nPassengers"]);
+}
+
 function assertEquality(any|error expected, any|error actual) {
     if expected is anydata && actual is anydata && expected == actual {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
@@ -161,10 +161,10 @@ type Employee record {|
     string dept;
 |};
 
-type Candidate record {
+type Candidate record {|
     string name;
     never university?;
-};
+|};
 
 function testSpreadFieldWithRecordTypeHavingNeverField() {
     Grades grades = { physics: 75 };

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
@@ -161,10 +161,10 @@ type Employee record {|
     string dept;
 |};
 
-type Candidate record {|
+type Candidate record {
     string name;
     never university?;
-|};
+};
 
 function testSpreadFieldWithRecordTypeHavingNeverField() {
     Grades grades = { physics: 75 };
@@ -183,7 +183,7 @@ function testSpreadFieldWithRecordTypeHavingNeverField() {
     assertEquality("Main Street", location["street"]);
 
     Candidate candidate = {name: "Jack"};
-    record {|string name;|} candidateInLine = {...candidate};
+    record {string name;} candidateInLine = {...candidate};
     assertEquality ("Jack", candidateInLine.name);
 
     record {|int i; string s; never n?;|} bar1InLine = {i: 1, s: "s"};
@@ -246,35 +246,48 @@ function testSpreadFieldWithRecordTypeHavingNeverField() {
     assertEquality(8, bar8.i);
 }
 
-type Vehicle record {
-    string model;
+type Vehicle record {|
     int year;
+    string manufacturer;
+    string model;
+    anydata...;
+|};
+
+type Truck record {
+    int year;
+    string manufacturer;
+    string model;
+    int loadCapacity;
 };
 
-type Car record {|
-    string model;
-    int year;
-    anydata ...;
+type RecA record {|
+    int i;
+    string s;
+    string m;
+    any|error...;
 |};
 
-type Van record {|
-    string model;
-    int year;
-    any ...;
-|};
+type RecB record {
+    int i;
+    string s;
+    string m;
+    error e;
+};
 
-function testSpreadFieldWithClosedRecordCreatedFromOpenRecord() {
-    Vehicle vehicle1 = { model: "Tesla", year: 2023, "isElectronic": true };
-    Car car = {...vehicle1};
-    assertEquality("Tesla", car.model);
-    assertEquality(2023, car.year);
-    assertEquality(true, car["isElectronic"]);
+function testSpreadFieldWithRecordTypeHavingRestDescriptor() {
+    Truck truck = {year: 2023, manufacturer: "Tesla", model: "Cybertruck", loadCapacity: 15000};
+    Vehicle vehicle = {...truck};
+    assertEquality("Cybertruck", vehicle.model);
+    assertEquality("Tesla", vehicle.manufacturer);
+    assertEquality(2023, vehicle.year);
+    assertEquality(15000, vehicle["loadCapacity"]);
 
-    Vehicle vehicle2 = { model: "Mercedes-Benz", year: 2023, "nPassengers": 10 };
-    Van van = {...vehicle2};
-    assertEquality("Mercedes-Benz", van.model);
-    assertEquality(2023, van.year);
-    assertEquality(10, van["nPassengers"]);
+    RecB recB = {i: 1, s: "s", m: "m", e: error("e")};
+    RecA recA = {...recB};
+    assertEquality(1, recA.i);
+    assertEquality("s", recA.s);
+    assertEquality("m", recA.m);
+    assertEquality("e", (<error>recA["e"]).message());
 }
 
 function assertEquality(any|error expected, any|error actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field_semantic_analysis_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field_semantic_analysis_negative.bal
@@ -79,12 +79,6 @@ type Street record {|
     string street;
 |};
 
-type Country record {|
-    string name;
-    string continent;
-    string ...;
-|};
-
 function testSpreadOfOpenRecordToCreateClosedRecord() {
     Address address1 = {street: "Main Street"};
     record {|string street;|} _ = {...address1};
@@ -104,12 +98,23 @@ function testSpreadOfOpenRecordToCreateClosedRecord() {
     record {string s;} foo1 = {s: "S"};
     record {int i;} foo2 = {i: 2};
     Foo _ = {...foo1, ...foo2};
+}
 
-    record {string name; string continent;} country1 = {name: "Sri Lanka", continent: "Asia"};
+type Country record {|
+    string name;
+    string continent;
+    string...;
+|};
+
+function testSpreadOpFieldOfMismatchingRestType() {
+    record {string name; string continent; int population;} country1 = {name: "China", continent: "Asia", population: 1400};
     Country _ = {...country1};
 
-    record {string name;} country2 = {name: "India"};
-    Country _ = {continent: "Asia", ...country2};
+    record {string name; string continent;} country2 = {name: "Sri Lanka", continent: "Asia"};
+    Country _ = {...country2};
+
+    record {string name;} country3 = {name: "India"};
+    Country _ = {continent: "Asia", ...country3};
 }
 
 ///////////////////////// Map Tests /////////////////////////

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field_semantic_analysis_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field_semantic_analysis_negative.bal
@@ -91,17 +91,11 @@ function testSpreadOfOpenRecordToCreateClosedRecord() {
     Address address1 = {street: "Main Street"};
     record {|string street;|} _ = {...address1};
 
-    Address address2 = {street: "Pine Street", "number": 40};
-    record {|string street;|} _ = {...address2};
+    Address address2 = {street: "Maple street" };
+    Street _ = {...address2};
 
-    Address address3 = {street: "Maple street" };
+    record {string street;} address3 = {street: "Jump Street"};
     Street _ = {...address3};
-
-    record {string street;} address4 = {street: "Jump Street"};
-    Street _ = {...address4};
-
-    record {string street;} address5 = {street: "Willow Street", "number": 60};
-    Street _ = {...address5};
 
     record {string s;} foo1 = {s: "S"};
     record {int i;} foo2 = {i: 2};
@@ -129,6 +123,12 @@ function testSpreadOpFieldOfMismatchingRestType() {
 
     record {string name;} country3 = {name: "India"};
     Country _ = {continent: "Asia", ...country3};
+
+     record {|string name; string continent; string...;|} country4 = {name: "Sri Lanka", continent: "Asia"};
+     record {|string name; string continent; int...;|} _ = {...country4};
+
+     record {|string name; string continent; error...;|} country5 = {name: "India", continent: "Asia"};
+     record {|string name; string continent;|} _ = {...country5};
 }
 
 ///////////////////////// Map Tests /////////////////////////

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field_semantic_analysis_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field_semantic_analysis_negative.bal
@@ -79,6 +79,12 @@ type Street record {|
     string street;
 |};
 
+type Country record {|
+    string name;
+    string continent;
+    string ...;
+|};
+
 function testSpreadOfOpenRecordToCreateClosedRecord() {
     Address address1 = {street: "Main Street"};
     record {|string street;|} _ = {...address1};
@@ -98,6 +104,12 @@ function testSpreadOfOpenRecordToCreateClosedRecord() {
     record {string s;} foo1 = {s: "S"};
     record {int i;} foo2 = {i: 2};
     Foo _ = {...foo1, ...foo2};
+
+    record {string name; string continent;} country1 = {name: "Sri Lanka", continent: "Asia"};
+    Country _ = {...country1};
+
+    record {string name;} country2 = {name: "India"};
+    Country _ = {continent: "Asia", ...country2};
 }
 
 ///////////////////////// Map Tests /////////////////////////

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field_semantic_analysis_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field_semantic_analysis_negative.bal
@@ -79,6 +79,14 @@ type Street record {|
     string street;
 |};
 
+type Foz record {|
+    string s;
+    int i;
+    int j;
+    boolean b;
+    string...;
+|};
+
 function testSpreadOfOpenRecordToCreateClosedRecord() {
     Address address1 = {street: "Main Street"};
     record {|string street;|} _ = {...address1};
@@ -98,6 +106,12 @@ function testSpreadOfOpenRecordToCreateClosedRecord() {
     record {string s;} foo1 = {s: "S"};
     record {int i;} foo2 = {i: 2};
     Foo _ = {...foo1, ...foo2};
+
+    record {|string s;|} foz1 = {s: "s"};
+    record {|int i;|} foz2 = {i: 1};
+    record {int j;} foz3 = {j: 2};
+    record {boolean b;} foz4 = {b: true};
+    Foz _ =  {...foz1, ...foz2, ...foz3, ...foz4};
 }
 
 type Country record {|

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field_semantic_analysis_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field_semantic_analysis_negative.bal
@@ -71,6 +71,35 @@ function testFieldWithNeverType() {
     Foo _ = {...rec5, ...rec6};
 }
 
+type Address record {
+    string street;
+};
+
+type Street record {|
+    string street;
+|};
+
+function testSpreadOfOpenRecordToCreateClosedRecord() {
+    Address address1 = {street: "Main Street"};
+    record {|string street;|} _ = {...address1};
+
+    Address address2 = {street: "Pine Street", "number": 40};
+    record {|string street;|} _ = {...address2};
+
+    Address address3 = {street: "Maple street" };
+    Street _ = {...address3};
+
+    record {string street;} address4 = {street: "Jump Street"};
+    Street _ = {...address4};
+
+    record {string street;} address5 = {street: "Willow Street", "number": 60};
+    Street _ = {...address5};
+
+    record {string s;} foo1 = {s: "S"};
+    record {int i;} foo2 = {i: 2};
+    Foo _ = {...foo1, ...foo2};
+}
+
 ///////////////////////// Map Tests /////////////////////////
 
 function testMapSpreadOpFieldOfIncorrectType() {


### PR DESCRIPTION
## Purpose

Fixes #41740 

## Approach

Give the error  `invalid usage of spread operator to construct a closed record from an open record` in such scenarios.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
