### PR TITLE
Remove the strandId when doing `generateCombinedTransactionId` in `TransactionResourceManager`

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
@@ -589,11 +589,11 @@ public class TransactionResourceManager {
     }
 
     private String generateCombinedTransactionId(String transactionId, String transactionBlockId) {
-        String compoundId =  transactionId + ":" + transactionBlockId;
         if (transactionBlockId.contains("_")) {
-            return compoundId;
+            // remove the strand id from the transaction block id
+            return transactionBlockId.split("_")[0];
         }
-        return compoundId + "_" + Scheduler.getStrand().getId();
+        return transactionId + ":" + transactionBlockId;
     }
 
     public void notifyResourceFailure(String gTransactionId) {


### PR DESCRIPTION
## Purpose
When there is a separate strand created for a transaction block it registers in the `resourceRegistry` with its strandID. Finally when we commit the original transaction with the main strand and we look in the `resourceRegistry` With the main strandID and the results will be zero. Hence, the transaction won’t be committed.

Since  `resourceRegistry` is a  map that holds list of `BallerinaTransactionContext`s for a given transaction block, we can prevent adding strandID to the keys of `resourceRegistry` which will fix the mismatch because of different strands.

Fixes  #41682

## Approach
Remove strandId when doing `generateCombinedTransactionId` in `TransactionResourceManager`

## Samples
Test cases added via https://github.com/ballerina-platform/module-ballerina-sql/pull/698

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
