### PR TITLE
Fix formatter adding of spaces in consecutive use of format command

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -245,6 +245,7 @@ import io.ballerina.compiler.syntax.tree.XMLSimpleNameNode;
 import io.ballerina.compiler.syntax.tree.XMLStartTagNode;
 import io.ballerina.compiler.syntax.tree.XMLStepExpressionNode;
 import io.ballerina.compiler.syntax.tree.XMLTextNode;
+import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.LineRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -4495,11 +4496,13 @@ public class FormattingTreeModifier extends TreeModifier {
      * @param token token of which the indentation is required.
      */
     private int getPreservedIndentation(Token token) {
-        int position = token.lineRange().startLine().offset();
-        int startLine = token.lineRange().startLine().line();
+        LinePosition startLinePos = token.lineRange().startLine();
+        int position = startLinePos.offset();
+        int startLine = startLinePos.line();
         for (Token invalidToken : token.leadingInvalidTokens()) {
-            if (invalidToken.lineRange().startLine().line() == startLine) {
-                position = invalidToken.lineRange().startLine().offset();
+            LinePosition invalidTokenStartLinePos = invalidToken.lineRange().startLine();
+            if (invalidTokenStartLinePos.line() == startLine) {
+                position = invalidTokenStartLinePos.offset();
                 break;
             }
         }

--- a/misc/formatter/modules/formatter-core/src/test/resources/declarations/function-definition/assert/function_definition_declaration_3.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/declarations/function-definition/assert/function_definition_declaration_3.bal
@@ -1,0 +1,6 @@
+function f  {
+    if
+    worker A {
+
+    }
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/declarations/function-definition/assert/function_definition_declaration_3.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/declarations/function-definition/assert/function_definition_declaration_3.bal
@@ -4,3 +4,11 @@ function f  {
 
     }
 }
+
+function g  {
+    if
+        worker
+        B {
+
+    }
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/declarations/function-definition/source/function_definition_declaration_3.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/declarations/function-definition/source/function_definition_declaration_3.bal
@@ -4,3 +4,11 @@ function f {
 
     }
 }
+
+function g  {
+    if
+    worker
+        B {
+
+    }
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/declarations/function-definition/source/function_definition_declaration_3.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/declarations/function-definition/source/function_definition_declaration_3.bal
@@ -1,0 +1,6 @@
+function f {
+       if
+    worker  A{
+
+    }
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/statements/do/assert/do_statement_3.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/statements/do/assert/do_statement_3.bal
@@ -1,0 +1,11 @@
+function baz() {
+    int x = 1;
+    do {
+        int b = 2;
+    } on f
+
+        if
+        while x < 5 {
+            x += 1;
+        }
+    }

--- a/misc/formatter/modules/formatter-core/src/test/resources/statements/do/source/do_statement_3.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/statements/do/source/do_statement_3.bal
@@ -1,0 +1,11 @@
+function baz() {
+    int x = 1;
+    do {
+        int b = 2;
+    } on f
+
+    if
+    while   x   <   5   {
+        x += 1;
+    }
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #41698 

## Approach
When calculating the number of spaces to add to the start of a line, formatter uses the start offset of the token to calculate the number of spaces. When there are invalid tokens in between the start of the line and the token formatter assumes that these are also spaces. This is handled in this PR by using the start offset of the first invalid token/node in the same line as the token.



## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
