### PR TITLE
Fix issue when using xml navigation with an element containing escape character

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
@@ -5117,7 +5117,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         switch (kind) {
             case SIMPLE_NAME_REFERENCE:
                 SimpleNameReferenceNode simpleNameReferenceNode = (SimpleNameReferenceNode) node;
-                elementName = simpleNameReferenceNode.name().text();
+                elementName = Utils.unescapeBallerina(simpleNameReferenceNode.name().text());
                 elemNamePos = getPosition(simpleNameReferenceNode);
                 break;
             case QUALIFIED_NAME_REFERENCE:
@@ -5129,7 +5129,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
                 break;
             case XML_ATOMIC_NAME_PATTERN:
                 XMLAtomicNamePatternNode atomicNamePatternNode = (XMLAtomicNamePatternNode) node;
-                elementName = atomicNamePatternNode.name().text();
+                elementName = Utils.unescapeBallerina(atomicNamePatternNode.name().text());
                 elemNamePos = getPosition(atomicNamePatternNode.name());
                 ns = atomicNamePatternNode.prefix().text();
                 nsPos = getPosition(atomicNamePatternNode.prefix());

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -225,6 +225,16 @@ public class XMLAccessTest {
     }
 
     @Test
+    public void testXMLNavigationWithEscapeCharacter() {
+        BArray returns = (BArray) BRunUtil.invoke(navigation, "testXMLNavigationWithEscapeCharacter");
+        Assert.assertEquals(returns.get(0).toString(), "<home-address>some address</home-address>");
+        Assert.assertEquals(returns.get(1).toString(), "<ns:child-node xmlns:ns=\"foo\"/>");
+        Assert.assertEquals(returns.get(2).toString(), "<home-address>some address</home-address>");
+        Assert.assertEquals(returns.get(3).toString(), "<name>John</name><home-address>some address</home-address>");
+        Assert.assertEquals(returns.get(4).toString(), "<home-address>some address</home-address>");
+    }
+
+    @Test
     public void testInvalidXMLAccessWithIndex() {
         int i = 0;
         BAssertUtil.validateError(negativeResult, i++, "invalid expr in assignment lhs", 4, 5);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -226,12 +226,7 @@ public class XMLAccessTest {
 
     @Test
     public void testXMLNavigationWithEscapeCharacter() {
-        BArray returns = (BArray) BRunUtil.invoke(navigation, "testXMLNavigationWithEscapeCharacter");
-        Assert.assertEquals(returns.get(0).toString(), "<home-address>some address</home-address>");
-        Assert.assertEquals(returns.get(1).toString(), "<ns:child-node xmlns:ns=\"foo\"/>");
-        Assert.assertEquals(returns.get(2).toString(), "<home-address>some address</home-address>");
-        Assert.assertEquals(returns.get(3).toString(), "<name>John</name><home-address>some address</home-address>");
-        Assert.assertEquals(returns.get(4).toString(), "<home-address>some address</home-address>");
+        BRunUtil.invoke(navigation, "testXMLNavigationWithEscapeCharacter");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
@@ -149,15 +149,31 @@ function testXMLNavigationDescendantsStepWithXMLSubtypeOnLHS() {
         panic error("Assertion error, expected: `<baz>1</baz>`, found: " + s);
 }
 
-function testXMLNavigationWithEscapeCharacter() returns [xml, xml, xml, xml, xml] {
+function testXMLNavigationWithEscapeCharacter() {
     xmlns "foo" as ns;
     xml x1 = xml `<person><name>John</name><home-address>some address</home-address></person>`;
     xml x2 = xml `<ns:root><ns:child-node></ns:child-node></ns:root>`;
-    xml x3 = x1/<home\-address>;
-    xml x4 = x2/<ns:child\-node>;
-    xml x5 = x1/**/<person>/<home\-address>;
-    xml x6 = x1/**/<person>/<name|home\-address>;
-    xml x7 = x1/**/<person>/<name|home\-address>.<home\-address>;
 
-    return [x3, x4, x5, x6, x7];
+    xml x3 = x1/<home\-address>;
+    assert(x3, xml `<home-address>some address</home-address>`);
+
+    xml x4 = x2/<ns:child\-node>;
+    assert(x4, xml `<ns:child-node xmlns:ns="foo"/>`);
+
+    xml x5 = x1/**/<person>/<home\-address>;
+    assert(x5, xml `<home-address>some address</home-address>`);
+
+    xml x6 = x1/**/<person>/<name|home\-address>;
+    assert(x6, xml `<name>John</name><home-address>some address</home-address>`);
+
+    xml x7 = x1/**/<person>/<name|home\-address>.<home\-address>;
+    assert(x7, xml `<home-address>some address</home-address>`);
+}
+
+function assert(anydata actual, anydata expected) {
+    if (expected != actual) {
+        string reason = "expected `" + expected.toString() + "`, but found `" + actual.toString() + "`";
+        error e = error(reason);
+        panic e;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
@@ -148,3 +148,16 @@ function testXMLNavigationDescendantsStepWithXMLSubtypeOnLHS() {
         }
         panic error("Assertion error, expected: `<baz>1</baz>`, found: " + s);
 }
+
+function testXMLNavigationWithEscapeCharacter() returns [xml, xml, xml, xml, xml] {
+    xmlns "foo" as ns;
+    xml x1 = xml `<person><name>John</name><home-address>some address</home-address></person>`;
+    xml x2 = xml `<ns:root><ns:child-node></ns:child-node></ns:root>`;
+    xml x3 = x1/<home\-address>;
+    xml x4 = x2/<ns:child\-node>;
+    xml x5 = x1/**/<person>/<home\-address>;
+    xml x6 = x1/**/<person>/<name|home\-address>;
+    xml x7 = x1/**/<person>/<name|home\-address>.<home\-address>;
+
+    return [x3, x4, x5, x6, x7];
+}


### PR DESCRIPTION
## Purpose
Fixes #41796

## Approach
Escape the string of the navigation in the BLangNodeBuilder

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
