### PR TITLE
[Worker Change] Add display annotation support for worker

### DIFF
--- a/langlib/lang.annotations/src/main/ballerina/annotations.bal
+++ b/langlib/lang.annotations/src/main/ballerina/annotations.bal
@@ -103,4 +103,4 @@ public const annotation record {
     "text"|"password"|"file" kind?;
 } display on source type, source class,
       source function, source return, source parameter, source field, source listener,
-      source var, source const, source annotation, source service;
+      source var, source const, source annotation, source service, source worker;

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/startActionAnnotation1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/startActionAnnotation1.json
@@ -401,6 +401,15 @@
       "sortText": "P",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "display",
+      "kind": "Property",
+      "detail": "Annotation",
+      "sortText": "B",
+      "insertText": "display {\n\tlabel: ${1:\"\"}\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/startActionAnnotation2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/startActionAnnotation2.json
@@ -401,6 +401,15 @@
       "sortText": "P",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "display",
+      "kind": "Property",
+      "detail": "Annotation",
+      "sortText": "B",
+      "insertText": "display {\n\tlabel: ${1:\"\"}\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/workerDeclAnnotation1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/workerDeclAnnotation1.json
@@ -401,6 +401,15 @@
       "sortText": "P",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "display",
+      "kind": "Property",
+      "detail": "Annotation",
+      "sortText": "B",
+      "insertText": "display {\n\tlabel: ${1:\"\"}\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/workerDeclAnnotation2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/workerDeclAnnotation2.json
@@ -401,6 +401,15 @@
       "sortText": "P",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "display",
+      "kind": "Property",
+      "detail": "Annotation",
+      "sortText": "B",
+      "insertText": "display {\n\tlabel: ${1:\"\"}\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     }
   ]
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/DisplayAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/DisplayAnnotationTest.java
@@ -18,6 +18,7 @@ package org.ballerinalang.test.annotations;
 
 import org.ballerinalang.model.tree.AnnotationAttachmentNode;
 import org.ballerinalang.model.tree.ClassDefinition;
+import org.ballerinalang.model.tree.FunctionNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.SimpleVariableNode;
 import org.ballerinalang.model.tree.TypeDefinition;
@@ -30,13 +31,17 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
+import org.wso2.ballerinalang.compiler.tree.BLangBlockFunctionBody;
 import org.wso2.ballerinalang.compiler.tree.BLangClassDefinition;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangService;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangSimpleVariableDef;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangStatement;
 
 import java.util.List;
 
@@ -91,7 +96,7 @@ public class DisplayAnnotationTest {
 
     @Test
     public void testDisplayAnnotOnRecord() {
-        TypeDefinition typeDefinition = result.getAST().getTypeDefinitions().get(13);
+        TypeDefinition typeDefinition = result.getAST().getTypeDefinitions().get(14);
         List<? extends AnnotationAttachmentNode> annot = typeDefinition.getAnnotationAttachments();
         Assert.assertEquals(annot.size(), 1);
         Assert.assertEquals(annot.get(0).getExpression().toString(),
@@ -102,6 +107,20 @@ public class DisplayAnnotationTest {
         Assert.assertEquals(fieldAnnot.size(), 1);
         Assert.assertEquals(fieldAnnot.get(0).getExpression().toString(), " {iconPath: <string?> Field.icon,label: " +
                 "clientSecret field,kind: <\"text\"|\"password\"|\"file\"?> password}");
+    }
+
+    @Test
+    public void testDisplayAnnotOnWorker() {
+        BLangBlockFunctionBody bLangBlockFunctionBody =
+                ((BLangBlockFunctionBody) result.getAST().getFunctions().get(2).getBody());
+        BLangStatement bLangStatement = bLangBlockFunctionBody.getStatements().get(1);
+        FunctionNode workerExpression =
+                ((BLangLambdaFunction) ((BLangSimpleVariableDef) bLangStatement).getVariable()
+                        .getInitialExpression()).getFunctionNode();
+        BLangAnnotationAttachment annot =
+                (BLangAnnotationAttachment) workerExpression.getAnnotationAttachments().get(0);
+        Assert.assertEquals(getActualExpressionFromAnnotationAttachmentExpr(annot.expr).toString(),
+                " {label: worker annotation,type: <anydata> named,id: <anydata> hash}");
     }
 
     @Test void testDisplayAnnotationNegative() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/display_annot.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/display_annot.bal
@@ -74,3 +74,14 @@ public type RefreshTokenGrantConfig record {|
     @display {iconPath: "Field.icon", label: "clientSecret field", kind: "password"}
     string clientSecret;
 |};
+
+function annotationOnWorker() {
+    @display {
+        label: "worker annotation",
+        'type: "named",
+        id: "hash"
+    }
+    worker testWorker {
+
+    }
+}


### PR DESCRIPTION
## Purpose
Currently, the `@display` annotation is not allowed for workers, and it is required for capturing the metadata of a worker.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
