### PR TITLE
Fix accessing resource-path-name with escaped dot characters

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
@@ -521,7 +521,9 @@ public class JvmCodeGenUtil {
     static String cleanupObjectTypeName(String typeName) {
         int index = typeName.lastIndexOf("."); // Internal type names can contain dots hence use the `lastIndexOf`
         int typeNameLength = typeName.length();
-        if (index > 0 && index != typeNameLength - 1) { // Resource method name can contain . at the end 
+        if (index - 1 > 0 && typeName.charAt(index - 1) == '\\') { // Methods can contain escaped characters
+            return typeName;
+        } else if (index > 0 && index != typeNameLength - 1) { // Resource method name can contain . at the end 
             return typeName.substring(index + 1);
         } else if (index > 0) {
             // We will reach here for resource methods eg: (MyClient8.$get$.)

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
@@ -521,7 +521,7 @@ public class JvmCodeGenUtil {
     static String cleanupObjectTypeName(String typeName) {
         int index = typeName.lastIndexOf("."); // Internal type names can contain dots hence use the `lastIndexOf`
         int typeNameLength = typeName.length();
-        if (index - 1 > 0 && typeName.charAt(index - 1) == '\\') { // Methods can contain escaped characters
+        if (index > 1 && typeName.charAt(index - 1) == '\\') { // Methods can contain escaped characters
             return typeName;
         } else if (index > 0 && index != typeNameLength - 1) { // Resource method name can contain . at the end 
             return typeName.substring(index + 1);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/ClientResourceAccessActionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/ClientResourceAccessActionTest.java
@@ -58,7 +58,8 @@ public class ClientResourceAccessActionTest {
                 {"testResourceAccessOfAnObjectConstructedViaObjectCons"},
                 {"testResourceAccessContainingSpecialChars"},
                 {"testClosuresFromPathParams"},
-                {"testAccessingResourceWithIncludedRecordParam"}
+                {"testAccessingResourceWithIncludedRecordParam"},
+                {"testAccessingResourceWithEscapedChars"}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/action/client_resource_access_action.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/action/client_resource_access_action.bal
@@ -710,6 +710,10 @@ client class Client11 {
         return "Path3";
     }
 
+    resource function get v1\.\.2() returns string {
+        return "Path4";
+    }
+        
     function abc\.abc() returns string {
         return "abc.abc";
     }
@@ -735,8 +739,11 @@ function testAccessingResourceWithEscapedChars() {
     string c2 = cl->/["v1.2"]/["ab.c"]/greeting3;
     assertEquality(c2, "Path3");
     
-    string d1 = cl.abc\.abc();
-    assertEquality(d1, "abc.abc");    
+    string d1 = cl->/v1\.\.2;
+    assertEquality(d1, "Path4");
+    
+    string e1 = cl.abc\.abc();
+    assertEquality(e1, "abc.abc");    
 }
 
 function assertEquality(any|error actual, any|error expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/action/client_resource_access_action.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/action/client_resource_access_action.bal
@@ -697,6 +697,48 @@ function testAccessingResourceWithIncludedRecordParam() {
     assertEquality(d, 3);
 }
 
+client class Client11 {
+    resource function get v1\.2/greeting1() returns string {
+        return "Path1";
+    }
+    
+    resource function get ["v1.2"]/greeting2() returns string {
+        return "Path2";
+    }
+    
+    resource function get v1\.2/ab\.c/greeting3() returns string {
+        return "Path3";
+    }
+
+    function abc\.abc() returns string {
+        return "abc.abc";
+    }
+}
+
+function testAccessingResourceWithEscapedChars() {
+    Client11 cl = new;
+    string a1 = cl->/v1\.2/greeting1;
+    assertEquality(a1, "Path1");
+    
+    string a2 = cl->/["v1.2"]/greeting1;
+    assertEquality(a2, "Path1");
+    
+    string b1 = cl->/["v1.2"]/greeting2;
+    assertEquality(b1, "Path2");
+    
+    string b2 = cl->/v1\.2/greeting2;
+    assertEquality(b2, "Path2");
+
+    string c1 = cl->/v1\.2/ab\.c/greeting3;
+    assertEquality(c1, "Path3");
+    
+    string c2 = cl->/["v1.2"]/["ab.c"]/greeting3;
+    assertEquality(c2, "Path3");
+    
+    string d1 = cl.abc\.abc();
+    assertEquality(d1, "abc.abc");    
+}
+
 function assertEquality(any|error actual, any|error expected) {
     if expected is anydata && actual is anydata && expected == actual {
         return;


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #41878

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
