### PR TITLE
Add display annotation support for worker and external function bodies

### DIFF
--- a/langlib/lang.annotations/src/main/ballerina/annotations.bal
+++ b/langlib/lang.annotations/src/main/ballerina/annotations.bal
@@ -103,4 +103,4 @@ public const annotation record {
     "text"|"password"|"file" kind?;
 } display on source type, source class,
       source function, source return, source parameter, source field, source listener,
-      source var, source const, source annotation, source service;
+      source var, source const, source annotation, source service, source worker;

--- a/langlib/lang.annotations/src/main/ballerina/annotations.bal
+++ b/langlib/lang.annotations/src/main/ballerina/annotations.bal
@@ -103,4 +103,4 @@ public const annotation record {
     "text"|"password"|"file" kind?;
 } display on source type, source class,
       source function, source return, source parameter, source field, source listener,
-      source var, source const, source annotation, source service, source worker;
+      source var, source const, source annotation, source service, source external, source worker;

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/externalFunctionAnnotation1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/externalFunctionAnnotation1.json
@@ -392,6 +392,15 @@
       "sortText": "P",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "display",
+      "kind": "Property",
+      "detail": "Annotation",
+      "sortText": "B",
+      "insertText": "display {\n\tlabel: ${1:\"\"}\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/externalFunctionAnnotation2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/externalFunctionAnnotation2.json
@@ -392,6 +392,15 @@
       "sortText": "P",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "display",
+      "kind": "Property",
+      "detail": "Annotation",
+      "sortText": "B",
+      "insertText": "display {\n\tlabel: ${1:\"\"}\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/startActionAnnotation1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/startActionAnnotation1.json
@@ -401,6 +401,15 @@
       "sortText": "P",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "display",
+      "kind": "Property",
+      "detail": "Annotation",
+      "sortText": "B",
+      "insertText": "display {\n\tlabel: ${1:\"\"}\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/startActionAnnotation2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/startActionAnnotation2.json
@@ -401,6 +401,15 @@
       "sortText": "P",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "display",
+      "kind": "Property",
+      "detail": "Annotation",
+      "sortText": "B",
+      "insertText": "display {\n\tlabel: ${1:\"\"}\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/workerDeclAnnotation1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/workerDeclAnnotation1.json
@@ -401,6 +401,15 @@
       "sortText": "P",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "display",
+      "kind": "Property",
+      "detail": "Annotation",
+      "sortText": "B",
+      "insertText": "display {\n\tlabel: ${1:\"\"}\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/workerDeclAnnotation2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/workerDeclAnnotation2.json
@@ -401,6 +401,15 @@
       "sortText": "P",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "display",
+      "kind": "Property",
+      "detail": "Annotation",
+      "sortText": "B",
+      "insertText": "display {\n\tlabel: ${1:\"\"}\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     }
   ]
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/DisplayAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/DisplayAnnotationTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.tree.BLangBlockFunctionBody;
 import org.wso2.ballerinalang.compiler.tree.BLangClassDefinition;
+import org.wso2.ballerinalang.compiler.tree.BLangExternalFunctionBody;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangService;
@@ -96,7 +97,7 @@ public class DisplayAnnotationTest {
 
     @Test
     public void testDisplayAnnotOnRecord() {
-        TypeDefinition typeDefinition = result.getAST().getTypeDefinitions().get(14);
+        TypeDefinition typeDefinition = result.getAST().getTypeDefinitions().get(15);
         List<? extends AnnotationAttachmentNode> annot = typeDefinition.getAnnotationAttachments();
         Assert.assertEquals(annot.size(), 1);
         Assert.assertEquals(annot.get(0).getExpression().toString(),
@@ -123,7 +124,16 @@ public class DisplayAnnotationTest {
                 " {label: worker annotation,type: <anydata> named,id: <anydata> hash}");
     }
 
-    @Test void testDisplayAnnotationNegative() {
+    @Test
+    public void testDisplayAnnotOnExternalFunctionBody() {
+        BLangExternalFunctionBody body = (BLangExternalFunctionBody) result.getAST().getFunctions().get(3).getBody();
+        BLangAnnotationAttachment annot = (BLangAnnotationAttachment) ((List) body.annAttachments).get(0);
+        Assert.assertEquals(getActualExpressionFromAnnotationAttachmentExpr(annot.expr).toString(),
+                " {label: external,id: <anydata> hash}");
+    }
+
+    @Test
+    void testDisplayAnnotationNegative() {
         BAssertUtil.validateError(negative, 0, "cannot specify more than one annotation value " +
                 "for annotation 'ballerina/lang.annotations:0.0.0:display'", 17, 1);
         BAssertUtil.validateError(negative, 1, "incompatible types: expected '\"text\"|\"password\"|\"file\"?'," +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/DisplayAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/DisplayAnnotationTest.java
@@ -18,6 +18,7 @@ package org.ballerinalang.test.annotations;
 
 import org.ballerinalang.model.tree.AnnotationAttachmentNode;
 import org.ballerinalang.model.tree.ClassDefinition;
+import org.ballerinalang.model.tree.FunctionNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.SimpleVariableNode;
 import org.ballerinalang.model.tree.TypeDefinition;
@@ -30,13 +31,17 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
+import org.wso2.ballerinalang.compiler.tree.BLangBlockFunctionBody;
 import org.wso2.ballerinalang.compiler.tree.BLangClassDefinition;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangService;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangSimpleVariableDef;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangStatement;
 
 import java.util.List;
 
@@ -91,7 +96,7 @@ public class DisplayAnnotationTest {
 
     @Test
     public void testDisplayAnnotOnRecord() {
-        TypeDefinition typeDefinition = result.getAST().getTypeDefinitions().get(13);
+        TypeDefinition typeDefinition = result.getAST().getTypeDefinitions().get(14);
         List<? extends AnnotationAttachmentNode> annot = typeDefinition.getAnnotationAttachments();
         Assert.assertEquals(annot.size(), 1);
         Assert.assertEquals(annot.get(0).getExpression().toString(),
@@ -102,6 +107,20 @@ public class DisplayAnnotationTest {
         Assert.assertEquals(fieldAnnot.size(), 1);
         Assert.assertEquals(fieldAnnot.get(0).getExpression().toString(), " {iconPath: <string?> Field.icon,label: " +
                 "clientSecret field,kind: <\"text\"|\"password\"|\"file\"?> password}");
+    }
+
+    @Test
+    public void testDisplayAnnotOnWorker() {
+        BLangBlockFunctionBody bLangBlockFunctionBody =
+                ((BLangBlockFunctionBody) result.getAST().getFunctions().get(2).getBody());
+        BLangStatement bLangStatement = bLangBlockFunctionBody.getStatements().get(1);
+        FunctionNode workerExpression =
+                ((BLangLambdaFunction) ((BLangSimpleVariableDef) bLangStatement).getVariable()
+                        .getInitialExpression()).getFunctionNode();
+        BLangAnnotationAttachment annot =
+                (BLangAnnotationAttachment) workerExpression.getAnnotationAttachments().get(0);
+        Assert.assertEquals(getActualExpressionFromAnnotationAttachmentExpr(annot.expr).toString(),
+                " {label: worker annotation,type: <anydata> named,id: <anydata> hash}");
     }
 
     @Test void testDisplayAnnotationNegative() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/display_annot.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/display_annot.bal
@@ -74,3 +74,14 @@ public type RefreshTokenGrantConfig record {|
     @display {iconPath: "Field.icon", label: "clientSecret field", kind: "password"}
     string clientSecret;
 |};
+
+function annotationOnWorker() {
+    @display {
+        label: "worker annotation",
+        'type: "named",
+        id: "hash"
+    }
+    worker testWorker {
+
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/display_annot.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/display_annot.bal
@@ -85,3 +85,5 @@ function annotationOnWorker() {
 
     }
 }
+
+function testExternalFunction() = @display { label: "external", id: "hash" } external;


### PR DESCRIPTION
## Purpose
$titile.

Fixes #41887

## Approach
Updated the annotation lang lib to support the worker and external attach points.

## Samples
The following scenarios of the display annotation are now supported.

```ballerina
function annotationOnWorker() {
    @display {
        label: "worker annotation",
        'type: "named",
        id: "hash"
    }
    worker testWorker {

    }
}

function testExternalFunction() = @display { label: "external", id: "hash" } external;
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
