### PR TITLE
Fix use of binding patterns in closures

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -691,7 +691,9 @@ public class ClosureDesugar extends BLangNodeVisitor {
     @Override
     public void visit(BLangBlockStmt blockNode) {
         SymbolEnv blockEnv = SymbolEnv.createBlockEnv(blockNode, env);
-        blockClosureMapCount++;
+         if (!blockNode.internal) {
+            blockClosureMapCount++;
+         }
         rewriteStmts(blockNode.stmts, blockEnv);
 
         // Add block map to the 0th position if a block map symbol is there.
@@ -746,7 +748,13 @@ public class ClosureDesugar extends BLangNodeVisitor {
      * @return assignment statement created
      */
     private BLangAssignment createAssignmentToClosureMap(BLangSimpleVariableDef varDefNode) {
-        BVarSymbol mapSymbol = createMapSymbolIfAbsent(env.node, blockClosureMapCount);
+        BVarSymbol mapSymbol;
+        BLangNode node = env.node;
+        if (node.getKind() == NodeKind.BLOCK && node.internal) {
+            mapSymbol = createMapSymbolIfAbsent(node.parent, blockClosureMapCount);
+        } else {
+            mapSymbol = createMapSymbolIfAbsent(node, blockClosureMapCount);
+        }
 
         // Add the variable to the created map.
         BLangIndexBasedAccess accessExpr =
@@ -2217,4 +2225,6 @@ public class ClosureDesugar extends BLangNodeVisitor {
             nodeList.set(i, rewriteExpr(nodeList.get(i)));
         }
     }
+
+    
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -762,13 +762,11 @@ public class ClosureDesugar extends BLangNodeVisitor {
 
     private BVarSymbol findClosureMapSymbol(int absoluteLevel) {
         SymbolEnv symbolEnv = env;
-        NodeKind nodeKind = symbolEnv.node.getKind();
-        while (nodeKind != NodeKind.PACKAGE) {
+        while (symbolEnv.node.getKind() != NodeKind.PACKAGE) {
             if (symbolEnv.envCount == absoluteLevel) {
                 return createMapSymbolIfAbsent(symbolEnv.node, symbolEnv.envCount);
             }
             symbolEnv = symbolEnv.enclEnv;
-            nodeKind = symbolEnv.node.getKind();
         }
         throw new IllegalStateException("Failed to find the closure symbol defined scope");
     }
@@ -1542,10 +1540,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
         // selfRelativeCount >= selfAbsoluteLevel - absoluteLevel ==> resolved within the same function.
         if (selfRelativeCount >= selfAbsoluteLevel - absoluteLevel) {
             BVarSymbol mapSym = findClosureMapSymbol(absoluteLevel);
-            if (mapSym != null) {
-                updateClosureVars(localVarRef, mapSym);
-                return;
-            }
+            updateClosureVars(localVarRef, mapSym);
         } else {
             // It is resolved from a parameter map.
             // Add parameter map symbol if one is not added.
@@ -1570,10 +1565,10 @@ public class ClosureDesugar extends BLangNodeVisitor {
                         PARAMETER_MAP_NAME + absoluteLevel, env));
                 updateClosureVars(localVarRef, ((BLangFunction) env.enclInvokable).paramClosureMap.get(absoluteLevel));
             }
-        }
 
-        // 3) Add the resolved level of the closure variable to the preceding function maps.
-        updatePrecedingFunc(env, absoluteLevel);
+            // 3) Add the resolved level of the closure variable to the preceding function maps.
+            updatePrecedingFunc(env, absoluteLevel);
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -748,9 +748,6 @@ public class ClosureDesugar extends BLangNodeVisitor {
     private BLangAssignment createAssignmentToClosureMap(BLangSimpleVariableDef varDefNode) {
         int absoluteLevel = findResolvedLevel(env, varDefNode.var.symbol);
         BVarSymbol mapSymbol = findClosureMapSymbol(absoluteLevel);
-        if (mapSymbol == null) {
-            mapSymbol = createMapSymbolIfAbsent(env.node, blockClosureMapCount);
-        }
         // Add the variable to the created map.
         BLangIndexBasedAccess accessExpr =
                 ASTBuilderUtil.createIndexBasesAccessExpr(varDefNode.pos, varDefNode.getBType(), mapSymbol,
@@ -766,15 +763,14 @@ public class ClosureDesugar extends BLangNodeVisitor {
     private BVarSymbol findClosureMapSymbol(int absoluteLevel) {
         SymbolEnv symbolEnv = env;
         NodeKind nodeKind = symbolEnv.node.getKind();
-        BVarSymbol mapSymbol = null;
-        while (symbolEnv != null && nodeKind != NodeKind.PACKAGE) {
+        while (nodeKind != NodeKind.PACKAGE) {
             if (symbolEnv.envCount == absoluteLevel) {
-                mapSymbol = createMapSymbolIfAbsent(symbolEnv.node, symbolEnv.envCount);
+                return createMapSymbolIfAbsent(symbolEnv.node, symbolEnv.envCount);
             }
             symbolEnv = symbolEnv.enclEnv;
             nodeKind = symbolEnv.node.getKind();
         }
-        return mapSymbol;
+        throw new IllegalStateException("Failed to find the closure symbol defined scope");
     }
 
     private BVarSymbol createMapSymbolIfAbsent(BLangNode node, int closureMapCount) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -2225,6 +2225,4 @@ public class ClosureDesugar extends BLangNodeVisitor {
             nodeList.set(i, rewriteExpr(nodeList.get(i)));
         }
     }
-
-    
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -748,13 +748,9 @@ public class ClosureDesugar extends BLangNodeVisitor {
      * @return assignment statement created
      */
     private BLangAssignment createAssignmentToClosureMap(BLangSimpleVariableDef varDefNode) {
-        BVarSymbol mapSymbol;
         BLangNode node = env.node;
-        if (node.getKind() == NodeKind.BLOCK && node.internal) {
-            mapSymbol = createMapSymbolIfAbsent(node.parent, blockClosureMapCount);
-        } else {
-            mapSymbol = createMapSymbolIfAbsent(node, blockClosureMapCount);
-        }
+        BLangNode inputNode = node.getKind() == NodeKind.BLOCK && node.internal ? node.parent : node;
+        BVarSymbol mapSymbol = createMapSymbolIfAbsent(inputNode, blockClosureMapCount);
 
         // Add the variable to the created map.
         BLangIndexBasedAccess accessExpr =

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1529,6 +1529,8 @@ public class Desugar extends BLangNodeVisitor {
     public void visit(BLangErrorVariable varNode) {
         // Create error destruct block stmt.
         final BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(varNode.pos);
+        blockStmt.parent = env.node;
+        blockStmt.internal = true;
 
         BType errorType = varNode.getBType() == null ? symTable.errorType : varNode.getBType();
         // Create a simple var for the error 'error x = ($error$)'.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1482,7 +1482,8 @@ public class Desugar extends BLangNodeVisitor {
 
         // Create tuple destruct block stmt
         final BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(varNode.pos);
-
+        blockStmt.parent = env.node;
+        blockStmt.internal = true;
         // Create a simple var for the array 'any[] x = (tuple)' based on the dimension for x
 
         String name = anonModelHelper.getNextTupleVarKey(env.enclPkg.packageID);
@@ -1507,6 +1508,8 @@ public class Desugar extends BLangNodeVisitor {
     public void visit(BLangRecordVariable varNode) {
         varNode.typeNode = rewrite(varNode.typeNode, env);
         final BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(varNode.pos);
+        blockStmt.parent = env.node;
+        blockStmt.internal = true;
         String name = anonModelHelper.getNextRecordVarKey(env.enclPkg.packageID);
         final BLangSimpleVariable mapVariable =
                 ASTBuilderUtil.createVariable(varNode.pos, name, symTable.mapAllType, null,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1482,8 +1482,7 @@ public class Desugar extends BLangNodeVisitor {
 
         // Create tuple destruct block stmt
         final BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(varNode.pos);
-        blockStmt.parent = env.node;
-        blockStmt.internal = true;
+
         // Create a simple var for the array 'any[] x = (tuple)' based on the dimension for x
 
         String name = anonModelHelper.getNextTupleVarKey(env.enclPkg.packageID);
@@ -1508,8 +1507,6 @@ public class Desugar extends BLangNodeVisitor {
     public void visit(BLangRecordVariable varNode) {
         varNode.typeNode = rewrite(varNode.typeNode, env);
         final BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(varNode.pos);
-        blockStmt.parent = env.node;
-        blockStmt.internal = true;
         String name = anonModelHelper.getNextRecordVarKey(env.enclPkg.packageID);
         final BLangSimpleVariable mapVariable =
                 ASTBuilderUtil.createVariable(varNode.pos, name, symTable.mapAllType, null,
@@ -1529,8 +1526,6 @@ public class Desugar extends BLangNodeVisitor {
     public void visit(BLangErrorVariable varNode) {
         // Create error destruct block stmt.
         final BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(varNode.pos);
-        blockStmt.parent = env.node;
-        blockStmt.internal = true;
 
         BType errorType = varNode.getBType() == null ? symTable.errorType : varNode.getBType();
         // Create a simple var for the error 'error x = ($error$)'.

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureTest.java
@@ -282,6 +282,11 @@ public class ClosureTest {
         BRunUtil.invoke(compileResult, "testClosureWithTupleBindingTypeParams");
     }
 
+    @Test(description = "Test closure with a param having a default value of a binding type")
+    public void testClosureWithBindingPatternDefaultValues() {
+        BRunUtil.invoke(compileResult, "testClosureWithBindingPatternDefaultValues");
+    }
+
     @AfterClass
     public void tearDown() {
         compileResult = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureTest.java
@@ -271,6 +271,17 @@ public class ClosureTest {
     public void forEachWithClosure() {
         BRunUtil.invoke(compileResult, "test30");
     }
+
+    @Test(description = "Test closure with a referenced param of structured binding type")
+    public void testClosureWithStructuredBindingTypeParams() {
+        BRunUtil.invoke(compileResult, "testClosureWithStructuredBindingTypeParams");
+    }
+
+    @Test(description = "Test closure with a referenced param of tuple binding type")
+    public void testClosureWithTupleBindingTypeParams() {
+        BRunUtil.invoke(compileResult, "testClosureWithTupleBindingTypeParams");
+    }
+
     @AfterClass
     public void tearDown() {
         compileResult = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureTest.java
@@ -292,6 +292,11 @@ public class ClosureTest {
         BRunUtil.invoke(compileResult, "testClosureWithErrorBindingPatterns");
     }
 
+    @Test(description = "Test closure with closure variable of binding patterns of foreach loop")
+    public void testClosureWithBindingPatternsInForEach() {
+        BRunUtil.invoke(compileResult, "testClosureWithBindingPatternsInForEach");
+    }
+
     @AfterClass
     public void tearDown() {
         compileResult = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -272,29 +273,20 @@ public class ClosureTest {
         BRunUtil.invoke(compileResult, "test30");
     }
 
-    @Test(description = "Test closure with a referenced param of structured binding type")
-    public void testClosureWithStructuredBindingTypeParams() {
-        BRunUtil.invoke(compileResult, "testClosureWithStructuredBindingTypeParams");
+    @Test(description = "Test closure with binding type param", dataProvider = "closureWithBindingPatternTypeParam")
+    public void testClosureWithBindingPatternTypeParam(String functionName) {
+        BRunUtil.invoke(compileResult, functionName);
     }
 
-    @Test(description = "Test closure with a referenced param of tuple binding type")
-    public void testClosureWithTupleBindingTypeParams() {
-        BRunUtil.invoke(compileResult, "testClosureWithTupleBindingTypeParams");
-    }
-
-    @Test(description = "Test closure with a param having a default value of a binding type")
-    public void testClosureWithBindingPatternDefaultValues() {
-        BRunUtil.invoke(compileResult, "testClosureWithBindingPatternDefaultValues");
-    }
-
-    @Test(description = "Test closure with a referenced variable of error binding type")
-    public void testClosureWithErrorBindingPatterns() {
-        BRunUtil.invoke(compileResult, "testClosureWithErrorBindingPatterns");
-    }
-
-    @Test(description = "Test closure with closure variable of binding patterns of foreach loop")
-    public void testClosureWithBindingPatternsInForEach() {
-        BRunUtil.invoke(compileResult, "testClosureWithBindingPatternsInForEach");
+    @DataProvider(name = "closureWithBindingPatternTypeParam")
+    private Object[] closureWithBindingPatternTypeParam() {
+        return new String[]{
+                "testClosureWithStructuredBindingTypeParams",
+                "testClosureWithTupleBindingTypeParams",
+                "testClosureWithBindingPatternDefaultValues",
+                "testClosureWithErrorBindingPatterns",
+                "testClosureWithBindingPatternsInForEach"
+        };
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureTest.java
@@ -287,6 +287,11 @@ public class ClosureTest {
         BRunUtil.invoke(compileResult, "testClosureWithBindingPatternDefaultValues");
     }
 
+    @Test(description = "Test closure with a referenced variable of error binding type")
+    public void testClosureWithErrorBindingPatterns() {
+        BRunUtil.invoke(compileResult, "testClosureWithErrorBindingPatterns");
+    }
+
     @AfterClass
     public void tearDown() {
         compileResult = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithBindingPatternVarTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithBindingPatternVarTest.java
@@ -1,7 +1,7 @@
 /*
  *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License.
  *  You may obtain a copy of the License at

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithBindingPatternVarTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithBindingPatternVarTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org).
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org).
  *
  *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithBindingPatternVarTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithBindingPatternVarTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org).
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.query;
+
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.BRunUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * This contains methods to test query expressions and query actions which uses variables defined in binding patterns.
+ *
+ * @since 2201.9.0
+ */
+public class QueryWithBindingPatternVarTest {
+
+    private CompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        result = BCompileUtil.compile("test-src/query/query_with_binding_pattern.bal");
+    }
+
+    @Test(dataProvider = "dataToTestQueryWithBindingPatternVar")
+    public void testQueryWithBindingPatternVars(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestQueryWithBindingPatternVar() {
+        return new Object[]{
+                "testSelectClauseWithBindingVar",
+                "testCollectClauseWithBindingVar",
+                "testFunctionPointerInvocationWithBindingVar",
+                "testQueryActionWithBindingVar",
+                "testClosureInQueryActionInDoWithBindingVar",
+                "testNestedQueryInSelectWithBindingVar",
+                "testLimitClauseAndQueryExprWithBindingVar"
+        };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithBindingPatternVarTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithBindingPatternVarTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org).
+ *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org).
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/AnonymousClosedRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/AnonymousClosedRecordTest.java
@@ -77,7 +77,7 @@ public class AnonymousClosedRecordTest {
 
     @Test(description = "Test record type with binding pattern var in default value")
     public void testRecordWithDefaultsFromBindingPatternVar() {
-        BRunUtil.invoke(compileResult, "recordWithDefaultsFromBindingPatternVar");
+        BRunUtil.invoke(compileResult, "testRecordWithDefaultsFromBindingPatternVar");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/AnonymousClosedRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/AnonymousClosedRecordTest.java
@@ -75,6 +75,11 @@ public class AnonymousClosedRecordTest {
         BRunUtil.invoke(compileResult, "anonymousRecordWithTypeInclusion");
     }
 
+    @Test(description = "Test record type with binding pattern var in default value", enabled = false)
+    public void testRecordWithDefaultsFromBindingPatternVar() {
+        BRunUtil.invoke(compileResult, "recordWithClosureInDefaultsFromBindingPatternVar");
+    }
+
     @AfterClass
     public void tearDown() {
         compileResult = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/AnonymousClosedRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/AnonymousClosedRecordTest.java
@@ -75,9 +75,9 @@ public class AnonymousClosedRecordTest {
         BRunUtil.invoke(compileResult, "anonymousRecordWithTypeInclusion");
     }
 
-    @Test(description = "Test record type with binding pattern var in default value", enabled = false)
+    @Test(description = "Test record type with binding pattern var in default value")
     public void testRecordWithDefaultsFromBindingPatternVar() {
-        BRunUtil.invoke(compileResult, "recordWithClosureInDefaultsFromBindingPatternVar");
+        BRunUtil.invoke(compileResult, "recordWithDefaultsFromBindingPatternVar");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
@@ -354,6 +354,10 @@ public class WorkerTest {
     public void testWorkerWithQuery() {
         BRunUtil.invoke(result, "testWorkerWithQuery", new Object[0]);
     }
+    
+    public void testBindingPatternVariablesInWorker() {
+        BRunUtil.invoke(result, "testBindingPatternVariablesInWorker");
+    }
 
     @AfterClass
     public void tearDown() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
@@ -354,7 +354,8 @@ public class WorkerTest {
     public void testWorkerWithQuery() {
         BRunUtil.invoke(result, "testWorkerWithQuery", new Object[0]);
     }
-    
+
+    @Test
     public void testBindingPatternVariablesInWorker() {
         BRunUtil.invoke(result, "testBindingPatternVariablesInWorker");
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/closures/closure.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/closures/closure.bal
@@ -813,6 +813,47 @@ function test30() {
     assert(y, 117);
 }
 
+type School record {|
+    string name;
+    string country;
+|};
+
+type Doctor record {
+    string name;
+    string category;
+    School school;
+};
+
+function testClosureWithStructuredBindingTypeParams() {
+    string[] categories = ["Orthopedic", "Dentist"];
+    string[] schools = [];
+    Doctor doctor = {name: "Dr. Smith", category: "Cardiologist", school: {name: "Medical College", country: "United States"}};
+    var {category, school: {name}} = doctor;
+    var f = function () {
+        categories.push(category);
+    };
+    var g = function () {
+        schools.push(name);
+    };
+    if !categories.some(existingCategory => existingCategory == category) {
+        f();
+    }
+    if !schools.some(existingSchool => existingSchool == name) {
+        g();
+    }
+    assert(categories, ["Orthopedic", "Dentist", "Cardiologist"]);
+    assert(schools, ["Medical College"]);
+}
+
+function testClosureWithTupleBindingTypeParams() {
+    [int, [string, string]] [id, [firstname, _]] = [1,["John", "Doe"]];
+    var increment = function() returns int {
+        int len = firstname.length();
+        return id + len;
+    };
+    assert(increment(), 5);
+}
+
 function assert(anydata actual, anydata expected) {
     if (expected == actual) {
             return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/closures/closure.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/closures/closure.bal
@@ -863,6 +863,23 @@ function testClosureWithBindingPatternDefaultValues() {
     assert(f(), "int");
 }
 
+type SampleErrorData record {|
+    int code;
+    string reason;
+|};
+
+type SampleError error<SampleErrorData>;
+
+function testClosureWithErrorBindingPatterns() {
+    SampleError e = error("Transaction Failure", error("Database Error"), code = 20,
+                                            reason = "deadlock condition");
+    var error(code = code, reason = reason) = e;
+    var formatMessage = function() returns string {
+        return code.toString() + ":" + reason;
+    };
+    assert(formatMessage(), "20:deadlock condition");
+}
+
 function assert(anydata actual, anydata expected) {
     if (expected == actual) {
             return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/closures/closure.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/closures/closure.bal
@@ -880,6 +880,49 @@ function testClosureWithErrorBindingPatterns() {
     assert(formatMessage(), "20:deadlock condition");
 }
 
+type R record {|
+    int a;
+    string b;
+|};
+
+function testClosureWithBindingPatternsInForEach() {
+    string[] values = ["a", "b", "c"];
+    string[] restrictedKeys = ["g", "h", "i"];
+    map<int> data = {
+        a: 1
+    };
+
+    foreach var [k, _] in data.entries() {
+        var isRestricted = function() returns boolean {
+            return restrictedKeys.indexOf(k) !is ();
+        };
+        assert(isRestricted(), false);
+        assert(values.filter(item => item == k), ["a"]);
+    }
+
+    R[] rs = [{a: 1, b: "a"}, {a: 2, b: "b"}, {a: 3, b: "c"}];
+    int[] allowedNs = [1, 2, 3];
+
+    foreach var {a: a, b: b1} in rs {
+        var isAllowed = function() returns boolean {
+            return allowedNs.indexOf(a) !is ();
+        };
+        assert(isAllowed(), true);
+        assert(values.filter(item => item == b1), [b1]);
+    }
+
+    SampleError e1 = error("Type Cast Failure", error("Type Error"), code = 21,
+                                            reason = "xml cannot be cast to json");
+    SampleError[] es = [e1];
+
+    foreach var error(code = code, reason = reason) in es {
+        var getErrorMessage = function() returns string {
+            return code.toString() + ":" + reason;
+        };
+        assert(getErrorMessage(), "21:xml cannot be cast to json");
+    }
+}
+
 function assert(anydata actual, anydata expected) {
     if (expected == actual) {
             return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/closures/closure.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/closures/closure.bal
@@ -815,7 +815,6 @@ function test30() {
 
 type School record {|
     string name;
-    string country;
 |};
 
 type Doctor record {
@@ -827,7 +826,7 @@ type Doctor record {
 function testClosureWithStructuredBindingTypeParams() {
     string[] categories = ["Orthopedic", "Dentist"];
     string[] schools = [];
-    Doctor doctor = {name: "Dr. Smith", category: "Cardiologist", school: {name: "Medical College", country: "United States"}};
+    Doctor doctor = {name: "Dr. Smith", category: "Cardiologist", school: {name: "Medical College"}};
     var {category, school: {name}} = doctor;
     var f = function () {
         categories.push(category);
@@ -852,6 +851,16 @@ function testClosureWithTupleBindingTypeParams() {
         return id + len;
     };
     assert(increment(), 5);
+}
+
+function testClosureWithBindingPatternDefaultValues() {
+    record {|string nt;|} r = {nt: "nt"};
+    [string] [i] = ["i"];
+    var {nt} = r;
+    var f = function(string s = i) returns string {
+        return i + nt;
+    };
+    assert(f(), "int");
 }
 
 function assert(anydata actual, anydata expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_binding_pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_binding_pattern.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
 //
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_binding_pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_binding_pattern.bal
@@ -135,13 +135,8 @@ function testLimitClauseAndQueryExprWithBindingVar() {
     assertEquality(topList, [{"name": "Alex", "grade": 85.0}, {"name": "Ranjan", "grade": 95.0}]);
 }
 
-const ASSERTION_ERROR_REASON = "AssertionError";
-
 function assertEquality(anydata actual, anydata expected) {
-    if expected == actual {
-        return;
+    if expected != actual {
+        panic error(string `expected '${expected.toBalString()}', found '${actual.toBalString()}'`);
     }
-
-    panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString() + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_binding_pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_binding_pattern.bal
@@ -1,0 +1,144 @@
+// Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function testSelectClauseWithBindingVar() {
+    record {|int nR; int[] valsR;|} a = {nR: 2, valsR: [1, 2, 4, 5]};
+    var {nR, valsR} = a;
+    int[] times = from int i in valsR
+        select nR * i;
+    assertEquality(times, [2, 4, 8, 10]);
+
+    [int, int[]] [nT, valsT] = [3, [1, 2, 3, 4, 5]];
+    times = from int i in valsT
+        select nT * i;
+    assertEquality(times, [3, 6, 9, 12, 15]);
+}
+
+function testCollectClauseWithBindingVar() {
+    record {|int n; int[] vals;|} a = {n: 2, vals: [1, 2, 4, 5]};
+    var {n, vals} = a;
+    int[] times = from int i in vals
+        collect [i].map(j => j * n);
+    assertEquality(times, [2, 4, 8, 10]);
+}
+
+function testFunctionPointerInvocationWithBindingVar() {
+    [int] [t] = [21];
+    record {|int r;|} rec = {r: 2};
+    var {r} = rec;
+    int[] x = from int i in [1, 2, 3]
+        let function () returns int func = function() returns int => i * r * t
+        select func();
+    assertEquality(x, [42, 84, 126]);
+}
+
+function testQueryActionWithBindingVar() {
+    [int] [t] = [21];
+    record {|int r;|} rec = {r: 2};
+    var {r} = rec;
+    int count = 0;
+    int[] intList = [1, 2, 3];
+
+    from var value in intList
+    do {
+        count += r * value + t;
+    };
+    assertEquality(count, 75);
+}
+
+function testClosureInQueryActionInDoWithBindingVar() {
+    record {|int[] lst;|} rec = {lst: [5, 6]};
+    [int] [offset] = [1];
+    var {lst} = rec;
+    int[] arr = [];
+    from var j in 1 ... 5
+    do {
+        from var k in lst
+        do {
+            arr.push(k + j + offset);
+        };
+    };
+    assertEquality([7, 8, 8, 9, 9, 10, 10, 11, 11, 12], arr);
+}
+
+type Student record {
+    string name;
+    int age;
+    float[] grades;
+};
+
+type Result record {|
+    string name;
+    float grade;
+|};
+
+function testNestedQueryInSelectWithBindingVar() returns () {
+    record {|float mx;|} rec = {mx: 80.0};
+    [int, float] [ageLimit, bonus] = [18, 5.0];
+    var {mx} = rec;
+
+    Student[] students = [
+        {name: "Alice", age: 22, grades: [75.2, 88.4, 92.9]},
+        {name: "Bob", age: 20, grades: [60.2, 70.3, 85.1]},
+        {name: "Charlie", age: 21, grades: [90.7, 95.4, 55.5]}
+    ];
+
+    Result[][] results = from var {name, age, grades} in students
+        where age > ageLimit
+        select from var grade in grades
+            where grade < mx
+            select {
+                name: name,
+                grade: grade + bonus
+            };
+
+    assertEquality([[{"name": "Alice", "grade": 80.2}], [{"name": "Bob", "grade": 65.2}, {"name": "Bob", "grade": 75.3}], [{"name": "Charlie", "grade": 60.5}]], results);
+}
+
+function testLimitClauseAndQueryExprWithBindingVar() {
+    record {|int lmt; float mx;|} rec = {lmt: 2, mx: 80.0};
+    [int, int] [curOutOf, outOf] = [40, 100];
+    var {lmt, mx} = rec;
+
+    Result r1 = {name: "Alex", grade: 34};
+    Result r2 = {name: "Ranjan", grade: 38};
+    Result r3 = {name: "John", grade: 39};
+    Result r4 = {name: "Max", grade: 33};
+    Result[] resultList = [r1, r2, r3, r4];
+
+    Result[] topList =
+            from var result in resultList
+    let float newMarks = (result.grade / curOutOf) * outOf
+    where newMarks > mx
+    limit lmt
+    select {
+        name: result.name,
+        grade: newMarks
+    };
+
+    assertEquality([{"name": "Alex", "grade": 85.0}, {"name": "Ranjan", "grade": 95.0}], topList);
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertEquality(anydata expected, anydata actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString() + "'");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_binding_pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_binding_pattern.bal
@@ -71,7 +71,7 @@ function testClosureInQueryActionInDoWithBindingVar() {
             arr.push(k + j + offset);
         };
     };
-    assertEquality([7, 8, 8, 9, 9, 10, 10, 11, 11, 12], arr);
+    assertEquality(arr, [7, 8, 8, 9, 9, 10, 10, 11, 11, 12]);
 }
 
 type Student record {
@@ -105,7 +105,10 @@ function testNestedQueryInSelectWithBindingVar() returns () {
                 grade: grade + bonus
             };
 
-    assertEquality([[{"name": "Alice", "grade": 80.2}], [{"name": "Bob", "grade": 65.2}, {"name": "Bob", "grade": 75.3}], [{"name": "Charlie", "grade": 60.5}]], results);
+    assertEquality(results,
+                   [[{"name": "Alice", "grade": 80.2}],
+                    [{"name": "Bob", "grade": 65.2}, {"name": "Bob", "grade": 75.3}],
+                    [{"name": "Charlie", "grade": 60.5}]]);
 }
 
 function testLimitClauseAndQueryExprWithBindingVar() {
@@ -129,12 +132,12 @@ function testLimitClauseAndQueryExprWithBindingVar() {
         grade: newMarks
     };
 
-    assertEquality([{"name": "Alex", "grade": 85.0}, {"name": "Ranjan", "grade": 95.0}], topList);
+    assertEquality(topList, [{"name": "Alex", "grade": 85.0}, {"name": "Ranjan", "grade": 95.0}]);
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";
 
-function assertEquality(anydata expected, anydata actual) {
+function assertEquality(anydata actual, anydata expected) {
     if expected == actual {
         return;
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/anon_record.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/anon_record.bal
@@ -100,6 +100,17 @@ public function anonymousRecordWithTypeInclusion() {
     assertEquality(3, rec.x);
 }
 
+function recordWithDefaultsFromBindingPatternVar() {
+    final record {|readonly int y;|} r = {y: 20};
+    final var {y} = r;
+    record {
+        string name;
+        int age = y;
+    } person = {name: "Ann"};
+
+    assertEquality(20, person.age);
+}
+
 function assertEquality(anydata expected, anydata actual) {
     if expected == actual {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/anon_record.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/anon_record.bal
@@ -100,7 +100,7 @@ public function anonymousRecordWithTypeInclusion() {
     assertEquality(3, rec.x);
 }
 
-function recordWithDefaultsFromBindingPatternVar() {
+function testRecordWithDefaultsFromBindingPatternVar() {
     final record {|readonly int y;|} r = {y: 20};
     final var {y} = r;
     record {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
@@ -667,6 +667,17 @@ public function testWorkerWithQuery() {
     assertEquals(4, sum);
 }
 
+function testBindingPatternVariablesInWorker() {
+    record {|string name;|} rec = {name: "name"};
+    [string] [colon] = [";"];
+    var {name} = rec;
+
+    worker A returns string {
+        return name + colon;
+    }
+    string _ = wait A;
+}
+
 public function sleep(int millis) = @java:Method {
     'class: "org.ballerinalang.test.utils.interop.Utils"
 } external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
@@ -668,14 +668,15 @@ public function testWorkerWithQuery() {
 }
 
 function testBindingPatternVariablesInWorker() {
-    record {|string name;|} rec = {name: "name"};
+    record {|string name;|} rec = {name: "workerName"};
     [string] [colon] = [";"];
     var {name} = rec;
 
     worker A returns string {
         return name + colon;
     }
-    string _ = wait A;
+    string result = wait A;
+    assertEquals("workerName;", result);
 }
 
 public function sleep(int millis) = @java:Method {


### PR DESCRIPTION
## Purpose
Fixes #41236 
Fixes #41832 
Fixes #41858 
Fixes #40615 

## Approach
For mapping/tuple binding patterns a block is created in the desugar phase and the variable definitions by the are defined inside this newly created block. Thus these variables are omitted from the map that is passed to the lambda function created from the closure. In the fix when a generated block from the desugar phase is identified using the `internal` flag and when the internal flag is present the variable definitions are attached to the parent of the block node created. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
