### PR TITLE
Use specialized get methods to access record fields

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -128,7 +128,23 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
     }
 
     public Long getIntValue(BString key) {
-        return (Long) get(key);
+        Object value = get(key);
+        if (value instanceof Integer) { // field is an int subtype
+            return ((Integer) value).longValue();
+        }
+        return (Long) value;
+    }
+
+    public long getUnboxedIntValue(BString key) {
+        return getIntValue(key);
+    }
+
+    public double getUnboxedFloatValue(BString key) {
+        return getFloatValue(key);
+    }
+
+    public boolean getUnboxedBooleanValue(BString key) {
+        return getBooleanValue(key);
     }
 
     public Double getFloatValue(BString key) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
@@ -86,7 +86,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_TO_STRING_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_TO_UNSIGNED_INT_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.LONG_VALUE;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MAP_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MAP_VALUE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.NUMBER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.REG_EXP_VALUE;
@@ -1331,7 +1331,7 @@ public class JvmCastGen {
                 break;
             case TypeTags.MAP:
             case TypeTags.RECORD:
-                targetTypeClass = MAP_VALUE;
+                targetTypeClass = MAP_VALUE_IMPL;
                 break;
             case TypeTags.TABLE:
                 targetTypeClass = TABLE_VALUE;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -429,6 +429,14 @@ public class JvmConstants {
     public static final String OBSERVABLE_ANNOTATION = "ballerina/observe/Observable";
     public static final String DISPLAY_ANNOTATION = "display";
     public static final String RECORD_CHECKPOINT_METHOD = "recordCheckpoint";
+    public static final String GET_ELEMENT_OR_NIL = "getElementOrNil";
+    public static final String GET_ELEMENT = "getElement";
+    public static final String FILL_AND_GET = "fillAndGet";
+    public static final String GET_BOXED_VALUE = "get";
+    public static final String GET_UNBOXED_INT_VALUE = "getUnboxedIntValue";
+    public static final String GET_UNBOXED_FLOAT_VALUE = "getUnboxedFloatValue";
+    public static final String GET_STRING_VALUE = "getStringValue";
+    public static final String GET_UNBOXED_BOOLEAN_VALUE = "getUnboxedBooleanValue";
     // visibility flags
     public static final int BAL_PUBLIC = 1;
     public static final int BAL_NATIVE = 2;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -142,7 +142,15 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DECIMAL_V
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DOUBLE_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.EQUALS_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ERROR_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FILL_AND_GET;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION_POINTER;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.GET_BOXED_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.GET_ELEMENT;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.GET_ELEMENT_OR_NIL;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.GET_STRING_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.GET_UNBOXED_BOOLEAN_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.GET_UNBOXED_FLOAT_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.GET_UNBOXED_INT_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.GET_VALUE_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.HANDLE_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.INSTANTIATE_FUNCTION;
@@ -1481,13 +1489,13 @@ public class JvmInstructionGen {
         boolean shouldUnbox = true;
         if (varRefType.tag == TypeTags.JSON) {
             if (mapLoadIns.optionalFieldAccess) {
-                this.mv.visitMethodInsn(INVOKESTATIC, JSON_UTILS, "getElementOrNil", JSON_GET_ELEMENT, false);
+                this.mv.visitMethodInsn(INVOKESTATIC, JSON_UTILS, GET_ELEMENT_OR_NIL, JSON_GET_ELEMENT, false);
             } else {
-                this.mv.visitMethodInsn(INVOKESTATIC, JSON_UTILS, "getElement", JSON_GET_ELEMENT, false);
+                this.mv.visitMethodInsn(INVOKESTATIC, JSON_UTILS, GET_ELEMENT, JSON_GET_ELEMENT, false);
             }
         } else {
             if (mapLoadIns.fillingRead) {
-                this.mv.visitMethodInsn(INVOKEINTERFACE, MAP_VALUE, "fillAndGet",
+                this.mv.visitMethodInsn(INVOKEINTERFACE, MAP_VALUE, FILL_AND_GET,
                         PASS_OBJECT_RETURN_OBJECT, true);
             } else {
                 shouldUnbox = generateMapGet(varRefType, targetType);
@@ -1503,32 +1511,32 @@ public class JvmInstructionGen {
 
     boolean generateMapGet(BType mapType, BType expectedType) {
         if (mapType.getKind() != TypeKind.RECORD) {
-            this.mv.visitMethodInsn(INVOKEINTERFACE, MAP_VALUE, "get", PASS_OBJECT_RETURN_OBJECT, true);
+            this.mv.visitMethodInsn(INVOKEINTERFACE, MAP_VALUE, GET_BOXED_VALUE, PASS_OBJECT_RETURN_OBJECT, true);
             return true;
         }
         return switch (expectedType.getKind()) {
             case INT -> {
-                this.mv.visitMethodInsn(INVOKEVIRTUAL, MAP_VALUE_IMPL, "getUnboxedIntValue",
+                this.mv.visitMethodInsn(INVOKEVIRTUAL, MAP_VALUE_IMPL, GET_UNBOXED_INT_VALUE,
                         PASS_B_STRING_RETURN_UNBOXED_LONG, false);
                 yield false;
             }
             case FLOAT -> {
-                this.mv.visitMethodInsn(INVOKEVIRTUAL, MAP_VALUE_IMPL, "getUnboxedFloatValue",
+                this.mv.visitMethodInsn(INVOKEVIRTUAL, MAP_VALUE_IMPL, GET_UNBOXED_FLOAT_VALUE,
                         PASS_B_STRING_RETURN_UNBOXED_DOUBLE, false);
                 yield false;
             }
             case STRING -> {
-                this.mv.visitMethodInsn(INVOKEVIRTUAL, MAP_VALUE_IMPL, "getStringValue", PASS_B_STRING_RETURN_B_STRING,
+                this.mv.visitMethodInsn(INVOKEVIRTUAL, MAP_VALUE_IMPL, GET_STRING_VALUE, PASS_B_STRING_RETURN_B_STRING,
                         false);
                 yield true;
             }
             case BOOLEAN -> {
-                this.mv.visitMethodInsn(INVOKEVIRTUAL, MAP_VALUE_IMPL, "getUnboxedBooleanValue",
+                this.mv.visitMethodInsn(INVOKEVIRTUAL, MAP_VALUE_IMPL, GET_UNBOXED_BOOLEAN_VALUE,
                         PASS_B_STRING_RETURN_UNBOXED_BOOLEAN, false);
                 yield false;
             }
             default -> {
-                this.mv.visitMethodInsn(INVOKEINTERFACE, MAP_VALUE, "get", PASS_OBJECT_RETURN_OBJECT, true);
+                this.mv.visitMethodInsn(INVOKEINTERFACE, MAP_VALUE, GET_BOXED_VALUE, PASS_OBJECT_RETURN_OBJECT, true);
                 yield true;
             }
         };
@@ -1542,7 +1550,7 @@ public class JvmInstructionGen {
         this.loadVar(objectLoadIns.keyOp.variableDcl);
 
         // invoke get() method, and unbox if needed
-        this.mv.visitMethodInsn(INVOKEINTERFACE, B_OBJECT, "get", BOBJECT_GET, true);
+        this.mv.visitMethodInsn(INVOKEINTERFACE, B_OBJECT, GET_BOXED_VALUE, BOBJECT_GET, true);
         BType targetType = objectLoadIns.lhsOp.variableDcl.type;
         jvmCastGen.addUnboxInsn(this.mv, targetType);
 
@@ -1720,7 +1728,7 @@ public class JvmInstructionGen {
         this.loadVar(inst.keyOp.variableDcl);
         jvmCastGen.addBoxInsn(this.mv, inst.keyOp.variableDcl.type);
         BType bType = inst.lhsOp.variableDcl.type;
-        this.mv.visitMethodInsn(INVOKEINTERFACE, TABLE_VALUE, "get",
+        this.mv.visitMethodInsn(INVOKEINTERFACE, TABLE_VALUE, GET_BOXED_VALUE,
                 PASS_OBJECT_RETURN_OBJECT, true);
 
         String targetTypeClass = getTargetClass(bType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -242,7 +242,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.LONG_STR
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.OBJECT_TYPE_DUPLICATE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.OBJECT_TYPE_IMPL_INIT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_B_STRING_RETURN_UNBOXED_BOOLEAN;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_B_STRING_RETURN_BSTRING;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_B_STRING_RETURN_B_STRING;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_B_STRING_RETURN_UNBOXED_DOUBLE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_B_STRING_RETURN_UNBOXED_LONG;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_OBJECT_RETURN_OBJECT;
@@ -1518,7 +1518,7 @@ public class JvmInstructionGen {
                 yield false;
             }
             case STRING -> {
-                this.mv.visitMethodInsn(INVOKEVIRTUAL, MAP_VALUE_IMPL, "getStringValue", PASS_B_STRING_RETURN_BSTRING,
+                this.mv.visitMethodInsn(INVOKEVIRTUAL, MAP_VALUE_IMPL, "getStringValue", PASS_B_STRING_RETURN_B_STRING,
                         false);
                 yield true;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -381,7 +381,14 @@ public class JvmSignatures {
     public static final String OBJECT_TYPE_DUPLICATE = "()L" + OBJECT_TYPE_IMPL + ";";
     public static final String OBJECT_TYPE_IMPL_INIT = "(L" + TYPE + ";)V";
     public static final String PANIC_IF_IN_LOCK = "(L" + STRAND_CLASS + ";)V";
-    public static final String PASS_BSTRING_RETURN_OBJECT = "(L" + B_STRING_VALUE + ";)L" + OBJECT + ";";
+    public static final String PASS_B_STRING_RETURN_OBJECT = "(L" + B_STRING_VALUE + ";)L" + OBJECT + ";";
+    public static final String PASS_B_STRING_RETURN_LONG = "(L" + B_STRING_VALUE + ";)L" + LONG_VALUE + ";";
+    public static final String PASS_B_STRING_RETURN_UNBOXED_LONG = "(L" + B_STRING_VALUE + ";)J";
+    public static final String PASS_B_STRING_RETURN_DOUBLE = "(L" + B_STRING_VALUE + ";)L" + DOUBLE_VALUE + ";";
+    public static final String PASS_B_STRING_RETURN_UNBOXED_DOUBLE = "(L" + B_STRING_VALUE + ";)D";
+    public static final String PASS_B_STRING_RETURN_BSTRING = "(L" + B_STRING_VALUE + ";)L" + B_STRING_VALUE + ";";
+    public static final String PASS_B_STRING_RETURN_BOOLEAN = "(L" + B_STRING_VALUE + ";)L" + BOOLEAN_VALUE + ";";
+    public static final String PASS_B_STRING_RETURN_UNBOXED_BOOLEAN = "(L" + B_STRING_VALUE + ";)Z";
     public static final String PASS_OBJECT_RETURN_OBJECT = "(L" + OBJECT + ";)L" + OBJECT + ";";
     public static final String PASS_OBJECT_RETURN_SAME_TYPE = "(L" + OBJECT + ";)TV;";
     public static final String POPULATE_ATTACHED_FUNCTION = "([L" + METHOD_TYPE_IMPL + ";)V";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -386,7 +386,7 @@ public class JvmSignatures {
     public static final String PASS_B_STRING_RETURN_UNBOXED_LONG = "(L" + B_STRING_VALUE + ";)J";
     public static final String PASS_B_STRING_RETURN_DOUBLE = "(L" + B_STRING_VALUE + ";)L" + DOUBLE_VALUE + ";";
     public static final String PASS_B_STRING_RETURN_UNBOXED_DOUBLE = "(L" + B_STRING_VALUE + ";)D";
-    public static final String PASS_B_STRING_RETURN_BSTRING = "(L" + B_STRING_VALUE + ";)L" + B_STRING_VALUE + ";";
+    public static final String PASS_B_STRING_RETURN_B_STRING = "(L" + B_STRING_VALUE + ";)L" + B_STRING_VALUE + ";";
     public static final String PASS_B_STRING_RETURN_BOOLEAN = "(L" + B_STRING_VALUE + ";)L" + BOOLEAN_VALUE + ";";
     public static final String PASS_B_STRING_RETURN_UNBOXED_BOOLEAN = "(L" + B_STRING_VALUE + ";)Z";
     public static final String PASS_OBJECT_RETURN_OBJECT = "(L" + OBJECT + ";)L" + OBJECT + ";";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
+import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PROTECTED;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
@@ -317,7 +318,8 @@ public class JvmValueGen {
         }
         JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen, types);
         LambdaGen lambdaGen = new LambdaGen(jvmPackageGen, jvmCastGen);
-        cw.visit(V17, ACC_PUBLIC + ACC_SUPER, className, RECORD_VALUE_CLASS, MAP_VALUE_IMPL, new String[]{MAP_VALUE});
+        cw.visit(V17, ACC_PUBLIC + ACC_SUPER + ACC_FINAL, className, RECORD_VALUE_CLASS, MAP_VALUE_IMPL,
+                new String[]{MAP_VALUE});
 
         Map<String, BField> fields = recordType.fields;
         this.createRecordFields(cw, fields);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
@@ -62,7 +62,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.CHECK_FI
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_JSTRING;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_OBJECT_FOR_STRING;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.OBJECT_SET;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_BSTRING_RETURN_OBJECT;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_B_STRING_RETURN_OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_OBJECT_RETURN_SAME_TYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SET_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.getTypeDesc;
@@ -174,7 +174,7 @@ public class JvmObjectGen {
 
     public void createAndSplitGetMethod(ClassWriter cw, Map<String, BField> fields, String className,
                                         JvmCastGen jvmCastGen) {
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "get", PASS_BSTRING_RETURN_OBJECT,
+        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "get", PASS_B_STRING_RETURN_OBJECT,
                 PASS_OBJECT_RETURN_SAME_TYPE, null);
         mv.visitCode();
         int selfIndex = 0;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmRecordGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmRecordGen.java
@@ -91,7 +91,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.MAP_PUT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.MAP_VALUES;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.MAP_VALUES_WITH_COLLECTION;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_B_STRING_RETURN_BOOLEAN;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_B_STRING_RETURN_BSTRING;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_B_STRING_RETURN_B_STRING;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_B_STRING_RETURN_DOUBLE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_B_STRING_RETURN_LONG;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_B_STRING_RETURN_UNBOXED_BOOLEAN;
@@ -935,7 +935,7 @@ public class JvmRecordGen {
     void createStringGetMethod(ClassWriter cw, Map<String, BField> fields, String className,
                                JvmCastGen jvmCastGen) {
         createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.STRING, "getStringValue",
-                PASS_B_STRING_RETURN_BSTRING, true, B_STRING_VALUE);
+                PASS_B_STRING_RETURN_B_STRING, true, B_STRING_VALUE);
     }
 
     private void createBasicTypeGetMethod(ClassWriter cw, Map<String, BField> fields, String className,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmRecordGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmRecordGen.java
@@ -160,14 +160,21 @@ public class JvmRecordGen {
         mv.visitEnd();
         splitGetMethod(cw, fields, className, jvmCastGen);
 
-        createBooleanGetMethod(cw, fields, className, jvmCastGen);
-        createFloatGetMethod(cw, fields, className, jvmCastGen);
-        createIntGetMethod(cw, fields, className, jvmCastGen);
-        createStringGetMethod(cw, fields, className, jvmCastGen);
+        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.BOOLEAN, "getBooleanValue",
+                PASS_B_STRING_RETURN_BOOLEAN, true, BOOLEAN_VALUE);
+        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.FLOAT, "getFloatValue",
+                PASS_B_STRING_RETURN_DOUBLE, true, DOUBLE_VALUE);
+        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.INT, "getIntValue",
+                PASS_B_STRING_RETURN_LONG, true, LONG_VALUE);
+        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.STRING, "getStringValue",
+                PASS_B_STRING_RETURN_B_STRING, true, B_STRING_VALUE);
 
-        createUnboxedBooleanGetMethod(cw, fields, className, jvmCastGen);
-        createUnboxedFloatGetMethod(cw, fields, className, jvmCastGen);
-        createUnboxedIntGetMethod(cw, fields, className, jvmCastGen);
+        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.BOOLEAN, "getUnboxedBooleanValue",
+                PASS_B_STRING_RETURN_UNBOXED_BOOLEAN, false, null);
+        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.FLOAT, "getUnboxedFloatValue",
+                PASS_B_STRING_RETURN_UNBOXED_DOUBLE, false, null);
+        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.INT, "getUnboxedIntValue",
+                PASS_B_STRING_RETURN_UNBOXED_LONG, false, null);
     }
 
     private void splitGetMethod(ClassWriter cw, Map<String, BField> fields, String className,
@@ -896,48 +903,6 @@ public class JvmRecordGen {
         }
     }
 
-    void createUnboxedIntGetMethod(ClassWriter cw, Map<String, BField> fields, String className,
-                                   JvmCastGen jvmCastGen) {
-        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.INT, "getUnboxedIntValue",
-                PASS_B_STRING_RETURN_UNBOXED_LONG, false, "");
-    }
-
-    void createUnboxedFloatGetMethod(ClassWriter cw, Map<String, BField> fields, String className,
-                                     JvmCastGen jvmCastGen) {
-        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.FLOAT, "getUnboxedFloatValue",
-                PASS_B_STRING_RETURN_UNBOXED_DOUBLE, false, "");
-    }
-
-    void createUnboxedBooleanGetMethod(ClassWriter cw, Map<String, BField> fields, String className,
-                                       JvmCastGen jvmCastGen) {
-        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.BOOLEAN, "getUnboxedBooleanValue",
-                PASS_B_STRING_RETURN_UNBOXED_BOOLEAN, false, "");
-    }
-
-    void createIntGetMethod(ClassWriter cw, Map<String, BField> fields, String className,
-                            JvmCastGen jvmCastGen) {
-        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.INT, "getIntValue",
-                PASS_B_STRING_RETURN_LONG, true, LONG_VALUE);
-    }
-
-    void createFloatGetMethod(ClassWriter cw, Map<String, BField> fields, String className,
-                              JvmCastGen jvmCastGen) {
-        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.FLOAT, "getFloatValue",
-                PASS_B_STRING_RETURN_DOUBLE, true, DOUBLE_VALUE);
-    }
-
-    void createBooleanGetMethod(ClassWriter cw, Map<String, BField> fields, String className,
-                                JvmCastGen jvmCastGen) {
-        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.BOOLEAN, "getBooleanValue",
-                PASS_B_STRING_RETURN_BOOLEAN, true, BOOLEAN_VALUE);
-    }
-
-    void createStringGetMethod(ClassWriter cw, Map<String, BField> fields, String className,
-                               JvmCastGen jvmCastGen) {
-        createBasicTypeGetMethod(cw, fields, className, jvmCastGen, TypeKind.STRING, "getStringValue",
-                PASS_B_STRING_RETURN_B_STRING, true, B_STRING_VALUE);
-    }
-
     private void createBasicTypeGetMethod(ClassWriter cw, Map<String, BField> fields, String className,
                                           JvmCastGen jvmCastGen, TypeKind basicType, String methodName,
                                           String methodDesc, boolean boxed, String boxedTypeDesc) {
@@ -992,8 +957,7 @@ public class JvmRecordGen {
 
         mv.visitVarInsn(ALOAD, selfRegister);
         mv.visitVarInsn(ALOAD, fieldNameBStringReg);
-        mv.visitMethodInsn(INVOKEVIRTUAL, className, "get", PASS_OBJECT_RETURN_OBJECT,
-                false);
+        mv.visitMethodInsn(INVOKEVIRTUAL, className, "get", PASS_OBJECT_RETURN_OBJECT, false);
 
         if (boxed) {
             mv.visitTypeInsn(CHECKCAST, boxedTypeDesc);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/FieldAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/FieldAccessTest.java
@@ -315,6 +315,12 @@ public class FieldAccessTest {
         BRunUtil.invoke(result, function);
     }
 
+    @Test
+    public void testFieldAccessOnIntSubtypeRecordFields() {
+        Object returns = BRunUtil.invoke(result, "testFieldAccessOnIntSubtype");
+        Assert.assertEquals(returns, 1L);
+    }
+
     @DataProvider(name = "fieldAccessOnJsonTypedRecordFields")
     public Object[][] fieldAccessOnJsonTypedRecordFields() {
         return new Object[][] {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/OptionalFieldAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/OptionalFieldAccessTest.java
@@ -172,6 +172,15 @@ public class OptionalFieldAccessTest {
         BRunUtil.invoke(result, "testNestedOptionalFieldAccessOnIntersectionTypes");
     }
 
+    @Test
+    public void testOptionalFieldAccessOnRecordsWithOnlyOptionalFields() {
+        Object return1 = BRunUtil.invoke(result, "getOptionalField1");
+        Assert.assertNull(return1);
+
+        Object return2 = BRunUtil.invoke(result, "getOptionalField2");
+        Assert.assertEquals(return2, 5L);
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/field_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/field_access.bal
@@ -562,3 +562,12 @@ function assertEquals(anydata actual, anydata expected) {
     }
     panic error(string `expected '${expected.toString()}', found '${actual.toString()}'`);
 }
+
+type IntSubtypeRecord record {|
+    int:Signed16 value;
+|};
+
+function testFieldAccessOnIntSubtype() returns int:Signed16 {
+    IntSubtypeRecord r = {value: 1};
+    return r.value;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
@@ -581,3 +581,17 @@ function assertEquality(anydata expected, anydata actual) {
 
     panic error("expected '" + expected.toString() + "', found '" + actual.toString() + "'");
 }
+
+type AllOptionalBasicTypeField record {|
+    int val?;
+|};
+
+function getOptionalField1() returns int? {
+    AllOptionalBasicTypeField r = {};
+    return r.val;
+}
+
+function getOptionalField2() returns int? {
+    AllOptionalBasicTypeField r = {val: 5};
+    return r.val;
+}


### PR DESCRIPTION
## Purpose
Use specialized get methods to access record fields.
Part of #41868

## Approach
+ If the record field is of a basic type use the specialized method for that type to access them.  (This should avoid unnecessary typecasts).
+ For `int`, `float` and `boolean` types introduce "unboxed" get functions (This should avoid unnecessary boxing and unboxing when accessing record fields).

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
