### PR TITLE
Add name for readonly records in config schema generation

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/TypeConverter.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/TypeConverter.java
@@ -181,14 +181,18 @@ public class TypeConverter {
         if (!requiredFields.isEmpty()) {
             typeNode.add("required", requiredFields);
         }
-        // Get record type and set the type name as a property
-        for (BType bType : intersectionType.getConstituentTypes()) {
-            // Does not consider anonymous records
-            if (bType.tag == TypeTags.TYPEREFDESC) {
-                typeNode.addProperty("name", bType.toString().trim());
+        // The tsymbol name is empty for anon intersection type created due to inferred readonly
+        if (!intersectionType.tsymbol.name.value.isEmpty()) {
+            typeNode.addProperty("name", intersectionType.tsymbol.toString().trim());
+        } else {
+            // Get record type and set the type name as a property
+            for (BType bType : intersectionType.getConstituentTypes()) {
+                // Does not consider anonymous records
+                if (bType.tag == TypeTags.TYPEREFDESC) {
+                    typeNode.addProperty("name", bType.toString().trim());
+                }
             }
         }
-
         return typeNode;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/TypeConverter.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/TypeConverter.java
@@ -20,6 +20,7 @@ package io.ballerina.projects.internal.configschema;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
@@ -182,9 +183,10 @@ public class TypeConverter {
         if (!requiredFields.isEmpty()) {
             typeNode.add("required", requiredFields);
         }
-        // The tsymbol name is empty for anon intersection type created due to inferred readonly
-        if (intersectionType.tsymbol.name != Names.EMPTY) {
-            typeNode.addProperty("name", intersectionType.tsymbol.toString().trim());
+        BTypeSymbol intersectionSymbol = intersectionType.tsymbol;
+        // The tsymbol name is implicitly empty
+        if (intersectionSymbol.name != Names.EMPTY) {
+            typeNode.addProperty("name", intersectionSymbol.toString().trim());
         } else {
             // Get record type and set the type name as a property
             for (BType bType : intersectionType.getConstituentTypes()) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/TypeConverter.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/TypeConverter.java
@@ -33,6 +33,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNumericLiteral;
+import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import java.util.HashMap;
@@ -182,13 +183,14 @@ public class TypeConverter {
             typeNode.add("required", requiredFields);
         }
         // The tsymbol name is empty for anon intersection type created due to inferred readonly
-        if (!intersectionType.tsymbol.name.value.isEmpty()) {
+        if (intersectionType.tsymbol.name != Names.EMPTY) {
             typeNode.addProperty("name", intersectionType.tsymbol.toString().trim());
         } else {
             // Get record type and set the type name as a property
             for (BType bType : intersectionType.getConstituentTypes()) {
                 // Does not consider anonymous records
                 if (bType.tag == TypeTags.TYPEREFDESC) {
+                    // Revisit with https://github.com/ballerina-platform/ballerina-lang/issues/24078
                     typeNode.addProperty("name", bType.toString().trim());
                 }
             }

--- a/misc/compiler-plugins/modules/configurable-schema-generator/src/test/resources/DefaultModuleProjects/ComplexTypeConfigs2/expected-schema.json
+++ b/misc/compiler-plugins/modules/configurable-schema-generator/src/test/resources/DefaultModuleProjects/ComplexTypeConfigs2/expected-schema.json
@@ -140,12 +140,31 @@
                 }
               },
               "description": ""
+            },
+            "employeeReadOnly": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "salary": {
+                  "type": "integer"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "salary"
+              ],
+              "name": "dilhashanazeer/complexconfigs2:0.1.0:EmployeeReadOnly",
+              "description": ""
             }
           },
           "additionalProperties": false,
           "required": [
             "employeeArray",
-            "empMapArray"
+            "empMapArray",
+            "employeeReadOnly"
           ]
         }
       },

--- a/misc/compiler-plugins/modules/configurable-schema-generator/src/test/resources/DefaultModuleProjects/ComplexTypeConfigs2/main.bal
+++ b/misc/compiler-plugins/modules/configurable-schema-generator/src/test/resources/DefaultModuleProjects/ComplexTypeConfigs2/main.bal
@@ -10,6 +10,11 @@ type Employee record {
     int salary;
 };
 
+type EmployeeReadOnly readonly & record {
+    string name;
+    int salary;
+};
+
 configurable table<Employee> key(name) t = table [
     { name: "John", salary: 100 },
     { name: "Jane", salary: 200 }
@@ -22,6 +27,7 @@ configurable map<int>[] myArray = [{"val1" : 22}, {"val2" : 32}];
 configurable Employee[] employeeArray = ?;
 configurable map<Employee> employeeMap = {"emp1": {name: "user1", salary: 1200}};
 configurable map<Employee>[] empMapArray = ?;
+configurable EmployeeReadOnly employeeReadOnly = ?;
 
 public function main() {
 }


### PR DESCRIPTION
## Purpose

Fix failure when Config Generation fails to add the name of Readonly Records to the Config Schema.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/41906

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
