### PR TITLE
Fix computed field node formatting

### DIFF
--- a/compiler/ballerina-parser/src/test/resources/misc/ambiguity/ambiguity_assert_05.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/ambiguity/ambiguity_assert_05.json
@@ -251,13 +251,7 @@
                                           ]
                                         },
                                         {
-                                          "kind": "CLOSE_BRACKET_TOKEN",
-                                          "trailingMinutiae": [
-                                            {
-                                              "kind": "WHITESPACE_MINUTIAE",
-                                              "value": " "
-                                            }
-                                          ]
+                                          "kind": "CLOSE_BRACKET_TOKEN"
                                         },
                                         {
                                           "kind": "COLON_TOKEN",

--- a/compiler/ballerina-parser/src/test/resources/misc/ambiguity/ambiguity_source_05.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/ambiguity/ambiguity_source_05.bal
@@ -3,5 +3,5 @@ function foo() {
         [a] b = c;
     }
 
-    {[a] : b} -> w1;
+    {[a]: b} -> w1;
 }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -1461,7 +1461,7 @@ public class FormattingTreeModifier extends TreeModifier {
     public ComputedNameFieldNode transform(ComputedNameFieldNode computedNameFieldNode) {
         Token openBracket = formatToken(computedNameFieldNode.openBracket(), 0, 0);
         ExpressionNode fieldNameExpr = formatNode(computedNameFieldNode.fieldNameExpr(), 0, 0);
-        Token closeBracket = formatToken(computedNameFieldNode.closeBracket(), 1, 0);
+        Token closeBracket = formatToken(computedNameFieldNode.closeBracket(), 0, 0);
         Token colonToken = formatToken(computedNameFieldNode.colonToken(), 1, 0);
         ExpressionNode valueExpr = formatNode(computedNameFieldNode.valueExpr(), env.trailingWS, env.trailingNL);
 

--- a/misc/formatter/modules/formatter-core/src/test/resources/types/structured/assert/map_type_2.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/types/structured/assert/map_type_2.bal
@@ -5,7 +5,7 @@ function foo() {
         line1: "No. 20",
         city: "Colombo 03",
         country,
-        [codeLiteral] : "00300"
+        [codeLiteral]: "00300"
     };
     string? countryValue = addrMap["country"];
     addrMap["postalCode"] = "00300";

--- a/misc/formatter/modules/formatter-core/src/test/resources/types/structured/assert/record_type_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/types/structured/assert/record_type_1.bal
@@ -16,5 +16,8 @@ function testRecords() returns record {}[] {
     record {||}[] recArr = [r1, r2, r3, r4];
     record {int a;}[] recArr;
     Person p = {name: "john", age: 20};
+    string avg = "avg";
+    string max = "max";
+    Grades _ = {maths: 10, [avg]: 20, [max]: 100};
     return recArr;
 }

--- a/misc/formatter/modules/formatter-core/src/test/resources/types/structured/source/record_type_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/types/structured/source/record_type_1.bal
@@ -12,5 +12,8 @@ function testRecords() returns record {}[] {
     record {||}[] recArr = [r1, r2, r3, r4];
     record {int a;}[] recArr;
     Person p = {name: "john", age: 20};
+    string avg = "avg";
+    string max = "max";
+    Grades _ = {maths: 10, [avg]    :20,[max]:100};
     return recArr;
 }


### PR DESCRIPTION
## Purpose
Fixes #41923 

## Approach
Remove space before colon in computed key field node.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
