### PR TITLE
Generate a typedesc instruction once for record and tuple types

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -544,6 +544,10 @@ public class TypeChecker {
         if (!(describingType instanceof BAnnotatableType)) {
             return null;
         }
+        MapValue annotations =  ((TypedescValueImpl) typedescValue).annotations;
+        if (annotations != null) {
+            return annotations.get(annotTag);
+        }
         return ((BAnnotatableType) describingType).getAnnotation(annotTag);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTupleType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTupleType.java
@@ -207,6 +207,10 @@ public class BTupleType extends BAnnotatableType implements TupleType {
         if (cachedToString != null) {
             return;
         }
+        if (typeName != null && !typeName.isEmpty()) {
+            cachedToString = typeName;
+            return;
+        }
         StringBuilder stringRep =
                 new StringBuilder("[").append(tupleTypes.stream().map(Type::toString).collect(Collectors.joining(",")));
         if (restType != null) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -121,6 +121,13 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
         populateInitialValues(initialValues);
     }
 
+    public MapValueImpl(Type type, BMapInitialValueEntry[] initialValues, TypedescValue typedesc) {
+        this(type, initialValues);
+        if (!type.isReadOnly()) {
+            this.typedesc = typedesc;
+        }
+    }
+
     public MapValueImpl() {
         super();
         type = PredefinedTypes.TYPE_MAP;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
@@ -53,7 +53,6 @@ public class TypedescValueImpl implements TypedescValue {
 
     final Type type;
     final Type describingType; // Type of the value describe by this typedesc.
-    public MapValue[] closures;
     public MapValue annotations;
     private BTypedesc typedesc;
 
@@ -63,15 +62,8 @@ public class TypedescValueImpl implements TypedescValue {
         this.describingType = describingType;
     }
 
-    @Deprecated
-    public TypedescValueImpl(Type describingType, MapValue[] closures) {
-        this.type = new BTypedescType(describingType);
-        this.describingType = describingType;
-        this.closures = closures;
-    }
-
-    public TypedescValueImpl(Type describingType, MapValue[] closures, MapValue annotations) {
-        this(describingType, closures);
+    public TypedescValueImpl(Type describingType, MapValue annotations) {
+        this(describingType);
         this.annotations = annotations;
         ((BAnnotatableType) describingType).setAnnotations(annotations);
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
@@ -97,8 +97,8 @@ public class TypedescValueImpl implements TypedescValue {
     @Override
     public Object instantiate(Strand s, BInitialValueEntry[] initialValues) {
         Type referredType = getImpliedType(this.describingType);
-        if (referredType.getTag() == TypeTags.MAP_TAG) {
-            return new MapValueImpl(this.describingType, (BMapInitialValueEntry[]) initialValues);
+        if (referredType.getTag() == TypeTags.MAP_TAG || referredType.getTag() == TypeTags.RECORD_TYPE_TAG) {
+            return new MapValueImpl(this.describingType, (BMapInitialValueEntry[]) initialValues, this);
         } else if (referredType.getTag() == TypeTags.TUPLE_TAG) {
             return new TupleValueImpl(this.describingType, (BListInitialValueEntry[]) initialValues, this);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -85,6 +85,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotation;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
@@ -1584,16 +1585,14 @@ public class BIRGen extends BLangNodeVisitor {
 
         BType type = astMapLiteralExpr.getBType();
         this.env.isInArrayOrStructure++;
-        visitTypedesc(astMapLiteralExpr.pos, type, Collections.emptyList(), getAnnotations(type.tsymbol, this.env));
 
-        BIRVariableDcl tempVarDcl =
-                new BIRVariableDcl(astMapLiteralExpr.getBType(), this.env.nextLocalVarId(names),
-                                   VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(type, this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                                                       VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
-        setScopeAndEmit(new BIRNonTerminator.NewStructure(astMapLiteralExpr.pos, toVarRef, this.env.targetOperand,
-                                               generateMappingConstructorEntries(astMapLiteralExpr.fields)));
+        setScopeAndEmit(createNewStructureInst(generateMappingConstructorEntries(astMapLiteralExpr.fields), toVarRef,
+                        Types.getImpliedType(type), astMapLiteralExpr.pos));
         this.env.targetOperand = toVarRef;
         this.env.isInArrayOrStructure--;
     }
@@ -1618,19 +1617,14 @@ public class BIRGen extends BLangNodeVisitor {
     public void visit(BLangStructLiteral astStructLiteralExpr) {
         this.env.isInArrayOrStructure++;
         BType type = astStructLiteralExpr.getBType();
-        visitTypedesc(astStructLiteralExpr.pos, type, Collections.emptyList(), getAnnotations(type.tsymbol, this.env));
-
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astStructLiteralExpr.getBType(),
-                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astStructLiteralExpr.getBType(), this.env.nextLocalVarId(names),
+                                                       VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
-
-        BIRNonTerminator.NewStructure instruction =
-                new BIRNonTerminator.NewStructure(astStructLiteralExpr.pos, toVarRef, this.env.targetOperand,
-                                                  generateMappingConstructorEntries(astStructLiteralExpr.fields));
-        setScopeAndEmit(instruction);
-
+        List<BIRNode.BIRMappingConstructorEntry> fields =
+                                                   generateMappingConstructorEntries(astStructLiteralExpr.fields);
+        setScopeAndEmit(createNewStructureInst(fields, toVarRef, type, astStructLiteralExpr.pos));
         this.env.targetOperand = toVarRef;
         this.env.isInArrayOrStructure--;
     }
@@ -1676,8 +1670,6 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangTupleLiteral tupleLiteral) {
-        BType type = tupleLiteral.getBType();
-        visitTypedesc(tupleLiteral.pos, type, getAnnotations(type.tsymbol, this.env));
         generateListConstructorExpr(tupleLiteral);
     }
 
@@ -1981,12 +1973,13 @@ public class BIRGen extends BLangNodeVisitor {
         visitTypedesc(waitLiteral.pos, waitLiteral.getBType());
         BIRBasicBlock thenBB = new BIRBasicBlock(this.env.nextBBId());
         addToTrapStack(thenBB);
-
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(waitLiteral.getBType(),
-                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+        BType type = waitLiteral.getBType();
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(type, this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                                                       VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
-        setScopeAndEmit(new BIRNonTerminator.NewStructure(waitLiteral.pos, toVarRef, this.env.targetOperand));
+        Location pos = waitLiteral.pos;
+        setScopeAndEmit(createNewStructureInst(new ArrayList<>(), toVarRef, type, pos));
         this.env.targetOperand = toVarRef;
 
         List<String> keys = new ArrayList<>();
@@ -1998,7 +1991,7 @@ public class BIRGen extends BLangNodeVisitor {
             BIROperand valueRegIndex = this.env.targetOperand;
             valueExprs.add(valueRegIndex);
         }
-        this.env.enclBB.terminator = new BIRTerminator.WaitAll(waitLiteral.pos, toVarRef, keys,
+        this.env.enclBB.terminator = new BIRTerminator.WaitAll(pos, toVarRef, keys,
                 valueExprs, thenBB, this.currentScope);
         this.env.targetOperand = toVarRef;
         this.env.enclFunc.basicBlocks.add(thenBB);
@@ -2194,14 +2187,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangTypedescExpr accessExpr) {
-        BIRVariableDcl tempVarDcl =
-                new BIRVariableDcl(accessExpr.getBType(), this.env.nextLocalVarId(names), VarScope.FUNCTION,
-                                   VarKind.TEMP);
-        this.env.enclFunc.localVars.add(tempVarDcl);
-        BIROperand toVarRef = new BIROperand(tempVarDcl);
-        setScopeAndEmit(new BIRNonTerminator.NewTypeDesc(accessExpr.pos, toVarRef, accessExpr.resolvedType,
-                                                         Collections.emptyList()));
-        this.env.targetOperand = toVarRef;
+        createNewTypedescInst(accessExpr.getBType(), accessExpr.resolvedType, accessExpr.pos);
     }
 
     @Override
@@ -2391,6 +2377,80 @@ public class BIRGen extends BLangNodeVisitor {
                 reDisjunction);
         setScopeAndEmit(newRegExp);
         this.env.targetOperand = toVarRef;
+    }
+
+    private BIRNonTerminator.NewStructure createNewStructureInst(List<BIRNode.BIRMappingConstructorEntry> fields,
+                                                                 BIROperand toVarRef, BType type, Location pos) {
+        if (getTypedescVariable(type) != null) {
+            return new BIRNonTerminator.NewStructure(pos, toVarRef, new BIROperand(getTypedescVariable(type)), fields, type);
+        } else {
+            createNewTypedescInst(type, type, pos);
+            return new BIRNonTerminator.NewStructure(pos, toVarRef, this.env.targetOperand, fields, type);
+        }
+    }
+
+    private BIRVariableDcl getTypedescVariable(BType type) {
+        for (Map.Entry<BSymbol, BIRVariableDcl> entry : env.symbolVarMap.entrySet()) {
+            if (isTypeDescSymbol(entry.getKey(), type)) {
+                return env.symbolVarMap.get(entry.getKey());
+            }
+        }
+
+        for (Map.Entry<BSymbol, BIRGlobalVariableDcl> entry : this.globalVarMap.entrySet()) {
+            if (isTypeDescSymbol(entry.getKey(), Types.getImpliedType(type))) {
+                return this.globalVarMap.get(entry.getKey());
+            }
+        }
+
+        return null;
+    }
+
+    private boolean isTypeDescSymbol(BSymbol symbol, BType targetType) {
+        return symbol.type.tag == TypeTags.TYPEDESC && ((BTypedescType) symbol.type).constraint == targetType;
+    }
+
+    private void createNewTypedescInst(BType type, BType resolveType, Location position) {
+        BTypeSymbol typeSymbol = resolveType.tsymbol;
+        BIRVariableDcl tempVarDcl = createTempVariable(type);
+        BIROperand toVarRef = new BIROperand(tempVarDcl);
+
+        BIRNonTerminator.NewTypeDesc newTypeDesc = createNewTypeDesc(position, toVarRef, resolveType, typeSymbol);
+
+        this.env.targetOperand = toVarRef;
+        setScopeAndEmit(newTypeDesc);
+    }
+
+    private BIRVariableDcl createTempVariable(BType type) {
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(type, this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+        this.env.enclFunc.localVars.add(tempVarDcl);
+        return tempVarDcl;
+    }
+
+    private BIRNonTerminator.NewTypeDesc createNewTypeDesc(Location position, BIROperand toVarRef, BType resolveType,
+                                                           BTypeSymbol typeSymbol) {
+        List<BIROperand> closures = Collections.emptyList();
+        if (typeSymbol != null && typeSymbol.annotations != null) {
+            BIROperand symbolVarOperand = this.env.symbolVarMap.containsKey(typeSymbol.annotations) ?
+                    new BIROperand(this.env.symbolVarMap.get(typeSymbol.annotations)) :
+                    new BIROperand(this.globalVarMap.get(typeSymbol.annotations));
+            return new BIRNonTerminator.NewTypeDesc(position, toVarRef, resolveType, closures, symbolVarOperand);
+        } else {
+            return new BIRNonTerminator.NewTypeDesc(position, toVarRef, resolveType, closures);
+        }
+    }
+
+    private BIRNonTerminator.NewArray createNewArrayInst(List<BIRNode.BIRListConstructorEntry> initialValues,
+                                                         BType listConstructorExprType, BIROperand sizeOp,
+                                                         BIROperand toVarRef, BType referredType, Location pos) {
+        if (getTypedescVariable(listConstructorExprType) != null) {
+            return new BIRNonTerminator.NewArray(pos, listConstructorExprType, toVarRef,
+                    new BIROperand(getTypedescVariable(listConstructorExprType)), sizeOp, initialValues);
+
+        } else {
+            createNewTypedescInst(referredType, referredType, pos);
+            return new BIRNonTerminator.NewArray(pos, listConstructorExprType, toVarRef, this.env.targetOperand, sizeOp,
+                                                 initialValues);
+        }
     }
 
     @Override
@@ -2732,9 +2792,9 @@ public class BIRGen extends BLangNodeVisitor {
         }
 
         if (referredType.tag == TypeTags.TUPLE) {
-            setScopeAndEmit(
-                    new BIRNonTerminator.NewArray(listConstructorExpr.pos, listConstructorExprType, toVarRef,
-                            typedescOp, sizeOp, initialValues));
+            setScopeAndEmit(createNewArrayInst(initialValues, listConstructorExprType, sizeOp, toVarRef, referredType,
+                                               listConstructorExpr.pos));
+
         } else {
             setScopeAndEmit(
                     new BIRNonTerminator.NewArray(listConstructorExpr.pos, listConstructorExprType, toVarRef, sizeOp,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -2382,10 +2382,10 @@ public class BIRGen extends BLangNodeVisitor {
     private BIRNonTerminator.NewStructure createNewStructureInst(List<BIRNode.BIRMappingConstructorEntry> fields,
                                                                  BIROperand toVarRef, BType type, Location pos) {
         if (getTypedescVariable(type) != null) {
-            return new BIRNonTerminator.NewStructure(pos, toVarRef, new BIROperand(getTypedescVariable(type)), fields, type);
+            return new BIRNonTerminator.NewStructure(pos, toVarRef, new BIROperand(getTypedescVariable(type)), fields);
         } else {
             createNewTypedescInst(type, type, pos);
-            return new BIRNonTerminator.NewStructure(pos, toVarRef, this.env.targetOperand, fields, type);
+            return new BIRNonTerminator.NewStructure(pos, toVarRef, this.env.targetOperand, fields);
         }
     }
 
@@ -2421,7 +2421,8 @@ public class BIRGen extends BLangNodeVisitor {
     }
 
     private BIRVariableDcl createTempVariable(BType type) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(type, this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(type, this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                                                       VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         return tempVarDcl;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -66,7 +66,6 @@ public class JvmConstants {
     public static final String XML_QNAME = "io/ballerina/runtime/internal/values/XmlQName";
     public static final String FUTURE_VALUE = "io/ballerina/runtime/internal/values/FutureValue";
     public static final String TYPEDESC_VALUE_IMPL = "io/ballerina/runtime/internal/values/TypedescValueImpl";
-    public static final String TYPEDESC_VALUE_IMPL_CLOSURES = "closures";
     public static final String TYPEDESC_VALUE = "io/ballerina/runtime/internal/values/TypedescValue";
     public static final String HANDLE_VALUE = "io/ballerina/runtime/internal/values/HandleValue";
     public static final String LOCK_VALUE = "io/ballerina/runtime/internal/BLock";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -24,10 +24,7 @@ import org.wso2.ballerinalang.compiler.bir.codegen.methodgen.InitMethodGen;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRBasicBlock;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunction;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunctionParameter;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRTypeDefinition;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRVariableDcl;
-import org.wso2.ballerinalang.compiler.bir.model.VarKind;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
@@ -41,14 +38,12 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
-import org.wso2.ballerinalang.util.Lists;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WRAPPER_GEN_BB_ID_NAME;
 
 /**
@@ -92,55 +87,6 @@ public class JvmDesugarPhase {
             paramTypes.add(counter, restType);
         }
         return paramTypes;
-    }
-
-    static void rewriteRecordInits(List<BIRTypeDefinition> typeDefs) {
-        for (BIRTypeDefinition typeDef : typeDefs) {
-            BType recordType = JvmCodeGenUtil.getImpliedType(typeDef.type);
-            if (recordType.tag != TypeTags.RECORD) {
-                continue;
-            }
-            List<BIRFunction> attachFuncs = typeDef.attachedFuncs;
-            for (BIRFunction func : attachFuncs) {
-                rewriteRecordInitFunction(func, (BRecordType) recordType);
-            }
-        }
-    }
-
-    private static void rewriteRecordInitFunction(BIRFunction func, BRecordType recordType) {
-
-        BIRVariableDcl receiver = func.receiver;
-
-        // Rename the function name by appending the record name to it.
-        // This done to avoid frame class name overlapping.
-        func.name = new Name(toNameString(recordType) + func.name.value);
-
-        // change the kind of receiver to 'ARG'
-        receiver.kind = VarKind.ARG;
-
-        // Update the name of the reciever. Then any instruction that was refering to the receiver will
-        // now refer to the injected parameter.
-        String paramName = "$_" + receiver.name.value;
-        receiver.name = new Name(paramName);
-
-        // Inject an additional parameter to accept the self-record value into the init function
-        BIRFunctionParameter selfParam = new BIRFunctionParameter(null, receiver.type, receiver.name,
-                receiver.scope, VarKind.ARG, paramName, false, false);
-
-        List<BType> updatedParamTypes = Lists.of(receiver.type);
-        updatedParamTypes.addAll(func.type.paramTypes);
-        func.type = new BInvokableType(updatedParamTypes, func.type.restType, func.type.retType, null);
-
-        List<BIRVariableDcl> localVars = func.localVars;
-        List<BIRVariableDcl> updatedLocalVars = new ArrayList<>();
-        updatedLocalVars.add(localVars.get(0));
-        updatedLocalVars.add(selfParam);
-        int index = 1;
-        while (index < localVars.size()) {
-            updatedLocalVars.add(localVars.get(index));
-            index += 1;
-        }
-        func.localVars = updatedLocalVars;
     }
 
     static HashMap<String, String> encodeModuleIdentifiers(BIRNode.BIRPackage module) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -257,7 +257,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.XML_GET_
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.XML_GET_ITEM;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.XML_SET_ATTRIBUTE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.getTypeDesc;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmValueGen.getTypeDescClassName;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmValueGen.getTypeValueClassName;
 
 /**
@@ -2182,11 +2181,7 @@ public class JvmInstructionGen {
     }
 
     private void generateNewTypedescCreate(BType btype, List<BIROperand> closureVars, BIROperand annotations) {
-        BType type = JvmCodeGenUtil.getImpliedType(btype);
         String className = TYPEDESC_VALUE_IMPL;
-        if (type.tag == TypeTags.RECORD) {
-            className = getTypeDescClassName(JvmCodeGenUtil.getPackageName(type.tsymbol.pkgID), toNameString(type));
-        }
         this.mv.visitTypeInsn(NEW, className);
         this.mv.visitInsn(DUP);
         jvmTypeGen.loadType(this.mv, btype);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -64,7 +64,6 @@ import static org.objectweb.asm.Opcodes.ACONST_NULL;
 import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.ANEWARRAY;
 import static org.objectweb.asm.Opcodes.ASTORE;
-import static org.objectweb.asm.Opcodes.BIPUSH;
 import static org.objectweb.asm.Opcodes.CHECKCAST;
 import static org.objectweb.asm.Opcodes.DADD;
 import static org.objectweb.asm.Opcodes.DCMPL;
@@ -219,7 +218,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_MAP_
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_MODULE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_STRING_AT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_STRING_FROM_ARRAY;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_TYPEDESC;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_TYPEDESC_OF_OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.HANDLE_MAP_STORE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.HANDLE_TABLE_STORE;
@@ -2158,15 +2156,17 @@ public class JvmInstructionGen {
     }
 
     void generateNewTypedescIns(BIRNonTerminator.NewTypeDesc newTypeDesc) {
-        List<BIROperand> closureVars = newTypeDesc.closureVars;
-        if (isNonReferredRecord(newTypeDesc.type)) {
-            BType type = JvmCodeGenUtil.getImpliedType(newTypeDesc.type);
-            PackageID packageID = type.tsymbol.pkgID;
-            String typeOwner = JvmCodeGenUtil.getPackageName(packageID) + MODULE_INIT_CLASS_NAME;
-            String fieldName = jvmTypeGen.getTypedescFieldName(toNameString(type));
-            mv.visitFieldInsn(GETSTATIC, typeOwner, fieldName, GET_TYPEDESC);
+        String className = TYPEDESC_VALUE_IMPL;
+        this.mv.visitTypeInsn(NEW, className);
+        this.mv.visitInsn(DUP);
+        jvmTypeGen.loadType(this.mv, newTypeDesc.type);
+        BIROperand annotations = newTypeDesc.annotations;
+        if (annotations != null) {
+            this.loadVar(annotations.variableDcl);
+            this.mv.visitMethodInsn(INVOKESPECIAL, className, JVM_INIT_METHOD, TYPE_DESC_CONSTRUCTOR_WITH_ANNOTATIONS,
+                    false);
         } else {
-            generateNewTypedescCreate(newTypeDesc.type, closureVars, newTypeDesc.annotations);
+            this.mv.visitMethodInsn(INVOKESPECIAL, className, JVM_INIT_METHOD, TYPE_DESC_CONSTRUCTOR, false);
         }
         this.storeToVar(newTypeDesc.lhsOp.variableDcl);
     }
@@ -2178,30 +2178,6 @@ public class JvmInstructionGen {
         BType referredType = ((BTypeReferenceType) type).referredType;
         return referredType.tag == TypeTags.RECORD &&
                 type.getQualifiedTypeName().equals(referredType.getQualifiedTypeName());
-    }
-
-    private void generateNewTypedescCreate(BType btype, List<BIROperand> closureVars, BIROperand annotations) {
-        String className = TYPEDESC_VALUE_IMPL;
-        this.mv.visitTypeInsn(NEW, className);
-        this.mv.visitInsn(DUP);
-        jvmTypeGen.loadType(this.mv, btype);
-
-        mv.visitIntInsn(BIPUSH, closureVars.size());
-        mv.visitTypeInsn(ANEWARRAY, MAP_VALUE);
-        for (int i = 0; i < closureVars.size(); i++) {
-            BIROperand closureVar = closureVars.get(i);
-            mv.visitInsn(DUP);
-            mv.visitIntInsn(BIPUSH, i);
-            this.loadVar(closureVar.variableDcl);
-            mv.visitInsn(AASTORE);
-        }
-        if (annotations != null) {
-            this.loadVar(annotations.variableDcl);
-            this.mv.visitMethodInsn(INVOKESPECIAL, className, JVM_INIT_METHOD, TYPE_DESC_CONSTRUCTOR_WITH_ANNOTATIONS,
-                                    false);
-        } else {
-            this.mv.visitMethodInsn(INVOKESPECIAL, className, JVM_INIT_METHOD, TYPE_DESC_CONSTRUCTOR, false);
-        }
     }
 
     void loadVar(BIRNode.BIRVariableDcl varDcl) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -121,7 +121,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SERVICE_E
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TEST_EXECUTE_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.VALUE_CREATOR;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.addDefaultableBooleanVarsToSignature;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.rewriteRecordInits;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_MODULE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.VOID_METHOD_DESC;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmValueGen.injectDefaultParamInitsToAttachedFuncs;
@@ -752,8 +751,6 @@ public class JvmPackageGen {
         new ShutDownListenerGen().generateShutdownSignalListener(moduleInitClass, jarEntries);
 
         removeSourceAnnotationTypeDefs(module.typeDefs);
-        // desugar the record init function
-        rewriteRecordInits(module.typeDefs);
 
         // generate object/record value classes
         JvmValueGen valueGen = new JvmValueGen(module, this, methodGen, typeHashVisitor, types);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -458,9 +458,8 @@ public class JvmSignatures {
     public static final String TRY_TAKE_DATA = "(L" + STRAND_CLASS + ";)L" + OBJECT + ";";
     public static final String TUPLE_SET_MEMBERS_METHOD = "(L" + LIST + ";L" + TYPE + ";)V";
     public static final String TWO_OBJECTS_ARGS = "(L" + OBJECT + ";L" + OBJECT + ";)V";
-    public static final String TYPE_DESC_CONSTRUCTOR = "(L" + TYPE + ";[L" + MAP_VALUE + ";)V";
-    public static final String TYPE_DESC_CONSTRUCTOR_WITH_ANNOTATIONS =
-                                                             "(L" + TYPE + ";[L" + MAP_VALUE + ";L" + MAP_VALUE + ";)V";
+    public static final String TYPE_DESC_CONSTRUCTOR = "(L" + TYPE + ";)V";
+    public static final String TYPE_DESC_CONSTRUCTOR_WITH_ANNOTATIONS = "(L" + TYPE + ";L" + MAP_VALUE + ";)V";
     public static final String TYPE_PARAMETER = "(L" + TYPE + ";)V";
     public static final String UPDATE_CHANNEL_DETAILS = "([L" + CHANNEL_DETAILS + ";)V";
     public static final String VALUE_CLASS_INIT = "(L" + STRAND_CLASS + ";L" + MAP_VALUE + ";)L" + OBJECT + ";";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -56,30 +56,22 @@ import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 import static org.objectweb.asm.Opcodes.ACC_SUPER;
 import static org.objectweb.asm.Opcodes.ALOAD;
-import static org.objectweb.asm.Opcodes.ARETURN;
 import static org.objectweb.asm.Opcodes.ATHROW;
-import static org.objectweb.asm.Opcodes.CHECKCAST;
 import static org.objectweb.asm.Opcodes.DUP;
 import static org.objectweb.asm.Opcodes.GETFIELD;
 import static org.objectweb.asm.Opcodes.IFEQ;
 import static org.objectweb.asm.Opcodes.ILOAD;
 import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
-import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
 import static org.objectweb.asm.Opcodes.IRETURN;
 import static org.objectweb.asm.Opcodes.ISTORE;
 import static org.objectweb.asm.Opcodes.NEW;
-import static org.objectweb.asm.Opcodes.POP;
 import static org.objectweb.asm.Opcodes.PUTFIELD;
 import static org.objectweb.asm.Opcodes.RETURN;
-import static org.objectweb.asm.Opcodes.SWAP;
 import static org.objectweb.asm.Opcodes.V17;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ABSTRACT_OBJECT_VALUE;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ANNOTATIONS_FIELD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_OPTIONAL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CLASS_FILE_SUFFIX;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.INSTANTIATE_FUNCTION;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_STATIC_INIT_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.LOCK_VALUE;
@@ -91,26 +83,14 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.POPULATE_
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.RECORD_INIT_WRAPPER_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SPLIT_CLASS_SUFFIX;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPEDESC_CLASS_PREFIX;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPEDESC_VALUE;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPEDESC_VALUE_IMPL;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPEDESC_VALUE_IMPL_CLOSURES;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.UNSUPPORTED_OPERATION_EXCEPTION;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.VALUE_CLASS_PREFIX;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.addDefaultableBooleanVarsToSignature;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.computeLockNameFromString;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.CAST_B_MAPPING_INITIAL_VALUE_ENTRY;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_MAP_ARRAY;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_MAP_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INIT_TYPEDESC;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INSTANTIATE;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INSTANTIATE_WITH_INITIAL_VALUES;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.OBJECT_TYPE_IMPL_INIT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.POPULATE_INITIAL_VALUES;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.RECORD_VALUE_CLASS;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.RETURN_OBJECT;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.TYPE_DESC_CONSTRUCTOR;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.TYPE_DESC_CONSTRUCTOR_WITH_ANNOTATIONS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.TYPE_PARAMETER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.VOID_METHOD_DESC;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.getTypeDesc;
@@ -211,95 +191,8 @@ public class JvmValueGen {
                 byte[] bytes = this.createRecordValueClass(recordType, className, optionalTypeDef, jvmConstantsGen
                         , asyncDataCollector, jvmTypeGen);
                 jarEntries.put(className + CLASS_FILE_SUFFIX, bytes);
-                String typedescClass = getTypeDescClassName(packageName, optionalTypeDef.internalName.value);
-                bytes = this.createRecordTypeDescClass(recordType, typedescClass, optionalTypeDef, jvmTypeGen);
-                jarEntries.put(typedescClass + CLASS_FILE_SUFFIX, bytes);
             }
         });
-    }
-
-
-    private byte[] createRecordTypeDescClass(BRecordType recordType, String className,
-                                             BIRNode.BIRTypeDefinition typeDef, JvmTypeGen jvmTypeGen) {
-
-        ClassWriter cw = new BallerinaClassWriter(COMPUTE_FRAMES);
-        if (typeDef.pos != null) {
-            cw.visitSource(typeDef.pos.lineRange().fileName(), null);
-        } else {
-            cw.visitSource(className, null);
-        }
-        cw.visit(V17, ACC_PUBLIC + ACC_SUPER, className, null, TYPEDESC_VALUE_IMPL, new String[]{TYPEDESC_VALUE});
-
-        FieldVisitor fv = cw.visitField(0, ANNOTATIONS_FIELD, GET_MAP_VALUE, null, null);
-        fv.visitEnd();
-
-        this.createTypeDescConstructor(cw, className);
-        this.createTypeDescConstructorWithAnnotations(cw, className);
-        this.createInstantiateMethod(cw, recordType, jvmTypeGen, className);
-        this.createInstantiateMethodWithInitialValues(cw, recordType, typeDef, className);
-
-        cw.visitEnd();
-        return jvmPackageGen.getBytes(cw, typeDef);
-    }
-
-    private void createInstantiateMethod(ClassWriter cw, BRecordType recordType, JvmTypeGen jvmTypeGen,
-                                         String className) {
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, INSTANTIATE_FUNCTION, INSTANTIATE, null, null);
-        mv.visitCode();
-        jvmTypeGen.loadType(mv, recordType);
-        mv.visitTypeInsn(CHECKCAST, TYPE_IMPL);
-        mv.visitMethodInsn(INVOKEVIRTUAL, TYPE_IMPL, "getZeroValue", RETURN_OBJECT, false);
-        mv.visitInsn(ARETURN);
-        JvmCodeGenUtil.visitMaxStackForMethod(mv, INSTANTIATE_FUNCTION, className);
-        mv.visitEnd();
-    }
-
-    private void createInstantiateMethodWithInitialValues(ClassWriter cw, BRecordType recordType,
-                                         BIRNode.BIRTypeDefinition typeDef, String typeClass) {
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, INSTANTIATE_FUNCTION, INSTANTIATE_WITH_INITIAL_VALUES,
-                null, null);
-        mv.visitCode();
-
-        String className = getTypeValueClassName(recordType.tsymbol.pkgID, toNameString(recordType));
-        mv.visitTypeInsn(NEW, className);
-        mv.visitInsn(DUP);
-        mv.visitInsn(DUP);
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKESPECIAL, className, JVM_INIT_METHOD, INIT_TYPEDESC, false);
-
-        // Invoke the init-function of this type.
-        mv.visitVarInsn(ALOAD, 1);
-        mv.visitInsn(SWAP);
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitFieldInsn(GETFIELD, TYPEDESC_VALUE_IMPL, TYPEDESC_VALUE_IMPL_CLOSURES,
-                          GET_MAP_ARRAY);
-        mv.visitInsn(POP);
-
-        // Invoke the init-function of this type.
-        String initFuncName;
-        String valueClassName;
-        List<BIRFunction> attachedFuncs = typeDef.attachedFuncs;
-
-        // Attached functions are empty for type-labeling. In such cases, call the init() of the original type value
-        if (!attachedFuncs.isEmpty()) {
-            initFuncName = attachedFuncs.get(0).name.value;
-            valueClassName = className;
-        } else {
-            // record type is the original record-type of this type-label
-            valueClassName = getTypeValueClassName(recordType.tsymbol.pkgID, toNameString(recordType));
-            initFuncName = recordType.name + ENCODED_RECORD_INIT;
-        }
-
-        mv.visitInsn(DUP);
-        mv.visitTypeInsn(CHECKCAST, valueClassName);
-        mv.visitVarInsn(ALOAD, 2);
-        mv.visitTypeInsn(CHECKCAST, CAST_B_MAPPING_INITIAL_VALUE_ENTRY);
-        mv.visitMethodInsn(INVOKEVIRTUAL, valueClassName, POPULATE_INITIAL_VALUES_METHOD,
-                           POPULATE_INITIAL_VALUES, false);
-
-        mv.visitInsn(ARETURN);
-        JvmCodeGenUtil.visitMaxStackForMethod(mv, INSTANTIATE_FUNCTION, typeClass);
-        mv.visitEnd();
     }
 
     public static String getTypeValueClassName(PackageID packageID, String typeName) {
@@ -340,51 +233,6 @@ public class JvmValueGen {
         cw.visitEnd();
 
         return jvmPackageGen.getBytes(cw, typeDef);
-    }
-
-    private void createTypeDescConstructor(ClassWriter cw, String className) {
-
-        String descriptor = TYPE_DESC_CONSTRUCTOR;
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, JVM_INIT_METHOD, descriptor, null, null);
-        mv.visitCode();
-
-        // load super
-        mv.visitVarInsn(ALOAD, 0);
-        // load type
-        mv.visitVarInsn(ALOAD, 1);
-
-        mv.visitVarInsn(ALOAD, 2);
-        // invoke `super(type)`;
-        mv.visitMethodInsn(INVOKESPECIAL, TYPEDESC_VALUE_IMPL, JVM_INIT_METHOD, descriptor, false);
-
-        mv.visitInsn(RETURN);
-        JvmCodeGenUtil.visitMaxStackForMethod(mv, JVM_INIT_METHOD, className);
-        mv.visitEnd();
-    }
-
-    private void createTypeDescConstructorWithAnnotations(ClassWriter cw, String name) {
-        String descriptor = TYPE_DESC_CONSTRUCTOR_WITH_ANNOTATIONS;
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, JVM_INIT_METHOD, descriptor, null, null);
-        mv.visitCode();
-
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitVarInsn(ALOAD, 3);
-        mv.visitFieldInsn(PUTFIELD, name, ANNOTATIONS_FIELD, GET_MAP_VALUE);
-        // load super
-        mv.visitVarInsn(ALOAD, 0);
-        // load type
-        mv.visitVarInsn(ALOAD, 1);
-        // load closures
-        mv.visitVarInsn(ALOAD, 2);
-        // load annotations
-        mv.visitVarInsn(ALOAD, 3);
-        // invoke `super(type)`;
-        mv.visitMethodInsn(INVOKESPECIAL, TYPEDESC_VALUE_IMPL, JVM_INIT_METHOD, TYPE_DESC_CONSTRUCTOR_WITH_ANNOTATIONS,
-                           false);
-
-        mv.visitInsn(RETURN);
-        JvmCodeGenUtil.visitMaxStackForMethod(mv, JVM_INIT_METHOD, name);
-        mv.visitEnd();
     }
 
     private void createRecordConstructor(ClassWriter cw, String argumentClass, String className,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmRecordTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmRecordTypeGen.java
@@ -22,7 +22,6 @@ import org.ballerinalang.model.elements.PackageID;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.wso2.ballerinalang.compiler.bir.codegen.BallerinaClassWriter;
-import org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil;
 import org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.JvmConstantsGen;
@@ -52,13 +51,13 @@ import static org.objectweb.asm.Opcodes.PUTSTATIC;
 import static org.objectweb.asm.Opcodes.SWAP;
 import static org.objectweb.asm.Opcodes.V17;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil.getModuleLevelClassName;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CLASS_FILE_SUFFIX;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.LINKED_HASH_MAP;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_RECORD_TYPES_CLASS_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.RECORD_TYPE_IMPL;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPEDESC_VALUE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_MODULE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_TYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_TYPEDESC;
@@ -67,7 +66,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SET_LINK
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SET_MAP;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.TYPE_DESC_CONSTRUCTOR;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.VOID_METHOD_DESC;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmValueGen.getTypeDescClassName;
 
 /**
  * BIR record type to JVM byte code generation class.
@@ -177,8 +175,7 @@ public class JvmRecordTypeGen {
         mv.visitMethodInsn(INVOKESPECIAL, RECORD_TYPE_IMPL, JVM_INIT_METHOD, RECORD_TYPE_IMPL_INIT, false);
 
         mv.visitInsn(DUP);
-        String packageName = JvmCodeGenUtil.getPackageName(recordType.tsymbol.pkgID);
-        String className = getTypeDescClassName(packageName, toNameString(recordType));
+        String className = TYPEDESC_VALUE_IMPL;
         mv.visitTypeInsn(NEW, className);
         mv.visitInsn(DUP_X1);
         mv.visitInsn(SWAP);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmRecordTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmRecordTypeGen.java
@@ -173,15 +173,6 @@ public class JvmRecordTypeGen {
 
         // initialize the record type
         mv.visitMethodInsn(INVOKESPECIAL, RECORD_TYPE_IMPL, JVM_INIT_METHOD, RECORD_TYPE_IMPL_INIT, false);
-
-        mv.visitInsn(DUP);
-        String className = TYPEDESC_VALUE_IMPL;
-        mv.visitTypeInsn(NEW, className);
-        mv.visitInsn(DUP_X1);
-        mv.visitInsn(SWAP);
-        mv.visitInsn(ACONST_NULL);
-        mv.visitMethodInsn(INVOKESPECIAL, className, JVM_INIT_METHOD, TYPE_DESC_CONSTRUCTOR, false);
-        mv.visitFieldInsn(PUTSTATIC, typeOwnerClass, jvmTypeGen.getTypedescFieldName(internalName), GET_TYPEDESC);
     }
 
     private String getFullName(BRecordType recordType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmRecordTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmRecordTypeGen.java
@@ -37,18 +37,14 @@ import java.util.Map;
 import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_SUPER;
-import static org.objectweb.asm.Opcodes.ACONST_NULL;
 import static org.objectweb.asm.Opcodes.CHECKCAST;
 import static org.objectweb.asm.Opcodes.DUP;
-import static org.objectweb.asm.Opcodes.DUP_X1;
 import static org.objectweb.asm.Opcodes.GETSTATIC;
 import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
 import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
 import static org.objectweb.asm.Opcodes.NEW;
 import static org.objectweb.asm.Opcodes.PUTFIELD;
-import static org.objectweb.asm.Opcodes.PUTSTATIC;
-import static org.objectweb.asm.Opcodes.SWAP;
 import static org.objectweb.asm.Opcodes.V17;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil.getModuleLevelClassName;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CLASS_FILE_SUFFIX;
@@ -57,14 +53,11 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.LINKED_HA
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_RECORD_TYPES_CLASS_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.RECORD_TYPE_IMPL;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPEDESC_VALUE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_MODULE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_TYPE;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_TYPEDESC;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.RECORD_TYPE_IMPL_INIT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SET_LINKED_HASH_MAP;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SET_MAP;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.TYPE_DESC_CONSTRUCTOR;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.VOID_METHOD_DESC;
 
 /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNonTerminator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNonTerminator.java
@@ -209,16 +209,14 @@ public abstract class BIRNonTerminator extends BIRAbstractInstruction implements
      */
     public static class NewStructure extends BIRNonTerminator {
         public BIROperand rhsOp;
-        public BType type;
         public List<BIRMappingConstructorEntry> initialValues;
 
         public NewStructure(Location pos, BIROperand lhsOp, BIROperand rhsOp,
-                            List<BIRMappingConstructorEntry> initialValues, BType type) {
+                            List<BIRMappingConstructorEntry> initialValues) {
             super(pos, InstructionKind.NEW_STRUCTURE);
             this.lhsOp = lhsOp;
             this.rhsOp = rhsOp;
             this.initialValues = initialValues;
-            this.type = type;
         }
 
         @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNonTerminator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNonTerminator.java
@@ -209,21 +209,16 @@ public abstract class BIRNonTerminator extends BIRAbstractInstruction implements
      */
     public static class NewStructure extends BIRNonTerminator {
         public BIROperand rhsOp;
+        public BType type;
         public List<BIRMappingConstructorEntry> initialValues;
 
-        public NewStructure(Location pos, BIROperand lhsOp, BIROperand rhsOp) {
-            super(pos, InstructionKind.NEW_STRUCTURE);
-            this.lhsOp = lhsOp;
-            this.rhsOp = rhsOp;
-            this.initialValues = new ArrayList<>();
-        }
-
         public NewStructure(Location pos, BIROperand lhsOp, BIROperand rhsOp,
-                            List<BIRMappingConstructorEntry> initialValues) {
+                            List<BIRMappingConstructorEntry> initialValues, BType type) {
             super(pos, InstructionKind.NEW_STRUCTURE);
             this.lhsOp = lhsOp;
             this.rhsOp = rhsOp;
             this.initialValues = initialValues;
+            this.type = type;
         }
 
         @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
@@ -280,10 +280,14 @@ public class ClosureGenerator extends BLangNodeVisitor {
             BLangSimpleVariable simpleVariable = queue.poll().var;
             simpleVariable.flagSet.add(Flag.PUBLIC);
             simpleVariable.symbol.flags |= Flags.PUBLIC;
-            pkgEnv.enclPkg.globalVars.add(0, simpleVariable);
+            BLangSimpleVariable variableDef = rewrite(simpleVariable, pkgEnv);
+            pkgEnv.enclPkg.globalVars.add(0, variableDef);
+            pkgEnv.enclPkg.topLevelNodes.add(0, variableDef);
         }
         for (BLangSimpleVariableDef closureReference : annotationClosureReferences) {
-            pkgEnv.enclPkg.globalVars.add(rewrite(closureReference.var, pkgEnv));
+            BLangSimpleVariable simpleVariable = rewrite(closureReference.var, pkgEnv);
+            pkgEnv.enclPkg.globalVars.add(simpleVariable);
+            pkgEnv.enclPkg.topLevelNodes.add(simpleVariable);
         }
     }
 
@@ -1738,7 +1742,9 @@ public class ClosureGenerator extends BLangNodeVisitor {
             E node = rewrite(nodeList.remove(0), env);
             Iterator<BLangSimpleVariableDef> iterator = annotationClosureReferences.iterator();
             while (iterator.hasNext()) {
-                nodeList.add(rewrite((E) annotationClosureReferences.poll().var, env));
+                E simpleVariable = rewrite((E) annotationClosureReferences.poll().var, env);
+                nodeList.add(simpleVariable);
+                env.enclPkg.topLevelNodes.add((BLangSimpleVariable) simpleVariable);
             }
             nodeList.add(node);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -833,32 +833,6 @@ public class Desugar extends BLangNodeVisitor {
         result = pkgNode;
     }
 
-    private void rewriteConstants(BLangPackage pkgNode, BLangBlockFunctionBody initFnBody) {
-        for (BLangConstant constant : pkgNode.constants) {
-            BType constType = Types.getReferredType(constant.symbol.type);
-            if (constType.tag != TypeTags.INTERSECTION) {
-                continue;
-            }
-            for (BType memberType : ((BIntersectionType) constType).getConstituentTypes()) {
-                BLangType typeNode;
-                switch (Types.getImpliedType(memberType).tag) {
-                    case TypeTags.RECORD:
-                        typeNode = constant.associatedTypeDefinition.typeNode;
-                        break;
-                    case TypeTags.TUPLE:
-                        typeNode = (BLangTupleTypeNode) TreeBuilder.createTupleTypeNode();
-                        break;
-                    default:
-                        continue;
-                }
-                BLangSimpleVarRef constVarRef = ASTBuilderUtil.createVariableRef(constant.pos, constant.symbol);
-                constant.expr = rewrite(constant.expr,
-                        SymbolEnv.createTypeEnv(typeNode, pkgNode.initFunction.symbol.scope, env));
-                BLangAssignment constInit = ASTBuilderUtil.createAssignmentStmt(constant.pos, constVarRef,
-                        constant.expr);
-                initFnBody.stmts.add(constInit);
-            }
-        }
     private void desugarConstants(BLangConstant constant, BLangBlockFunctionBody initFnBody,
                                   SymbolEnv initFunctionEnv) {
         BType constType = Types.getReferredType(constant.symbol.type);
@@ -871,6 +845,19 @@ public class Desugar extends BLangNodeVisitor {
         initFnBody.stmts.add(constInit);
         constant.expr = null;
     }
+
+    private void createTypedescVariableDef(BLangType typeNode) {
+        Name name = new Name(TYPEDESC + typedescCount++);
+        Location pos = typeNode.pos;
+        BType type = typeNode.getBType();
+        BType typedescType = new BTypedescType(type, symTable.typeDesc.tsymbol);
+        BSymbol owner = this.env.scope.owner;
+        BVarSymbol varSymbol  = new BVarSymbol(0, name, owner.pkgID, typedescType, owner, pos, VIRTUAL);
+        BLangTypedescExpr typedescExpr = ASTBuilderUtil.createTypedescExpr(pos, typedescType, type);
+        typedescExpr.typeNode = typeNode;
+        BLangSimpleVariableDef simpleVariableDef = createSimpleVariableDef(pos, name.value, typedescType, typedescExpr,
+                                                                           varSymbol);
+        typedescList.add(simpleVariableDef);
     }
 
     private BLangSimpleVariableDef createSimpleVariableDef(Location pos, String name, BType type, BLangExpression expr,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -308,7 +308,6 @@ import org.wso2.ballerinalang.util.Lists;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -359,6 +358,7 @@ public class Desugar extends BLangNodeVisitor {
     private static final String PUSH_LANGLIB_METHOD = "push";
     private static final String DESUGARED_VARARG_KEY = "$vararg$";
     private static final String GENERATED_ERROR_VAR = "$error$";
+    private static final String TYPEDESC = "$typedesc$";
     private static final String HAS_KEY = "hasKey";
     private static final String CREATE_RECORD_VALUE = "createRecordFromMap";
 
@@ -400,6 +400,7 @@ public class Desugar extends BLangNodeVisitor {
     private List<BLangOnFailClause> enclosingOnFailClause = new ArrayList<>();
     private Map<BLangOnFailClause, BLangSimpleVarRef> enclosingShouldPanic = new HashMap<>();
     private List<BLangSimpleVarRef> enclosingShouldContinue = new ArrayList<>();
+    private List<BLangSimpleVariableDef> typedescList = new ArrayList<>();
     private BLangSimpleVarRef shouldRetryRef;
 
     private SymbolEnv env;
@@ -413,6 +414,7 @@ public class Desugar extends BLangNodeVisitor {
     private int funcParamCount = 1;
     private boolean isVisitingQuery;
     private boolean desugarToReturn;
+    private int typedescCount = 0;
 
     // Safe navigation related variables
     private Stack<BLangMatchStatement> matchStmtStack = new Stack<>();
@@ -772,36 +774,29 @@ public class Desugar extends BLangNodeVisitor {
         // Initialize the annotation map
         annotationDesugar.initializeAnnotationMap(pkgNode);
 
-        pkgNode.constants.stream()
-                .filter(constant -> (constant.expr.getKind() == NodeKind.LITERAL ||
-                        constant.expr.getKind() == NodeKind.NUMERIC_LITERAL)
-                        && constant.expr.getBType().tag != TypeTags.TUPLE)
-                .forEach(constant -> pkgNode.typeDefinitions.add(constant.associatedTypeDefinition));
+        pkgNode.constants = removeDuplicateConstants(pkgNode);
+        for (BLangConstant constant : pkgNode.constants) {
+            if ((constant.expr.getKind() == NodeKind.LITERAL ||
+                    constant.expr.getKind() == NodeKind.NUMERIC_LITERAL)
+                    && constant.expr.getBType().tag != TypeTags.TUPLE) {
+                pkgNode.typeDefinitions.add(constant.associatedTypeDefinition);
+            }
+        }
 
         BLangBlockStmt serviceAttachments = serviceDesugar.rewriteServiceVariables(pkgNode.services, env);
-        BLangBlockFunctionBody initFnBody = (BLangBlockFunctionBody) pkgNode.initFunction.body;
-
-        rewriteConstants(pkgNode, initFnBody);
-
-        pkgNode.constants = removeDuplicateConstants(pkgNode);
-
-        pkgNode.globalVars = desugarGlobalVariables(pkgNode, initFnBody);
-
         pkgNode.services.forEach(service -> serviceDesugar.engageCustomServiceDesugar(service, env));
+
+        desugarTopLevelNodes(pkgNode);
 
         annotationDesugar.rewritePackageAnnotations(pkgNode, env);
 
+        rewrite(pkgNode.xmlnsList, env);
+        rewrite(pkgNode.constants, env);
+        rewrite(pkgNode.globalVars, env);
+        rewrite(pkgNode.classDefinitions, env);
+
         // Add invocation for user specified module init function (`init()`) if present and return.
         addUserDefinedModuleInitInvocationAndReturn(pkgNode);
-
-        //Sort type definitions with precedence
-        pkgNode.typeDefinitions.sort(Comparator.comparing(t -> t.precedence));
-
-        pkgNode.typeDefinitions = rewrite(pkgNode.typeDefinitions, env);
-        pkgNode.xmlnsList = rewrite(pkgNode.xmlnsList, env);
-        pkgNode.constants = rewrite(pkgNode.constants, env);
-        pkgNode.globalVars = rewrite(pkgNode.globalVars, env);
-        pkgNode.classDefinitions = rewrite(pkgNode.classDefinitions, env);
 
         serviceDesugar.rewriteListeners(pkgNode.globalVars, env, pkgNode.startFunction, pkgNode.stopFunction);
         ASTBuilderUtil.appendStatements(serviceAttachments, (BLangBlockFunctionBody) pkgNode.initFunction.body);
@@ -864,6 +859,27 @@ public class Desugar extends BLangNodeVisitor {
                 initFnBody.stmts.add(constInit);
             }
         }
+    private void desugarConstants(BLangConstant constant, BLangBlockFunctionBody initFnBody,
+                                  SymbolEnv initFunctionEnv) {
+        BType constType = Types.getReferredType(constant.symbol.type);
+        if (constType.tag != TypeTags.INTERSECTION) {
+            return;
+        }
+        BLangSimpleVarRef constVarRef = ASTBuilderUtil.createVariableRef(constant.pos, constant.symbol);
+        BLangExpression expression = rewrite(constant.expr, initFunctionEnv);
+        BLangAssignment constInit = ASTBuilderUtil.createAssignmentStmt(constant.pos, constVarRef, expression);
+        initFnBody.stmts.add(constInit);
+        constant.expr = null;
+    }
+    }
+
+    private BLangSimpleVariableDef createSimpleVariableDef(Location pos, String name, BType type, BLangExpression expr,
+                                                           BVarSymbol varSymbol) {
+        BLangSimpleVariable simpleVariable = ASTBuilderUtil.createVariable(pos, name, type, expr, varSymbol);
+        BLangSimpleVariableDef variableDef = ASTBuilderUtil.createVariableDef(pos);
+        variableDef.var = simpleVariable;
+        variableDef.setBType(type);
+        return variableDef;
     }
 
     private List<BLangConstant> removeDuplicateConstants(BLangPackage pkgNode) {
@@ -954,63 +970,93 @@ public class Desugar extends BLangNodeVisitor {
         return new ArrayList<>(Arrays.asList(orgLiteral, moduleNameLiteral, versionLiteral, configNameLiteral,
                 typedescExpr));
     }
-
-    private List<BLangVariable> desugarGlobalVariables(BLangPackage pkgNode, BLangBlockFunctionBody initFnBody) {
+    private void desugarTopLevelNodes(BLangPackage pkgNode) {
         List<BLangVariable> desugaredGlobalVarList = new ArrayList<>();
+        typedescList = new ArrayList<>();
+        BLangBlockFunctionBody initFnBody = (BLangBlockFunctionBody) pkgNode.initFunction.body;
         SymbolEnv initFunctionEnv =
                 SymbolEnv.createFunctionEnv(pkgNode.initFunction, pkgNode.initFunction.symbol.scope, env);
-
-        for (BLangVariable globalVar : pkgNode.globalVars) {
-            this.env.enclPkg.topLevelNodes.remove(globalVar);
-            // This will convert complex variables to simple variables.
-            switch (globalVar.getKind()) {
+        for (int i =0; i < pkgNode.topLevelNodes.size(); i++) {
+            TopLevelNode topLevelNode = pkgNode.topLevelNodes.get(i);
+            switch (topLevelNode.getKind()) {
                 case TUPLE_VARIABLE:
-                    BLangNode blockStatementNode = rewrite(globalVar, initFunctionEnv);
-                    List<BLangStatement> statements = ((BLangBlockStmt) blockStatementNode).stmts;
-
-                    int statementSize = statements.size();
-                    for (int i = 0; i < statementSize; i++) {
-                        addToGlobalVariableList(statements.get(i), initFnBody, globalVar, desugaredGlobalVarList);
-                    }
-                    break;
                 case RECORD_VARIABLE:
                 case ERROR_VARIABLE:
-                    blockStatementNode = rewrite(globalVar, initFunctionEnv);
-                    for (BLangStatement statement : ((BLangBlockStmt) blockStatementNode).stmts) {
-                        addToGlobalVariableList(statement, initFnBody, globalVar, desugaredGlobalVarList);
-                    }
+                    desugarVariable((BLangVariable) topLevelNode, initFunctionEnv, initFnBody, desugaredGlobalVarList);
                     break;
-                default:
-                    long globalVarFlags = globalVar.symbol.flags;
-                    BLangSimpleVariable simpleGlobalVar = (BLangSimpleVariable) globalVar;
-                    if (Symbols.isFlagOn(globalVarFlags, Flags.CONFIGURABLE)) {
-                        if (Symbols.isFlagOn(globalVarFlags, Flags.REQUIRED)) {
-                            // If it is required configuration get directly
-                            List<BLangExpression> args = getConfigurableLangLibInvocationParam(simpleGlobalVar);
-                            BLangInvocation getValueInvocation = createLangLibInvocationNode("getConfigurableValue",
-                                    args, symTable.anydataType, simpleGlobalVar.pos);
-                            simpleGlobalVar.expr = getValueInvocation;
-                        } else {
-                            // If it is optional configuration create if else
-                            simpleGlobalVar.expr = createIfElseFromConfigurable(simpleGlobalVar, initFunctionEnv);
-                        }
-                    }
-
-                    // Module init should fail if listener is a error value.
-                    if (Symbols.isFlagOn(globalVarFlags, Flags.LISTENER)
-                            && types.containsErrorType(globalVar.expr.getBType())) {
-                        globalVar.expr = ASTBuilderUtil.createCheckExpr(globalVar.expr.pos, globalVar.expr,
-                                                                        globalVar.getBType());
-                    }
-
-                    addToInitFunction(simpleGlobalVar, initFnBody);
-                    desugaredGlobalVarList.add(simpleGlobalVar);
+                case VARIABLE:
+                    desugarGlobalVariables(initFunctionEnv, desugaredGlobalVarList, (BLangVariable) topLevelNode,
+                                           initFnBody);
+                    break;
+                case CONSTANT:
+                    desugarConstants((BLangConstant) topLevelNode, initFnBody, initFunctionEnv);
+                    break;
+                case TYPE_DEFINITION:
+                    rewrite((BLangTypeDefinition) topLevelNode, env);
                     break;
             }
+            if (!typedescList.isEmpty()) {
+                for (BLangSimpleVariableDef variableDef : typedescList) {
+                    desugarGlobalVariables(initFunctionEnv, desugaredGlobalVarList, variableDef.var, initFnBody);
+                }
+                typedescList.clear();
+            }
+        }
+        pkgNode.globalVars = desugaredGlobalVarList;
+    }
+
+    private void desugarVariable(BLangVariable variable, SymbolEnv initFunctionEnv,
+                                 BLangBlockFunctionBody initFnBody, List<BLangVariable> desugaredGlobalVarList) {
+        BLangNode blockStatementNode = rewrite(variable, initFunctionEnv);
+        List<BLangStatement> statements = ((BLangBlockStmt) blockStatementNode).stmts;
+
+        for (BLangStatement statement : statements) {
+            addToGlobalVariableList(statement, initFnBody, variable, desugaredGlobalVarList);
+        }
+    }
+
+    private void desugarGlobalVariables(SymbolEnv initFunctionEnv, List<BLangVariable> desugaredGlobalVarList,
+                                        BLangVariable globalVar, BLangBlockFunctionBody initFnBody) {
+        long globalVarFlags = globalVar.symbol.flags;
+        BLangSimpleVariable simpleGlobalVar = (BLangSimpleVariable) globalVar;
+
+        // Handle configurable global variables
+        if (Symbols.isFlagOn(globalVarFlags, Flags.CONFIGURABLE)) {
+            handleConfigurableGlobalVariable(simpleGlobalVar, initFunctionEnv);
         }
 
-        this.env.enclPkg.topLevelNodes.addAll(desugaredGlobalVarList);
-        return desugaredGlobalVarList;
+        // Handle listener with error type
+        if (Symbols.isFlagOn(globalVarFlags, Flags.LISTENER) && containsErrorType(globalVar.expr.getBType())) {
+            handleListenerWithErrorType(globalVar);
+        }
+
+        // Add variable to the initialization function
+        addToInitFunction(simpleGlobalVar, initFnBody);
+        desugaredGlobalVarList.add(simpleGlobalVar);
+    }
+
+    private void handleConfigurableGlobalVariable(BLangSimpleVariable simpleGlobalVar, SymbolEnv initFunctionEnv) {
+        long globalVarFlags = simpleGlobalVar.symbol.flags;
+
+        if (Symbols.isFlagOn(globalVarFlags, Flags.REQUIRED)) {
+            // If it is a required configuration, get directly
+            List<BLangExpression> args = getConfigurableLangLibInvocationParam(simpleGlobalVar);
+            simpleGlobalVar.expr = createLangLibInvocationNode("getConfigurableValue", args,
+                    symTable.anydataType, simpleGlobalVar.pos);
+        } else {
+            // If it is an optional configuration, create if-else
+            simpleGlobalVar.expr = createIfElseFromConfigurable(simpleGlobalVar, initFunctionEnv);
+        }
+    }
+
+    private void handleListenerWithErrorType(BLangVariable globalVar) {
+        globalVar.expr = ASTBuilderUtil.createCheckExpr(globalVar.expr.pos, globalVar.expr,
+                globalVar.getBType());
+    }
+
+    private boolean containsErrorType(BType type) {
+        // Check if the type contains an error type
+        return types.containsErrorType(type);
     }
 
     private void addToGlobalVariableList(BLangStatement bLangStatement, BLangBlockFunctionBody initFnBody,
@@ -1050,7 +1096,9 @@ public class Desugar extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangTypeDefinition typeDef) {
-        typeDef.typeNode = rewrite(typeDef.typeNode, env);
+        if (!Symbols.isFlagOn(typeDef.symbol.flags, Flags.SOURCE_ANNOTATION)) {
+            typeDef.typeNode = rewrite(typeDef.typeNode, env);
+        }
 
         typeDef.annAttachments.forEach(attachment ->  rewrite(attachment, env));
         result = typeDef;
@@ -1189,7 +1237,7 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         recordTypeNode.restFieldType = rewrite(recordTypeNode.restFieldType, env);
-
+        createTypedescVariableDef(recordTypeNode);
         if (recordTypeNode.isAnonymous && recordTypeNode.isLocal) {
             BLangUserDefinedType userDefinedType = desugarLocalAnonRecordTypeNode(recordTypeNode);
             TypeDefBuilderHelper.createTypeDefinitionForTSymbol(recordTypeNode.getBType(),
@@ -1198,7 +1246,6 @@ public class Desugar extends BLangNodeVisitor {
             result = userDefinedType;
             return;
         }
-
         result = recordTypeNode;
     }
 
@@ -1316,6 +1363,7 @@ public class Desugar extends BLangNodeVisitor {
     public void visit(BLangTupleTypeNode tupleTypeNode) {
         tupleTypeNode.members.forEach(member -> member.typeNode = rewrite(member.typeNode, env));
         tupleTypeNode.restParamType = rewrite(tupleTypeNode.restParamType, env);
+        createTypedescVariableDef(tupleTypeNode);
         result = tupleTypeNode;
     }
 
@@ -9035,7 +9083,14 @@ public class Desugar extends BLangNodeVisitor {
 
     private <E extends BLangStatement> List<E> rewriteStmt(List<E> nodeList, SymbolEnv env) {
         for (int i = 0; i < nodeList.size(); i++) {
+            typedescList = new ArrayList<>();
             nodeList.set(i, rewrite(nodeList.get(i), env));
+            for (BLangSimpleVariableDef variableDef : typedescList) {
+                nodeList.add(i, rewrite((E) variableDef, env));
+                BSymbol symbol = variableDef.var.symbol;
+                env.scope.define(symbol.name, symbol);
+                i++;
+            }
         }
         return nodeList;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -963,7 +963,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangBlockFunctionBody initFnBody = (BLangBlockFunctionBody) pkgNode.initFunction.body;
         SymbolEnv initFunctionEnv =
                 SymbolEnv.createFunctionEnv(pkgNode.initFunction, pkgNode.initFunction.symbol.scope, env);
-        for (int i =0; i < pkgNode.topLevelNodes.size(); i++) {
+        for (int i = 0; i < pkgNode.topLevelNodes.size(); i++) {
             TopLevelNode topLevelNode = pkgNode.topLevelNodes.get(i);
             switch (topLevelNode.getKind()) {
                 case TUPLE_VARIABLE:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
@@ -155,8 +155,10 @@ public class ServiceDesugar {
 
         final Location pos = service.pos;
 
-        ASTBuilderUtil.defineVariable(service.serviceVariable, env.enclPkg.symbol, names);
-        env.enclPkg.globalVars.add(service.serviceVariable);
+        BLangSimpleVariable serviceVariable = service.serviceVariable;
+        ASTBuilderUtil.defineVariable(serviceVariable, env.enclPkg.symbol, names);
+        env.enclPkg.globalVars.add(serviceVariable);
+        env.enclPkg.topLevelNodes.add(serviceVariable);
 
         int count = 0;
         for (BLangExpression attachExpr : service.attachedExprs) {
@@ -173,6 +175,7 @@ public class ServiceDesugar {
                 ASTBuilderUtil.defineVariable(listenerVar, env.enclPkg.symbol, names);
                 listenerVar.symbol.flags |= Flags.LISTENER;
                 env.enclPkg.globalVars.add(listenerVar);
+                env.enclPkg.topLevelNodes.add(listenerVar);
                 listenerVarRef = ASTBuilderUtil.createVariableRef(pos, listenerVar.symbol);
             }
 
@@ -187,6 +190,7 @@ public class ServiceDesugar {
                         null);
                 ASTBuilderUtil.defineVariable(listenerWithoutErrors, env.enclPkg.symbol, names);
                 env.enclPkg.globalVars.add(listenerWithoutErrors);
+                env.enclPkg.topLevelNodes.add(listenerWithoutErrors);
                 BLangSimpleVarRef checkedRef = ASTBuilderUtil.createVariableRef(pos, listenerWithoutErrors.symbol);
                 listenerVarRef = checkedRef;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -45,6 +45,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
@@ -265,6 +266,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     private Map<BSymbol, InitStatus> uninitializedVars;
     private Map<BSymbol, Location> unusedErrorVarsDeclaredWithVar;
     private Map<BSymbol, Location> unusedLocalVariables;
+    private final Map<BSymbol, BSymbol> symbolOwner;
     private Map<BSymbol, Set<BSymbol>> globalNodeDependsOn;
     private Map<BSymbol, Set<BSymbol>> functionToDependency;
     private Map<BLangOnFailClause, Map<BSymbol, InitStatus>> possibleFailureUnInitVars;
@@ -287,6 +289,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         this.currDependentSymbolDeque = new ArrayDeque<>();
         this.globalVariableRefAnalyzer = GlobalVariableRefAnalyzer.getInstance(context);
         this.unusedLocalVariables = new HashMap<>();
+        this.symbolOwner = new HashMap<>();
     }
 
     public static DataflowAnalyzer getInstance(CompilerContext context) {
@@ -346,7 +349,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         }
         checkForUninitializedGlobalVars(pkgNode.globalVars);
         pkgNode.getTestablePkgs().forEach(testablePackage -> visit((BLangPackage) testablePackage));
-        this.globalVariableRefAnalyzer.analyzeAndReOrder(pkgNode, this.globalNodeDependsOn);
+        this.globalVariableRefAnalyzer.analyzeAndReOrder(pkgNode, this.globalNodeDependsOn, this.symbolOwner);
         this.globalVariableRefAnalyzer.populateFunctionDependencies(this.functionToDependency, pkgNode.globalVars);
         pkgNode.globalVariableDependencies = globalVariableRefAnalyzer.getGlobalVariablesDependsOn();
         checkUnusedImports(pkgNode.imports);
@@ -422,6 +425,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         funcNode.annAttachments.forEach(bLangAnnotationAttachment -> analyzeNode(bLangAnnotationAttachment.expr, env));
         funcNode.requiredParams.forEach(param -> analyzeNode(param, funcEnv));
         analyzeNode(funcNode.restParam, funcEnv);
+        analyzeNode(funcNode.returnTypeNode, env);
 
         if (funcNode.flagSet.contains(Flag.OBJECT_CTOR)) {
             visitFunctionBodyWithDynamicEnv(funcNode, funcEnv);
@@ -520,14 +524,15 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangTypeDefinition typeDefinition) {
-        SymbolEnv typeDefEnv;
         BSymbol symbol = typeDefinition.symbol;
         if (typeDefinition.symbol.kind == SymbolKind.TYPE_DEF) {
             symbol = symbol.type.tsymbol;
         }
-        typeDefEnv = SymbolEnv.createTypeEnv(typeDefinition.typeNode, symbol.scope, env);
         this.currDependentSymbolDeque.push(symbol);
-        analyzeNode(typeDefinition.typeNode, typeDefEnv);
+        for (BLangAnnotationAttachment bLangAnnotationAttachment : typeDefinition.annAttachments) {
+            analyzeNode(bLangAnnotationAttachment.expr, env);
+        }
+        analyzeNode(typeDefinition.typeNode, env);
         this.currDependentSymbolDeque.pop();
     }
 
@@ -550,18 +555,19 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
             this.definiteFailureReached = false;
             visitedOCE = true;
         }
-        SymbolEnv objectEnv = SymbolEnv.createClassEnv(classDef, classDef.symbol.scope, env);
         this.currDependentSymbolDeque.push(classDef.symbol);
 
         for (BLangAnnotationAttachment bLangAnnotationAttachment : classDef.annAttachments) {
             analyzeNode(bLangAnnotationAttachment.expr, env);
         }
 
-        classDef.fields.forEach(field -> analyzeNode(field, objectEnv));
-        classDef.referencedFields.forEach(field -> analyzeNode(field, objectEnv));
+        classDef.fields.forEach(field -> analyzeNode(field, this.env));
+        classDef.referencedFields.forEach(field -> analyzeNode(field, this.env));
 
         // Visit the constructor with the same scope as the object
+        analyzeNode(classDef.initFunction, env);
         if (classDef.initFunction != null) {
+            SymbolEnv objectEnv = SymbolEnv.createClassEnv(classDef, classDef.symbol.scope, env);
             if (classDef.initFunction.body == null) {
                 // if the init() function is defined as an outside function definition
                 Optional<BLangFunction> outerFuncDef =
@@ -664,7 +670,10 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
             return;
         }
 
-        this.currDependentSymbolDeque.push(symbol);
+        boolean isRecordField = variable.flagSet.contains(Flag.FIELD);
+        if (!isRecordField) {
+            this.currDependentSymbolDeque.push(symbol);
+        }
         if (variable.typeNode != null && variable.typeNode.getBType() != null) {
             BType type = variable.typeNode.getBType();
             recordGlobalVariableReferenceRelationship(Types.getImpliedType(type).tsymbol);
@@ -707,7 +716,9 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
             if (withInModuleVarLetExpr) { // double pop
                 this.currDependentSymbolDeque.pop();
             }
-            this.currDependentSymbolDeque.pop();
+            if (!isRecordField) {
+                this.currDependentSymbolDeque.pop();
+            }
         }
     }
 
@@ -1564,6 +1575,10 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangRecordLiteral recordLiteral) {
+        BType type = recordLiteral.getBType();
+        if (type != null) {
+            recordGlobalVariableReferenceRelationship(Types.getImpliedType(type).tsymbol);
+        }
         for (RecordLiteralNode.RecordField field : recordLiteral.fields) {
             if (field.isKeyValueField()) {
                 BLangRecordLiteral.BLangRecordKeyValueField keyValuePair =
@@ -1686,6 +1701,8 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         for (BLangNamedArgsExpression namedArg : errorConstructorExpr.namedArgs) {
             analyzeNode(namedArg, env);
         }
+        BType detailType = ((BErrorType) Types.getImpliedType(errorConstructorExpr.getBType())).detailType;
+        recordGlobalVariableReferenceRelationship(detailType.tsymbol);
     }
 
     @Override
@@ -2374,6 +2391,10 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangErrorType errorType) {
+        BLangType detailType = errorType.detailType;
+        if (detailType != null && detailType.getBType() != null) {
+            recordGlobalVariableReferenceRelationship(Types.getImpliedType(detailType.getBType()).tsymbol);
+        }
     }
 
     @Override
@@ -2415,6 +2436,9 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         analyzeNode(bLangTupleVariable.typeNode, env);
         populateUnusedVariableMapForNonSimpleBindingPatternVariables(this.unusedLocalVariables, bLangTupleVariable);
         this.currDependentSymbolDeque.push(bLangTupleVariable.symbol);
+        for (BLangVariable memberVariable : bLangTupleVariable.memberVariables) {
+            symbolOwner.put(memberVariable.symbol, bLangTupleVariable.symbol);
+        }
         analyzeNode(bLangTupleVariable.expr, env);
         this.currDependentSymbolDeque.pop();
     }
@@ -2429,6 +2453,9 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         analyzeNode(bLangRecordVariable.typeNode, env);
         populateUnusedVariableMapForNonSimpleBindingPatternVariables(this.unusedLocalVariables, bLangRecordVariable);
         this.currDependentSymbolDeque.push(bLangRecordVariable.symbol);
+        for(BLangRecordVariable.BLangRecordVariableKeyValue recordVariableKeyValue : bLangRecordVariable.variableList) {
+            symbolOwner.put(recordVariableKeyValue.valueBindingPattern.symbol, bLangRecordVariable.symbol);
+        }
         analyzeNode(bLangRecordVariable.expr, env);
         this.currDependentSymbolDeque.pop();
     }
@@ -2443,6 +2470,21 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         analyzeNode(bLangErrorVariable.typeNode, env);
         populateUnusedVariableMapForNonSimpleBindingPatternVariables(this.unusedLocalVariables, bLangErrorVariable);
         this.currDependentSymbolDeque.push(bLangErrorVariable.symbol);
+        BSymbol symbol = bLangErrorVariable.symbol;
+        if (bLangErrorVariable.message != null) {
+            symbolOwner.put(bLangErrorVariable.message.symbol, symbol);
+        }
+        if (bLangErrorVariable.cause != null) {
+            symbolOwner.put(bLangErrorVariable.cause.symbol, symbol);
+        }
+        if (bLangErrorVariable.restDetail != null) {
+            symbolOwner.put(bLangErrorVariable.restDetail.symbol, symbol);
+        }
+
+        for (BLangErrorVariable.BLangErrorDetailEntry errorDetailEntry : bLangErrorVariable.detail) {
+            symbolOwner.put(errorDetailEntry.valueBindingPattern.symbol, bLangErrorVariable.symbol);
+        }
+
         analyzeNode(bLangErrorVariable.expr, env);
         this.currDependentSymbolDeque.pop();
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -2453,7 +2453,8 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         analyzeNode(bLangRecordVariable.typeNode, env);
         populateUnusedVariableMapForNonSimpleBindingPatternVariables(this.unusedLocalVariables, bLangRecordVariable);
         this.currDependentSymbolDeque.push(bLangRecordVariable.symbol);
-        for(BLangRecordVariable.BLangRecordVariableKeyValue recordVariableKeyValue : bLangRecordVariable.variableList) {
+        for (BLangRecordVariable.BLangRecordVariableKeyValue recordVariableKeyValue :
+                                                                                bLangRecordVariable.variableList) {
             symbolOwner.put(recordVariableKeyValue.valueBindingPattern.symbol, bLangRecordVariable.symbol);
         }
         analyzeNode(bLangRecordVariable.expr, env);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -2859,6 +2859,10 @@ public class Types {
 
         @Override
         public Boolean visit(BTupleType t, BType s) {
+            if (t == s) {
+                return true;
+            }
+
             List<BType> tTupleTypes = t.getTupleTypes();
             if (((!tTupleTypes.isEmpty() && checkAllTupleMembersBelongNoType(tTupleTypes)) ||
                     (t.restType != null && t.restType.tag == TypeTags.NONE)) &&

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
@@ -293,28 +293,24 @@ public class GlobalVariableRefAnalyzer {
 
     private Map<BSymbol, TopLevelNode> collectAssociateSymbolsWithTopLevelNodes() {
         Map<BSymbol, TopLevelNode> varMap = new LinkedHashMap<>();
+
         for (TopLevelNode topLevelNode : this.pkgNode.topLevelNodes) {
-            switch (topLevelNode.getKind()) {
-                case VARIABLE:
-                case RECORD_VARIABLE:
-                case TUPLE_VARIABLE:
-                case ERROR_VARIABLE:
-                    if (((BLangVariable) topLevelNode).symbol != null) {
-                        varMap.put(((BLangVariable) topLevelNode).symbol, topLevelNode);
-                    }
-                    continue;
-                case TYPE_DEFINITION:
-                    if (((BLangTypeDefinition) topLevelNode).symbol.type.tsymbol != null) {
-                        varMap.put(((BLangTypeDefinition) topLevelNode).symbol.type.tsymbol, topLevelNode);
-                    }
-                    continue;
-                case CONSTANT:
-                    if (((BLangConstant) topLevelNode).symbol != null) {
-                        varMap.put(((BLangConstant) topLevelNode).symbol, topLevelNode);
-                    }
+            BSymbol symbol = getSymbolFromTopLevelNode(topLevelNode);
+            if (symbol != null) {
+                varMap.put(symbol, topLevelNode);
             }
         }
+
         return varMap;
+    }
+
+    private BSymbol getSymbolFromTopLevelNode(TopLevelNode topLevelNode) {
+        return switch (topLevelNode.getKind()) {
+            case VARIABLE, RECORD_VARIABLE, TUPLE_VARIABLE, ERROR_VARIABLE -> ((BLangVariable) topLevelNode).symbol;
+            case TYPE_DEFINITION -> ((BLangTypeDefinition) topLevelNode).symbol.type.tsymbol;
+            case CONSTANT -> ((BLangConstant) topLevelNode).symbol;
+            default -> null;
+        };
     }
 
     private int analyzeProvidersRecursively(NodeInfo node) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
@@ -46,8 +46,8 @@ import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -64,6 +64,7 @@ public class GlobalVariableRefAnalyzer {
     private final BLangDiagnosticLog dlog;
     private BLangPackage pkgNode;
     private Map<BSymbol, Set<BSymbol>> globalNodeDependsOn;
+    Map<BSymbol, BSymbol> symbolOwner;
     private Map<BSymbol, Set<BVarSymbol>> globalVariablesDependsOn;
     private final Map<BSymbol, NodeInfo> dependencyNodes;
     private final Deque<NodeInfo> nodeInfoStack;
@@ -228,54 +229,21 @@ public class GlobalVariableRefAnalyzer {
     }
 
     /**
-     * Analyze the global variable references and reorder them or emit error if they contain cyclic references.
+     * Analyze the global references and reorder them or emit error if they contain cyclic references.
      *
      * @param pkgNode package to be analyzed.
      * @param globalNodeDependsOn symbol dependency relationship.
+     * @param symbolOwner symbol owner relationship.
      */
-    public void analyzeAndReOrder(BLangPackage pkgNode, Map<BSymbol, Set<BSymbol>> globalNodeDependsOn) {
+    public void analyzeAndReOrder(BLangPackage pkgNode, Map<BSymbol, Set<BSymbol>> globalNodeDependsOn,
+                                  Map<BSymbol, BSymbol> symbolOwner) {
         this.dlog.setCurrentPackageId(pkgNode.packageID);
         this.pkgNode = pkgNode;
         this.globalNodeDependsOn = globalNodeDependsOn;
+        this.symbolOwner = symbolOwner;
         resetAnalyzer();
 
-        List<BSymbol> globalVarsAndDependentFuncs = getGlobalVariablesAndDependentFunctions();
-
-        pruneDependencyRelations();
-
-        Set<BSymbol> sorted = new LinkedHashSet<>();
-        LinkedList<BSymbol> dependencies = new LinkedList<>();
-
-        for (BSymbol symbol : globalVarsAndDependentFuncs) {
-            List<BSymbol> dependencyTrain = analyzeDependenciesStartingFrom(symbol);
-            dependencies.addAll(dependencyTrain);
-
-            Set<BSymbol> symbolsProviders = globalNodeDependsOn.get(symbol);
-            boolean symbolHasProviders = symbolsProviders != null && !symbolsProviders.isEmpty();
-            boolean notInSortedList = !sorted.contains(symbol);
-
-            // Independent variable declaration, add to sorted list.
-            if (notInSortedList && !symbolHasProviders) {
-                moveAndAppendToSortedList(symbol, dependencies, sorted);
-            }
-            // Dependent variable, and all the dependencies are satisfied, add to sorted list.
-            if (notInSortedList && symbolHasProviders && sorted.containsAll(symbolsProviders)) {
-                moveAndAppendToSortedList(symbol, dependencies, sorted);
-            }
-
-            // If we can satisfy the dependencies' dependencies then we can add those dependencies to sorted list now.
-            addDependenciesDependencies(dependencies, sorted);
-        }
-        sorted.addAll(dependencies);
-
-        // Cyclic error found no need to sort.
-        if (cyclicErrorFound) {
-            return;
-        }
-
-        sortConstants(sorted);
-        projectSortToGlobalVarsList(sorted);
-        projectSortToTopLevelNodesList();
+        reOrderTopLevelNodeList();
     }
 
     private List<BSymbol> analyzeDependenciesStartingFrom(BSymbol symbol) {
@@ -298,148 +266,55 @@ public class GlobalVariableRefAnalyzer {
         return new ArrayList<>();
     }
 
-    private void pruneDependencyRelations() {
-        List<BSymbol> dependents = new ArrayList<>(this.globalNodeDependsOn.keySet());
-        Set<BSymbol> visited = new HashSet<>();
-        for (BSymbol dependent : dependents) {
-            // Taking a copy as we need to modify the original list.
-            List<BSymbol> providers = new ArrayList<>(this.globalNodeDependsOn.get(dependent));
-            for (BSymbol provider : providers) {
-                pruneFunctions(dependent, provider, this.globalNodeDependsOn, visited);
-            }
-        }
-    }
+    private void reOrderTopLevelNodeList() {
+        Map<BSymbol, TopLevelNode> varMap = collectAssociateSymbolsWithTopLevelNodes();
 
-    private void pruneFunctions(BSymbol dependent, BSymbol provider, Map<BSymbol, Set<BSymbol>> globalNodeDependsOn,
-                                Set<BSymbol> visited) {
-        if (visited.contains(provider)) {
-            return;
-        } else {
-            visited.add(provider);
+        Set<BSymbol> sorted = new LinkedHashSet<>();
+        for (BSymbol symbol : varMap.keySet()) {
+            sorted.addAll(analyzeDependenciesStartingFrom(symbol));
         }
 
-        // Dependent has a dependency on a global var.
-        if (provider.tag != SymTag.FUNCTION) {
+        // Cyclic error found no need to sort.
+        if (cyclicErrorFound) {
             return;
         }
 
-        // Provider is a function.
-        // And doesn't have dependency on a global variable. We can prune provider.
-        if (!globalNodeDependsOn.containsKey(provider) || globalNodeDependsOn.get(provider).isEmpty()) {
-            globalNodeDependsOn.get(dependent).remove(provider);
-            return;
-        }
-
-        // Taking a copy as we need to modify the original list.
-        List<BSymbol> providersProviders = new ArrayList<>(globalNodeDependsOn.get(provider));
-        for (BSymbol prov : providersProviders) {
-            pruneFunctions(provider, prov, globalNodeDependsOn, visited);
-        }
-    }
-
-    private void addDependenciesDependencies(LinkedList<BSymbol> dependencies, Set<BSymbol> sorted) {
-        // For each dependency if they satisfy their dependencies in sorted list, then add them to sorted list.
-        ArrayList<BSymbol> depCopy = new ArrayList<>(dependencies);
-        for (BSymbol dep : depCopy) {
-            Set<BSymbol> depsDependencies = globalNodeDependsOn.getOrDefault(dep, new LinkedHashSet<>());
-            if (!depsDependencies.isEmpty() && sorted.containsAll(depsDependencies)) {
-                moveAndAppendToSortedList(dep, dependencies, sorted);
-            }
-        }
-    }
-
-    private void projectSortToTopLevelNodesList() {
-        // Swap global variable nodes in 'topLevelNodes' list to reflect sorted global variables.
-        List<Integer> topLevelPositions = new ArrayList<>();
-        for (BLangVariable globalVar : pkgNode.globalVars) {
-            topLevelPositions.add(pkgNode.topLevelNodes.indexOf(globalVar));
-        }
-        topLevelPositions.sort(Comparator.comparingInt(i -> i));
-        for (int i = 0; i < topLevelPositions.size(); i++) {
-            Integer targetIndex = topLevelPositions.get(i);
-            pkgNode.topLevelNodes.set(targetIndex, pkgNode.globalVars.get(i));
-        }
-
-        topLevelPositions = new ArrayList<>();
-        for (BLangConstant constant : pkgNode.constants) {
-            topLevelPositions.add(pkgNode.topLevelNodes.indexOf(constant));
-        }
-        topLevelPositions.sort(Comparator.comparingInt(i -> i));
-        for (int i = 0; i < topLevelPositions.size(); i++) {
-            Integer targetIndex = topLevelPositions.get(i);
-            pkgNode.topLevelNodes.set(targetIndex, pkgNode.constants.get(i));
-        }
-    }
-
-    private void projectSortToGlobalVarsList(Set<BSymbol> sorted) {
-        Map<BSymbol, BLangVariable> varMap = new HashMap<>();
-        this.pkgNode.globalVars.forEach(globalVar -> {
-            if (globalVar.symbol != null) {
-                varMap.put(globalVar.symbol, globalVar);
-            }
-        });
-
-        List<BLangVariable> sortedGlobalVars = sorted.stream()
-                .filter(varMap::containsKey)
-                .map(varMap::get)
-                .collect(Collectors.toList());
-
-        if (sortedGlobalVars.size() != this.pkgNode.globalVars.size()) {
-            List<BLangVariable> symbolLessGlobalVars = this.pkgNode.globalVars.stream()
-                    .filter(g -> g.symbol == null)
-                    .collect(Collectors.toList());
-            sortedGlobalVars.addAll(symbolLessGlobalVars);
-        }
-        this.pkgNode.globalVars.clear();
-        this.pkgNode.globalVars.addAll(sortedGlobalVars);
-    }
-
-    private void sortConstants(Set<BSymbol> sorted) {
-        Map<BSymbol, BLangConstant> varMap = this.pkgNode.constants.stream()
-                .collect(Collectors.toMap(k -> k.symbol, k -> k));
-
-        List<BLangConstant> sortedConstants = sorted.stream()
-                .filter(varMap::containsKey)
-                .map(varMap::get)
-                .collect(Collectors.toList());
-
-        if (sortedConstants.size() != this.pkgNode.constants.size()) {
-            List<BLangConstant> symbolLessGlobalVars = this.pkgNode.constants.stream()
-                    .filter(c -> !sortedConstants.contains(c))
-                    .collect(Collectors.toList());
-            sortedConstants.addAll(symbolLessGlobalVars);
-        }
-        this.pkgNode.constants.clear();
-        this.pkgNode.constants.addAll(sortedConstants);
-    }
-    
-    private List<BSymbol> getGlobalVariablesAndDependentFunctions() {
-        List<BSymbol> dependents = new ArrayList<>();
-
-        for (BSymbol s : globalNodeDependsOn.keySet()) {
-            if ((s.tag & SymTag.FUNCTION) == SymTag.FUNCTION) {
-                dependents.add(s);
+        Set<TopLevelNode> sortedTopLevelNodes = new LinkedHashSet<>();
+        for (BSymbol symbol : sorted) {
+            if (varMap.containsKey(symbol)) {
+                sortedTopLevelNodes.add(varMap.get(symbol));
             }
         }
 
-        for (BLangVariable var : this.pkgNode.globalVars) {
-            if (var.symbol != null) {
-                dependents.add(var.symbol);
-            }
-        }
-
-        for (BLangConstant constant : this.pkgNode.constants) {
-            if (constant.symbol != null) {
-                dependents.add(constant.symbol);
-            }
-        }
-
-        return dependents;
+        sortedTopLevelNodes.addAll(pkgNode.topLevelNodes);
+        this.pkgNode.topLevelNodes.clear();
+        this.pkgNode.topLevelNodes.addAll(sortedTopLevelNodes);
     }
 
-    private void moveAndAppendToSortedList(BSymbol symbol, List<BSymbol> moveFrom, Set<BSymbol> sorted) {
-        sorted.add(symbol);
-        moveFrom.remove(symbol);
+    private Map<BSymbol, TopLevelNode> collectAssociateSymbolsWithTopLevelNodes() {
+        Map<BSymbol, TopLevelNode> varMap = new LinkedHashMap<>();
+        for (TopLevelNode topLevelNode : this.pkgNode.topLevelNodes) {
+            switch (topLevelNode.getKind()) {
+                case VARIABLE:
+                case RECORD_VARIABLE:
+                case TUPLE_VARIABLE:
+                case ERROR_VARIABLE:
+                    if (((BLangVariable) topLevelNode).symbol != null) {
+                        varMap.put(((BLangVariable) topLevelNode).symbol, topLevelNode);
+                    }
+                    continue;
+                case TYPE_DEFINITION:
+                    if (((BLangTypeDefinition) topLevelNode).symbol.type.tsymbol != null) {
+                        varMap.put(((BLangTypeDefinition) topLevelNode).symbol.type.tsymbol, topLevelNode);
+                    }
+                    continue;
+                case CONSTANT:
+                    if (((BLangConstant) topLevelNode).symbol != null) {
+                        varMap.put(((BLangConstant) topLevelNode).symbol, topLevelNode);
+                    }
+            }
+        }
+        return varMap;
     }
 
     private int analyzeProvidersRecursively(NodeInfo node) {
@@ -454,8 +329,9 @@ public class GlobalVariableRefAnalyzer {
 
         Set<BSymbol> providers = globalNodeDependsOn.getOrDefault(node.symbol, new LinkedHashSet<>());
         for (BSymbol providerSym : providers) {
+            BSymbol symbol = symbolOwner.getOrDefault(providerSym, providerSym);
             NodeInfo providerNode =
-                    dependencyNodes.computeIfAbsent(providerSym, s -> new NodeInfo(curNodeId++, providerSym));
+                    dependencyNodes.computeIfAbsent(providerSym, s -> new NodeInfo(curNodeId++, symbol));
             int lastLowLink = analyzeProvidersRecursively(providerNode);
             if (providerNode.onStack) {
                 node.lowLink = Math.min(node.lowLink, lastLowLink);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
@@ -152,7 +152,7 @@ public class VariableReturnType {
     }
 
     public static BStream getStreamOfRecords(ObjectValue objectValue, BStream strm, BTypedesc typedesc) {
-        RecordType streamConstraint = (RecordType) typedesc.getDescribingType();
+        RecordType streamConstraint = (RecordType) TypeUtils.getImpliedType(typedesc.getDescribingType());
         Assert.assertSame(streamConstraint, TypeUtils.getImpliedType(strm.getConstraintType()));
         return strm;
     }
@@ -160,7 +160,7 @@ public class VariableReturnType {
     public static ArrayValue getTuple(BTypedesc td1, BTypedesc td2, BTypedesc td3) {
         List<Type> memTypes = new ArrayList<>();
         memTypes.add(td1.getDescribingType());
-        memTypes.add(td2.getDescribingType());
+        memTypes.add(TypeUtils.getImpliedType(td2.getDescribingType()));
         memTypes.add(td3.getDescribingType());
         BTupleType tupleType = new BTupleType(memTypes);
 
@@ -192,7 +192,7 @@ public class VariableReturnType {
     }
 
     public static MapValue getRecord(BTypedesc td) {
-        BRecordType recType = (BRecordType) td.getDescribingType();
+        BRecordType recType = (BRecordType) TypeUtils.getImpliedType(td.getDescribingType());
         MapValueImpl person = new MapValueImpl(recType);
 
         if (recType.getName().equals("Person")) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/constant/MapConstantPanicInBalaTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/constant/MapConstantPanicInBalaTest.java
@@ -41,7 +41,7 @@ public class MapConstantPanicInBalaTest {
     // boolean ----------------------------------------------
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'bm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'bm11k' in record of type 'foo:.*")
     public void updateReturnedConstantBooleanMapWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateReturnedConstantBooleanMapWithExistingKey");
     }
@@ -54,7 +54,7 @@ public class MapConstantPanicInBalaTest {
     }
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'bm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'bm11k' in record of type 'foo:.*")
     public void updateConstantBooleanMapValueInArrayWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateConstantBooleanMapValueInArrayWithExistingKey");
     }
@@ -69,7 +69,7 @@ public class MapConstantPanicInBalaTest {
     // int ---------------------------------------------------
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'im11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'im11k' in record of type 'foo:.*")
     public void updateNestedConstantIntMapValueWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateNestedConstantIntMapValueWithExistingKey");
     }
@@ -82,7 +82,7 @@ public class MapConstantPanicInBalaTest {
     }
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'im11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'im11k' in record of type 'foo:.*")
     public void updateReturnedConstantIntMapWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateReturnedConstantIntMapWithExistingKey");
     }
@@ -95,7 +95,7 @@ public class MapConstantPanicInBalaTest {
     }
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'im11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'im11k' in record of type 'foo:.*")
     public void updateConstantIntMapValueInArrayWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateConstantIntMapValueInArrayWithExistingKey");
     }
@@ -111,7 +111,7 @@ public class MapConstantPanicInBalaTest {
 
     @Test(expectedExceptions = BLangTestException.class,
             expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field " +
-                    "'bytem11k' in record of type '\\(foo:.*")
+                    "'bytem11k' in record of type 'foo:.*")
     public void updateNestedConstantByteMapValueWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateNestedConstantByteMapValueWithExistingKey");
     }
@@ -125,7 +125,7 @@ public class MapConstantPanicInBalaTest {
 
     @Test(expectedExceptions = BLangTestException.class,
             expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'bytem11k' " +
-                    "in record of type '\\(foo:.*")
+                    "in record of type 'foo:.*")
     public void updateReturnedConstantByteMapWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateReturnedConstantByteMapWithExistingKey");
     }
@@ -139,7 +139,7 @@ public class MapConstantPanicInBalaTest {
 
     @Test(expectedExceptions = BLangTestException.class,
             expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'bytem11k' " +
-                    "in record of type '\\(foo:.*")
+                    "in record of type 'foo:.*")
     public void updateConstantByteMapValueInArrayWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateConstantByteMapValueInArrayWithExistingKey");
     }
@@ -154,7 +154,7 @@ public class MapConstantPanicInBalaTest {
     // float -------------------------------------------------
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'fm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'fm11k' in record of type 'foo:.*")
     public void updateNestedConstantFloatMapValueWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateNestedConstantFloatMapValueWithExistingKey");
     }
@@ -167,7 +167,7 @@ public class MapConstantPanicInBalaTest {
     }
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'fm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'fm11k' in record of type 'foo:.*")
     public void updateReturnedConstantFloatMapWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateReturnedConstantFloatMapWithExistingKey");
     }
@@ -180,7 +180,7 @@ public class MapConstantPanicInBalaTest {
     }
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'fm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'fm11k' in record of type 'foo:.*")
     public void updateConstantFloatMapValueInArrayWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateConstantFloatMapValueInArrayWithExistingKey");
     }
@@ -195,7 +195,7 @@ public class MapConstantPanicInBalaTest {
     // decimal -----------------------------------------------
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'dm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'dm11k' in record of type 'foo:.*")
     public void updateNestedConstantDecimalMapValueWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateNestedConstantDecimalMapValueWithExistingKey");
     }
@@ -208,7 +208,7 @@ public class MapConstantPanicInBalaTest {
     }
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'dm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'dm11k' in record of type 'foo:.*")
     public void updateReturnedConstantDecimalMapWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateReturnedConstantDecimalMapWithExistingKey");
     }
@@ -221,7 +221,7 @@ public class MapConstantPanicInBalaTest {
     }
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'dm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'dm11k' in record of type 'foo:.*")
     public void updateConstantDecimalMapValueInArrayWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateConstantDecimalMapValueInArrayWithExistingKey");
     }
@@ -236,7 +236,7 @@ public class MapConstantPanicInBalaTest {
     // string ------------------------------------------------
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'sm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'sm11k' in record of type 'foo:.*")
     public void updateNestedConstantStringMapValueWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateNestedConstantStringMapValueWithExistingKey");
     }
@@ -249,7 +249,7 @@ public class MapConstantPanicInBalaTest {
     }
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'sm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'sm11k' in record of type 'foo:.*")
     public void updateReturnedConstantStringMapWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateReturnedConstantStringMapWithExistingKey");
     }
@@ -262,7 +262,7 @@ public class MapConstantPanicInBalaTest {
     }
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'sm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'sm11k' in record of type 'foo:.*")
     public void updateConstantStringMapValueInArrayWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateConstantStringMapValueInArrayWithExistingKey");
     }
@@ -277,7 +277,7 @@ public class MapConstantPanicInBalaTest {
     // nil ---------------------------------------------------
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'nm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'nm11k' in record of type 'foo:.*")
     public void updateNestedConstantNilMapValueWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateNestedConstantNilMapValueWithExistingKey");
     }
@@ -290,7 +290,7 @@ public class MapConstantPanicInBalaTest {
     }
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'nm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'nm11k' in record of type 'foo:.*")
     public void updateReturnedConstantNilMapWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateReturnedConstantNilMapWithExistingKey");
     }
@@ -303,7 +303,7 @@ public class MapConstantPanicInBalaTest {
     }
 
     @Test(expectedExceptions = BLangTestException.class,
-            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'nm11k' in record of type '\\(foo:.*")
+            expectedExceptionsMessageRegExp = ".*cannot update 'readonly' field 'nm11k' in record of type 'foo:.*")
     public void updateConstantNilMapValueInArrayWithExistingKey() {
         BRunUtil.invoke(compileResult, "updateConstantNilMapValueInArrayWithExistingKey");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -84,8 +84,8 @@ public class ErrorTest {
         Object returns = BRunUtil.invoke(errorTestResult, "testIndirectErrorConstructor");
         BArray errors = (BArray) returns;
         Assert.assertEquals(errors.size(), 4);
-        Assert.assertEquals(errors.get(0).toString(), "error UserDefErrorTwoA (\"arg\",message=\"\",data={})");
-        Assert.assertEquals(errors.get(1).toString(), "error UserDefErrorTwoA (\"arg\",message=\"\",data={})");
+        Assert.assertEquals(errors.get(0).toString(), "error UserDefErrorTwoA (\"arg\",data={},message=\"\")");
+        Assert.assertEquals(errors.get(1).toString(), "error UserDefErrorTwoA (\"arg\",data={},message=\"\")");
         Assert.assertEquals(errors.get(2), errors.get(0));
         Assert.assertEquals(errors.get(3), errors.get(1));
     }
@@ -138,7 +138,7 @@ public class ErrorTest {
     @Test
     public void customErrorDetailsTest() {
         Object returns = BRunUtil.invoke(errorTestResult, "testCustomErrorDetails");
-        Assert.assertEquals(returns.toString(), "error TrxError (\"trxErr\",message=\"\",data=\"test\")");
+        Assert.assertEquals(returns.toString(), "error TrxError (\"trxErr\",data=\"test\",message=\"\")");
         Assert.assertEquals(getType(((BError) returns).getDetails()).getTag(), TypeTags.RECORD_TYPE_TAG);
         Assert.assertEquals(getType(((BError) returns).getDetails()).getName(), "(TrxErrorData & readonly)");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
@@ -262,12 +262,11 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
                         "\"lastName\":\"Fonseka\",\"score\":90.6}]");
         Assert.assertEquals(teacher1.get(StringUtils.fromString("experience")).toString(),
                 "{\"duration\":10,\"qualitifications\":\"B.Sc.\"}");
-        Assert.assertEquals(teacher1.toString(),
-                "{\"classStudents\":[{\"firstName\":\"Alex\",\"lastName\":\"George\",\"score\":82.5}," +
-                        "{\"firstName\":\"Ranjan\",\"lastName\":\"Fonseka\",\"score\":90.6}]," +
-                        "\"experience\":{\"duration\":10,\"qualitifications\":\"B.Sc.\"}," +
-                        "\"firstName\":\"Alex\",\"lastName\":\"George\",\"deptAccess\":\"XYZ\"," +
-                        "\"address\":{\"city\":\"NY\",\"country\":\"America\"}}");
+        Assert.assertEquals(teacher1.toString(), "{\"firstName\":\"Alex\",\"address\":{\"city\":\"NY\"," +
+                "\"country\":\"America\"},\"classStudents\":[{\"firstName\":\"Alex\",\"lastName\":\"George\"," +
+                "\"score\":82.5},{\"firstName\":\"Ranjan\",\"lastName\":\"Fonseka\",\"score\":90.6}]," +
+                "\"deptAccess\":\"XYZ\",\"lastName\":\"George\",\"experience\":{\"duration\":10," +
+                "\"qualitifications\":\"B.Sc.\"}}");
 
         Assert.assertTrue(teacher2.get(StringUtils.fromString("classStudents")) instanceof BArray);
         Assert.assertTrue(teacher2.get(StringUtils.fromString("experience")) instanceof BMap);
@@ -277,11 +276,10 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(teacher2.get(StringUtils.fromString("experience")).toString(),
                 "{\"duration\":10,\"qualitifications\":\"B.Sc.\"}");
         Assert.assertEquals(teacher2.toString(),
-                "{\"classStudents\":[{\"firstName\":\"Alex\",\"lastName\":\"George\",\"score\":82.5}," +
-                        "{\"firstName\":\"Ranjan\",\"lastName\":\"Fonseka\",\"score\":90.6}]," +
-                        "\"experience\":{\"duration\":10,\"qualitifications\":\"B.Sc.\"}," +
-                        "\"firstName\":\"Ranjan\",\"lastName\":\"Fonseka\",\"deptAccess\":\"XYZ\"," +
-                        "\"address\":{\"city\":\"NY\",\"country\":\"America\"}}");
+                "{\"firstName\":\"Ranjan\",\"address\":{\"city\":\"NY\",\"country\":\"America\"}," +
+                        "\"classStudents\":[{\"firstName\":\"Alex\",\"lastName\":\"George\",\"score\":82.5}," +
+                        "{\"firstName\":\"Ranjan\",\"lastName\":\"Fonseka\",\"score\":90.6}],\"deptAccess\":\"XYZ\"," +
+                        "\"lastName\":\"Fonseka\",\"experience\":{\"duration\":10,\"qualitifications\":\"B.Sc.\"}}");
     }
 
     @Test(description = "Test query expressions with tuple typed binding in let")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordTest.java
@@ -134,22 +134,22 @@ public class ClosedRecordTest {
     @Test(description = "Test negative default values in record")
     public void testStructToString() {
         Object returns = BRunUtil.invoke(compileResult, "getStruct");
-        Assert.assertEquals(returns.toString(), "{\"name\":\"aaa\",\"lname\":\"\",\"adrs\":{},\"age\":25," +
-                "\"family\":{\"spouse\":\"\",\"noOfChildren\":0,\"children\":[]},\"parent\":{\"name\":\"bbb\"," +
-                "\"lname\":\"ccc\",\"adrs\":{},\"age\":50,\"family\":{\"spouse\":\"\",\"noOfChildren\":0," +
-                "\"children\":[]},\"parent\":null}}");
+        Assert.assertEquals(returns.toString(), "{\"name\":\"aaa\",\"age\":25,\"parent\":{\"name\":\"bbb\"," +
+                "\"lname\":\"ccc\",\"age\":50,\"parent\":null,\"adrs\":{},\"family\":{\"children\":[]," +
+                "\"noOfChildren\":0,\"spouse\":\"\"}},\"lname\":\"\",\"adrs\":{},\"family\":{\"children\":[]," +
+                "\"noOfChildren\":0,\"spouse\":\"\"}}");
     }
 
     @Test
     public void testStructLiteral() {
         CompileResult compileResult = BCompileUtil.compile("test-src/record/sealed_record_literals.bal");
         Object returns = BRunUtil.invoke(compileResult, "testStructLiteral1");
-        Assert.assertEquals(returns.toString(), "{\"dptName\":\"\",\"employees\":[],\"manager\":{\"name\":\"default " +
-                "first name\",\"lname\":\"\",\"adrs\":{},\"age\":999,\"child\":null}}");
+        Assert.assertEquals(returns.toString(), "{\"manager\":{\"lname\":\"\",\"name\":\"default first " +
+                "name\",\"adrs\":{},\"age\":999,\"child\":null},\"dptName\":\"\",\"employees\":[]}");
 
         returns = BRunUtil.invoke(compileResult, "testStructLiteral2");
         Assert.assertEquals(returns.toString(),
-                "{\"name\":\"default first name\",\"lname\":\"\",\"adrs\":{},\"age\":999,\"child\":null}");
+                "{\"lname\":\"\",\"name\":\"default first name\",\"adrs\":{},\"age\":999,\"child\":null}");
     }
 
     @Test
@@ -157,8 +157,9 @@ public class ClosedRecordTest {
         CompileResult result = BCompileUtil.compile("test-src/record/nested_sealed_record_inline_init.bal");
         Object returns = BRunUtil.invoke(result, "testCreateStruct");
         Assert.assertEquals(returns.toString(),
-                "{\"name\":\"default first name\",\"fname\":\"\",\"lname\":\"Doe\",\"adrs\":{},\"age\":999," +
-                        "\"family\":{\"spouse\":\"Jane\",\"noOfChildren\":0,\"children\":[\"Alex\",\"Bob\"]}}");
+                "{\"lname\":\"Doe\",\"fname\":\"\",\"name\":\"default first name\",\"adrs\":{}," +
+                        "\"family\":{\"spouse\":\"Jane\",\"children\":[\"Alex\",\"Bob\"],\"noOfChildren\":0}," +
+                        "\"age\":999}");
     }
 
     @Test(description = "Negative test to test attaching functions to record literal")
@@ -177,8 +178,8 @@ public class ClosedRecordTest {
         Object returns = BRunUtil.invoke(compileResult, "testStructWithRecordKeyword");
 
         Assert.assertEquals(returns.toString(), "{\"name\":\"John\",\"lname\":\"Doe\"," +
-                "\"address\":{\"country\":\"USA\",\"state\":\"CA\"},\"age\":25,\"family\":{\"spouse\":\"\"," +
-                "\"noOfChildren\":0,\"children\":[]},\"parent\":null,\"designation\":\"Software Engineer\"}");
+                "\"address\":{\"country\":\"USA\",\"state\":\"CA\"},\"age\":25,\"designation\":\"Software Engineer\"," +
+                "\"parent\":null,\"family\":{\"children\":[],\"noOfChildren\":0,\"spouse\":\"\"}}");
     }
 
     @Test(description = "Test function pointer as a record field")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordTest.java
@@ -136,32 +136,31 @@ public class OpenRecordTest {
     @Test(description = "Test negative default values in record")
     public void testStructToString() {
         Object returns = BRunUtil.invoke(compileResult, "getStruct");
-        Assert.assertEquals(returns.toString(), "{\"name\":\"aaa\",\"lname\":\"\",\"adrs\":{},\"age\":25," +
-                "\"family\":{\"spouse\":\"\",\"noOfChildren\":0,\"children\":[]},\"parent\":{\"name\":\"bbb\"," +
-                "\"lname\":\"ccc\",\"adrs\":{},\"age\":50,\"family\":{\"spouse\":\"\",\"noOfChildren\":0," +
-                "\"children\":[]},\"parent\":null}}");
+        Assert.assertEquals(returns.toString(), "{\"name\":\"aaa\",\"age\":25,\"parent\":{\"name\":\"bbb\"," +
+                "\"lname\":\"ccc\",\"age\":50,\"parent\":null,\"adrs\":{},\"family\":{\"children\":[]," +
+                "\"noOfChildren\":0,\"spouse\":\"\"}},\"lname\":\"\",\"adrs\":{},\"family\":{\"children\":[]," +
+                "\"noOfChildren\":0,\"spouse\":\"\"}}");
     }
 
     @Test
     public void testStructLiteral() {
         CompileResult compileResult = BCompileUtil.compile("test-src/record/record_literals.bal");
         Object returns = BRunUtil.invoke(compileResult, "testStructLiteral1");
-        Assert.assertEquals(returns.toString(), "{\"dptName\":\"\",\"employees\":[],\"manager\":{\"name\":\"default " +
-                "first name\",\"lname\":\"\",\"adrs\":{},\"age\":999,\"child\":null}}");
+        Assert.assertEquals(returns.toString(), "{\"manager\":{\"lname\":\"\",\"name\":\"default first " +
+                "name\",\"adrs\":{},\"age\":999,\"child\":null},\"dptName\":\"\",\"employees\":[]}");
 
         returns = BRunUtil.invoke(compileResult, "testStructLiteral2");
         Assert.assertEquals(returns.toString(),
-                "{\"name\":\"default first name\",\"lname\":\"\",\"adrs\":{},\"age\":999,\"child\":null}");
+                "{\"lname\":\"\",\"name\":\"default first name\",\"adrs\":{},\"age\":999,\"child\":null}");
     }
 
     @Test
     public void testStructLiteralInitFunc() {
         CompileResult result = BCompileUtil.compile("test-src/record/nested_record_inline_init.bal");
         Object returns = BRunUtil.invoke(result, "testCreateStruct");
-        Assert.assertEquals(returns.toString(),
-                "{\"name\":\"default first name\",\"fname\":\"\",\"lname\":\"Doe\",\"adrs\":{}," +
-                        "\"age\":999,\"family\":{\"spouse\":\"Jane\",\"noOfChildren\":0," +
-                        "\"children\":[\"Alex\",\"Bob\"]}}");
+        Assert.assertEquals(returns.toString(), "{\"lname\":\"Doe\",\"fname\":\"\"," +
+                "\"name\":\"default first name\",\"adrs\":{},\"family\":{\"spouse\":\"Jane\"," +
+                "\"children\":[\"Alex\",\"Bob\"],\"noOfChildren\":0},\"age\":999}");
     }
 
     @Test(description = "Negative test to test attaching functions to record literal")
@@ -188,10 +187,9 @@ public class OpenRecordTest {
 
         Assert.assertTrue(person.get(StringUtils.fromString("firstName")) instanceof BString);
         Assert.assertEquals(person.get(StringUtils.fromString("firstName")).toString(), "John");
-
-        Assert.assertEquals(person.toString(), "{\"name\":\"Foo\",\"lname\":\"\",\"adrs\":{},\"age\":25," +
-                "\"family\":{\"spouse\":\"\",\"noOfChildren\":0,\"children\":[]},\"parent\":null,\"mname\":\"Bar\"," +
-                "\"height\":5.9,\"firstName\":\"John\"}");
+        Assert.assertEquals(person.toString(), "{\"name\":\"Foo\",\"mname\":\"Bar\",\"age\":25," +
+                "\"height\":5.9,\"parent\":null,\"lname\":\"\",\"adrs\":{},\"family\":{\"children\":[]," +
+                "\"noOfChildren\":0,\"spouse\":\"\"},\"firstName\":\"John\"}");
     }
 
     @Test(description = "Test non-existent anydata or error rest field RHS index-based access")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordValueTest.java
@@ -154,7 +154,7 @@ public class RecordValueTest {
                 "{\"name\":\"Jane\",\"age\":25,\"spouse\":\"John\",\"gender\":\"female\"}");
     }
 
-    @Test(expectedExceptions = {UnsupportedOperationException.class})
+    @Test
     public void testRecordRemove() {
         Object result = BRunUtil.invokeAndGetJVMResult(compileResult, "getDefaultPerson");
         Assert.assertTrue(result instanceof MapValue);
@@ -162,7 +162,7 @@ public class RecordValueTest {
         person.remove(StringUtils.fromString("name"));
     }
 
-    @Test(expectedExceptions = {UnsupportedOperationException.class})
+    @Test
     public void testRecordClear() {
         Object result = BRunUtil.invokeAndGetJVMResult(compileResult, "getDefaultPerson");
         Assert.assertTrue(result instanceof MapValue);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
@@ -185,9 +185,8 @@ public class ArrayTest {
     public void testArraysOfCyclicDependentTypes() {
         Object retVals = BRunUtil.invoke(compileResult, "testArraysOfCyclicDependentTypes");
         BArray arr = (BArray) retVals;
-        Assert.assertEquals(arr.toString(),
-                "[{\"b\":{\"b1\":\"B1\"}},{\"b\":{\"b1\":\"B1\"}},{\"b\":{\"b1\":\"B1\"}},{\"b\":{\"b1\":\"B1\"}," +
-                        "\"a1\":\"A1\"}]");
+        Assert.assertEquals(arr.toString(), "[{\"b\":{\"b1\":\"B1\"}},{\"b\":{\"b1\":\"B1\"}}," +
+                "{\"b\":{\"b1\":\"B1\"}},{\"a1\":\"A1\",\"b\":{\"b1\":\"B1\"}}]");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructTest.java
@@ -157,10 +157,10 @@ public class StructTest {
     @Test(description = "Test negative default values in struct")
     public void testStructToString() {
         Object returns = BRunUtil.invoke(compileResult, "getStruct");
-        Assert.assertEquals(returns.toString(), "{\"name\":\"aaa\",\"lname\":\"\",\"adrs\":{},\"age\":25," +
-                "\"family\":{\"spouse\":\"\",\"noOfChildren\":0,\"children\":[]},\"parent\":{\"name\":\"bbb\"," +
-                "\"lname\":\"ccc\",\"adrs\":{},\"age\":50,\"family\":{\"spouse\":\"\",\"noOfChildren\":0," +
-                "\"children\":[]},\"parent\":null}}");
+        Assert.assertEquals(returns.toString(), "{\"name\":\"aaa\",\"age\":25," +
+                "\"parent\":{\"name\":\"bbb\",\"lname\":\"ccc\",\"age\":50,\"parent\":null,\"adrs\":{}," +
+                "\"family\":{\"children\":[],\"noOfChildren\":0,\"spouse\":\"\"}},\"lname\":\"\",\"adrs\":{}," +
+                "\"family\":{\"children\":[],\"noOfChildren\":0,\"spouse\":\"\"}}");
     }
 
     @Test
@@ -168,12 +168,13 @@ public class StructTest {
         CompileResult compileResult = BCompileUtil.compile(
                 "test-src/structs/ObjectWithPrivateFieldsTestProject/struct-literals.bal");
         Object returns = BRunUtil.invoke(compileResult, "testStructLiteral1");
-        Assert.assertEquals(returns.toString(), "{\"dptName\":\"\",\"employees\":[],\"manager\":{\"name\":\"default " +
-                "first name\",\"lname\":\"\",\"adrs\":{},\"age\":999,\"child\":null}}");
+        Assert.assertEquals(returns.toString(), "{\"manager\":{\"lname\":\"\"," +
+                "\"name\":\"default first name\",\"adrs\":{},\"age\":999,\"child\":null}," +
+                "\"dptName\":\"\",\"employees\":[]}");
 
         returns = BRunUtil.invoke(compileResult, "testStructLiteral2");
         Assert.assertEquals(returns.toString(),
-                "{\"name\":\"default first name\",\"lname\":\"\",\"adrs\":{},\"age\":999,\"child\":null}");
+                "{\"lname\":\"\",\"name\":\"default first name\",\"adrs\":{},\"age\":999,\"child\":null}");
     }
 
     @Test
@@ -181,9 +182,9 @@ public class StructTest {
         CompileResult result = BCompileUtil.compile(
                 "test-src/structs/ObjectWithPrivateFieldsTestProject/nested-struct-inline-init.bal");
         Object returns = BRunUtil.invoke(result, "testCreateStruct");
-        Assert.assertEquals(returns.toString(),
-                "{\"name\":\"default first name\",\"fname\":\"\",\"lname\":\"Doe\",\"adrs\":{},\"age\":999," +
-                        "\"family\":{\"spouse\":\"Jane\",\"noOfChildren\":0,\"children\":[\"Alex\",\"Bob\"]}}");
+        Assert.assertEquals(returns.toString(), "{\"lname\":\"Doe\",\"fname\":\"\"," +
+                "\"name\":\"default first name\",\"adrs\":{},\"family\":{\"spouse\":\"Jane\"," +
+                "\"children\":[\"Alex\",\"Bob\"],\"noOfChildren\":0},\"age\":999}");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/typedesc/TypedescTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/typedesc/TypedescTests.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.types.typedesc;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BTypedesc;
+import io.ballerina.runtime.internal.types.BTypeReferenceType;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
@@ -124,7 +125,8 @@ public class TypedescTests {
         Assert.assertEquals(returns.size(), 2);
         Assert.assertEquals(returns.get(0).toString(), "typedesc RecordA");
         Assert.assertTrue(returns.get(1) instanceof BTypedesc);
-        Assert.assertEquals(TypeTags.RECORD_TYPE_TAG, ((BTypedesc) returns.get(1)).getDescribingType().getTag());
+        Assert.assertEquals(TypeTags.RECORD_TYPE_TAG,
+                (((BTypeReferenceType) ((BTypedesc) returns.get(1)).getDescribingType())).getReferredType().getTag());
     }
 
     @Test(description = "Test any to typedesc cast")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/largePackage/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/largePackage/main.bal
@@ -50,7 +50,7 @@ public function main() {
     r:BigRecord1 bigRecord1 = {};
     r:BigRecord2 bigRecord2 = {'\/workers\/workAssignments\/assignmentStatus\/statusCode\/codeValue: "hello"};
     r:BigRecord3 bigRecord3 = {};
-    test:assertEquals(bigRecord1.v2.toString(), "{\"a\":\"hello\",\"b1\":5,\"m1\":{\"a\":\"apple\"},\"d1\":[1,2,3],\"t\":[{\"id\":1,\"firstName\":\"Waruna\"}]}");
+    test:assertEquals(bigRecord1.v2.toString(), "{\"a\":\"hello\",\"m1\":{\"a\":\"apple\"},\"t\":[{\"id\":1,\"firstName\":\"Waruna\"}],\"d1\":[1,2,3],\"b1\":5}");
     test:assertEquals(bigRecord2?.'\/workers\/workAssignments\/assignmentStatus\/statusCode\/codeValue, "hello");
     test:assertEquals(bigRecord3?.'\/workers\/workAssignments\/assignmentStatus\/statusCode\/codeValue, "waruna");   
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
@@ -530,8 +530,8 @@ function testTableTypeInferenceWithVarType2() {
     v1.add({...m});
     v1.add({a: true, c: 2, b: false});
 
-    assertEquality("[{\"a\":1},{\"a\":\"str\",\"b\":2},{\"a\":true,\"b\":false,\"c\":2}," +
-    "{\"a\":1},{\"a\":\"str\",\"b\":2},{\"a\":true,\"b\":false,\"c\":2}]", v1.toString());
+    assertEquality("[{\"a\":1},{\"a\":\"str\",\"b\":2},{\"a\":true,\"c\":2,\"b\":false},{\"a\":1}," +
+    "{\"a\":\"str\",\"b\":2},{\"a\":true,\"c\":2,\"b\":false}]", v1.toString());
 }
 
 function testTableTypeInferenceWithVarType3() {
@@ -581,8 +581,8 @@ function testTableTypeInferenceWithVarType5() {
     v1.add({...m});
     v1.add({[s1] : true, c: 2, [s2] : false});
 
-    assertEquality("[{\"a\":1},{\"a\":\"str\",\"b\":2},{\"a\":true,\"b\":false,\"c\":2},{\"a\":1}," +
-    "{\"a\":\"str\",\"b\":2},{\"a\":true,\"b\":false,\"c\":2}]", v1.toString());
+    assertEquality("[{\"a\":1},{\"a\":\"str\",\"b\":2},{\"c\":2,\"a\":true,\"b\":false},{\"a\":1}," +
+    "{\"a\":\"str\",\"b\":2},{\"c\":2,\"a\":true,\"b\":false}]", v1.toString());
 }
 
 type FooUnion int|string;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-type-table-key.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-type-table-key.bal
@@ -85,7 +85,7 @@ type Employee1 record {
 type EmployeeTable table<Employee1> key<EmployeeId>;
 
 function testTableTypeWithMultiFieldKeys() {
-    string expected = "[{\"leaves\":10,\"firstname\":\"John\",\"lastname\":\"Wick\"}]";
+    string expected = "[{\"firstname\":\"John\",\"lastname\":\"Wick\",\"leaves\":10}]";
     table<Employee1> key<EmployeeId> t1 = table key(firstname,lastname) [{firstname: "John", lastname: "Wick", leaves: 10}];
     assertEquality(expected, t1.toString());
 


### PR DESCRIPTION
## Purpose
> $title.

Fixes #38844
Fixes #41946

In this PR, I have generated a new 'typedesc' (type descriptor) only once for the tuple and record. 
For example:
```
type Foo record {||};
public function main() {
    Foo f = {};
}
```

We have desugared the above program as follows:

```
type Foo record {||};
typedesc<Foo> typedesc = Foo;
public function main() {
    Foo f = {};
}
```
We then use the generated 'typedesc' when creating a map value using that type.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
