### PR TITLE
Avoid unnessary boxing when setting record fields

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MapUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MapUtils.java
@@ -52,6 +52,17 @@ public class MapUtils {
         updateMapValue(TypeUtils.getImpliedType(mapValue.getType()), mapValue, fieldName, value);
     }
 
+    public static void handleMapStore(MapValue<BString, Object> mapValue, BString fieldName, long value) {
+        updateMapValue(TypeUtils.getImpliedType(mapValue.getType()), mapValue, fieldName, value);
+    }
+
+    public static void handleMapStore(MapValue<BString, Object> mapValue, BString fieldName, boolean value) {
+        updateMapValue(TypeUtils.getImpliedType(mapValue.getType()), mapValue, fieldName, value);
+    }
+
+    public static void handleMapStore(MapValue<BString, Object> mapValue, BString fieldName, double value) {
+        updateMapValue(TypeUtils.getImpliedType(mapValue.getType()), mapValue, fieldName, value);
+    }
     public static void handleInherentTypeViolatingMapUpdate(Object value, BMapType mapType) {
         if (TypeChecker.checkIsType(value, mapType.getConstrainedType())) {
             return;
@@ -83,7 +94,6 @@ public class MapUtils {
                         ErrorHelper.getErrorDetails(ErrorCodes.RECORD_INVALID_READONLY_FIELD_UPDATE,
                                                              fieldName, mapValue.getType()));
             }
-
             // If it can be updated, use it.
             recFieldType = recField.getFieldType();
             if (value == null && SymbolFlags.isFlagOn(recField.getFlags(), SymbolFlags.OPTIONAL)
@@ -160,5 +170,41 @@ public class MapUtils {
             case TypeTags.TYPE_REFERENCED_TYPE_TAG:
                 updateMapValue(((BTypeReferenceType) mapType).getReferredType(), mapValue, fieldName, value);
         }
+    }
+
+    private static void updateMapValue(Type mapType, MapValue<BString, Object> mapValue, BString fieldName,
+                                       long value) {
+        if (mapType.getTag() != TypeTags.RECORD_TYPE_TAG) {
+            throw new IllegalArgumentException("Typed record store is only supported for records");
+        }
+        if (handleInherentTypeViolatingRecordUpdate(mapValue, fieldName, value, (BRecordType) mapType, false)) {
+            mapValue.put(fieldName, value);
+            return;
+        }
+        mapValue.remove(fieldName);
+    }
+
+    private static void updateMapValue(Type mapType, MapValue<BString, Object> mapValue, BString fieldName,
+                                       boolean value) {
+        if (mapType.getTag() != TypeTags.RECORD_TYPE_TAG) {
+            throw new IllegalArgumentException("Typed record store is only supported for records");
+        }
+        if (handleInherentTypeViolatingRecordUpdate(mapValue, fieldName, value, (BRecordType) mapType, false)) {
+            mapValue.put(fieldName, value);
+            return;
+        }
+        mapValue.remove(fieldName);
+    }
+
+    private static void updateMapValue(Type mapType, MapValue<BString, Object> mapValue, BString fieldName,
+                                       double value) {
+        if (mapType.getTag() != TypeTags.RECORD_TYPE_TAG) {
+            throw new IllegalArgumentException("Typed record store is only supported for records");
+        }
+        if (handleInherentTypeViolatingRecordUpdate(mapValue, fieldName, value, (BRecordType) mapType, false)) {
+            mapValue.put(fieldName, value);
+            return;
+        }
+        mapValue.remove(fieldName);
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MapUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MapUtils.java
@@ -39,7 +39,6 @@ import static io.ballerina.runtime.api.PredefinedTypes.TYPE_BOOLEAN;
 import static io.ballerina.runtime.api.PredefinedTypes.TYPE_FLOAT;
 import static io.ballerina.runtime.api.PredefinedTypes.TYPE_INT;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.MAP_LANG_LIB;
-import static io.ballerina.runtime.internal.TypeChecker.checkIsType;
 import static io.ballerina.runtime.internal.errors.ErrorReasons.INHERENT_TYPE_VIOLATION_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.errors.ErrorReasons.MAP_KEY_NOT_FOUND_ERROR;
 import static io.ballerina.runtime.internal.errors.ErrorReasons.OPERATION_NOT_SUPPORTED_IDENTIFIER;
@@ -85,7 +84,7 @@ public class MapUtils {
     }
 
     public static void handleInherentTypeViolatingMapUpdate(Object value, BMapType mapType) {
-        if (checkIsType(value, mapType.getConstrainedType())) {
+        if (TypeChecker.checkIsType(value, mapType.getConstrainedType())) {
             return;
         }
 
@@ -129,7 +128,7 @@ public class MapUtils {
     // Note this will box the value
     private static void handleInherentTypeViolatingRecordUpdateFinish(Type inherentFieldType, BString fieldName,
                                                                       Object value) {
-        if (checkIsType(value, inherentFieldType)) {
+        if (TypeChecker.checkIsType(value, inherentFieldType)) {
             return;
         }
         Type valuesType = TypeChecker.getType(value);
@@ -154,7 +153,7 @@ public class MapUtils {
                 throw ErrorCreator.createError(
                         getModulePrefixedReason(MAP_LANG_LIB, INHERENT_TYPE_VIOLATION_ERROR_IDENTIFIER),
                         ErrorHelper.getErrorDetails(ErrorCodes.RECORD_INVALID_READONLY_FIELD_UPDATE,
-                                fieldName, mapValue.getType()));
+                                                             fieldName, mapValue.getType()));
             }
 
             // If it can be updated, use it.
@@ -173,16 +172,16 @@ public class MapUtils {
                     ErrorCodes.INVALID_RECORD_FIELD_ACCESS, fieldName, mapValue.getType()));
         }
 
-        if (checkIsType(value, recFieldType)) {
+        if (TypeChecker.checkIsType(value, recFieldType)) {
             return true;
         }
         Type valuesType = TypeChecker.getType(value);
 
         throw ErrorCreator.createError(getModulePrefixedReason(MAP_LANG_LIB,
-                        INHERENT_TYPE_VIOLATION_ERROR_IDENTIFIER),
-                ErrorHelper.getErrorDetails(
-                        ErrorCodes.INVALID_RECORD_FIELD_ADDITION, fieldName, recFieldType,
-                        valuesType));
+                                                               INHERENT_TYPE_VIOLATION_ERROR_IDENTIFIER),
+                                       ErrorHelper.getErrorDetails(
+                                                  ErrorCodes.INVALID_RECORD_FIELD_ADDITION, fieldName, recFieldType,
+                                                  valuesType));
     }
 
     private static boolean containsNilType(Type type) {
@@ -234,5 +233,4 @@ public class MapUtils {
                 updateMapValue(((BTypeReferenceType) mapType).getReferredType(), mapValue, fieldName, value);
         }
     }
-
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MapUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MapUtils.java
@@ -52,11 +52,11 @@ import static io.ballerina.runtime.internal.errors.ErrorReasons.getModulePrefixe
  */
 public class MapUtils {
 
-    // FIXME: may be shouldn't overload this instead use named functions
     public static void handleMapStore(MapValue<BString, Object> mapValue, BString fieldName, Object value) {
         updateMapValue(TypeUtils.getImpliedType(mapValue.getType()), mapValue, fieldName, value);
     }
 
+    // We are monomorphizing handleMapStore and updateMapValue to avoid boxing when storing basic type values in records
     public static void handleMapStore(MapValue<BString, Object> mapValue, BString fieldName, long value) {
         updateMapValue(TypeUtils.getImpliedType(mapValue.getType()), mapValue, fieldName, value);
     }
@@ -207,7 +207,7 @@ public class MapUtils {
             throw new IllegalArgumentException("Unboxed store is only supported for records");
         }
         if (handleInherentTypeViolatingRecordUpdateSimple(mapValue, fieldName, TYPE_INT, (BRecordType) mapType)) {
-            mapValue.put(fieldName, value);
+            mapValue.putInt(fieldName, value);
             return;
         }
         mapValue.remove(fieldName);
@@ -219,7 +219,7 @@ public class MapUtils {
             throw new IllegalArgumentException("Unboxed store is only supported for records");
         }
         if (handleInherentTypeViolatingRecordUpdateSimple(mapValue, fieldName, TYPE_BOOLEAN, (BRecordType) mapType)) {
-            mapValue.put(fieldName, value);
+            mapValue.putBoolean(fieldName, value);
             return;
         }
         mapValue.remove(fieldName);
@@ -231,7 +231,7 @@ public class MapUtils {
             throw new IllegalArgumentException("Unboxed store is only supported for records");
         }
         if (handleInherentTypeViolatingRecordUpdateSimple(mapValue, fieldName, TYPE_FLOAT, (BRecordType) mapType)) {
-            mapValue.put(fieldName, value);
+            mapValue.putFloat(fieldName, value);
             return;
         }
         mapValue.remove(fieldName);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValue.java
@@ -34,4 +34,11 @@ import io.ballerina.runtime.api.values.BMap;
  */
 public interface MapValue<K, V> extends RefValue, CollectionValue, BMap<K, V> {
 
+    V put(K key, long value);
+
+    V put(K key, double value);
+
+    V put(K key, boolean value);
+
+    boolean isReadonly();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValue.java
@@ -34,6 +34,7 @@ import io.ballerina.runtime.api.values.BMap;
  */
 public interface MapValue<K, V> extends RefValue, CollectionValue, BMap<K, V> {
 
+    // FIXME: may be we shouldn't overload put
     V put(K key, long value);
 
     V put(K key, double value);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValue.java
@@ -34,7 +34,6 @@ import io.ballerina.runtime.api.values.BMap;
  */
 public interface MapValue<K, V> extends RefValue, CollectionValue, BMap<K, V> {
 
-    // FIXME: may be we shouldn't overload put
     void putInt(K key, long value);
 
     void putFloat(K key, double value);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValue.java
@@ -35,11 +35,11 @@ import io.ballerina.runtime.api.values.BMap;
 public interface MapValue<K, V> extends RefValue, CollectionValue, BMap<K, V> {
 
     // FIXME: may be we shouldn't overload put
-    V put(K key, long value);
+    void putInt(K key, long value);
 
-    V put(K key, double value);
+    void putFloat(K key, double value);
 
-    V put(K key, boolean value);
+    void putBoolean(K key, boolean value);
 
     boolean isReadonly();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -128,7 +128,23 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
     }
 
     public Long getIntValue(BString key) {
-        return (Long) get(key);
+        Object value = get(key);
+        if (value instanceof Integer) { // field is an int subtype
+            return ((Integer) value).longValue();
+        }
+        return (Long) value;
+    }
+
+    public long getUnboxedIntValue(BString key) {
+        return getIntValue(key);
+    }
+
+    public double getUnboxedFloatValue(BString key) {
+        return getFloatValue(key);
+    }
+
+    public boolean getUnboxedBooleanValue(BString key) {
+        return getBooleanValue(key);
     }
 
     public Double getFloatValue(BString key) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -587,18 +587,18 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
     }
 
     @Override
-    public V put(K key, long value) {
-        return put(key, (V) Long.valueOf(value));
+    public void putInt(K key, long value) {
+        put(key, (V) Long.valueOf(value));
     }
 
     @Override
-    public V put(K key, double value) {
-        return put(key, (V) Double.valueOf(value));
+    public void putFloat(K key, double value) {
+        put(key, (V) Double.valueOf(value));
     }
 
     @Override
-    public V put(K key, boolean value) {
-        return put(key, (V) Boolean.valueOf(value));
+    public void putBoolean(K key, boolean value) {
+        put(key, (V) Boolean.valueOf(value));
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BFunctionPointer;
@@ -583,6 +584,26 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
     @Override
     public IteratorValue getIterator() {
         return new MapIterator<>(new LinkedHashSet<>(this.entrySet()).iterator());
+    }
+
+    @Override
+    public V put(K key, long value) {
+        return put(key, (V) Long.valueOf(value));
+    }
+
+    @Override
+    public V put(K key, double value) {
+        return put(key, (V) Double.valueOf(value));
+    }
+
+    @Override
+    public V put(K key, boolean value) {
+        return put(key, (V) Boolean.valueOf(value));
+    }
+
+    @Override
+    public boolean isReadonly() {
+        return TypeUtils.getImpliedType(getType()).isReadOnly();
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -211,12 +211,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
 import javax.xml.XMLConstants;
 
 import static org.ballerinalang.model.tree.NodeKind.CLASS_DEFN;
 import static org.ballerinalang.model.tree.NodeKind.INVOCATION;
-import static org.ballerinalang.model.tree.NodeKind.LITERAL;
 import static org.ballerinalang.model.tree.NodeKind.STATEMENT_EXPRESSION;
 import static org.wso2.ballerinalang.compiler.bir.writer.BIRWriterUtils.createBIRAnnotationAttachment;
 import static org.wso2.ballerinalang.compiler.bir.writer.BIRWriterUtils.getBIRAnnotAttachments;
@@ -2832,18 +2830,10 @@ public class BIRGen extends BLangNodeVisitor {
             } else {
                 insKind = InstructionKind.MAP_LOAD;
             }
-            BIRNonTerminator.FieldAccess ins;
-            if (astIndexBasedAccessExpr.indexExpr.getKind() == LITERAL) {
-                BLangLiteral literal = (BLangLiteral) astIndexBasedAccessExpr.indexExpr;
-                ins = new BIRNonTerminator.RecordFieldAccess(astIndexBasedAccessExpr.pos, insKind, tempVarRef,
-                        keyRegIndex,
-                        varRefRegIndex, except,
-                        astIndexBasedAccessExpr.isLValue && !astIndexBasedAccessExpr.leafNode, (String) literal.value);
-            } else {
-                ins = new BIRNonTerminator.FieldAccess(astIndexBasedAccessExpr.pos, insKind, tempVarRef, keyRegIndex,
-                        varRefRegIndex, except, astIndexBasedAccessExpr.isLValue && !astIndexBasedAccessExpr.leafNode);
-            }
-            setScopeAndEmit(ins);
+            setScopeAndEmit(
+                    new BIRNonTerminator.FieldAccess(astIndexBasedAccessExpr.pos, insKind, tempVarRef, keyRegIndex,
+                            varRefRegIndex, except,
+                            astIndexBasedAccessExpr.isLValue && !astIndexBasedAccessExpr.leafNode));
             this.env.targetOperand = tempVarRef;
         }
         this.varAssignment = variableStore;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -211,6 +211,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
 import javax.xml.XMLConstants;
 
 import static org.ballerinalang.model.tree.NodeKind.CLASS_DEFN;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -216,6 +216,7 @@ import javax.xml.XMLConstants;
 
 import static org.ballerinalang.model.tree.NodeKind.CLASS_DEFN;
 import static org.ballerinalang.model.tree.NodeKind.INVOCATION;
+import static org.ballerinalang.model.tree.NodeKind.LITERAL;
 import static org.ballerinalang.model.tree.NodeKind.STATEMENT_EXPRESSION;
 import static org.wso2.ballerinalang.compiler.bir.writer.BIRWriterUtils.createBIRAnnotationAttachment;
 import static org.wso2.ballerinalang.compiler.bir.writer.BIRWriterUtils.getBIRAnnotAttachments;
@@ -2831,10 +2832,18 @@ public class BIRGen extends BLangNodeVisitor {
             } else {
                 insKind = InstructionKind.MAP_LOAD;
             }
-            setScopeAndEmit(
-                    new BIRNonTerminator.FieldAccess(astIndexBasedAccessExpr.pos, insKind, tempVarRef, keyRegIndex,
-                            varRefRegIndex, except,
-                            astIndexBasedAccessExpr.isLValue && !astIndexBasedAccessExpr.leafNode));
+            BIRNonTerminator.FieldAccess ins;
+            if (astIndexBasedAccessExpr.indexExpr.getKind() == LITERAL) {
+                BLangLiteral literal = (BLangLiteral) astIndexBasedAccessExpr.indexExpr;
+                ins = new BIRNonTerminator.RecordFieldAccess(astIndexBasedAccessExpr.pos, insKind, tempVarRef,
+                        keyRegIndex,
+                        varRefRegIndex, except,
+                        astIndexBasedAccessExpr.isLValue && !astIndexBasedAccessExpr.leafNode, (String) literal.value);
+            } else {
+                ins = new BIRNonTerminator.FieldAccess(astIndexBasedAccessExpr.pos, insKind, tempVarRef, keyRegIndex,
+                        varRefRegIndex, except, astIndexBasedAccessExpr.isLValue && !astIndexBasedAccessExpr.leafNode);
+            }
+            setScopeAndEmit(ins);
             this.env.targetOperand = tempVarRef;
         }
         this.varAssignment = variableStore;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
@@ -86,7 +86,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_TO_STRING_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_TO_UNSIGNED_INT_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.LONG_VALUE;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MAP_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MAP_VALUE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.NUMBER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.REG_EXP_VALUE;
@@ -1331,7 +1331,7 @@ public class JvmCastGen {
                 break;
             case TypeTags.MAP:
             case TypeTags.RECORD:
-                targetTypeClass = MAP_VALUE;
+                targetTypeClass = MAP_VALUE_IMPL;
                 break;
             case TypeTags.TABLE:
                 targetTypeClass = TABLE_VALUE;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -52,12 +52,10 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
-import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -1467,23 +1467,20 @@ public class JvmInstructionGen {
             jvmCastGen.addBoxInsn(this.mv, valueType);
             this.mv.visitMethodInsn(INVOKEINTERFACE, MAP_VALUE, "populateInitialValue",
                                     TWO_OBJECTS_ARGS, true);
-        } else {
-            String methodDesc;
-            if (varRefType.tag == TypeTags.RECORD) {
-                methodDesc = switch (valueType.getKind()) {
-                    case INT -> HANDLE_MAP_STORE_INT;
-                    case BOOLEAN -> HANDLE_MAP_STORE_BOOLEAN;
-                    case FLOAT -> HANDLE_MAP_STORE_FLOAT;
-                    default -> {
-                        jvmCastGen.addBoxInsn(this.mv, valueType);
-                        yield HANDLE_MAP_STORE;
-                    }
-                };
-            } else {
-                jvmCastGen.addBoxInsn(this.mv, valueType);
-                methodDesc = HANDLE_MAP_STORE;
-            }
+        } else if (varRefType.tag == TypeTags.RECORD) {
+            String methodDesc = switch (valueType.getKind()) {
+                case INT -> HANDLE_MAP_STORE_INT;
+                case BOOLEAN -> HANDLE_MAP_STORE_BOOLEAN;
+                case FLOAT -> HANDLE_MAP_STORE_FLOAT;
+                default -> {
+                    jvmCastGen.addBoxInsn(this.mv, valueType);
+                    yield HANDLE_MAP_STORE;
+                }
+            };
             this.mv.visitMethodInsn(INVOKESTATIC, MAP_UTILS, "handleMapStore", methodDesc, false);
+        } else {
+            jvmCastGen.addBoxInsn(this.mv, valueType);
+            this.mv.visitMethodInsn(INVOKESTATIC, MAP_UTILS, "handleMapStore", HANDLE_MAP_STORE, false);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -381,7 +381,14 @@ public class JvmSignatures {
     public static final String OBJECT_TYPE_DUPLICATE = "()L" + OBJECT_TYPE_IMPL + ";";
     public static final String OBJECT_TYPE_IMPL_INIT = "(L" + TYPE + ";)V";
     public static final String PANIC_IF_IN_LOCK = "(L" + STRAND_CLASS + ";)V";
-    public static final String PASS_BSTRING_RETURN_OBJECT = "(L" + B_STRING_VALUE + ";)L" + OBJECT + ";";
+    public static final String PASS_B_STRING_RETURN_OBJECT = "(L" + B_STRING_VALUE + ";)L" + OBJECT + ";";
+    public static final String PASS_B_STRING_RETURN_LONG = "(L" + B_STRING_VALUE + ";)L" + LONG_VALUE + ";";
+    public static final String PASS_B_STRING_RETURN_UNBOXED_LONG = "(L" + B_STRING_VALUE + ";)J";
+    public static final String PASS_B_STRING_RETURN_DOUBLE = "(L" + B_STRING_VALUE + ";)L" + DOUBLE_VALUE + ";";
+    public static final String PASS_B_STRING_RETURN_UNBOXED_DOUBLE = "(L" + B_STRING_VALUE + ";)D";
+    public static final String PASS_B_STRING_RETURN_BSTRING = "(L" + B_STRING_VALUE + ";)L" + B_STRING_VALUE + ";";
+    public static final String PASS_B_STRING_RETURN_BOOLEAN = "(L" + B_STRING_VALUE + ";)L" + BOOLEAN_VALUE + ";";
+    public static final String PASS_B_STRING_RETURN_UNBOXED_BOOLEAN = "(L" + B_STRING_VALUE + ";)Z";
     public static final String PASS_OBJECT_RETURN_OBJECT = "(L" + OBJECT + ";)L" + OBJECT + ";";
     public static final String PASS_OBJECT_RETURN_SAME_TYPE = "(L" + OBJECT + ";)TV;";
     public static final String POPULATE_ATTACHED_FUNCTION = "([L" + METHOD_TYPE_IMPL + ";)V";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -393,9 +393,9 @@ public class JvmSignatures {
     public static final String PASS_B_STRING_RETURN_DOUBLE = "(L" + B_STRING_VALUE + ";)L" + DOUBLE_VALUE + ";";
     public static final String PASS_B_STRING_RETURN_UNBOXED_DOUBLE = "(L" + B_STRING_VALUE + ";)D";
     public static final String PASS_B_STRING_RETURN_BSTRING = "(L" + B_STRING_VALUE + ";)L" + B_STRING_VALUE + ";";
-    public static final String INT_RECORD_PUT = "(L" + OBJECT + ";J)L" + OBJECT + ";";
-    public static final String BOOLEAN_RECORD_PUT = "(L" + OBJECT + ";Z)L" + OBJECT + ";";
-    public static final String DOUBLE_RECORD_PUT = "(L" + OBJECT + ";D)L" + OBJECT + ";";
+    public static final String RECORD_PUT_INT = "(L" + OBJECT + ";J)V";
+    public static final String RECORD_PUT_BOOLEAN = "(L" + OBJECT + ";Z)V";
+    public static final String RECORD_PUT_FLOAT = "(L" + OBJECT + ";D)V";
     public static final String PASS_B_STRING_RETURN_BOOLEAN = "(L" + B_STRING_VALUE + ";)L" + BOOLEAN_VALUE + ";";
     public static final String PASS_B_STRING_RETURN_UNBOXED_BOOLEAN = "(L" + B_STRING_VALUE + ";)Z";
     public static final String PASS_OBJECT_RETURN_OBJECT = "(L" + OBJECT + ";)L" + OBJECT + ";";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -268,6 +268,12 @@ public class JvmSignatures {
     public static final String HANDLE_ERROR_RETURN = "(L" + OBJECT + ";)V";
     public static final String HANDLE_FLUSH = "([L" + CHANNEL_DETAILS + ";)L" + ERROR_VALUE + ";";
     public static final String HANDLE_MAP_STORE = "(L" + MAP_VALUE + ";L" + B_STRING_VALUE + ";L" + OBJECT + ";)V";
+    public static final String HANDLE_MAP_STORE_INT =
+            "(L" + MAP_VALUE + ";L" + B_STRING_VALUE + ";J)V";
+    public static final String HANDLE_MAP_STORE_BOOLEAN =
+            "(L" + MAP_VALUE + ";L" + B_STRING_VALUE + ";Z)V";
+    public static final String HANDLE_MAP_STORE_FLOAT =
+            "(L" + MAP_VALUE + ";L" + B_STRING_VALUE + ";D)V";
     public static final String HANDLE_STOP_PANIC = "(L" + THROWABLE + ";)V";
     public static final String HANDLE_TABLE_STORE = "(L" + TABLE_VALUE + ";L" + OBJECT + ";L" + OBJECT + ";)V";
     public static final String HANDLE_THROWABLE = "(L" + JvmConstants.THROWABLE + ";)V";
@@ -387,6 +393,9 @@ public class JvmSignatures {
     public static final String PASS_B_STRING_RETURN_DOUBLE = "(L" + B_STRING_VALUE + ";)L" + DOUBLE_VALUE + ";";
     public static final String PASS_B_STRING_RETURN_UNBOXED_DOUBLE = "(L" + B_STRING_VALUE + ";)D";
     public static final String PASS_B_STRING_RETURN_BSTRING = "(L" + B_STRING_VALUE + ";)L" + B_STRING_VALUE + ";";
+    public static final String INT_RECORD_PUT = "(L" + OBJECT + ";J)L" + OBJECT + ";";
+    public static final String BOOLEAN_RECORD_PUT = "(L" + OBJECT + ";Z)L" + OBJECT + ";";
+    public static final String DOUBLE_RECORD_PUT = "(L" + OBJECT + ";D)L" + OBJECT + ";";
     public static final String PASS_B_STRING_RETURN_BOOLEAN = "(L" + B_STRING_VALUE + ";)L" + BOOLEAN_VALUE + ";";
     public static final String PASS_B_STRING_RETURN_UNBOXED_BOOLEAN = "(L" + B_STRING_VALUE + ";)Z";
     public static final String PASS_OBJECT_RETURN_OBJECT = "(L" + OBJECT + ";)L" + OBJECT + ";";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
+import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PROTECTED;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
@@ -317,7 +318,8 @@ public class JvmValueGen {
         }
         JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen, types);
         LambdaGen lambdaGen = new LambdaGen(jvmPackageGen, jvmCastGen);
-        cw.visit(V17, ACC_PUBLIC + ACC_SUPER, className, RECORD_VALUE_CLASS, MAP_VALUE_IMPL, new String[]{MAP_VALUE});
+        cw.visit(V17, ACC_PUBLIC + ACC_SUPER + ACC_FINAL, className, RECORD_VALUE_CLASS, MAP_VALUE_IMPL,
+                new String[]{MAP_VALUE});
 
         Map<String, BField> fields = recordType.fields;
         this.createRecordFields(cw, fields);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
@@ -62,7 +62,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.CHECK_FI
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_JSTRING;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_OBJECT_FOR_STRING;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.OBJECT_SET;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_BSTRING_RETURN_OBJECT;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_B_STRING_RETURN_OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PASS_OBJECT_RETURN_SAME_TYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SET_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.getTypeDesc;
@@ -174,7 +174,7 @@ public class JvmObjectGen {
 
     public void createAndSplitGetMethod(ClassWriter cw, Map<String, BField> fields, String className,
                                         JvmCastGen jvmCastGen) {
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "get", PASS_BSTRING_RETURN_OBJECT,
+        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "get", PASS_B_STRING_RETURN_OBJECT,
                 PASS_OBJECT_RETURN_SAME_TYPE, null);
         mv.visitCode();
         int selfIndex = 0;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmRecordGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmRecordGen.java
@@ -968,8 +968,8 @@ public class JvmRecordGen {
                                           String methodDesc, String signature) {
         List<BField> sortedFields = fields.values().stream()
                 .filter(field -> field.type.getKind() == basicType &&
-                        !isOptionalRecordField(field)) // optional fields will be handled by the default get method
-                .limit(MAX_FIELDS_PER_SPLIT_METHOD) // rest will go through the default get method
+                        !isOptionalRecordField(field)) // optional fields will be handled by the default set method
+                .limit(MAX_FIELDS_PER_SPLIT_METHOD) // rest will go through the default set method
                 .sorted(FIELD_NAME_HASH_COMPARATOR)
                 .toList();
         if (sortedFields.isEmpty()) {
@@ -987,7 +987,7 @@ public class JvmRecordGen {
         mv.visitVarInsn(ALOAD, selfRegister);
         mv.visitMethodInsn(INVOKEVIRTUAL, className, "isReadonly", "()Z", false);
         mv.visitJumpInsn(IFEQ, notReadonly);
-        // if it is readonly we'll simply call the super method which will construct the error for us
+        // If it is readonly we'll call the super method which will construct the error for us
         mv.visitVarInsn(ALOAD, selfRegister);
         mv.visitVarInsn(ALOAD, fieldNameBStringReg);
         int loadIns = switch (basicType) {
@@ -1024,7 +1024,7 @@ public class JvmRecordGen {
         }
 
         // This could happen when we access the rest field, having more than 500 fields or optional field,
-        // in which case we will simply call the default putValue method
+        // in which case we will call the default putValue method
         mv.visitLabel(defaultCaseLabel);
         mv.visitVarInsn(ALOAD, selfRegister);
         mv.visitVarInsn(ALOAD, fieldNameStringReg);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNonTerminator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNonTerminator.java
@@ -442,17 +442,6 @@ public abstract class BIRNonTerminator extends BIRAbstractInstruction implements
         }
     }
 
-    public static class RecordFieldAccess extends FieldAccess {
-
-        final String fieldName;
-
-        public RecordFieldAccess(Location pos, InstructionKind kind, BIROperand lhsOp, BIROperand keyOp,
-                                 BIROperand rhsOp, boolean optionalFieldAccess, boolean fillingRead, String fieldName) {
-            super(pos, kind, lhsOp, keyOp, rhsOp, optionalFieldAccess, fillingRead);
-            this.fieldName = fieldName;
-        }
-    }
-
     /**
      * An error constructor expression.
      * <p>

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNonTerminator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNonTerminator.java
@@ -442,6 +442,17 @@ public abstract class BIRNonTerminator extends BIRAbstractInstruction implements
         }
     }
 
+    public static class RecordFieldAccess extends FieldAccess {
+
+        final String fieldName;
+
+        public RecordFieldAccess(Location pos, InstructionKind kind, BIROperand lhsOp, BIROperand keyOp,
+                                 BIROperand rhsOp, boolean optionalFieldAccess, boolean fillingRead, String fieldName) {
+            super(pos, kind, lhsOp, keyOp, rhsOp, optionalFieldAccess, fillingRead);
+            this.fieldName = fieldName;
+        }
+    }
+
     /**
      * An error constructor expression.
      * <p>

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -2468,7 +2468,7 @@ public class Desugar extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangAssignment assignNode) {
-        boolean isOptionalFieldAssignment = isOptionalFieldAssignment(assignNode);
+        boolean isOptionalFieldAssignment = isOptionalBasicTypeFieldAssignment(assignNode);
         assignNode.varRef = rewriteExpr(assignNode.varRef);
         assignNode.expr = rewriteExpr(assignNode.expr);
         BType castingType = assignNode.varRef.getBType();
@@ -2479,7 +2479,7 @@ public class Desugar extends BLangNodeVisitor {
         result = assignNode;
     }
 
-    private boolean isOptionalFieldAssignment(BLangAssignment assignNode) {
+    private boolean isOptionalBasicTypeFieldAssignment(BLangAssignment assignNode) {
         if (assignNode.varRef.getKind() != NodeKind.FIELD_BASED_ACCESS_EXPR) {
             return false;
         }
@@ -2490,10 +2490,14 @@ public class Desugar extends BLangNodeVisitor {
         }
         BRecordType recordType = (BRecordType) targetType;
         BField field = recordType.fields.get(fieldAccessNode.field.value);
-        if (field == null) {
+        if (field == null || (field.symbol.flags & Flags.OPTIONAL) != Flags.OPTIONAL) {
             return false;
         }
-        return (field.symbol.flags & Flags.OPTIONAL) == Flags.OPTIONAL;
+        BType fieldType = field.getType();
+        return switch (fieldType.getKind()) {
+            case BOOLEAN, FLOAT, STRING, DECIMAL -> true;
+            default -> TypeTags.isIntegerTypeTag(fieldType.tag);
+        };
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -2480,24 +2480,22 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private boolean isOptionalBasicTypeFieldAssignment(BLangAssignment assignNode) {
-        if (assignNode.varRef.getKind() != NodeKind.FIELD_BASED_ACCESS_EXPR) {
+        BLangNode varRef = assignNode.varRef;
+        if (varRef.getKind() != NodeKind.FIELD_BASED_ACCESS_EXPR) {
             return false;
         }
-        BLangFieldBasedAccess fieldAccessNode = (BLangFieldBasedAccess) assignNode.varRef;
+        BLangFieldBasedAccess fieldAccessNode = (BLangFieldBasedAccess) varRef;
         BType targetType = Types.getImpliedType(fieldAccessNode.expr.getBType());
-        if (targetType.getKind() != TypeKind.RECORD) {
+        if (targetType.tag != TypeTags.RECORD) {
             return false;
         }
         BRecordType recordType = (BRecordType) targetType;
         BField field = recordType.fields.get(fieldAccessNode.field.value);
-        if (field == null || (field.symbol.flags & Flags.OPTIONAL) != Flags.OPTIONAL) {
+        if (field == null || !Symbols.isOptional(field.symbol)) {
             return false;
         }
-        BType fieldType = field.getType();
-        return switch (fieldType.getKind()) {
-            case BOOLEAN, FLOAT, STRING, DECIMAL -> true;
-            default -> TypeTags.isIntegerTypeTag(fieldType.tag);
-        };
+        BType fieldType = Types.getImpliedType(field.getType());
+        return TypeTags.isSimpleBasicType(fieldType.tag);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -118,7 +118,6 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangCheckedExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstant;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLetExpression;
@@ -246,6 +245,7 @@ import static org.ballerinalang.model.tree.NodeKind.NUMERIC_LITERAL;
 import static org.ballerinalang.model.tree.NodeKind.RECORD_LITERAL_EXPR;
 import static org.ballerinalang.model.tree.NodeKind.REG_EXP_CAPTURING_GROUP;
 import static org.ballerinalang.model.tree.NodeKind.REG_EXP_CHARACTER_CLASS;
+import static org.wso2.ballerinalang.compiler.util.CompilerUtils.isOptionalFieldAssignment;
 
 /**
  * @since 0.94
@@ -2311,15 +2311,20 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         validateFunctionVarRef(varRef, data);
 
         checkInvalidTypeDef(varRef);
-        if (varRef.getKind() == NodeKind.FIELD_BASED_ACCESS_EXPR && data.expType.tag != TypeTags.SEMANTIC_ERROR) {
-            BLangFieldBasedAccess fieldBasedAccessVarRef = (BLangFieldBasedAccess) varRef;
-            int varRefTypeTag = Types.getImpliedType(fieldBasedAccessVarRef.expr.getBType()).tag;
-            if (varRefTypeTag == TypeTags.RECORD && Symbols.isOptional(fieldBasedAccessVarRef.symbol)) {
-                data.expType = types.addNilForNillableAccessType(data.expType);
-            }
+        BType actualExpectedType = null;
+        // For optional field assignments we add nil to the expected type before doing type checking in order to get
+        // the type in error messages correct. But we don't need an implicit conversion since desugar will add a
+        // cast if needed.
+        if (data.expType.tag != TypeTags.SEMANTIC_ERROR && isOptionalFieldAssignment(assignNode)) {
+            actualExpectedType = data.expType;
+            data.expType = types.addNilForNillableAccessType(data.expType);
         }
 
-        data.typeChecker.checkExpr(assignNode.expr, data.env, data.expType, data.prevEnvs, data.commonAnalyzerData);
+        BLangExpression expr = assignNode.expr;
+        data.typeChecker.checkExpr(expr, data.env, data.expType, data.prevEnvs, data.commonAnalyzerData);
+        if (actualExpectedType != null && expr.impConversionExpr != null) {
+            data.typeChecker.resetImpConversionExpr(expr, expr.getBType(), actualExpectedType);
+        }
 
         validateWorkerAnnAttachments(assignNode.expr, data);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6325,7 +6325,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         data.resultType = types.checkType(checkedExpr, actualType, data.expType);
     }
 
-    private void resetImpConversionExpr(BLangExpression expr, BType actualType, BType targetType) {
+    protected void resetImpConversionExpr(BLangExpression expr, BType actualType, BType targetType) {
         expr.impConversionExpr = null;
         types.setImplicitCastExpr(expr, actualType, targetType);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/CompilerUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/CompilerUtils.java
@@ -19,8 +19,16 @@ package org.wso2.ballerinalang.compiler.util;
 
 import org.ballerinalang.compiler.CompilerOptionName;
 import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.model.tree.NodeKind;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
+import org.wso2.ballerinalang.compiler.tree.BLangNode;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
 
 import static org.wso2.ballerinalang.compiler.util.Constants.MAIN_FUNCTION_NAME;
 
@@ -69,4 +77,17 @@ public class CompilerUtils {
         return org + packageID.name + Names.VERSION_SEPARATOR.value + getMajorVersion(packageID.version.value);
     }
 
+    public static boolean isOptionalFieldAssignment(BLangAssignment assignNode) {
+        BLangNode varRef = assignNode.varRef;
+        if (varRef.getKind() != NodeKind.FIELD_BASED_ACCESS_EXPR) {
+            return false;
+        }
+        BLangFieldBasedAccess fieldAccessNode = (BLangFieldBasedAccess) varRef;
+        BType targetType = Types.getImpliedType(fieldAccessNode.expr.getBType());
+        if (targetType.tag != TypeTags.RECORD) {
+            return false;
+        }
+        BField field = ((BRecordType) targetType).fields.get(fieldAccessNode.field.value);
+        return field != null && Symbols.isOptional(field.symbol);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bir/RecordDesugarTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bir/RecordDesugarTest.java
@@ -1,0 +1,93 @@
+/*
+ *   Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org).
+ *
+ *   WSO2 LLC. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+
+package org.ballerinalang.test.bir;
+
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.ballerinalang.compiler.bir.emit.BIREmitter;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * This class contains unit tests to validate various desugaring/optimizations on records produce the expected BIR.
+ *
+ * @since 2201.9.0
+ */
+public class RecordDesugarTest {
+
+    private BIREmitter birEmitter;
+    private BCompileUtil.BIRCompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        birEmitter = BIREmitter.getInstance(new CompilerContext());
+        result = BCompileUtil.generateBIR("test-src/bir/record_desugar.bal");
+    }
+
+    @Test(description = "Test record field set")
+    public void testRecordFieldSet() {
+        List<String> functions = Arrays.asList("setRequiredField", "setNillableField", "setOptionalField");
+        result.getExpectedBIR().functions.stream().filter(function -> functions.contains(function.name.value))
+                .forEach(this::assertFunctions);
+    }
+
+    private void assertFunctions(BIRNode.BIRFunction function) {
+        String actual = BIREmitter.emitFunction(function, 0);
+        String expected = null;
+        try {
+            expected = readFile(function.name.value);
+        } catch (IOException e) {
+            Assert.fail("Failed to read the expected BIR file for function: " + function.name.value, e);
+        }
+        Assert.assertEquals(actual, expected);
+    }
+
+    private String readFile(String name) throws IOException {
+        // The files in the bir-dump folder are named with the function name and contain the expected bir dump for
+        // the function
+        Path filePath = Paths.get("src", "test", "resources", "test-src", "bir", "bir-dump", name).toAbsolutePath();
+        if (Files.exists(filePath)) {
+            StringBuilder contentBuilder = new StringBuilder();
+
+            Stream<String> stream = Files.lines(filePath, StandardCharsets.UTF_8);
+            stream.forEach(s -> contentBuilder.append(s).append("\n"));
+
+            return contentBuilder.toString().trim();
+        }
+        Assert.fail("Expected BIR file not found for function: " + name);
+        return null;
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/FieldAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/FieldAccessTest.java
@@ -315,6 +315,12 @@ public class FieldAccessTest {
         BRunUtil.invoke(result, function);
     }
 
+    @Test
+    public void testFieldAccessOnIntSubtypeRecordFields() {
+        Object returns = BRunUtil.invoke(result, "testFieldAccessOnIntSubtype");
+        Assert.assertEquals(returns, 1L);
+    }
+
     @DataProvider(name = "fieldAccessOnJsonTypedRecordFields")
     public Object[][] fieldAccessOnJsonTypedRecordFields() {
         return new Object[][] {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/FieldAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/FieldAccessTest.java
@@ -49,111 +49,110 @@ public class FieldAccessTest {
     public void testNegativeCases() {
         int i = 0;
         validateError(negativeResult, i++, "field access cannot be used to access an optional field of a type " +
-                "that includes nil, use optional field access or member access", 32, 9);
+                "that includes nil, use optional field access or member access", 34, 9);
         validateError(negativeResult, i++, "invalid field access: 'salary' is not a required field in record " +
-                "'Employee', use member access to access a field that may have been specified as a rest field", 33, 9);
+                "'Employee', use member access to access a field that may have been specified as a rest field", 35, 9);
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
-                "fields of non-nilable types, field 'salary' is undeclared in record(s) 'Employee'", 39, 9);
-        validateError(negativeResult, i++, "incompatible types: expected 'string', found '(int|string)'", 56, 17);
-        validateError(negativeResult, i++, "incompatible types: expected 'int', found '(int|string)'", 57, 15);
+                "fields of non-nilable types, field 'salary' is undeclared in record(s) 'Employee'", 41, 9);
+        validateError(negativeResult, i++, "incompatible types: expected 'string', found '(int|string)'", 58, 17);
+        validateError(negativeResult, i++, "incompatible types: expected 'int', found '(int|string)'", 59, 15);
         validateError(negativeResult, i++, "invalid operation: type 'map<string>' does not support field access",
-                62, 16);
+                64, 16);
         validateError(negativeResult, i++, "invalid operation: type '(map<string>|EmployeeTwo)' does not support " +
-                "field access", 68, 16);
+                "field access", 70, 16);
         validateError(negativeResult, i++, "invalid operation: type 'EmployeeTwo?' does not support field access",
-                74, 17);
+                76, 17);
         validateError(negativeResult, i++, "invalid operation: type '(map<string>|map<int>)' does not support " +
-                "field access", 80, 20);
-        validateError(negativeResult, i++, "incompatible types: expected 'json', found '(json|error)'", 85, 14);
-        validateError(negativeResult, i++, "incompatible types: expected 'json', found '(json|error)'", 90, 14);
-        validateError(negativeResult, i++, "invalid operation: type '(json|error)' does not support field access", 96,
+                "field access", 82, 20);
+        validateError(negativeResult, i++, "incompatible types: expected 'json', found '(json|error)'", 87, 14);
+        validateError(negativeResult, i++, "incompatible types: expected 'json', found '(json|error)'", 92, 14);
+        validateError(negativeResult, i++, "invalid operation: type '(json|error)' does not support field access", 98,
                 22);
         validateError(negativeResult, i++, "incompatible types: expected '(map<json>|error)', " +
-                "found '(map<json>|json|error)'", 102, 26);
+                "found '(map<json>|json|error)'", 104, 26);
         validateError(negativeResult, i++, "incompatible types: expected 'map<json>', found '(json|map<json>|error)'",
-                106, 20);
-        validateError(negativeResult, i++, "invalid operation: type 'Foo?' does not support field access", 131, 14);
-        validateError(negativeResult, i++, "function invocation on type 'Foo' is not supported", 134, 19);
-        validateError(negativeResult, i++, "invalid operation: type 'Foo[]' does not support field access", 138, 9);
+                108, 20);
+        validateError(negativeResult, i++, "invalid operation: type 'Foo?' does not support field access", 133, 14);
+        validateError(negativeResult, i++, "function invocation on type 'Foo' is not supported", 136, 19);
+        validateError(negativeResult, i++, "invalid operation: type 'Foo[]' does not support field access", 140, 9);
 
-        validateError(negativeResult, i++, "undeclared field 'a' in record 'R1'", 155, 13);
+        validateError(negativeResult, i++, "undeclared field 'a' in record 'R1'", 157, 13);
         validateError(negativeResult, i++, "field access cannot be used to access an optional field of a type that " +
-                "includes nil, use optional field access or member access", 164, 13);
+                "includes nil, use optional field access or member access", 166, 13);
         validateError(negativeResult, i++, "field access cannot be used to access an optional field of a type that " +
-                "includes nil, use optional field access or member access", 173, 13);
+                "includes nil, use optional field access or member access", 175, 13);
         validateError(negativeResult, i++, "invalid field access: 'y' is not a required field in record 'R5', use " +
-                "member access to access a field that may have been specified as a rest field", 182, 17);
+                "member access to access a field that may have been specified as a rest field", 184, 17);
         validateError(negativeResult, i++, "invalid field access: 'y' is not a required field in record 'R6', use " +
-                "member access to access a field that may have been specified as a rest field", 191, 17);
+                "member access to access a field that may have been specified as a rest field", 193, 17);
         validateError(negativeResult, i++, "invalid field access: 'y' is not a required field in record 'R7', use " +
-                "member access to access a field that may have been specified as a rest field", 202, 17);
+                "member access to access a field that may have been specified as a rest field", 204, 17);
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
                 "fields of non-nilable types, type of field 'a' includes nil in record(s) 'SA', 'UA', and 'VA'",
-                247, 17);
+                249, 17);
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
                 "fields of non-nilable types, type of field 'b' includes nil in record(s) 'SA', and 'UA'",
-                248, 17);
+                250, 17);
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
                 "fields of non-nilable types, type of field 'c' includes nil in record(s) 'TA'",
-                249, 17);
+                251, 17);
 
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
-                "fields of non-nilable types, field 'x' is undeclared in record(s) 'SA', 'UA', and 'VA'", 251, 17);
+                "fields of non-nilable types, field 'x' is undeclared in record(s) 'SA', 'UA', and 'VA'", 253, 17);
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
-                "fields of non-nilable types, field 'y' is undeclared in record(s) 'SA', and 'UA'", 252, 17);
+                "fields of non-nilable types, field 'y' is undeclared in record(s) 'SA', and 'UA'", 254, 17);
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
-                "fields of non-nilable types, field 'z' is undeclared in record(s) 'TA'", 253, 17);
+                "fields of non-nilable types, field 'z' is undeclared in record(s) 'TA'", 255, 17);
 
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
                 "fields of non-nilable types, field 'x' is undeclared in record(s) 'RB', 'TB', and 'UB'",
-                293, 17);
+                295, 17);
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
                 "fields of non-nilable types, field 'y' is undeclared in record(s) 'QB', and 'TB'",
-                294, 17);
+                296, 17);
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
                 "fields of non-nilable types, field 'z' is undeclared in record(s) 'RB', 'SB', and 'VB'",
-                295, 17);
+                297, 17);
 
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
                 "fields of non-nilable types, type of field 'i' includes nil in record(s) 'BarOne'",
-                308, 14);
+                310, 14);
 
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
                 "fields of non-nilable types, field 'x' is undeclared in record(s) 'CD' and type includes nil " +
-                "in record(s) 'BC'", 329, 17);
+                "in record(s) 'BC'", 331, 17);
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
                 "fields of non-nilable types, field 'y' is undeclared in record(s) 'BC' and type includes nil in " +
-                "record(s) 'AB'", 330, 17);
+                "record(s) 'AB'", 332, 17);
         validateError(negativeResult, i++, "field access can only be used to access required fields or optional " +
                 "fields of non-nilable types, field 'z' is undeclared in record(s) 'CD' and type includes nil in " +
-                "record(s) 'BC'", 331, 17);
-        validateError(negativeResult, i++, "undefined field 'id' in union '(AB|BC)'", 337, 5);
+                "record(s) 'BC'", 333, 17);
+        validateError(negativeResult, i++, "undefined field 'id' in union '(AB|BC)'", 339, 5);
 
         validateError(negativeResult, i++, "'remote' methods of an object cannot be accessed using the field access " +
-                "expression", 369, 20);
+                "expression", 371, 20);
         validateError(negativeResult, i++, "'remote' methods of an object cannot be accessed using the field access " +
-                "expression", 371, 11);
+                "expression", 373, 11);
         validateError(negativeResult, i++, "'remote' methods of an object cannot be accessed using the field access " +
-                "expression", 373, 26);
-        validateError(negativeResult, i++, "'remote' methods of an object cannot be accessed using the field access " +
-                "expression", 375, 15);
+                "expression", 375, 26);
         validateError(negativeResult, i++, "'remote' methods of an object cannot be accessed using the field access " +
                 "expression", 377, 15);
+        validateError(negativeResult, i++, "'remote' methods of an object cannot be accessed using the field access " +
+                "expression", 379, 15);
         validateError(negativeResult, i++, "invalid operation: type 'map<xml>' does not support field access"
-                , 382, 19);
+                , 384, 19);
         validateError(negativeResult, i++, "invalid operation: type 'map<xml>' does not support field access"
-                , 387, 19);
+                , 389, 19);
         validateError(negativeResult, i++, "invalid operation: type 'map<xml>' does not support field access"
-                , 393, 19);
+                , 395, 19);
         validateError(negativeResult, i++, "invalid operation: type 'map<(xml|json)>' does not support field access"
-                , 399, 24);
+                , 401, 24);
         validateError(negativeResult, i++, "invalid operation: type 'map<xml>' does not support " +
-                        "optional field access", 404, 13);
+                "optional field access", 406, 13);
         validateError(negativeResult, i++, "invalid operation: type 'map<xml>' does not support " +
-                "optional field access", 409, 14);
+                "optional field access", 411, 14);
         validateError(negativeResult, i++, "invalid operation: type 'map<xml>' does not support " +
-                "optional field access", 414, 13);
-
+                "optional field access", 416, 13);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 
@@ -329,6 +328,32 @@ public class FieldAccessTest {
                 { "testFieldAccessOnJsonTypedRecordFieldsResultingInErrorWithCheckExpr" },
                 { "testOptionalFieldAccessOnOptionalJsonTypedRecordFields" },
                 { "testOptionalFieldAccessOnOptionalJsonTypedRecordFieldsResultingInError" }
+        };
+    }
+
+    @Test(dataProvider = "fieldAccessWithSingletonRecordFields")
+    public void testFieldAccessWithSingletonRecordFields(String function) {
+        BRunUtil.invoke(result, function);
+    }
+
+    @DataProvider(name = "fieldAccessWithSingletonRecordFields")
+    public Object[][] fieldAccessWithSingletonRecordFields() {
+        return new Object[][]{
+                {"testFieldAccessOnFloatSingleton"},
+                {"testFieldAccessOnIntSingleton"}
+        };
+    }
+
+    @Test(dataProvider = "fieldAccessWithSingletonRecordFieldsNegative")
+    public void testFieldAccessWithSingletonRecordFieldsNegative(String function) {
+        BRunUtil.invoke(result, function);
+    }
+
+    @DataProvider(name = "fieldAccessWithSingletonRecordFieldsNegative")
+    public Object[][] fieldAccessWithSingletonRecordFieldsNegative() {
+        return new Object[][]{
+                {"testFieldAccessOnFloatSingleton"},
+                {"testFieldAccessOnIntSingleton"}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/OptionalFieldAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/OptionalFieldAccessTest.java
@@ -167,6 +167,21 @@ public class OptionalFieldAccessTest {
         BRunUtil.invoke(result, "testOptionalFieldAccessOnMethodCall");
     }
 
+    @Test(dataProvider = "optionalFieldRemovalFunctions")
+    public void testOptionalFieldRemoval(String function) {
+        Object returns = BRunUtil.invoke(result, function);
+        Assert.assertFalse((Boolean) returns);
+    }
+
+    @DataProvider(name = "optionalFieldRemovalFunctions")
+    public Object[][] optionalFieldRemovalFunctions() {
+        return new Object[][]{
+                {"testOptionalFieldRemovalBasicType"},
+                {"testOptionalFieldRemovalIndirect"},
+                {"testOptionalFieldRemovalComplex"}
+        };
+    }
+
     @Test
     public void testNestedOptionalFieldAccessOnIntersectionTypes() {
         BRunUtil.invoke(result, "testNestedOptionalFieldAccessOnIntersectionTypes");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/OptionalFieldAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/OptionalFieldAccessTest.java
@@ -110,7 +110,10 @@ public class OptionalFieldAccessTest {
                 { "testUnavailableFinalAccessInNestedAccess" },
                 { "testAvailableFinalAccessInNestedAccess" },
                 { "testUnavailableIntermediateAccessInNestedAccess" },
-                { "testNilValuedFinalAccessInNestedAccess" }
+                { "testNilValuedFinalAccessInNestedAccess" },
+                { "testSubtypeAssignment" },
+                { "testUnionAssignment" },
+                { "testNullableAssignment" }
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/OptionalFieldAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/OptionalFieldAccessTest.java
@@ -169,8 +169,7 @@ public class OptionalFieldAccessTest {
 
     @Test(dataProvider = "optionalFieldRemovalFunctions")
     public void testOptionalFieldRemoval(String function) {
-        Object returns = BRunUtil.invoke(result, function);
-        Assert.assertFalse((Boolean) returns);
+        BRunUtil.invoke(result, function);
     }
 
     @DataProvider(name = "optionalFieldRemovalFunctions")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/OptionalFieldAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/OptionalFieldAccessTest.java
@@ -189,6 +189,15 @@ public class OptionalFieldAccessTest {
         BRunUtil.invoke(result, "testNestedOptionalFieldAccessOnIntersectionTypes");
     }
 
+    @Test
+    public void testOptionalFieldAccessOnRecordsWithOnlyOptionalFields() {
+        Object return1 = BRunUtil.invoke(result, "getOptionalField1");
+        Assert.assertNull(return1);
+
+        Object return2 = BRunUtil.invoke(result, "getOptionalField2");
+        Assert.assertEquals(return2, 5L);
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/setNillableField
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/setNillableField
@@ -1,0 +1,32 @@
+setNillableField function() -> () {
+    %0(RETURN) ();
+    %1(LOCAL) R2;
+    %2(TEMP) typeDesc<any|error>;
+    %4(TEMP) string;
+    %5(TEMP) int|();
+    %6(TEMP) int;
+    %12(TEMP) ();
+
+    bb0 {
+        %2 = newType R2;
+        %4 = ConstLoad x;
+        %6 = ConstLoad 1;
+        %5 = <int|()> %6;
+        %1 = NewMap %2{%4:%5};
+        %6 = ConstLoad 2;
+        %5 = <int|()> %6;
+        %4 = ConstLoad x;
+        %1[%4] = %5;
+        %12 = ConstLoad 0;
+        %5 = <int|()> %12;
+        %4 = ConstLoad x;
+        %1[%4] = %5;
+        %0 = ConstLoad 0;
+        GOTO bb1;
+    }
+    bb1 {
+        return;
+    }
+
+
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/setOptionalField
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/setOptionalField
@@ -1,0 +1,24 @@
+setOptionalField function() -> () {
+    %0(RETURN) ();
+    %1(LOCAL) R3;
+    %2(TEMP) typeDesc<any|error>;
+    %4(TEMP) int|();
+    %5(TEMP) int;
+    %7(TEMP) string;
+
+    bb0 {
+        %2 = newType R3;
+        %1 = NewMap %2{};
+        %5 = ConstLoad 2;
+        %4 = <int|()> %5;
+        %7 = ConstLoad x;
+        %1[%7] = %4;
+        %0 = ConstLoad 0;
+        GOTO bb1;
+    }
+    bb1 {
+        return;
+    }
+
+
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/setOptionalField
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/setOptionalField
@@ -2,17 +2,21 @@ setOptionalField function() -> () {
     %0(RETURN) ();
     %1(LOCAL) R3;
     %2(TEMP) typeDesc<any|error>;
-    %4(TEMP) int|();
-    %5(TEMP) int;
-    %7(TEMP) string;
+    %4(TEMP) int;
+    %6(TEMP) string;
+    %7(TEMP) int|();
+    %8(TEMP) ();
 
     bb0 {
         %2 = newType R3;
         %1 = NewMap %2{};
-        %5 = ConstLoad 2;
-        %4 = <int|()> %5;
-        %7 = ConstLoad x;
-        %1[%7] = %4;
+        %4 = ConstLoad 2;
+        %6 = ConstLoad x;
+        %1[%6] = %4;
+        %8 = ConstLoad 0;
+        %7 = <int|()> %8;
+        %6 = ConstLoad x;
+        %1[%6] = %7;
         %0 = ConstLoad 0;
         GOTO bb1;
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/setRequiredField
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/setRequiredField
@@ -1,0 +1,24 @@
+setRequiredField function() -> () {
+    %0(RETURN) ();
+    %1(LOCAL) R1;
+    %2(TEMP) typeDesc<any|error{map<ballerina/lang.value:0.0.0:Cloneable>}>;
+    %4(TEMP) string;
+    %5(TEMP) int;
+
+    bb0 {
+        %2 = newType R1;
+        %4 = ConstLoad x;
+        %5 = ConstLoad 1;
+        %1 = NewMap %2{%4:%5};
+        %5 = ConstLoad 2;
+        %4 = ConstLoad x;
+        %1[%4] = %5;
+        %0 = ConstLoad 0;
+        GOTO bb1;
+    }
+    bb1 {
+        return;
+    }
+
+
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/record_desugar.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/record_desugar.bal
@@ -24,4 +24,5 @@ function setNillableField() {
 function setOptionalField() {
     R3 r3 = {};
     r3.x = 2;
+    r3.x = ();
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/record_desugar.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/record_desugar.bal
@@ -1,0 +1,27 @@
+type R1 record {|
+    int x;
+|};
+
+type R2 record {|
+    int? x;
+|};
+
+type R3 record {|
+    int x?;
+|};
+
+function setRequiredField() {
+    R1 r1 = { x: 1 };
+    r1.x = 2;
+}
+
+function setNillableField() {
+    R2 r2 = { x: 1 };
+    r2.x = 2;
+    r2.x = ();
+}
+
+function setOptionalField() {
+    R3 r3 = { };
+    r3.x = 2;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/record_desugar.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/record_desugar.bal
@@ -11,17 +11,17 @@ type R3 record {|
 |};
 
 function setRequiredField() {
-    R1 r1 = { x: 1 };
+    R1 r1 = {x: 1};
     r1.x = 2;
 }
 
 function setNillableField() {
-    R2 r2 = { x: 1 };
+    R2 r2 = {x: 1};
     r2.x = 2;
     r2.x = ();
 }
 
 function setOptionalField() {
-    R3 r3 = { };
+    R3 r3 = {};
     r3.x = 2;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/field_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/field_access.bal
@@ -562,3 +562,12 @@ function assertEquals(anydata actual, anydata expected) {
     }
     panic error(string `expected '${expected.toString()}', found '${actual.toString()}'`);
 }
+
+type IntSubtypeRecord record {|
+    int:Signed16 value;
+|};
+
+function testFieldAccessOnIntSubtype() returns int:Signed16 {
+    IntSubtypeRecord r = { value: 1 };
+    return r.value;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/field_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/field_access.bal
@@ -552,6 +552,32 @@ isolated function isEqual(anydata|error val1, anydata|error val2) returns boolea
     }
 }
 
+type FloatSingletonRecord record {|
+    0.1|0.2 value;
+|};
+
+function testFieldAccessOnFloatSingleton() {
+    FloatSingletonRecord r = { value: 0.1 };
+    r.value = 0.2;
+    assertEquals(r.value, 0.2);
+    record { float value; } r2 = r;
+    r2.value = 0.1;
+    assertEquals(r.value, 0.1);
+}
+
+type IntSingletonRecord record {|
+    1|2 value;
+|};
+
+function testFieldAccessOnIntSingleton() {
+    IntSingletonRecord r = { value: 1 };
+    r.value = 2;
+    assertEquals(r.value, 2);
+    record { int value; } r2 = r;
+    r2.value = 1;
+    assertEquals(r.value, 1);
+}
+
 function assertTrue(boolean actual) {
     assertEquals(actual, true);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/field_access_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/field_access_negative.bal
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/lang.test as test;
+
 type Employee record {
     string name;
     Employee? employer = ();
@@ -412,4 +414,22 @@ function testInvalidXMLMapFieldAccess6() returns error? {
 function testInvalidXMLMapFieldAccess7() returns error? {
     map<xml> m = {a: xml `foo`};
     xml x = m?.b; // error
+}
+
+function testFieldAccessOnFloatSingleton() {
+    record {|0.1|0.2 value;|} r = {value: 0.1};
+    record {|float value;|} r2 = r;
+    var updateFn = function() { r2.value = 0.7; };
+    test:assertError(trap updateFn());
+}
+
+type IntSingletonRecord record {|
+    1|2 value;
+|};
+
+function testFieldAccessOnIntSingleton() {
+    record {|1|2 value;|} r = {value: 1};
+    record {int value;} r2 = r;
+    var updateFn = function() { r2.value = 7; };
+    test:assertError(trap updateFn());
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
@@ -60,32 +60,35 @@ function testOptionalFieldAccessOnRequiredRecordField() returns boolean {
     return name == s;
 }
 
-function testOptionalFieldRemovalBasicType() returns boolean {
-    R1 r = { a: 1, b: 2.0, c: "test", d: true, e: 3.0 };
+function testOptionalFieldRemovalBasicType() {
+    R1 r = {a: 1, b: 2.0, c: "test", d: true, e: 3.0};
     r.a = ();
     r.b = ();
     r.c = ();
     r.d = ();
     r.e = ();
-    return r.hasKey("a") || r.hasKey("b") || r.hasKey("c") || r.hasKey("d") || r.hasKey("e");
+    assertFalse(r.hasKey("a"));
+    assertFalse(r.hasKey("b"));
+    assertFalse(r.hasKey("c"));
+    assertFalse(r.hasKey("d"));
+    assertFalse(r.hasKey("e"));
 }
 
-function testOptionalFieldRemovalIndirect() returns boolean {
-    R2 r = { a: 1, r1: { a: 1, b: 2.0, c: "test" } };
+function testOptionalFieldRemovalIndirect() {
+    R2 r = {a: 1, r1: {a: 1, b: 2.0, c: "test"}};
     r.r1.a = ();
     r.r1.b = ();
     r.r1.c = ();
-    R1? r1 = r.r1;
-    if r1 is () {
-        return true;
-    }
-    return r1.hasKey("a") || r1.hasKey("b") || r1.hasKey("c");
+    R1 r1 = <R1>r.r1;
+    assertFalse(r1.hasKey("a"));
+    assertFalse(r1.hasKey("b"));
+    assertFalse(r1.hasKey("c"));
 }
 
-function testOptionalFieldRemovalComplex() returns boolean {
-    R2 r = { a: 1, r1: { a: 1, b: 2.0, c: "test" } };
+function testOptionalFieldRemovalComplex() {
+    R2 r = {a: 1, r1: {a: 1, b: 2.0, c: "test"}};
     r.r1 = ();
-    return r.hasKey("r1");
+    assertFalse(r.hasKey("r1"));
 }
 
 function testOptionalFieldAccessOnRequiredRecordFieldInRecordUnion() returns boolean {
@@ -613,6 +616,10 @@ public function testNestedOptionalFieldAccessOnIntersectionTypes() {
 
 function assertTrue(anydata actual) {
     assertEquality(true, actual);
+}
+
+function assertFalse(anydata actual) {
+    assertEquality(false, actual);
 }
 
 function assertEquality(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
@@ -719,3 +719,17 @@ function assertEquality(anydata expected, anydata actual) {
 
     panic error("expected '" + expected.toString() + "', found '" + actual.toString() + "'");
 }
+
+type AllOptionalBasicTypeField record {|
+    int val?;
+|};
+
+function getOptionalField1() returns int? {
+    AllOptionalBasicTypeField r = {};
+    return r.val;
+}
+
+function getOptionalField2() returns int? {
+    AllOptionalBasicTypeField r = { val: 5 };
+    return r.val;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
@@ -622,6 +622,88 @@ public function testNestedOptionalFieldAccessOnIntersectionTypes() {
     assertEquality((), v5);
 }
 
+type MyInt int;
+type Rxx record {
+    int val;
+};
+type Rxy record {
+    int val;
+    float otherVal;
+};
+type Rx record {|
+    int a?;
+    MyInt b?;
+    Rxx c?;
+|};
+
+function testSubtypeAssignment() {
+    int:Signed16 init = 2;
+    Rx r = {a:init, b:init};
+    int:Signed32 val = 5;
+    r.a = val;
+    assertEquality(val, r.a);
+    r.a = ();
+    assertFalse(r.hasKey("a"));
+    r.b = val;
+    assertEquality(val, r.b);
+    r.b = ();
+    assertFalse(r.hasKey("b"));
+    Rxy c = {val: 5, otherVal: 10.0};
+    r.c = c;
+    assertEquality(c, r.c);
+    r.c = ();
+    assertFalse(r.hasKey("b"));
+}
+
+function testNullableAssignment() {
+    Rx r = {};
+    int? val = 12;
+    r.a = val;
+    assertEquality(val, r.a);
+    int? b = ();
+    r.a = b;
+    assertFalse(r.hasKey("a"));
+    Rxy? c = {val: 5, otherVal: 10.0};
+    r.c = c;
+    assertEquality(c, r.c);
+    c = ();
+    r.c = c;
+    assertFalse(r.hasKey("c"));
+}
+
+type MyUnion int|float|string;
+type Ry record {|
+    int|float|string a?;
+    MyUnion b?;
+    int|Rxx c?;
+|};
+
+function testUnionAssignment() {
+    int init = 5;
+    Ry r = {a:init, b:init};
+    int:Signed32 val = 5;
+    r.a = val;
+    assertEquality(val, r.a);
+    int|float val2 = 10;
+    r.a = val2;
+    assertEquality(val2, r.a);
+    r.a = ();
+    assertFalse(r.hasKey("a"));
+
+    r.b = val;
+    assertEquality(val, r.b);
+    r.b = val2;
+    assertEquality(val2, r.b);
+    r.b = ();
+    assertFalse(r.hasKey("b"));
+
+    Rxx c = {val: 5};
+    r.c = c;
+    assertEquality(c, r.c);
+    r.c = ();
+    assertFalse(r.hasKey("b"));
+}
+
 function assertTrue(anydata actual) {
     assertEquality(true, actual);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
@@ -40,12 +40,16 @@ type Bar record {
     decimal c;
 };
 
+type MyString string;
+
 type R1 record {
     int a?;
     float b?;
     string c?;
     boolean d?;
     decimal e?;
+    string:Char f?;
+    MyString g?;
 };
 
 type R2 record {
@@ -61,17 +65,21 @@ function testOptionalFieldAccessOnRequiredRecordField() returns boolean {
 }
 
 function testOptionalFieldRemovalBasicType() {
-    R1 r = {a: 1, b: 2.0, c: "test", d: true, e: 3.0};
+    R1 r = {a: 1, b: 2.0, c: "test", d: true, e: 3.0, f:"c", g: "test"};
     r.a = ();
     r.b = ();
     r.c = ();
     r.d = ();
     r.e = ();
+    r.f = ();
+    r.g = ();
     assertFalse(r.hasKey("a"));
     assertFalse(r.hasKey("b"));
     assertFalse(r.hasKey("c"));
     assertFalse(r.hasKey("d"));
     assertFalse(r.hasKey("e"));
+    assertFalse(r.hasKey("f"));
+    assertFalse(r.hasKey("g"));
 }
 
 function testOptionalFieldRemovalIndirect() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
@@ -40,11 +40,52 @@ type Bar record {
     decimal c;
 };
 
+type R1 record {
+    int a?;
+    float b?;
+    string c?;
+    boolean d?;
+    decimal e?;
+};
+
+type R2 record {
+    int a;
+    R1 r1?;
+};
+
 function testOptionalFieldAccessOnRequiredRecordField() returns boolean {
     string s = "Anne";
     Employee e = { name: s, id: 100 };
     string name = e?.name;
     return name == s;
+}
+
+function testOptionalFieldRemovalBasicType() returns boolean {
+    R1 r = { a: 1, b: 2.0, c: "test", d: true, e: 3.0 };
+    r.a = ();
+    r.b = ();
+    r.c = ();
+    r.d = ();
+    r.e = ();
+    return r.hasKey("a") || r.hasKey("b") || r.hasKey("c") || r.hasKey("d") || r.hasKey("e");
+}
+
+function testOptionalFieldRemovalIndirect() returns boolean {
+    R2 r = { a: 1, r1: { a: 1, b: 2.0, c: "test" } };
+    r.r1.a = ();
+    r.r1.b = ();
+    r.r1.c = ();
+    R1? r1 = r.r1;
+    if r1 is () {
+        return true;
+    }
+    return r1.hasKey("a") || r1.hasKey("b") || r1.hasKey("c");
+}
+
+function testOptionalFieldRemovalComplex() returns boolean {
+    R2 r = { a: 1, r1: { a: 1, b: 2.0, c: "test" } };
+    r.r1 = ();
+    return r.hasKey("r1");
 }
 
 function testOptionalFieldAccessOnRequiredRecordFieldInRecordUnion() returns boolean {


### PR DESCRIPTION
## Purpose
Extend #41902 to avoid boxing when setting fields whose type is a simple basic type
Depends on #41917 

Part of #41868

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
