### PR TITLE
Fix XAER_RMFAIL error on transaction rollback

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionLocalContext.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionLocalContext.java
@@ -159,6 +159,7 @@ public class TransactionLocalContext {
 
     public void notifyAbortAndClearTransaction(String transactionBlockId) {
         transactionContextStore.clear();
+        transactionResourceManager.endXATransaction(globalTransactionId, transactionBlockId, true);
         transactionResourceManager.notifyAbort(globalTransactionId, transactionBlockId);
     }
 


### PR DESCRIPTION
## Purpose
Handle proper signaling of transaction completion to XA Resources when aborting a transaction as invoking xa_rollback() without signaling the end of the transaction's work triggers an `XAER_RMFAIL: The command cannot be executed when the global transaction is in the ACTIVE state` error.

Fixes #41948

## Approach
Added the boolean flag `abortOnly` to track the transaction's abort status within the `endXATransaction()` method. This flag indicates whether the transaction is set for abort or not, providing clarity on the success or failure of work within the transaction context. If the transaction is in the process of aborting, the xa_end() method is invoked on the XA Resource using the TMFAIL flag. This flag indicates the failure of a portion of work within the transaction, effectively marking the transaction as rollback-only. However, in cases where the transaction is proceeding normally without an abort condition, the TMSUCCESS flag is used as per normal operation.
Modified the transaction handling sequence by introducing a call to `endXATransaction` before invoking `notifyAbort`. This change guarantees explicit signaling of the transaction's completion before initiating the rollback phase. It prevents XAER_RMFAIL error during xa_rollback() on the XA Resource.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
