### PR TITLE
Handle hash collisions in the put method in tables

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -613,7 +613,6 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             if (entries.containsKey(hash)) {
                 return updateExistingEntry(key, data, entry, hash);
             }
-
             return putNewData(key, data, entry, hash);
         }
 
@@ -638,22 +637,19 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             if (entries.containsKey(hash)) {
                 return updateExistingEntry(key, data, entry, hash);
             }
-
             return putNewData((K) key, data, entry, hash);
         }
 
         private V updateExistingEntry(K key, V data, Map.Entry<K, V> entry, Long hash) {
             updateIndexKeyMappings(hash, key, data);
+            List<V> valueList = values.get(hash);
             List<Map.Entry<K, V>> entryList = entries.get(hash);
             for (Map.Entry<K, V> extEntry: entryList) {
                 // Handle hash-collided entries
                 if (TypeChecker.isEqual(key, extEntry.getKey())) {
                     entryList.remove(extEntry);
-                    entryList.add(entry);
-                    List<V> valueList = values.get(hash);
                     valueList.remove(extEntry.getValue());
-                    valueList.add(data);
-                    return data;
+                    break;
                 }
             }
             entryList.add(entry);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -616,7 +616,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             }
 
             if (entries.containsKey(hash)) {
-                return handleHashCollisionInPut(key, data, entry, hash);
+                return handleHashCollisionForPut(key, data, entry, hash);
             }
 
             return putData(key, data, newData, entry, hash);
@@ -639,7 +639,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             Long hash = TableUtils.hash(key, null);
 
             if (entries.containsKey(hash)) {
-                return handleHashCollisionInPut(key, data, entry, hash);
+                return handleHashCollisionForPut(key, data, entry, hash);
             }
 
             ArrayList<V> newData = new ArrayList<>();
@@ -648,7 +648,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             return putData((K) key, data, newData, entry, hash);
         }
 
-        private V handleHashCollisionInPut(K key, V data, Map.Entry<K, V> entry, Long hash) {
+        private V handleHashCollisionForPut(K key, V data, Map.Entry<K, V> entry, Long hash) {
             updateIndexKeyMappings(hash, key, data);
             List<Map.Entry<K, V>> entryList = entries.get(hash);
             for (Map.Entry<K, V> extEntry: entryList) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -616,7 +616,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             }
 
             if (entries.containsKey(hash)) {
-                return handleHashCollisionForPut(key, data, entry, hash);
+                return updateExistingEntry(key, data, entry, hash);
             }
 
             return putData(key, data, newData, entry, hash);
@@ -639,7 +639,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             Long hash = TableUtils.hash(key, null);
 
             if (entries.containsKey(hash)) {
-                return handleHashCollisionForPut(key, data, entry, hash);
+                return updateExistingEntry(key, data, entry, hash);
             }
 
             ArrayList<V> newData = new ArrayList<>();
@@ -648,10 +648,11 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             return putData((K) key, data, newData, entry, hash);
         }
 
-        private V handleHashCollisionForPut(K key, V data, Map.Entry<K, V> entry, Long hash) {
+        private V updateExistingEntry(K key, V data, Map.Entry<K, V> entry, Long hash) {
             updateIndexKeyMappings(hash, key, data);
             List<Map.Entry<K, V>> entryList = entries.get(hash);
             for (Map.Entry<K, V> extEntry: entryList) {
+                // Handle hash-collided entries
                 if (TypeChecker.isEqual(key, extEntry.getKey())) {
                     entryList.remove(extEntry);
                     entryList.add(entry);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -661,10 +661,8 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
                     return data;
                 }
             }
-            List<Map.Entry<K, V>> extEntries = entries.get(hash);
-            extEntries.add(entry);
-            List<V> extValues = values.get(hash);
-            extValues.add(data);
+            entryList.add(entry);
+            values.get(hash).add(data);
             return data;
         }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -583,9 +583,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
                 return;
             }
 
-            ArrayList<V> newData = new ArrayList<>();
-            newData.add(data);
-            putData(key, data, newData, entry, hash);
+            putNewData(key, data, entry, hash);
         }
 
         public V getData(K key) {
@@ -602,9 +600,6 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         }
 
         public V putData(K key, V data) {
-            ArrayList<V> newData = new ArrayList<>();
-            newData.add(data);
-
             Map.Entry<K, V> entry = new AbstractMap.SimpleEntry(key, data);
             Object actualKey = this.keyWrapper.wrapKey((MapValue) data);
             Long actualHash = TableUtils.hash(actualKey, null);
@@ -619,10 +614,12 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
                 return updateExistingEntry(key, data, entry, hash);
             }
 
-            return putData(key, data, newData, entry, hash);
+            return putNewData(key, data, entry, hash);
         }
 
-        private V putData(K key, V value, List<V> data, Map.Entry<K, V> entry, Long hash) {
+        private V putNewData(K key, V value, Map.Entry<K, V> entry, Long hash) {
+            List<V> data = new ArrayList<>();
+            data.add(value);
             updateIndexKeyMappings(hash, key, value);
             List<Map.Entry<K, V>> entryList = new ArrayList<>();
             entryList.add(entry);
@@ -642,10 +639,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
                 return updateExistingEntry(key, data, entry, hash);
             }
 
-            ArrayList<V> newData = new ArrayList<>();
-            newData.add(data);
-
-            return putData((K) key, data, newData, entry, hash);
+            return putNewData((K) key, data, entry, hash);
         }
 
         private V updateExistingEntry(K key, V data, Map.Entry<K, V> entry, Long hash) {

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTableTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTableTest.java
@@ -118,31 +118,6 @@ public class LangLibTableTest {
     }
 
     @Test
-    public void testHashCollisionHandlingScenarios() {
-        BRunUtil.invoke(compileResult, "testHashCollisionHandlingScenarios");
-    }
-
-    @Test
-    public void testHashCollisionInQueryWithAdd() {
-        BRunUtil.invoke(compileResult, "testHashCollisionInQueryWithAdd");
-    }
-
-    @Test
-    public void testHashCollisionInQueryWithPut() {
-        BRunUtil.invoke(compileResult, "testHashCollisionInQueryWithPut");
-    }
-
-    @Test
-    public void testHashCollisionInFilter() {
-        BRunUtil.invoke(compileResult, "testHashCollisionInFilter");
-    }
-
-    @Test
-    public void testGetKeysOfHashCollidedKeys() {
-        BRunUtil.invoke(compileResult, "testGetKeysOfHashCollidedKeys");
-    }
-
-    @Test
     public void testGetKeyList() {
         Object result = BRunUtil.invoke(compileResult, "testGetKeyList");
         BArray returns = (BArray) result;
@@ -611,5 +586,21 @@ public class LangLibTableTest {
         BRunUtil.invoke(compileResult, "testTableIterationAfterPut2");
         BRunUtil.invoke(compileResult, "testTableIterationAfterPut3");
         BRunUtil.invoke(compileResult, "testTableIterationAfterPut4");
+    }
+
+    @Test(dataProvider = "functionsToTestHashCollisionInTable")
+    public void testHashCollisionInTable(String function) {
+        BRunUtil.invoke(compileResult, function);
+    }
+
+    @DataProvider
+    public Object[] functionsToTestHashCollisionInTable() {
+        return new String[]{
+                "testHashCollisionHandlingScenarios",
+                "testHashCollisionInQueryWithAdd",
+                "testHashCollisionInQueryWithPut",
+                "testHashCollisionInFilter",
+                "testGetKeysOfHashCollidedKeys"
+        };
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTableTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTableTest.java
@@ -123,8 +123,18 @@ public class LangLibTableTest {
     }
 
     @Test
-    public void testHashCollisionInQuery() {
-        BRunUtil.invoke(compileResult, "testHashCollisionInQuery");
+    public void testHashCollisionInQueryWithAdd() {
+        BRunUtil.invoke(compileResult, "testHashCollisionInQueryWithAdd");
+    }
+
+    @Test
+    public void testHashCollisionInQueryWithPut() {
+        BRunUtil.invoke(compileResult, "testHashCollisionInQueryWithPut");
+    }
+
+    @Test
+    public void testHashCollisionInFilter() {
+        BRunUtil.invoke(compileResult, "testHashCollisionInFilter");
     }
 
     @Test

--- a/langlib/langlib-test/src/test/resources/test-src/tablelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/tablelib_test.bal
@@ -358,6 +358,8 @@ function testHashCollisionHandlingScenarios() {
 function testHashCollisionInQueryWithAdd() {
     table<record {readonly int|string|float? k;}> key(k) tbl1 = table [{k: "10"}];
     table<record {readonly int|string|float? k;}> tbl2 = table [{k: 0}];
+    table<record {readonly int|string|float? k;}> key(k) tbl3 = table [
+        {k: "10"}, {k: 5}, {k: ()}, {k: -31}, {k: 0}, {k: 100.05}, {k: 30}];
 
     tbl1.add({k: 5});
     tbl1.add({k: ()});
@@ -365,23 +367,27 @@ function testHashCollisionInQueryWithAdd() {
     tbl1.add({k: 0});
     tbl1.add({k: 100.05});
     tbl1.add({k: 30});
-    table<record {|readonly int|string|float? k; anydata...;|}> tbl3 =
-        from var tid in tbl1
-            where tid["k"] == 0
-            select tid;
-    assertEquals(tbl2, tbl3);
+    assertEquals(tbl3, tbl1);
 
-    _ = tbl1.remove(());
     table<record {|readonly int|string|float? k; anydata...;|}> tbl4 =
         from var tid in tbl1
             where tid["k"] == 0
             select tid;
     assertEquals(tbl2, tbl4);
+
+    _ = tbl1.remove(());
+    table<record {|readonly int|string|float? k; anydata...;|}> tbl5 =
+        from var tid in tbl1
+            where tid["k"] == 0
+            select tid;
+    assertEquals(tbl2, tbl5);
 }
 
 function testHashCollisionInQueryWithPut() {
     table<record {readonly int|string|float? k;}> key(k) tbl1 = table [{k: "10"}];
     table<record {readonly int|string|float? k;}> tbl2 = table [{k: 0}];
+    table<record {readonly int|string|float? k;}> key(k) tbl3 = table [
+        {k: "10"}, {k: 5}, {k: ()}, {k: -31}, {k: 0}, {k: 100.05}, {k: 30}];
 
     tbl1.put({k: 5});
     tbl1.put({k: ()});
@@ -389,18 +395,20 @@ function testHashCollisionInQueryWithPut() {
     tbl1.put({k: 0});
     tbl1.put({k: 100.05});
     tbl1.put({k: 30});
-    table<record {|readonly int|string|float? k; anydata...;|}> tbl3 =
-        from var tid in tbl1
-            where tid["k"] == 0
-            select tid;
-    assertEquals(tbl2, tbl3);
+    assertEquals(tbl3, tbl1);
 
-    _ = tbl1.remove(());
     table<record {|readonly int|string|float? k; anydata...;|}> tbl4 =
         from var tid in tbl1
             where tid["k"] == 0
             select tid;
     assertEquals(tbl2, tbl4);
+
+    _ = tbl1.remove(());
+    table<record {|readonly int|string|float? k; anydata...;|}> tbl5 =
+        from var tid in tbl1
+            where tid["k"] == 0
+            select tid;
+    assertEquals(tbl2, tbl5);
 }
 
 function testHashCollisionInFilter() {
@@ -414,10 +422,10 @@ function testHashCollisionInFilter() {
     tbl1.put({k: 100.05});
     tbl1.put({k: 30});
 
-    table<record {readonly int|string|float? k;}> tbl3 = tbl1.filter(
+    table<record {readonly int|string|float? k;}> tbl4 = tbl1.filter(
         function(record {readonly int|string|float? k;} tid) returns boolean 
             => tid["k"] == 0 || tid["k"] == ());
-    assertEquals(tbl2, tbl3);
+    assertEquals(tbl2, tbl4);
 }
 public function testGetKeysOfHashCollidedKeys() {
     table<record {readonly int? k;}> key(k) tbl1 = table [

--- a/langlib/langlib-test/src/test/resources/test-src/tablelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/tablelib_test.bal
@@ -384,17 +384,19 @@ function testHashCollisionInQueryWithAdd() {
 }
 
 function testHashCollisionInQueryWithPut() {
-    table<record {readonly int|string|float? k;}> key(k) tbl1 = table [{k: "10"}];
-    table<record {readonly int|string|float? k;}> tbl2 = table [{k: 0}];
-    table<record {readonly int|string|float? k;}> key(k) tbl3 = table [
-        {k: "10"}, {k: 5}, {k: ()}, {k: -31}, {k: 0}, {k: 100.05}, {k: 30}];
+    table<record {readonly int|string|float? k; int v;}> key(k) tbl1 = table [{k: "10", v: 1}];
+    table<record {readonly int|string|float? k; int v;}> tbl2 = table [{k: 0, v: 2}];
+    table<record {readonly int|string|float? k; int v;}> key(k) tbl3 = table [
+        {k: "10", v: 1}, {k: 5, v: 2}, {k: 0, v: 2}, {k: (), v: 3}, {k: -31, v: 4}, {k: 100.05, v: 1}, {k: 30, v: 2}];
 
-    tbl1.put({k: 5});
-    tbl1.put({k: ()});
-    tbl1.put({k: -31});
-    tbl1.put({k: 0});
-    tbl1.put({k: 100.05});
-    tbl1.put({k: 30});
+    tbl1.put({k: 5, v: 1});
+    tbl1.put({k: (), v: 1});
+    tbl1.put({k: -31, v: 4});
+    tbl1.put({k: 0, v: 2});
+    tbl1.put({k: 5, v: 2});
+    tbl1.put({k: 100.05, v: 1});
+    tbl1.put({k: 30, v: 2});
+    tbl1.put({k: (), v: 3});
     assertEquals(tbl3, tbl1);
 
     table<record {|readonly int|string|float? k; anydata...;|}> tbl4 =
@@ -433,6 +435,18 @@ public function testGetKeysOfHashCollidedKeys() {
     ];
 
     assertEquals(tbl1.keys(), [5, 0, (), 2]);
+
+    table<record {readonly int? k;}> key(k) tbl2 = table [
+        {k: 5}, {k: 0}, {k: 2}
+    ];
+    tbl2.add({k: ()});
+    assertEquals(tbl2.keys(), [5, 0, 2, ()]);
+
+    table<record {readonly int? k;}> key(k) tbl3 = table [
+        {k: 5}, {k: 0}, {k: 2}
+    ];
+    tbl3.put({k: ()});
+    assertEquals(tbl3.keys(), [5, 0, 2, ()]);
 }
 
 function testGetKeyList() returns any[] {


### PR DESCRIPTION
## Purpose
The current implementation of the put API does not consider hash-collided keys. Thus, it behaves incorrectly when handling hash-collided keys.

Fixes #41723

## Approach
The PR modifies the put method to handle hash collision scenarios.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
