### PR TITLE
Fix incompatible JRE version warning which is popped up while profiling a Ballerina program

### DIFF
--- a/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/codegen/ProfilerMethodWrapper.java
+++ b/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/codegen/ProfilerMethodWrapper.java
@@ -42,6 +42,7 @@ import java.util.jar.Manifest;
 
 import static io.ballerina.runtime.profiler.util.Constants.CURRENT_DIR_KEY;
 import static io.ballerina.runtime.profiler.util.Constants.ERROR_STREAM;
+import static io.ballerina.runtime.profiler.util.Constants.JAVA_COMMAND;
 import static io.ballerina.runtime.profiler.util.Constants.OUT_STREAM;
 import static io.ballerina.runtime.profiler.util.Constants.USER_DIR;
 
@@ -55,7 +56,7 @@ public class ProfilerMethodWrapper extends ClassLoader {
     public void invokeMethods(String debugArg) throws IOException, InterruptedException {
         String balJarArgs = Main.getBalJarArgs();
         List<String> commands = new ArrayList<>();
-        commands.add("java");
+        commands.add(System.getenv(JAVA_COMMAND));
         commands.add("-jar");
         if (debugArg != null) {
             commands.add(debugArg);

--- a/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/codegen/ProfilerMethodWrapper.java
+++ b/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/codegen/ProfilerMethodWrapper.java
@@ -42,7 +42,6 @@ import java.util.jar.Manifest;
 
 import static io.ballerina.runtime.profiler.util.Constants.CURRENT_DIR_KEY;
 import static io.ballerina.runtime.profiler.util.Constants.ERROR_STREAM;
-import static io.ballerina.runtime.profiler.util.Constants.JAVA_COMMAND;
 import static io.ballerina.runtime.profiler.util.Constants.OUT_STREAM;
 import static io.ballerina.runtime.profiler.util.Constants.USER_DIR;
 
@@ -56,7 +55,7 @@ public class ProfilerMethodWrapper extends ClassLoader {
     public void invokeMethods(String debugArg) throws IOException, InterruptedException {
         String balJarArgs = Main.getBalJarArgs();
         List<String> commands = new ArrayList<>();
-        commands.add(System.getenv(JAVA_COMMAND));
+        commands.add(System.getenv("java.command"));
         commands.add("-jar");
         if (debugArg != null) {
             commands.add(debugArg);

--- a/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/util/Constants.java
+++ b/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/util/Constants.java
@@ -51,6 +51,7 @@ public class Constants {
     public static final String PROFILE_ANALYZER = "io/ballerina/runtime/profiler/runtime/ProfileAnalyzer";
     public static final String GET_INSTANCE_DESCRIPTOR = "()L" + PROFILE_ANALYZER + ";";
     public static final String BALLERINA_HOME = "ballerina.home";
+    public static final String JAVA_COMMAND = "java.command";
     public static final String WORKING_DIRECTORY = "user.dir";
     public static final String PROFILE_DATA = "${profile_data}";
     public static final String HTML_TEMPLATE_FILE = "profiler_output.html";

--- a/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/util/Constants.java
+++ b/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/util/Constants.java
@@ -51,7 +51,6 @@ public class Constants {
     public static final String PROFILE_ANALYZER = "io/ballerina/runtime/profiler/runtime/ProfileAnalyzer";
     public static final String GET_INSTANCE_DESCRIPTOR = "()L" + PROFILE_ANALYZER + ";";
     public static final String BALLERINA_HOME = "ballerina.home";
-    public static final String JAVA_COMMAND = "java.command";
     public static final String WORKING_DIRECTORY = "user.dir";
     public static final String PROFILE_DATA = "${profile_data}";
     public static final String HTML_TEMPLATE_FILE = "profiler_output.html";

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunProfilerTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunProfilerTask.java
@@ -52,7 +52,6 @@ public class RunProfilerTask implements Task {
     private final PrintStream err;
     private static final String JAVA_OPTS = "JAVA_OPTS";
     private static final String CURRENT_DIR_KEY = "current.dir";
-    private static final String JAVA_COMMAND = "java.command";
 
     public RunProfilerTask(PrintStream errStream) {
         this.err = errStream;
@@ -67,7 +66,7 @@ public class RunProfilerTask implements Task {
         try {
             Files.copy(sourcePath, targetPath, copyOption);
             List<String> commands = new ArrayList<>();
-            commands.add(System.getProperty(JAVA_COMMAND));
+            commands.add(System.getProperty("java.command"));
             commands.add("-jar");
             if (isInDebugMode()) {
                 commands.add(getDebugArgs(err));
@@ -84,7 +83,7 @@ public class RunProfilerTask implements Task {
             pb.environment().put(JAVA_OPTS, getAgentArgs());
             pb.environment().put(BALLERINA_HOME, System.getProperty(BALLERINA_HOME));
             pb.environment().put(CURRENT_DIR_KEY, System.getProperty(USER_DIR));
-            pb.environment().put(JAVA_COMMAND, System.getProperty(JAVA_COMMAND));
+            pb.environment().put("java.command", System.getProperty("java.command"));
             pb.directory(new File(getProfilerPath(project).toUri()));
             Process process = pb.start();
             process.waitFor();

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunProfilerTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunProfilerTask.java
@@ -52,6 +52,7 @@ public class RunProfilerTask implements Task {
     private final PrintStream err;
     private static final String JAVA_OPTS = "JAVA_OPTS";
     private static final String CURRENT_DIR_KEY = "current.dir";
+    private static final String JAVA_COMMAND = "java.command";
 
     public RunProfilerTask(PrintStream errStream) {
         this.err = errStream;
@@ -66,7 +67,7 @@ public class RunProfilerTask implements Task {
         try {
             Files.copy(sourcePath, targetPath, copyOption);
             List<String> commands = new ArrayList<>();
-            commands.add(System.getProperty("java.command"));
+            commands.add(System.getProperty(JAVA_COMMAND));
             commands.add("-jar");
             if (isInDebugMode()) {
                 commands.add(getDebugArgs(err));
@@ -83,6 +84,7 @@ public class RunProfilerTask implements Task {
             pb.environment().put(JAVA_OPTS, getAgentArgs());
             pb.environment().put(BALLERINA_HOME, System.getProperty(BALLERINA_HOME));
             pb.environment().put(CURRENT_DIR_KEY, System.getProperty(USER_DIR));
+            pb.environment().put(JAVA_COMMAND, System.getProperty(JAVA_COMMAND));
             pb.directory(new File(getProfilerPath(project).toUri()));
             Process process = pb.start();
             process.waitFor();


### PR DESCRIPTION
## Purpose
> The above mentioned warning is observed when two or more java versions have been installed. 

Fixes #41548

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
