### PR TITLE
Fix module constant usage in xml attribute access

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BaseVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BaseVisitor.java
@@ -607,7 +607,7 @@ abstract class BaseVisitor extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixedFieldBasedAccess) {
+    public void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess prefixedFieldBasedAccess) {
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -95,7 +95,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorConstructorExp
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
@@ -863,9 +863,9 @@ public class ReferenceFinder extends BaseVisitor {
     }
 
     @Override
-    public void visit(BLangNSPrefixedFieldBasedAccess nsPrefixedFieldBasedAccess) {
-        find(nsPrefixedFieldBasedAccess.expr);
-        addIfSameSymbol(nsPrefixedFieldBasedAccess.nsSymbol, nsPrefixedFieldBasedAccess.nsPrefix.pos);
+    public void visit(BLangPrefixedFieldBasedAccess prefixedFieldBasedAccess) {
+        find(prefixedFieldBasedAccess.expr);
+        addIfSameSymbol(prefixedFieldBasedAccess.symbol, prefixedFieldBasedAccess.prefix.pos);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -920,12 +920,12 @@ class SymbolFinder extends BaseVisitor {
     }
 
     @Override
-    public void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixedFieldBasedAccess) {
-        if (setEnclosingNode(nsPrefixedFieldBasedAccess.nsSymbol, nsPrefixedFieldBasedAccess.nsPrefix.pos)) {
+    public void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess prefixedFieldBasedAccess) {
+        if (setEnclosingNode(prefixedFieldBasedAccess.symbol, prefixedFieldBasedAccess.prefix.pos)) {
             return;
         }
 
-        lookupNode(nsPrefixedFieldBasedAccess.expr);
+        lookupNode(prefixedFieldBasedAccess.expr);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeBuilder.java
@@ -615,7 +615,7 @@ public final class TreeBuilder {
     }
 
     public static FieldBasedAccessNode createFieldBasedAccessWithPrefixNode() {
-        return new BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess();
+        return new BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess();
     }
 
     public static TableKeySpecifierNode createTableKeySpecifierNode() {

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -387,7 +387,7 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     INVALID_NAMESPACE_DECLARATION("BCE2624", "invalid.namespace.declaration"),
     CANNOT_UPDATE_XML_SEQUENCE("BCE2625", "cannot.update.xml.sequence"),
     INVALID_XML_NS_INTERPOLATION("BCE2626", "invalid.xml.ns.interpolation"),
-    CANNOT_FIND_XML_NAMESPACE("BCE2627", "cannot.find.xml.namespace.prefix"),
+    CANNOT_FIND_XML_NAMESPACE("BCE2627", "cannot.find.xml.prefix"),
     UNSUPPORTED_METHOD_INVOCATION_XML_NAV("BCE2628", "method.invocation.in.xml.navigation.expressions.not.supported"),
     DEPRECATED_XML_ATTRIBUTE_ACCESS("BCE2629", "deprecated.xml.attribute.access.expression"),
     UNSUPPORTED_MEMBER_ACCESS_IN_XML_NAVIGATION("BCE2630",

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -424,6 +424,7 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
             "invalid.field.binding.pattern.with.non.required.field"),
     INFER_SIZE_ONLY_SUPPORTED_IN_FIRST_DIMENSION("BCE2654", "infer.size.only.supported.in.the.first.dimension"),
     FUNCTION_CALL_SYNTAX_NOT_DEFINED("BCE2655", "function.call.syntax.not.defined"),
+    UNDEFINED_CONSTANT_SYMBOL("BCE2656", "undefined.constant.symbol"),
 
     // Error codes related to iteration.
     ITERABLE_NOT_SUPPORTED_COLLECTION("BCE2800", "iterable.not.supported.collection"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
@@ -1506,9 +1506,8 @@ public class ClosureGenerator extends BLangNodeVisitor {
         result = isLikeExpr;
     }
 
-    @Override
-    public void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixedFieldBasedAccess) {
-        result = nsPrefixedFieldBasedAccess;
+    public void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess prefixedFieldBasedAccess) {
+        result = prefixedFieldBasedAccess;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
@@ -665,9 +665,9 @@ public class ConstantPropagation extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixedFieldBasedAccess) {
-        nsPrefixedFieldBasedAccess.expr = rewrite(nsPrefixedFieldBasedAccess.expr);
-        result = nsPrefixedFieldBasedAccess;
+    public void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess prefixedFieldBasedAccess) {
+        prefixedFieldBasedAccess.expr = rewrite(prefixedFieldBasedAccess.expr);
+        result = prefixedFieldBasedAccess;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -6329,8 +6329,8 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixedFieldBasedAccess) {
-        rewriteFieldBasedAccess(nsPrefixedFieldBasedAccess);
+    public void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess prefixedFieldBasedAccess) {
+        rewriteFieldBasedAccess(prefixedFieldBasedAccess);
     }
 
     private void rewriteFieldBasedAccess(BLangFieldBasedAccess fieldAccessExpr) {
@@ -6624,9 +6624,13 @@ public class Desugar extends BLangNodeVisitor {
 
         String fieldName = fieldAccessExpr.field.value;
         if (fieldAccessExpr.fieldKind == FieldKind.WITH_NS) {
-            BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixAccess =
-                    (BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess) fieldAccessExpr;
-            fieldName = createExpandedQName(nsPrefixAccess.nsSymbol.namespaceURI, fieldName);
+            BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess prefixAccess =
+                    (BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess) fieldAccessExpr;
+            if (prefixAccess.symbol.getKind() == SymbolKind.CONSTANT) {
+                fieldName = (String) ((BConstantSymbol) prefixAccess.symbol).value.value;
+            } else {
+                fieldName = createExpandedQName(((BXMLNSSymbol) prefixAccess.symbol).namespaceURI, fieldName);
+            }
         }
 
         // Handle element name access.
@@ -10310,9 +10314,9 @@ public class Desugar extends BLangNodeVisitor {
         if (accessExpr.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR) {
             ((BLangIndexBasedAccess) tempAccessExpr).indexExpr = ((BLangIndexBasedAccess) accessExpr).indexExpr;
         }
-        if (accessExpr instanceof BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess) {
-            ((BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess) tempAccessExpr).nsSymbol =
-                    ((BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess) accessExpr).nsSymbol;
+        if (accessExpr instanceof BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess) {
+            ((BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess) tempAccessExpr).symbol =
+                    ((BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess) accessExpr).symbol;
         }
 
         tempAccessExpr.expr = types.addConversionExprIfRequired(successPatternVarRef, type);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -1713,9 +1713,9 @@ public class QueryDesugar extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixedFieldBasedAccess) {
-        nsPrefixedFieldBasedAccess.expr = rewrite(nsPrefixedFieldBasedAccess.expr);
-        result = nsPrefixedFieldBasedAccess;
+    public void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess prefixedFieldBasedAccess) {
+        prefixedFieldBasedAccess.expr = rewrite(prefixedFieldBasedAccess.expr);
+        result = prefixedFieldBasedAccess;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
@@ -2175,10 +2175,10 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         Node fieldName = fieldAccessExprNode.fieldName();
         if (fieldName.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
             QualifiedNameReferenceNode qualifiedFieldName = (QualifiedNameReferenceNode) fieldName;
-            BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess accessWithPrefixNode =
-                    (BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess)
+            BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess accessWithPrefixNode =
+                    (BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess)
                             TreeBuilder.createFieldBasedAccessWithPrefixNode();
-            accessWithPrefixNode.nsPrefix = createIdentifier(qualifiedFieldName.modulePrefix());
+            accessWithPrefixNode.prefix = createIdentifier(qualifiedFieldName.modulePrefix());
             accessWithPrefixNode.field = createIdentifier(qualifiedFieldName.identifier());
             bLFieldBasedAccess = accessWithPrefixNode;
             bLFieldBasedAccess.fieldKind = FieldKind.WITH_NS;
@@ -2209,10 +2209,10 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
 
         if (fieldName.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
             QualifiedNameReferenceNode qualifiedFieldName = (QualifiedNameReferenceNode) fieldName;
-            BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess accessWithPrefixNode =
-                    (BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess) TreeBuilder
+            BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess accessWithPrefixNode =
+                    (BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess) TreeBuilder
                             .createFieldBasedAccessWithPrefixNode();
-            accessWithPrefixNode.nsPrefix = createIdentifier(qualifiedFieldName.modulePrefix());
+            accessWithPrefixNode.prefix = createIdentifier(qualifiedFieldName.modulePrefix());
             accessWithPrefixNode.field = createIdentifier(qualifiedFieldName.identifier());
             bLFieldBasedAccess = accessWithPrefixNode;
             bLFieldBasedAccess.fieldKind = FieldKind.WITH_NS;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -1171,13 +1171,13 @@ public class NodeCloner extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess source) {
+    public void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess source) {
 
-        BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess clone =
-                new BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess();
+        BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess clone =
+                new BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess();
 
         source.cloneRef = clone;
-        clone.nsPrefix = source.nsPrefix;
+        clone.prefix = source.prefix;
         clone.field = source.field;
         clone.fieldKind = source.fieldKind;
         cloneBLangAccessExpression(source, clone);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -2580,9 +2580,9 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
     }
 
     @Override
-    public void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixedFieldBasedAccess,
+    public void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess prefixedFieldBasedAccess,
                       AnalyzerData data) {
-        analyzeFieldBasedAccessExpr(nsPrefixedFieldBasedAccess, data);
+        analyzeFieldBasedAccessExpr(prefixedFieldBasedAccess, data);
     }
 
     private void analyzeFieldBasedAccessExpr(BLangFieldBasedAccess fieldAccessExpr, AnalyzerData data) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -1621,11 +1621,11 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixedFieldBasedAccess) {
-        if (!nsPrefixedFieldBasedAccess.isLValue && isObjectMemberAccessWithSelf(nsPrefixedFieldBasedAccess)) {
-            checkVarRef(nsPrefixedFieldBasedAccess.symbol, nsPrefixedFieldBasedAccess.pos);
+    public void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess prefixedFieldBasedAccess) {
+        if (!prefixedFieldBasedAccess.isLValue && isObjectMemberAccessWithSelf(prefixedFieldBasedAccess)) {
+            checkVarRef(prefixedFieldBasedAccess.symbol, prefixedFieldBasedAccess.pos);
         }
-        analyzeNode(nsPrefixedFieldBasedAccess.expr, env);
+        analyzeNode(prefixedFieldBasedAccess.expr, env);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
@@ -1375,8 +1375,8 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixedFieldBasedAccess) {
-        analyzeFieldBasedAccess(nsPrefixedFieldBasedAccess);
+    public void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess prefixedFieldBasedAccess) {
+        analyzeFieldBasedAccess(prefixedFieldBasedAccess);
     }
 
     private void analyzeFieldBasedAccess(BLangFieldBasedAccess fieldAccessExpr) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -987,6 +987,27 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
     }
 
     /**
+     * Return the symbol with the given name even with a different package.
+     *
+     * @param scope     current scope
+     * @param name      symbol name
+     * @param expSymTag expected symbol type/tag
+     * @return resolved symbol
+     */
+    public BSymbol lookupPossibleMemberSymbol(Scope scope, Name name, long expSymTag) {
+        ScopeEntry entry = scope.lookup(name);
+        while (entry != NOT_FOUND_ENTRY) {
+            if ((entry.symbol.tag & expSymTag) != expSymTag) {
+                entry = entry.next;
+                continue;
+            }
+            return entry.symbol;
+        }
+
+        return symTable.notFoundSymbol;
+    }
+
+    /**
      * Resolve and return the namespaces visible to the given environment, as a map.
      *
      * @param env Environment to get the visible namespaces

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -5990,7 +5990,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             return null;
         }
 
-        if (pkgSymbol.getKind() == SymbolKind.PACKAGE && !PackageID.isLangLibPackageID(pkgSymbol.pkgID)) {
+        if (!PackageID.isLangLibPackageID(pkgSymbol.pkgID)) {
             pkgSymbol.isUsed = true;
             return constantSymbol;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -5974,12 +5974,17 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
     private BSymbol findXMLNamespaceFromPackageConst(String localname, String prefix,
                                                      BPackageSymbol pkgSymbol, Location pos, AnalyzerData data) {
         // Resolve a const from module scope.
-        BSymbol constSymbol = symResolver.lookupMemberSymbol(pos, pkgSymbol.scope, data.env,
-                Names.fromString(localname), SymTag.CONSTANT);
+        BSymbol constSymbol =
+                symResolver.lookupPossibleMemberSymbol(pkgSymbol.scope, names.fromString(localname), SymTag.CONSTANT);
         if (constSymbol == symTable.notFoundSymbol) {
             if (!missingNodesHelper.isMissingNode(prefix) && !missingNodesHelper.isMissingNode(localname)) {
-                dlog.error(pos, DiagnosticErrorCode.UNDEFINED_SYMBOL, prefix + ":" + localname);
+                dlog.error(pos, DiagnosticErrorCode.UNDEFINED_CONSTANT_SYMBOL, prefix + ":" + localname);
             }
+            return null;
+        }
+
+        if (!data.env.enclPkg.packageID.equals(pkgSymbol.pkgID) && !Symbols.isPublic(constSymbol)) {
+            dlog.error(pos, DiagnosticErrorCode.ATTEMPT_REFER_NON_ACCESSIBLE_SYMBOL, constSymbol.name);
             return null;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3517,9 +3517,9 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
     }
 
     @Override
-    public void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixedFieldBasedAccess,
+    public void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess prefixedFieldBasedAccess,
                       AnalyzerData data) {
-        checkFieldBasedAccess(nsPrefixedFieldBasedAccess, true, data);
+        checkFieldBasedAccess(prefixedFieldBasedAccess, true, data);
     }
 
     @Override
@@ -5990,6 +5990,10 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             return null;
         }
 
+        if (pkgSymbol.getKind() == SymbolKind.PACKAGE && !PackageID.isLangLibPackageID(pkgSymbol.pkgID)) {
+            pkgSymbol.isUsed = true;
+            return constantSymbol;
+        }
         // If resolve const contain a string in {namespace url}local form extract namespace uri and local part.
         String constVal = (String) constantSymbol.value.value;
         int s = constVal.indexOf('{');
@@ -8594,7 +8598,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 return symTable.semanticError;
             }
             if (fieldAccessExpr.fieldKind == FieldKind.WITH_NS) {
-                resolveXMLNamespace((BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess) fieldAccessExpr, data);
+                resolveXMLNamespace((BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess) fieldAccessExpr, data);
             }
             BType laxFieldAccessType = getLaxFieldAccessType(varRefType);
             actualType = BUnionType.create(null, laxFieldAccessType, symTable.errorType);
@@ -8604,7 +8608,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             BType laxFieldAccessType =
                     getLaxFieldAccessType(((BLangFieldBasedAccess) fieldAccessExpr.expr).originalType);
             if (fieldAccessExpr.fieldKind == FieldKind.WITH_NS) {
-                resolveXMLNamespace((BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess) fieldAccessExpr, data);
+                resolveXMLNamespace((BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess) fieldAccessExpr, data);
             }
             actualType = BUnionType.create(null, laxFieldAccessType, symTable.errorType);
             fieldAccessExpr.errorSafeNavigation = true;
@@ -8625,21 +8629,21 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         return actualType;
     }
 
-    private void resolveXMLNamespace(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess fieldAccessExpr,
+    private void resolveXMLNamespace(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess fieldAccessExpr,
                                      AnalyzerData data) {
-        BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixedFieldAccess = fieldAccessExpr;
-        String nsPrefix = nsPrefixedFieldAccess.nsPrefix.value;
-        BSymbol nsSymbol = symResolver.lookupSymbolInPrefixSpace(data.env, Names.fromString(nsPrefix));
+        BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess prefixedFieldAccess = fieldAccessExpr;
+        String nsPrefix = prefixedFieldAccess.prefix.value;
+        BSymbol nsSymbol = symResolver.lookupSymbolInPrefixSpace(data.env, names.fromString(nsPrefix));
 
         if (nsSymbol == symTable.notFoundSymbol) {
-            dlog.error(nsPrefixedFieldAccess.nsPrefix.pos, DiagnosticErrorCode.CANNOT_FIND_XML_NAMESPACE,
-                    nsPrefixedFieldAccess.nsPrefix);
+            dlog.error(prefixedFieldAccess.prefix.pos, DiagnosticErrorCode.CANNOT_FIND_XML_NAMESPACE,
+                    prefixedFieldAccess.prefix);
         } else if (nsSymbol.getKind() == SymbolKind.PACKAGE) {
-            nsPrefixedFieldAccess.nsSymbol = (BXMLNSSymbol) findXMLNamespaceFromPackageConst(
-                    nsPrefixedFieldAccess.field.value, nsPrefixedFieldAccess.nsPrefix.value,
+            prefixedFieldAccess.symbol = findXMLNamespaceFromPackageConst(
+                    prefixedFieldAccess.field.value, prefixedFieldAccess.prefix.value,
                     (BPackageSymbol) nsSymbol, fieldAccessExpr.pos, data);
         } else {
-            nsPrefixedFieldAccess.nsSymbol = (BXMLNSSymbol) nsSymbol;
+            prefixedFieldAccess.symbol = nsSymbol;
         }
     }
 
@@ -8711,7 +8715,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             actualType = accessCouldResultInError(referredType) ?
                     BUnionType.create(null, laxFieldAccessType, symTable.errorType) : laxFieldAccessType;
             if (fieldAccessExpr.fieldKind == FieldKind.WITH_NS) {
-                resolveXMLNamespace((BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess) fieldAccessExpr, data);
+                resolveXMLNamespace((BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess) fieldAccessExpr, data);
             }
             fieldAccessExpr.originalType = laxFieldAccessType;
             fieldAccessExpr.nilSafeNavigation = true;
@@ -8723,7 +8727,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             actualType = accessCouldResultInError(referredType) ?
                     BUnionType.create(null, laxFieldAccessType, symTable.errorType) : laxFieldAccessType;
             if (fieldAccessExpr.fieldKind == FieldKind.WITH_NS) {
-                resolveXMLNamespace((BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess) fieldAccessExpr, data);
+                resolveXMLNamespace((BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess) fieldAccessExpr, data);
             }
             fieldAccessExpr.errorSafeNavigation = true;
             fieldAccessExpr.originalType = laxFieldAccessType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNodeAnalyzer.java
@@ -351,7 +351,7 @@ public abstract class BLangNodeAnalyzer<T> {
 
     public abstract void visit(BLangFieldBasedAccess.BLangStructFunctionVarRef node, T data);
 
-    public abstract void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess node, T data);
+    public abstract void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess node, T data);
 
     public abstract void visit(BLangGroupExpr node, T data);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNodeTransformer.java
@@ -495,7 +495,7 @@ public abstract class BLangNodeTransformer<T, R> {
         return transformNode(node, data);
     }
 
-    public R transform(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess node, T data) {
+    public R transform(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess node, T data) {
         return transformNode(node, data);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNodeVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNodeVisitor.java
@@ -631,7 +631,7 @@ public abstract class BLangNodeVisitor {
         throw new AssertionError();
     }
 
-    public void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixedFieldBasedAccess) {
+    public void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess prefixedFieldBasedAccess) {
         throw new AssertionError();
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/SimpleBLangNodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/SimpleBLangNodeAnalyzer.java
@@ -739,11 +739,10 @@ public abstract class SimpleBLangNodeAnalyzer<T> extends BLangNodeAnalyzer<T> {
         visit((BLangFieldBasedAccess) node, data);
     }
 
-    @Override
-    public void visit(BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess node, T data) {
+    public void visit(BLangFieldBasedAccess.BLangPrefixedFieldBasedAccess node, T data) {
         analyzeNode(node, data);
         visit((BLangFieldBasedAccess) node, data);
-        visitNode(node.nsPrefix, data);
+        visitNode(node.prefix, data);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangFieldBasedAccess.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangFieldBasedAccess.java
@@ -20,8 +20,8 @@ package org.wso2.ballerinalang.compiler.tree.expressions;
 
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.expressions.FieldBasedAccessNode;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
-import org.wso2.ballerinalang.compiler.semantics.model.symbols.BXMLNSSymbol;
 import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeAnalyzer;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeTransformer;
@@ -117,13 +117,13 @@ public class BLangFieldBasedAccess extends BLangAccessExpression implements Fiel
      *
      * @since 1.2.0
      */
-    public static class BLangNSPrefixedFieldBasedAccess extends BLangFieldBasedAccess {
+    public static class BLangPrefixedFieldBasedAccess extends BLangFieldBasedAccess {
 
         // BLangNodes
-        public BLangIdentifier nsPrefix;
+        public BLangIdentifier prefix;
 
         // Semantic Data
-        public BXMLNSSymbol nsSymbol;
+        public BSymbol symbol;
 
         @Override
         public void accept(BLangNodeVisitor visitor) {
@@ -131,7 +131,7 @@ public class BLangFieldBasedAccess extends BLangAccessExpression implements Fiel
         }
 
         public String toString() {
-            return expr + "." + nsPrefix + ":" + field;
+            return expr + "." + prefix + ":" + field;
         }
 
         @Override

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -135,6 +135,9 @@ error.redeclared.builtin.symbol=\
 error.undefined.symbol=\
   undefined symbol ''{0}''
 
+error.undefined.constant.symbol=\
+  undefined constant symbol ''{0}''
+
 error.undefined.function=\
   undefined function ''{0}''
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -725,7 +725,7 @@ error.xml.function.does.not.support.argument.type=\
 error.invalid.xml.ns.interpolation=\
   xml namespaces cannot be interpolated
 
-error.cannot.find.xml.namespace.prefix=\
+error.cannot.find.xml.prefix=\
   cannot find the prefix ''{0}''
 
 error.method.invocation.in.xml.navigation.expressions.not.supported=\

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -726,7 +726,7 @@ error.invalid.xml.ns.interpolation=\
   xml namespaces cannot be interpolated
 
 error.cannot.find.xml.namespace.prefix=\
-  cannot find xml namespace prefix ''{0}''
+  cannot find the prefix ''{0}''
 
 error.method.invocation.in.xml.navigation.expressions.not.supported=\
   method invocations are not yet supported within XML navigation expressions, use a grouping expression \

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/XMLAttrAccessWithModulePrefix.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/XMLAttrAccessWithModulePrefix.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.bala.types;
+
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.BRunUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.ballerinalang.test.BAssertUtil.validateError;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @since 2201.9.0
+ */
+public class XMLAttrAccessWithModulePrefix {
+    CompileResult compileResult;
+    CompileResult negative;
+
+    @BeforeClass
+    public void setup() {
+        CompileResult projectCompileResult =
+                BCompileUtil.compileAndCacheBala("test-src/bala/test_projects/test_project");
+        if (projectCompileResult.getErrorCount() > 0) {
+            Arrays.stream(projectCompileResult.getDiagnostics()).forEach(System.out::println);
+            Assert.fail("Compilation contains errors");
+        }
+        compileResult = BCompileUtil.compile("test-src/bala/test_bala/types/xml_attribute_access.bal");
+        negative = BCompileUtil.compile("test-src/bala/test_bala/types/xml_attribute_access_negative.bal");
+    }
+
+    @Test
+    public void testXMLAttributeAccessWithModulePrefix() {
+        BRunUtil.invoke(compileResult, "testXMLAttributeAccessWithModulePrefix");
+    }
+
+    @Test
+    public void testOptionalXMLAttributeAccessWithModulePrefix() {
+        BRunUtil.invoke(compileResult, "testOptionalXMLAttributeAccessWithModulePrefix");
+    }
+
+    @Test
+    public void testXMLAttributeAccessErrors() {
+        BRunUtil.invoke(compileResult, "testXMLAttributeAccessErrors");
+    }
+
+    @Test
+    public void testXMLAttributeAccessCompileNegative() {
+        int i = 0;
+        validateError(negative, i++, "attempt to refer to non-accessible symbol 'XMLD'", 24, 22);
+        validateError(negative, i++, "undefined symbol 'foo:XMLD'", 24, 22);
+        validateError(negative, i++, "undefined symbol 'foo:XMLE'", 25, 22);
+        validateError(negative, i++, "undefined symbol 'foo:XMLG'", 26, 22);
+        validateError(negative, i++, "cannot find the prefix 'bar'", 27, 24);
+        validateError(negative, i++, "attempt to refer to non-accessible symbol 'XMLD'", 33, 23);
+        validateError(negative, i++, "undefined symbol 'foo:XMLD'", 33, 23);
+        validateError(negative, i++, "undefined symbol 'foo:XMLE'", 34, 23);
+        validateError(negative, i++, "undefined symbol 'foo:XMLG'", 35, 23);
+        validateError(negative, i++, "cannot find the prefix 'bar'", 36, 26);
+        assertEquals(negative.getErrorCount(), i);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        negative = null;
+    }
+
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/XMLAttrAccessWithModulePrefixTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/XMLAttrAccessWithModulePrefixTest.java
@@ -32,9 +32,11 @@ import static org.ballerinalang.test.BAssertUtil.validateError;
 import static org.testng.Assert.assertEquals;
 
 /**
+ * Tests for xml attribute access using module constants.
+ *
  * @since 2201.9.0
  */
-public class XMLAttrAccessWithModulePrefix {
+public class XMLAttrAccessWithModulePrefixTest {
     CompileResult compileResult;
     CompileResult negative;
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/XMLAttrAccessWithModulePrefixTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/XMLAttrAccessWithModulePrefixTest.java
@@ -21,12 +21,10 @@ package org.ballerinalang.test.bala.types;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import java.util.Arrays;
 
 import static org.ballerinalang.test.BAssertUtil.validateError;
 import static org.testng.Assert.assertEquals;
@@ -37,48 +35,41 @@ import static org.testng.Assert.assertEquals;
  * @since 2201.9.0
  */
 public class XMLAttrAccessWithModulePrefixTest {
+
     CompileResult compileResult;
-    CompileResult negative;
 
     @BeforeClass
     public void setup() {
-        CompileResult projectCompileResult =
-                BCompileUtil.compileAndCacheBala("test-src/bala/test_projects/test_project");
-        if (projectCompileResult.getErrorCount() > 0) {
-            Arrays.stream(projectCompileResult.getDiagnostics()).forEach(System.out::println);
-            Assert.fail("Compilation contains errors");
-        }
+        BCompileUtil.compileAndCacheBala("test-src/bala/test_projects/test_project");
         compileResult = BCompileUtil.compile("test-src/bala/test_bala/types/xml_attribute_access.bal");
-        negative = BCompileUtil.compile("test-src/bala/test_bala/types/xml_attribute_access_negative.bal");
+    }
+
+    @Test(dataProvider = "xmlAttributeAccessWithModulePrefix")
+    public void testXmlAttributeAccessWithModulePrefix(String function) {
+        BRunUtil.invoke(compileResult, function);
+    }
+
+    @DataProvider(name = "xmlAttributeAccessWithModulePrefix")
+    public Object[] xmlAttributeAccessWithModulePrefix() {
+        return new Object[]{
+                "testXmlRequiredAttributeAccessWithModulePrefix",
+                "testXmlOptionalAttributeAccessWithModulePrefix",
+                "testXmlAttributeAccessErrors"
+        };
     }
 
     @Test
-    public void testXMLAttributeAccessWithModulePrefix() {
-        BRunUtil.invoke(compileResult, "testXMLAttributeAccessWithModulePrefix");
-    }
-
-    @Test
-    public void testOptionalXMLAttributeAccessWithModulePrefix() {
-        BRunUtil.invoke(compileResult, "testOptionalXMLAttributeAccessWithModulePrefix");
-    }
-
-    @Test
-    public void testXMLAttributeAccessErrors() {
-        BRunUtil.invoke(compileResult, "testXMLAttributeAccessErrors");
-    }
-
-    @Test
-    public void testXMLAttributeAccessCompileNegative() {
+    public void testXmlAttributeAccessCompileNegative() {
+        CompileResult negative =
+                BCompileUtil.compile("test-src/bala/test_bala/types/xml_attribute_access_negative.bal");
         int i = 0;
         validateError(negative, i++, "attempt to refer to non-accessible symbol 'XMLD'", 24, 22);
-        validateError(negative, i++, "undefined symbol 'foo:XMLD'", 24, 22);
-        validateError(negative, i++, "undefined symbol 'foo:XMLE'", 25, 22);
-        validateError(negative, i++, "undefined symbol 'foo:XMLG'", 26, 22);
+        validateError(negative, i++, "undefined constant symbol 'foo:XMLE'", 25, 22);
+        validateError(negative, i++, "undefined constant symbol 'foo:XMLG'", 26, 22);
         validateError(negative, i++, "cannot find the prefix 'bar'", 27, 24);
         validateError(negative, i++, "attempt to refer to non-accessible symbol 'XMLD'", 33, 23);
-        validateError(negative, i++, "undefined symbol 'foo:XMLD'", 33, 23);
-        validateError(negative, i++, "undefined symbol 'foo:XMLE'", 34, 23);
-        validateError(negative, i++, "undefined symbol 'foo:XMLG'", 35, 23);
+        validateError(negative, i++, "undefined constant symbol 'foo:XMLE'", 34, 23);
+        validateError(negative, i++, "undefined constant symbol 'foo:XMLG'", 35, 23);
         validateError(negative, i++, "cannot find the prefix 'bar'", 36, 26);
         assertEquals(negative.getErrorCount(), i);
     }
@@ -86,7 +77,5 @@ public class XMLAttrAccessWithModulePrefixTest {
     @AfterClass
     public void tearDown() {
         compileResult = null;
-        negative = null;
     }
-
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/XMLAttrAccessWithModulePrefixTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/XMLAttrAccessWithModulePrefixTest.java
@@ -32,7 +32,7 @@ import static org.testng.Assert.assertEquals;
 /**
  * Tests for xml attribute access using module constants.
  *
- * @since 2201.9.0
+ * @since 2201.11.0
  */
 public class XMLAttrAccessWithModulePrefixTest {
 
@@ -63,13 +63,13 @@ public class XMLAttrAccessWithModulePrefixTest {
         CompileResult negative =
                 BCompileUtil.compile("test-src/bala/test_bala/types/xml_attribute_access_negative.bal");
         int i = 0;
-        validateError(negative, i++, "attempt to refer to non-accessible symbol 'XMLD'", 24, 22);
-        validateError(negative, i++, "undefined constant symbol 'foo:XMLE'", 25, 22);
-        validateError(negative, i++, "undefined constant symbol 'foo:XMLG'", 26, 22);
+        validateError(negative, i++, "attempt to refer to non-accessible symbol 'XMLD'", 24, 24);
+        validateError(negative, i++, "undefined constant symbol 'foo:XMLE'", 25, 24);
+        validateError(negative, i++, "undefined constant symbol 'foo:XMLG'", 26, 24);
         validateError(negative, i++, "cannot find the prefix 'bar'", 27, 24);
-        validateError(negative, i++, "attempt to refer to non-accessible symbol 'XMLD'", 33, 23);
-        validateError(negative, i++, "undefined constant symbol 'foo:XMLE'", 34, 23);
-        validateError(negative, i++, "undefined constant symbol 'foo:XMLG'", 35, 23);
+        validateError(negative, i++, "attempt to refer to non-accessible symbol 'XMLD'", 33, 26);
+        validateError(negative, i++, "undefined constant symbol 'foo:XMLE'", 34, 26);
+        validateError(negative, i++, "undefined constant symbol 'foo:XMLG'", 35, 26);
         validateError(negative, i++, "cannot find the prefix 'bar'", 36, 26);
         assertEquals(negative.getErrorCount(), i);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -329,7 +329,7 @@ public class XMLAccessTest {
         BAssertUtil.validateError(navigationFilterNegative, index++,
                 "incompatible types: expected 'xml', found 'int'", 8, 14);
         BAssertUtil.validateError(navigationFilterNegative, index++,
-                "cannot find xml namespace prefix 'foo'", 13, 16);
+                "cannot find the prefix 'foo'", 13, 16);
         Assert.assertEquals(navigationFilterNegative.getErrorCount(), index);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
@@ -73,7 +73,7 @@ public class XMLLiteralTest {
         BAssertUtil.validateError(negativeResult, index++, "cannot assign values to an xml qualified name", 38, 5);
 
         // use of undefined namespace for qname
-        BAssertUtil.validateError(negativeResult, index++, "cannot find xml namespace prefix 'ns0'", 46, 24);
+        BAssertUtil.validateError(negativeResult, index++, "cannot find the prefix 'ns0'", 46, 24);
 
         // define namespace with empty URI
         BAssertUtil.validateError(negativeResult, index++, "cannot bind prefix 'ns0' to the empty namespace name",

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/xml_attribute_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/xml_attribute_access.bal
@@ -1,0 +1,72 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import testorg/foo;
+
+xmlns "http://ballerinalang.org" as ns;
+
+function testXMLAttributeAccessWithModulePrefix() {
+    xml x = xml `<a ns:a="content" ns:B="nsB" b="identity"></a>`;
+    assertEquality(x.ns:a, "content");
+    assertEquality(x.foo:XMLA, "content");
+    assertEquality(x.foo:XMLB, "identity");
+}
+
+function testOptionalXMLAttributeAccessWithModulePrefix() {
+    xml x = xml `<a ns:a="content" ns:B="nsB" b="identity"></a>`;
+    assertEquality(x?.ns:a, "content");
+    assertEquality(x?.foo:XMLA, "content");
+    assertEquality(x?.foo:XMLB, "identity");
+    assertEquality(x?.foo:XMLC, ());
+    assertEquality(x?.foo:XMLF, ());
+}
+
+function testXMLAttributeAccessErrors() {
+    xml x = xml `<a ns:A="content" id="identity"></a>`;
+    assertError(x.foo:XMLF, "{ballerina/lang.xml}XMLOperationError", "attribute '{http://ballerinalang.org}f' not found");
+    assertError(x.foo:XMLC, "{ballerina/lang.xml}XMLOperationError", "attribute 'c' not found");
+}
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    panic error("Assertion Error",
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
+}
+
+type Error error<record { string message; }>;
+
+function assertError(any|error value, string errorMessage, string expDetailMessage) {
+    if value is Error {
+        if (value.message() != errorMessage) {
+            panic error("Expected error message: " + errorMessage + " found: " + value.message());
+        }
+
+        if value.detail().message == expDetailMessage {
+            return;
+        }
+        panic error("Expected error detail message: " + expDetailMessage + " found: " + value.detail().message);
+    }
+    panic error("Expected: Error, found: " + (typeof value).toString());
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/xml_attribute_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/xml_attribute_access.bal
@@ -13,60 +13,56 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import testorg/foo;
 
 xmlns "http://ballerinalang.org" as ns;
 
-function testXMLAttributeAccessWithModulePrefix() {
+function testXmlRequiredAttributeAccessWithModulePrefix() {
     xml x = xml `<a ns:a="content" ns:B="nsB" b="identity"></a>`;
-    assertEquality(x.ns:a, "content");
-    assertEquality(x.foo:XMLA, "content");
-    assertEquality(x.foo:XMLB, "identity");
+    assertNonErrorValue("content", x.ns:a);
+    assertNonErrorValue("content", x.foo:XMLA);
+    assertNonErrorValue("identity", x.foo:XMLB);
 }
 
-function testOptionalXMLAttributeAccessWithModulePrefix() {
+function testXmlOptionalAttributeAccessWithModulePrefix() {
     xml x = xml `<a ns:a="content" ns:B="nsB" b="identity"></a>`;
-    assertEquality(x?.ns:a, "content");
-    assertEquality(x?.foo:XMLA, "content");
-    assertEquality(x?.foo:XMLB, "identity");
-    assertEquality(x?.foo:XMLC, ());
-    assertEquality(x?.foo:XMLF, ());
+    assertNonErrorValue("content", x?.ns:a);
+    assertNonErrorValue("content", x?.foo:XMLA);
+    assertNonErrorValue("identity", x?.foo:XMLB);
+    assertNonErrorValue((), x?.foo:XMLC);
+    assertNonErrorValue((), x?.foo:XMLF);
 }
 
-function testXMLAttributeAccessErrors() {
+function testXmlAttributeAccessErrors() {
     xml x = xml `<a ns:A="content" id="identity"></a>`;
-    assertError(x.foo:XMLF, "{ballerina/lang.xml}XMLOperationError", "attribute '{http://ballerinalang.org}f' not found");
+    assertError(x.foo:XMLF, "{ballerina/lang.xml}XMLOperationError",
+            "attribute '{http://ballerinalang.org}f' not found");
     assertError(x.foo:XMLC, "{ballerina/lang.xml}XMLOperationError", "attribute 'c' not found");
 }
 
-function assertEquality(any|error expected, any|error actual) {
-    if expected is anydata && actual is anydata && expected == actual {
-        return;
+function assertNonErrorValue(anydata expected, any|error actual) {
+    if actual is error {
+        panic error("expected [" + expected.toString() + "] " + ", but got error with message " + actual.message());
     }
 
-    if expected === actual {
-        return;
+    if expected != actual {
+        panic error(string `expected ${expected.toBalString()}, found ${actual.toBalString()}`);
     }
-
-    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
-    string actualValAsString = actual is error ? actual.toString() : actual.toString();
-    panic error("Assertion Error",
-            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }
 
-type Error error<record { string message; }>;
+type Error error<record {string message;}>;
 
 function assertError(any|error value, string errorMessage, string expDetailMessage) {
     if value is Error {
-        if (value.message() != errorMessage) {
-            panic error("Expected error message: " + errorMessage + " found: " + value.message());
+        string actualErrorMessage = value.message();
+        if actualErrorMessage != errorMessage {
+            panic error("Expected error message: " + errorMessage + " found: " + actualErrorMessage);
         }
-
-        if value.detail().message == expDetailMessage {
+        string actualDetailMessage = value.detail().message;
+        if actualDetailMessage == expDetailMessage {
             return;
         }
-        panic error("Expected error detail message: " + expDetailMessage + " found: " + value.detail().message);
+        panic error("Expected error detail message: " + expDetailMessage + " found: " + actualDetailMessage);
     }
     panic error("Expected: Error, found: " + (typeof value).toString());
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/xml_attribute_access_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/xml_attribute_access_negative.bal
@@ -18,7 +18,7 @@ import testorg/foo;
 
 xmlns "http://ballerinalang.org" as ns;
 
-function testXMLAttributeAccessNegative() returns error? {
+function testXmlRequiredAttributeAccessNegative() returns error? {
     xml x = xml `<a ns:A="content" id="identity"></a>`;
 
     string _ = check x.foo:XMLD; // const exist but not public
@@ -27,7 +27,7 @@ function testXMLAttributeAccessNegative() returns error? {
     string _ = check x.bar:Y; // non-existing prefix
 }
 
-function testXMLOptionalAttributeAccessNegative() returns error? {
+function testXmlOptionalAttributeAccessNegative() returns error? {
     xml x = xml `<a ns:A="content" id="identity"></a>`;
 
     string? _ = check x?.foo:XMLD;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/xml_attribute_access_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/xml_attribute_access_negative.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import testorg/foo;
+
+xmlns "http://ballerinalang.org" as ns;
+
+function testXMLAttributeAccessNegative() returns error? {
+    xml x = xml `<a ns:A="content" id="identity"></a>`;
+
+    string _ = check x.foo:XMLD; // const exist but not public
+    string _ = check x.foo:XMLE; // Referred value not a const
+    string _ = check x.foo:XMLG; // non-existing const
+    string _ = check x.bar:Y; // non-existing prefix
+}
+
+function testXMLOptionalAttributeAccessNegative() returns error? {
+    xml x = xml `<a ns:A="content" id="identity"></a>`;
+
+    string? _ = check x?.foo:XMLD;
+    string? _ = check x?.foo:XMLE;
+    string? _ = check x?.foo:XMLG;
+    string? _ = check x?.bar:Y;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/xml-const.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/xml-const.bal
@@ -1,0 +1,6 @@
+public const XMLA = "{http://ballerinalang.org}a";
+public const XMLB = "b";
+public const XMLC = "c";
+const XMLD = "d";
+public final string XMLE = "e";
+public const XMLF = "{http://ballerinalang.org}f";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/xml-const.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/xml-const.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 public const XMLA = "{http://ballerinalang.org}a";
 public const XMLB = "b";
 public const XMLC = "c";


### PR DESCRIPTION
## Purpose

Fixes #32624

## Approach
Previously, the assumption was that when a `qualifiedName:identifier` appeared in an XML attribute access, the qualified name referred to an XML namespace. This assumption originated at the BLangNodeBuilder level (referenced [here](https://github.com/ballerina-platform/ballerina-lang/blob/master/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java#L2165-L2173)). At the `BLangNodeBuilder` level,  there is not enough information to differentiate whether this referred to a moduleName constant or an XML namespace. A class `BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess`  was created at the `BLangNodeBuilder` level which stored a `BXMLNSSymbol`.
Since it was not possible to differentiate between the module constant and the xml namespace the existing class was renamed and modified to store a BSymbol rather than a XMLNSymbol. 
Thus in the case of a module constant this field stored a BConstantSymbol and in the presence of a xml namespace this stored a BXMLNSSymbol.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
