### PR TITLE
Improve the error message for invalid table key values

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1573,6 +1573,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                             }
                         }
                         default -> {
+                            // Ignore the default case
                         }
                     }
                 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
@@ -191,6 +191,66 @@ public class TableNegativeTest {
         validateError(compileResult, index++, "incompatible types: expected " +
                 "'table<ballerina/lang.table:0.0.0:MapType> key<ballerina/lang.table:0.0.0:KeyType>', " +
                 "found 'table<record {| int id; |}>'", 566, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                576, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                586, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                587, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                588, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                596, 23);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                605, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                606, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                607, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                608, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                616, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                625, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                626, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                627, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                628, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                629, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                630, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                631, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                632, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                633, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                634, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                642, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                643, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                644, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                645, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                646, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                647, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                648, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                649, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                650, 5);
+        validateError(compileResult, index++, "value expression of key specifier 'k' must be a constant expression",
+                651, 5);
         Assert.assertEquals(compileResult.getErrorCount(), index);
     }
 
@@ -215,17 +275,17 @@ public class TableNegativeTest {
                         "</BLangXMLQName: (p) empId> [][5005]]'",
                 54, 9);
         validateError(compileResult, index++, "duplicate key found in table row key('firstName') : '<string> " +
-                        "(name is string && ! invalid?(BLangStringTemplateLiteral: [Hello , name, !!!]):James)'",
-                64, 9);
+                        "(val > 10 && ! (val < 10)?(BLangStringTemplateLiteral: [Hello , name, !!!]):James)'",
+                67, 9);
         validateError(compileResult, index++, "duplicate key found in table row key('id') : '[5005, 5006]'",
-                76, 5);
+                79, 5);
         validateError(compileResult, index++, "duplicate key found in table row key('id') : ' '",
-                102, 9);
+                105, 9);
         validateError(compileResult, index++, "duplicate key found in table row key('id') : " +
                         "'<(byte[] & readonly)> (base16 `5A`)'",
-                128, 9);
+                131, 9);
         validateError(compileResult, index, "duplicate key found in table row key('id') : 'ID2'",
-                136, 9);
+                139, 9);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
@@ -565,3 +565,88 @@ function testKeyConstraint() {
     var ids = from var {id} in keylessTable select {id};
     _ = ids.remove(0); // error
 }
+
+string strValue = "abc";
+type Row6 record {
+    readonly string k;
+    int value;
+};
+
+table<Row6> key(k) tbl5 = table [
+    {k: string `A${idValue}C${strValue}`, value: 17}
+];
+
+type Row7 record {
+    readonly int[] k;
+    int value;
+};
+int[] intArr = [12, 12];
+
+table<Row7> key(k) tbl7 = table [
+    {k: [12, 12, intVal], value: 5},
+    {k: [intVal, intVal], value: 17},
+    {k: [12, ...intArr], value: 17}
+];
+
+type Row8 record {
+    readonly table<Row6> key(k) k;
+    int value;
+};
+table<Row8> key(k) tbl8 = table [
+    {k: table key(k) [{k: strValue, value: 17}], value: 17}
+];
+
+type Row9 record {
+    readonly map<anydata> k;
+    int value;
+};
+Row9 mapVal = {k: {idValue, "C": [13.5, 24.3]}, value: 17};
+table<Row9> key(k) tbl9 = table [
+    {k: {"A": strValue, "B": idValue, "C": [13.5, 24.3]}, value: 17},
+    {k: {strValue, "B": "idValue", "C": [13.5, 24.3]}, value: 17},
+    {k: {[strValue]: "a", "B": "idValue", "C": [13.5, 24.3]}, value: 17},
+    {...mapVal}
+];
+
+type Row10 record {
+    readonly float k;
+    int value;
+};
+table<Row10> key(k) tbl10 = table [
+    {k: <float>idValue, value: 17}
+];
+
+int? intOrNull = 12;
+type Row11 record {
+    readonly int k;
+    int value;
+};
+table<Row11> key(k) tbl11 = table [
+    {k: +idValue, value: 17},
+    {k: idValue * 12, value: 19},
+    {k: idValue + 12, value: 11},
+    {k: idValue >> 13, value: 11},
+    {k: idValue | 13, value: 11},
+    {k: idValue & 13, value: 11},
+    {k: idValue is int ? 12 : 1, value: 11},
+    {k: idValue, value: 11},
+    {k: intOrNull ?: 1, value: 11},
+    {k: (idValue is int ? (<int> 10.5) : 20), value: 11}
+];
+
+type Row12 record {
+    readonly boolean k;
+    int value;
+};
+table<Row12> key(k) tbl12 = table [
+    {k: 5 < idValue, value: 17},
+    {k: idValue is int, value: 19},
+    {k: idValue !is int, value: 11},
+    {k: idValue == 15, value: 11},
+    {k: idValue != 15, value: 11},
+    {k: idValue === 15, value: 11},
+    {k: idValue !== 15, value: 11},
+    {k: idValue == 15 || false, value: 11},
+    {k: idValue == 15 && true, value: 11},
+    {k: !(idValue == 15 && true), value: 11}
+];

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
@@ -18,14 +18,23 @@ type Row1 record {
     readonly int k;
     int value;
 };
+const int INT_VAL1 = 55;
+const int INT_VAL2 = 22;
 
 function testLiteralAsKeyValue() {
     table<Row1> key(k) tbl = table [
-       {k: 12, value: 17}
+       {k: 12, value: 17},
+       {k: INT_VAL1, value: 17}
     ];
 
     tbl.add({k: 13, value: 25});
-    var tbl2 = table key(k) [{ k: 12, value: 17 }, {k: 13, value: 25}];
+    tbl.add({k: INT_VAL2, value: 25});
+    var tbl2 = table key(k) [
+        {k: 12, value: 17},
+        {k: 55, value: 17},
+        {k: 13, value: 25},
+        {k: 22, value: 25}
+    ];
     assertEqual(tbl2, tbl);
 
     Row1 row = {k: 13, value: 25};
@@ -46,11 +55,18 @@ type Row2 record {
 
 function testStringTemplateExprAsKeyValue() {
     table<Row2> key(k) tbl = table [
-       {k: string `ABC`, value: 17}
+       {k: string `ABC`, value: 17},
+       {k: string `ABC-${INT_VAL1}`, value: 17}
     ];
 
     tbl.add({k: string `DEF`, value: 25});
-    var tbl2 = table key(k) [{ k: string `ABC`, value: 17 }, {k: string `DEF`, value: 25}];
+    tbl.add({k: string `DEF-${INT_VAL1}`, value: 25});
+    var tbl2 = table key(k) [
+        {k: string `ABC`, value: 17},
+        {k: string `ABC-55`, value: 17},
+        {k: string `DEF`, value: 25},
+        {k: string `DEF-55`, value: 25}
+    ];
     assertEqual(tbl2, tbl);
 
     Row2 row = {k: string `ABC`, value: 17};
@@ -72,10 +88,19 @@ type Row3 record {
 function testXmlTemplateExprAsKeyValue() {
     table<Row3> key(k) tbl = table [
        {k: xml `ABC`, value: 17}
+    // Blocked by #41985
+    //    {k: xml `ABC-${INT_VAL1}`, value: 17}
     ];
 
     tbl.add({k: xml `DEF`, value: 25});
-    var tbl2 = table key(k) [{ k: xml `ABC`, value: 17 }, {k: xml `DEF`, value: 25}];
+    // Blocked by #41981
+    // tbl.add({k: xml `DEF-${INT_VAL1}`, value: 25});
+    var tbl2 = table key(k) [
+        {k: xml `ABC`, value: 17},
+        // {k: xml `ABC-55`, value: 17},
+        {k: xml `DEF`, value: 25}
+        // {k: xml `DEF-55`, value: 25}
+    ];
     assertEqual(tbl2, tbl);
 
     Row3 row = {k: xml `ABC`, value: 17};
@@ -93,14 +118,27 @@ type Row4 record {
     readonly int[] k;
     int value;
 };
+const int[] INT_ARR = [22 , 44];
 
 function testListConstructorExprAsKeyValue() {
     table<Row4> key(k) tbl = table [
-       {k: [12 , 13], value: 17}
+       {k: [12 , 13], value: 17},
+       {k: [12 , INT_VAL1], value: 17}
+    // Blocked by #41979
+    //    {k: [12 , ...INT_ARR], value: 17}
     ];
 
     tbl.add({k: [13 , 14], value: 25});
-    var tbl2 = table key(k) [{ k: [12 , 13], value: 17 }, {k: [13 , 14], value: 25}];
+    tbl.add({k: [13 , INT_VAL1], value: 25});
+    tbl.add({k: [13 , ...INT_ARR], value: 25});
+    var tbl2 = table key(k) [
+        {k: [12, 13], value: 17},
+        {k: [12, 55], value: 17},
+        // {k: [12, 22, 44], value: 17},
+        {k: [13, 14], value: 25},
+        {k: [13, 55], value: 25},
+        {k: [13, 22, 44], value: 25}
+    ];
     assertEqual(tbl2, tbl);
 
     Row4 row = {k: [13 , 14], value: 25};
@@ -121,11 +159,18 @@ type Row5 record {
 
 function testTableConstructorExprAsKeyValue() {
     table<Row5> key(k) tbl = table [
-       {k: table key(k) [{k: 12, value: 17}], value: 17}
+       {k: table key(k) [{k: 12, value: 17}], value: 17},
+       {k: table key(k) [{k: INT_VAL1, value: 17}], value: 17}
     ];
 
     tbl.add({k: table key(k) [{k: 13, value: 25}], value: 25});
-    var tbl2 = table key(k) [{k: table key(k) [{k: 12, value: 17}], value: 17}, {k: table key(k) [{k: 13, value: 25}], value: 25}];
+    tbl.add({k: table key(k) [{k: INT_VAL2, value: 25}], value: 25});
+    var tbl2 = table key(k) [
+        {k: table key(k) [{k: 12, value: 17}], value: 17},
+        {k: table key(k) [{k: 55, value: 17}], value: 17},
+        {k: table key(k) [{k: 13, value: 25}], value: 25},
+        {k: table key(k) [{k: 22, value: 25}], value: 25}
+    ];
     assertEqual(tbl2, tbl);
 
     Row5 row = {k: table key(k) [{k: 13, value: 25}], value: 25};
@@ -146,15 +191,31 @@ type Row6 record {
     readonly map<anydata> k;
     int value;
 };
+const string STR_VAL1 = "X";
+const string STR_VAL2 = "Y";
 
 function testMappingConstructorExprAsKeyValue() {
     table<Row6> key(k) tbl = table [
-       {k: {"A": "a", "B": 12, "C": [13.5, 24.3]}, value: 17}
+        {k: {"A": "a", "B": 12, "C": [13.5, 24.3]}, value: 17},
+        {k: {"A": "a", "B": INT_VAL1, "C": [13.5, 24.3]}, value: 17},
+        {k: {"A": "a", [STR_VAL1] : INT_VAL1, "C": [13.5, 24.3]}, value: 17},
+        {k: {"A": "a", STR_VAL1, "C": [13.5, 24.3]}, value: 17}
     ];
 
     tbl.add({k: {"A": "z", "B": 12, "C": [23.5, 65.3]}, value: 25});
-    var tbl2 = table key(k) [{k: {"A": "a", "B": 12, "C": [13.5, 24.3]}, value: 17},
-                               {k: {"A": "z", "B": 12, "C": [23.5, 65.3]}, value: 25}];
+    tbl.add({k: {"A": "z", "B": INT_VAL2, "C": [23.5, 65.3]}, value: 25});
+    tbl.add({k: {"A": "z", [STR_VAL2] : INT_VAL2, "C": [23.5, 65.3]}, value: 25});
+    tbl.add({k: {"A": "z", STR_VAL2, "C": [23.5, 65.3]}, value: 25});
+    var tbl2 = table key(k) [
+        {k: {"A": "a", "B": 12, "C": [13.5, 24.3]}, value: 17},
+        {k: {"A": "a", "B": 55, "C": [13.5, 24.3]}, value: 17},
+        {k: {"A": "a", "X": 55, "C": [13.5, 24.3]}, value: 17},
+        {k: {"A": "a", "STR_VAL1": "X", "C": [13.5, 24.3]}, value: 17},
+        {k: {"A": "z", "B": 12, "C": [23.5, 65.3]}, value: 25},
+        {k: {"A": "z", "B": 22, "C": [23.5, 65.3]}, value: 25},
+        {k: {"A": "z", "Y": 22, "C": [23.5, 65.3]}, value: 25},
+        {k: {"A": "z", "STR_VAL2": "Y", "C": [23.5, 65.3]}, value: 25}
+    ];
     assertEqual(tbl2, tbl);
 
     Row6 row = {k: {"A": "z", "B": 12, "C": [23.5, 65.3]}, value: 25};
@@ -191,13 +252,22 @@ function testConstRefExprAsKeyValue() {
     }
 }
 
+const float FLOAT_VAL1 = 10.5;
+const float FLOAT_VAL2 = 4.5;
 function testTypeCastExprAsKeyValue() {
     table<Row1> key(k) tbl = table [
-       {k: <int>1.2, value: 17}
+       {k: <int>1.2, value: 17},
+       {k: <int>FLOAT_VAL1, value: 17}
     ];
 
     tbl.add({k: <int>2.5, value: 25});
-    var tbl2 = table key(k) [{k: 1, value: 17}, {k: 2, value: 25}];
+    tbl.add({k: <int>FLOAT_VAL2, value: 25});
+    var tbl2 = table key(k) [
+        {k: 1, value: 17},
+        {k: 10, value: 17},
+        {k: 2, value: 25},
+        {k: 4, value: 25}
+    ];
     assertEqual(tbl2, tbl);
 
     Row1 row = {k: 2, value: 25};
@@ -213,11 +283,18 @@ function testTypeCastExprAsKeyValue() {
 
 function testUnaryExprAsKeyValue() {
     table<Row1> key(k) tbl = table [
-       {k: +1, value: 17}
+       {k: +1, value: 17},
+       {k: +INT_VAL1, value: 17}
     ];
 
     tbl.add({k: +2, value: 25});
-    var tbl2 = table key(k) [{k: 1, value: 17}, {k: 2, value: 25}];
+    tbl.add({k: +INT_VAL2, value: 25});
+    var tbl2 = table key(k) [
+        {k: 1, value: 17},
+        {k: 55, value: 17},
+        {k: 2, value: 25},
+        {k: 22, value: 25}
+    ];
     assertEqual(tbl2, tbl);
 
     Row1 row = {k: 2, value: 25};
@@ -233,11 +310,18 @@ function testUnaryExprAsKeyValue() {
 
 function testMultiplicativeExprAsKeyValue() {
     table<Row1> key(k) tbl = table [
-       {k: 1 * 10, value: 17}
+       {k: 1 * 10, value: 17},
+       {k: INT_VAL1 * 10, value: 17}
     ];
 
     tbl.add({k: 2 * 10, value: 25});
-    var tbl2 = table key(k) [{k: 10, value: 17}, {k: 20, value: 25}];
+    tbl.add({k: INT_VAL2 * 10, value: 25});
+    var tbl2 = table key(k) [
+        {k: 10, value: 17},
+        {k: 550, value: 17},
+        {k: 20, value: 25},
+        {k: 220, value: 25}
+    ];
     assertEqual(tbl2, tbl);
 
     Row1 row = {k: 20, value: 25};
@@ -253,11 +337,18 @@ function testMultiplicativeExprAsKeyValue() {
 
 function testAdditiveExprAsKeyValue() {
     table<Row1> key(k) tbl = table [
-       {k: 1 + 10, value: 17}
+       {k: 1 + 10, value: 17},
+       {k: INT_VAL1 + 10, value: 17}
     ];
 
     tbl.add({k: 2 + 10, value: 25});
-    var tbl2 = table key(k) [{k: 11, value: 17}, {k: 12, value: 25}];
+    tbl.add({k: INT_VAL2 + 10, value: 25});
+    var tbl2 = table key(k) [
+        {k: 11, value: 17},
+        {k: 65, value: 17},
+        {k: 12, value: 25},
+        {k: 32, value: 25}
+    ];
     assertEqual(tbl2, tbl);
 
     Row1 row = {k: 12, value: 25};
@@ -273,11 +364,18 @@ function testAdditiveExprAsKeyValue() {
 
 function testShiftExprAsKeyValue() {
     table<Row1> key(k) tbl = table [
-       {k: 1 << 64, value: 17}
+       {k: 1 << 64, value: 17},
+       {k: INT_VAL1 << 64, value: 17}
     ];
 
     tbl.add({k: 1 << 65, value: 25});
-    var tbl2 = table key(k) [{k: 1, value: 17}, {k: 2, value: 25}];
+    tbl.add({k: INT_VAL2 << 65, value: 25});
+    var tbl2 = table key(k) [
+        {k: 1, value: 17},
+        {k: 55, value: 17},
+        {k: 2, value: 25},
+        {k: 44, value: 25}
+    ];
     assertEqual(tbl2, tbl);
 
     Row1 row = {k: 2, value: 25};
@@ -299,11 +397,18 @@ type Row7 record {
 
 function testRelationalExprAsKeyValue() {
     table<Row7> key(k, m) tbl = table [
-       {k: 10 < 20, m: 20.5, value: 17}
+       {k: 10 < 20, m: 20.5, value: 17},
+       {k: INT_VAL1 < 20, m: 20.5, value: 17}
     ];
 
     tbl.add({k: 10 >= 20, m: 30.5, value: 25});
-    var tbl2 = table key(k) [{k: true, m: 20.5, value: 17}, {k: false, m: 30.5, value: 25}];
+    tbl.add({k: INT_VAL2 >= 20, m: 30.5, value: 25});
+    var tbl2 = table key(k, m) [
+        {k: true, m: 20.5, value: 17},
+        {k: false, m: 20.5, value: 17},
+        {k: false, m: 30.5, value: 25},
+        {k: true, m: 30.5, value: 25}
+    ];
     assertEqual(tbl2, tbl);
 
     Row7 row = {k: true, m: 20.5, value: 17};
@@ -318,12 +423,11 @@ function testRelationalExprAsKeyValue() {
 }
 
 function testIsExprAsKeyValue() {
-    anydata a = 20;
     table<Row7> key(k, m) tbl = table [
-       {k: a is int, m: 20.5, value: 17}
+       {k: INT_VAL1 is int, m: 20.5, value: 17}
     ];
 
-    tbl.add({k: a is map<int>, m: 30.5, value: 25});
+    tbl.add({k: INT_VAL2 !is int, m: 30.5, value: 25});
     var tbl2 = table key(k) [{k: true, m: 20.5, value: 17}, {k: false, m: 30.5, value: 25}];
     assertEqual(tbl2, tbl);
 
@@ -339,13 +443,11 @@ function testIsExprAsKeyValue() {
 }
 
 function testEqualityExprAsKeyValue() {
-    anydata a = 20;
-    any b = 10;
     table<Row7> key(k, m) tbl = table [
-       {k: a == 20, m: 20.5, value: 17}
+       {k: INT_VAL1 == 55, m: 20.5, value: 17}
     ];
 
-    tbl.add({k: a === b, m: 30.5, value: 25});
+    tbl.add({k: INT_VAL1 === INT_VAL2, m: 30.5, value: 25});
     var tbl2 = table key(k) [{k: true, m: 20.5, value: 17}, {k: false, m: 30.5, value: 25}];
     assertEqual(tbl2, tbl);
 
@@ -362,11 +464,18 @@ function testEqualityExprAsKeyValue() {
 
 function testBinaryBitwiseExprAsKeyValue() {
     table<Row1> key(k) tbl = table [
-       {k: 100 | 10, value: 17}
+       {k: 100 | 10, value: 17},
+       {k: INT_VAL1 | 10, value: 17}
     ];
 
     tbl.add({k: 100 & 1000, value: 25});
-    var tbl2 = table key(k) [{k: 110, value: 17}, {k: 96, value: 25}];
+    tbl.add({k: 100 & INT_VAL2, value: 25});
+    var tbl2 = table key(k) [
+        {k: 110, value: 17},
+        {k: 63, value: 17},
+        {k: 96, value: 25},
+        {k: 4, value: 25}
+    ];
     assertEqual(tbl2, tbl);
 
     Row1 row = {k: 96, value: 25};
@@ -380,21 +489,21 @@ function testBinaryBitwiseExprAsKeyValue() {
     }
 }
 
+const boolean BOOL_VAL1 = true;
+const boolean BOOL_VAL2 = false;
 function testLogicalExprAsKeyValue() {
-    boolean a = true;
-    boolean b = false;
     table<Row7> key(k, m) tbl = table [
-       {k: a || b, m: 20.5, value: 17}
+       {k: BOOL_VAL1 || BOOL_VAL2, m: 20.5, value: 17}
     ];
 
-    tbl.add({k: a && b, m: 30.5, value: 25});
+    tbl.add({k: BOOL_VAL1 && BOOL_VAL2, m: 30.5, value: 25});
     var tbl2 = table key(k) [{k: true, m: 20.5, value: 17}, {k: false, m: 30.5, value: 25}];
     assertEqual(tbl2, tbl);
 
     Row7 row = {k: true, m: 20.5, value: 17};
     assertEqual(row, tbl.get([true, 20.5]));
 
-    error? err = trap tbl.add({k: a && b, m: 30.5, value: 25});
+    error? err = trap tbl.add({k: BOOL_VAL1 && BOOL_VAL2, m: 30.5, value: 25});
     assertEqual(true, err is error);
     if (err is error) {
         map<string> msg = {"message":"a value found for key '[false,30.5]'"};
@@ -403,19 +512,18 @@ function testLogicalExprAsKeyValue() {
 }
 
 function testConditionalExprAsKeyValue() {
-    anydata a = 10;
     table<Row1> key(k) tbl = table [
-       {k: a is int ? 10 : 20, value: 17}
+       {k: INT_VAL1 is int ? 10 : 20, value: 17}
     ];
 
-    tbl.add({k: a is string ? 30 : 40, value: 25});
+    tbl.add({k: INT_VAL1 !is int ? 30 : 40, value: 25});
     var tbl2 = table key(k) [{k: 10, value: 17}, {k: 40, value: 25}];
     assertEqual(tbl2, tbl);
 
     Row1 row = {k: 40, value: 25};
     assertEqual(row, tbl.get(40));
 
-    error? err = trap tbl.add({k: a is float ? 20 : 40, value: 17});
+    error? err = trap tbl.add({k: INT_VAL1 !is int ? 20 : 40, value: 17});
     assertEqual(true, err is error);
     if (err is error) {
         map<string> msg = {"message":"a value found for key '40'"};
@@ -424,19 +532,18 @@ function testConditionalExprAsKeyValue() {
 }
 
 function testGroupExprAsKeyValue() {
-    anydata a = 10;
     table<Row1> key(k) tbl = table [
-       {k: (a is int ? (<int> 10.5) : 20), value: 17}
+       {k: (INT_VAL1 is int ? (<int> 10.5) : 20), value: 17}
     ];
 
-    tbl.add({k: (a is string ? 30 : (<int> 40.5)), value: 25});
+    tbl.add({k: (INT_VAL1 !is int ? 30 : (<int> 40.5)), value: 25});
     var tbl2 = table key(k) [{k: 10, value: 17}, {k: 40, value: 25}];
     assertEqual(tbl2, tbl);
 
     Row1 row = {k: 40, value: 25};
     assertEqual(row, tbl.get(40));
 
-    error? err = trap tbl.add({k: (a is float ? 20 : 40), value: 17});
+    error? err = trap tbl.add({k: (INT_VAL1 !is int ? 20 : 40), value: 17});
     assertEqual(true, err is error);
     if (err is error) {
         map<string> msg = {"message":"a value found for key '40'"};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_violations.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_violations.bal
@@ -58,10 +58,13 @@ table<CustomerWithXmlId> key<xml> _ = table key(id) [
         }
     ];
 
-function createTable(string|int name, boolean invalid) {
+const string name = "A";
+const int val = 13;
+
+function createTable() {
     table<Customer> key<string> _ = table key(firstName) [
-        {id: 5005, firstName: <string> (name is string && !invalid ? (string `Hello ${name}!!!`) : "James"), lastName: "Gordon"},
-        {id: 5005, firstName: <string> (name is string && !invalid ? (string `Hello ${name}!!!`) : "James"), lastName: "Wayne"}
+        {id: 5005, firstName: <string> (val > 10 && !(val < 10) ? (string `Hello ${name}!!!`) : "James"), lastName: "Gordon"},
+        {id: 5005, firstName: <string> (val > 10 && !(val < 10) ? (string `Hello ${name}!!!`) : "James"), lastName: "Wayne"}
     ];
 }
 


### PR DESCRIPTION
## Purpose

The current implementation of checking whether the table key value is a constant expression does not consider its nested expressions. Thus, this PR improves the implementation to precisely capture the `value expression of key specifier 'k' must be a constant expression` error message.

As mentioned in the specification, a constant-reference expression must reference a module-const-decl, and within a const-expr, any nested expression must also be a const-expr. The existing positive table key field value tests do not adhere to this condition, and this PR updates those test cases with the necessary changes. https://ballerina.io/spec/lang/master/#const-expr

Fixes #35043

## Approach
The PR modifies the TypeChecker to improve its implementation of checking the constant expression for table key values.

## Remarks
* The table constructor uses a method named `isConstExpression` that is specific to the table itself. Hence, the changes made by the PR only affect this area. Ideally, this method can be used in other areas as well, and this is tracked with another issue:
* The current implementation does not consider the `list constructor spread operator` as it is blocked by: https://github.com/ballerina-platform/ballerina-lang/issues/41979
* The current implementation does not consider the `xml templates` as it is blocked by: https://github.com/ballerina-platform/ballerina-lang/issues/41985
* The current implementation does not consider the `regex templates` it is blocked by: https://github.com/ballerina-platform/ballerina-lang/issues/41982


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
