### PR TITLE
Fix type creation of xml sequence with `xml:Text`

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2980,8 +2980,8 @@ public class TypeChecker {
                 return checkDecimalEqual((DecimalValue) lhsValue, (DecimalValue) rhsValue);
             case TypeTags.XML_TAG:
                 // Instance of xml never
-                if (lhsValue instanceof XmlText) {
-                    return TypeTags.isXMLTypeTag(rhsValTypeTag) && isEqual((XmlText) lhsValue, (XmlValue) rhsValue);
+                if (lhsValue instanceof XmlText xmlText) {
+                    return TypeTags.isXMLTypeTag(rhsValTypeTag) && isEqual(xmlText, (XmlValue) rhsValue);
                 }
                 return TypeTags.isXMLTypeTag(rhsValTypeTag) && isEqual((XmlSequence) lhsValue, (XmlValue) rhsValue);
             case TypeTags.XML_ELEMENT_TAG:

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
@@ -634,8 +634,7 @@ public final class XmlSequence extends XmlValue implements BXmlSequence {
             case TypeTags.XML_PI_TAG:
                 return new BXmlType(PredefinedTypes.TYPE_PROCESSING_INSTRUCTION, false);
             default:
-                // Since 'xml:Text is same as xml<'xml:Text>
-                return PredefinedTypes.TYPE_TEXT;
+                return new BXmlType(PredefinedTypes.TYPE_TEXT, false);
         }
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
@@ -190,7 +190,8 @@ public class EqualAndNotEqualOperationsTest {
                 "testUnequalXmlIgnoringAttributeOrder", "testEqualXmlWithPI", "testUnequalXmlWithUnequalPI",
                 "testUnequalXmlWithPIInWrongOrder", "testUnequalXmlWithMultiplePIInWrongOrder",
                 "testUnequalXmlWithMissingPI", "testXmlWithNamespacesPositive", "testXmlWithNamespacesNegative",
-                "testXmlSequenceAndXmlItemEqualityPositive", "testXmlSequenceAndXmlItemEqualityNegative"
+                "testXmlSequenceAndXmlItemEqualityPositive", "testXmlSequenceAndXmlItemEqualityNegative",
+                "testXmlSequenceLHSEquals"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
@@ -1135,6 +1135,18 @@ public function testXmlSequenceAndXmlItemEqualityNegative() {
     test:assertFalse(x1 == x3 || !(x1 != x3) || x3 == x1 || !(x3 != x1));
 }
 
+public function testXmlSequenceLHSEquals() {
+    string a = "hello";
+    xml x1 = xml `AS-${a}`;
+    xml x2 = xml `AS-${a}`;
+    test:assertTrue(x1 == x2 && !(x1 != x2));
+
+    x1 = xml `<?target data?><?target_two data_two?>`;
+    x2 = xml `<?target data?><?target_two data_two?>`;
+    test:assertTrue(x1 == x2 && !(x1 != x2));
+}
+
+
 function testXmlStringNegative() {
     anydata x1 = xml `<book>The Lost World</book>`;
     anydata x2 = "<book>The Lost World</book>";


### PR DESCRIPTION
## Purpose
$subject
Fixes #41981 

## Approach
Created XML sequence with `xml:Text` constraint instead of simple `xml:Text`. This will have a consistent approach with other XML types

## Samples
```ballerina
import ballerina/io;

public function main() {
    string a = "hello";
    xml x1 = xml `AS-${a}`;
    xml x2 = xml `AS-${a}`;
    io:println(x1 == x2);
}
```

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
