### PR TITLE
Fix type not set for `isTransactionalCheck` in TransactionDesugar

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/TransactionDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/TransactionDesugar.java
@@ -441,6 +441,7 @@ public class TransactionDesugar extends BLangNodeVisitor {
 
         // transactional
         BLangTransactionalExpr isTransactionalCheck = TreeBuilder.createTransactionalExpressionNode();
+        isTransactionalCheck.setBType(symTable.booleanType);
         isTransactionalCheck.pos = pos;
 
         // if(($trxError$ is error) && !($trxError$ is TransactionError) && transactional)


### PR DESCRIPTION
## Purpose
Fixes #41975

## Approach
The fix involves setting the type of `BLangTransactionalExpr` node, `isTransactionalCheck` to boolean type in accordance with the [spec](https://ballerina.io/spec/lang/master/#section_6.37).

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
