### PR TITLE
Uber JAR creation for test modules

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -19,7 +19,13 @@ package io.ballerina.cli.cmd;
 
 import io.ballerina.cli.BLauncherCmd;
 import io.ballerina.cli.TaskExecutor;
-import io.ballerina.cli.task.*;
+import io.ballerina.cli.task.CleanTargetCacheDirTask;
+import io.ballerina.cli.task.CompileTask;
+import io.ballerina.cli.task.CreateTestExecutableTask;
+import io.ballerina.cli.task.DumpBuildTimeTask;
+import io.ballerina.cli.task.ResolveMavenDependenciesTask;
+import io.ballerina.cli.task.RunNativeImageTestTask;
+import io.ballerina.cli.task.RunTestsTask;
 import io.ballerina.cli.utils.BuildTime;
 import io.ballerina.cli.utils.FileUtils;
 import io.ballerina.projects.BuildOptions;
@@ -274,7 +280,9 @@ public class TestCommand implements BLauncherCmd {
 
         // If project is empty
         if (ProjectUtils.isProjectEmpty(project)) {
-            CommandUtil.printError(this.errStream, "package is empty. Please add at least one .bal file.", null, false);
+            CommandUtil.printError(this.errStream,
+                    "package is empty. Please add at least one .bal file.",
+                    null, false);
             CommandUtil.exitError(this.exitWhenFinish);
             return;
         }
@@ -342,7 +350,8 @@ public class TestCommand implements BLauncherCmd {
                 buildOptions.enableCache());
         RunTestsTask runTestsTask = new RunTestsTask(outStream, errStream, rerunTests, groupList, disableGroupList,
                 testList, includes, coverageFormat, moduleMap, listGroups, excludes, cliArgs);
-        CreateTestExecutableTask createTestExecutableTask = new CreateTestExecutableTask(outStream, this.output, runTestsTask);
+        CreateTestExecutableTask createTestExecutableTask =
+                new CreateTestExecutableTask(outStream, this.output, runTestsTask);
 
         RunNativeImageTestTask runNativeImageTestTask = new RunNativeImageTestTask(outStream, rerunTests, groupList,
                 disableGroupList, testList, includes, coverageFormat, moduleMap, listGroups);
@@ -358,7 +367,7 @@ public class TestCommand implements BLauncherCmd {
                 .addTask(createTestExecutableTask) // create the uber jars for test modules
                 .addTask(runTestsTask, project.buildOptions().nativeImage())
                 .addTask(runNativeImageTestTask, !project.buildOptions().nativeImage())
-                .addTask(dumpBuildTimeTask,!project.buildOptions().dumpBuildTime())
+                .addTask(dumpBuildTimeTask, !project.buildOptions().dumpBuildTime())
                 .build();
 
         taskExecutor.executeTasks(project);

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -19,12 +19,7 @@ package io.ballerina.cli.cmd;
 
 import io.ballerina.cli.BLauncherCmd;
 import io.ballerina.cli.TaskExecutor;
-import io.ballerina.cli.task.CleanTargetCacheDirTask;
-import io.ballerina.cli.task.CompileTask;
-import io.ballerina.cli.task.DumpBuildTimeTask;
-import io.ballerina.cli.task.ResolveMavenDependenciesTask;
-import io.ballerina.cli.task.RunNativeImageTestTask;
-import io.ballerina.cli.task.RunTestsTask;
+import io.ballerina.cli.task.*;
 import io.ballerina.cli.utils.BuildTime;
 import io.ballerina.cli.utils.FileUtils;
 import io.ballerina.projects.BuildOptions;
@@ -196,6 +191,11 @@ public class TestCommand implements BLauncherCmd {
             "generation")
     private String graalVMBuildOptions;
 
+    @CommandLine.Option(names = {"--output", "-o"}, description = "Write the output to the given file. The provided " +
+            "output file name may or may not contain the " +
+            "'.jar' extension.")
+    private String output;
+
 
     private static final String testCmd = "bal test [--OPTIONS]\n" +
             "                   [<ballerina-file> | <package-path>] [(-Ckey=value)...]";
@@ -342,6 +342,7 @@ public class TestCommand implements BLauncherCmd {
                 // compile the modules
                 .addTask(new CompileTask(outStream, errStream, false, isPackageModified, buildOptions.enableCache()))
 //                .addTask(new CopyResourcesTask(), listGroups) // merged with CreateJarTask
+                .addTask(new CreateTestExecutableTask(outStream, this.output)) // create the uber jars for test modules
                 .addTask(new RunTestsTask(outStream, errStream, rerunTests, groupList, disableGroupList, testList,
                         includes, coverageFormat, moduleMap, listGroups, excludes, cliArgs),
                         project.buildOptions().nativeImage())

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateExecutableTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateExecutableTask.java
@@ -54,9 +54,9 @@ import static io.ballerina.projects.util.ProjectConstants.USER_DIR;
  * @since 2.0.0
  */
 public class CreateExecutableTask implements Task {
-    private final transient PrintStream out;
-    private Path output;
-    private Path currentDir;
+    protected final transient PrintStream out;
+    protected Path output;
+    protected Path currentDir;
 
     public CreateExecutableTask(PrintStream out, String output) {
         this.out = out;
@@ -74,27 +74,10 @@ public class CreateExecutableTask implements Task {
         }
 
         this.currentDir = Paths.get(System.getProperty(USER_DIR));
-        Target target;
+        Target target = getTarget(project);
 
-        try {
-            if (project.kind().equals(ProjectKind.BUILD_PROJECT)) {
-                target = new Target(project.targetDir());
-            } else {
-                target = new Target(Files.createTempDirectory("ballerina-cache" + System.nanoTime()));
-                target.setOutputPath(getExecutablePath(project));
-            }
-        } catch (IOException e) {
-            throw createLauncherException("unable to resolve target path:" + e.getMessage());
-        } catch (ProjectException e) {
-            throw createLauncherException("unable to create executable:" + e.getMessage());
-        }
+        Path executablePath = getExecutablePath(project, target);
 
-        Path executablePath;
-        try {
-            executablePath = target.getExecutablePath(project.currentPackage()).toAbsolutePath().normalize();
-        } catch (IOException e) {
-            throw createLauncherException(e.getMessage());
-        }
         try {
             PackageCompilation pkgCompilation = project.currentPackage().getCompilation();
             JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(pkgCompilation, JvmTarget.JAVA_17);
@@ -163,7 +146,34 @@ public class CreateExecutableTask implements Task {
         notifyPlugins(project, target);
     }
 
-    private void notifyPlugins(Project project, Target target) {
+    private Path getExecutablePath(Project project, Target target) {
+        Path executablePath;
+        try {
+            executablePath = target.getExecutablePath(project.currentPackage()).toAbsolutePath().normalize();
+        } catch (IOException e) {
+            throw createLauncherException(e.getMessage());
+        }
+        return executablePath;
+    }
+
+    protected Target getTarget(Project project) {
+        Target target;
+        try {
+            if (project.kind().equals(ProjectKind.BUILD_PROJECT)) {
+                target = new Target(project.targetDir());
+            } else {
+                target = new Target(Files.createTempDirectory("ballerina-cache" + System.nanoTime()));
+                target.setOutputPath(getExecutablePath(project));
+            }
+        } catch (IOException e) {
+            throw createLauncherException("unable to resolve target path:" + e.getMessage());
+        } catch (ProjectException e) {
+            throw createLauncherException("unable to create executable:" + e.getMessage());
+        }
+        return target;
+    }
+
+    protected void notifyPlugins(Project project, Target target) {
         ServiceLoader<CompilerPlugin> processorServiceLoader = ServiceLoader.load(CompilerPlugin.class);
         for (CompilerPlugin plugin : processorServiceLoader) {
             plugin.codeGenerated(project, target);

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateTestExecutableTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateTestExecutableTask.java
@@ -56,13 +56,17 @@ public class CreateTestExecutableTask extends CreateExecutableTask {
                 Module module = project.currentPackage().module(moduleDescriptor.name());
                 Path testExecutablePath = getTestExecutablePath(target, module);
 
+                List<String> allArgs = this.runTestsTask.getAllTestArgs(target,
+                        project.currentPackage().packageName().toString(),
+                        module.moduleName().toString(),
+                        project,
+                        moduleDescriptor
+                );
+
                 emitResult = jBallerinaBackend.emit(JBallerinaBackend.OutputType.TEST,
                         testExecutablePath,
                         module.moduleName(),
-                        this.runTestsTask.getTestRunnerCmdArgs(target,
-                                project.currentPackage().packageName().toString(),
-                                module.moduleName().toString()
-                        )
+                        allArgs
                 );
 
                 diagnostics.addAll(emitResult.diagnostics().diagnostics());

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateTestExecutableTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateTestExecutableTask.java
@@ -19,9 +19,11 @@ import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
 import static io.ballerina.projects.util.ProjectConstants.USER_DIR;
 
 public class CreateTestExecutableTask extends CreateExecutableTask {
+    private RunTestsTask runTestsTask;
 
-    public CreateTestExecutableTask(PrintStream out, String output) {
+    public CreateTestExecutableTask(PrintStream out, String output, RunTestsTask runTestsTask) {
         super(out, output);
+        this.runTestsTask = runTestsTask;   //to use the getCmdArgs() method
     }
 
     @Override
@@ -48,7 +50,16 @@ public class CreateTestExecutableTask extends CreateExecutableTask {
 
                 Module module = project.currentPackage().module(moduleDescriptor.name());
                 Path testExecutablePath = getTestExecutablePath(target, module);
-                emitResult = jBallerinaBackend.emit(JBallerinaBackend.OutputType.TEST, testExecutablePath, module.moduleName());
+
+                emitResult = jBallerinaBackend.emit(JBallerinaBackend.OutputType.TEST,
+                        testExecutablePath,
+                        module.moduleName(),
+                        this.runTestsTask.getTestRunnerCmdArgs(target,
+                                project.currentPackage().packageName().toString(),
+                                module.moduleName().toString()
+                        )
+                );
+
                 diagnostics.addAll(emitResult.diagnostics().diagnostics());
             }
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateTestExecutableTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateTestExecutableTask.java
@@ -1,0 +1,96 @@
+package io.ballerina.cli.task;
+
+import io.ballerina.cli.utils.BuildTime;
+import io.ballerina.projects.*;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.internal.model.Target;
+import io.ballerina.tools.diagnostics.Diagnostic;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
+import static io.ballerina.projects.util.ProjectConstants.USER_DIR;
+
+public class CreateTestExecutableTask extends CreateExecutableTask {
+
+    public CreateTestExecutableTask(PrintStream out, String output) {
+        super(out, output);
+    }
+
+    @Override
+    public void execute(Project project) {
+        this.out.println();
+
+        this.currentDir = Paths.get(System.getProperty(USER_DIR));
+        Target target = getTarget(project);
+        EmitResult emitResult;
+
+        try{
+            PackageCompilation pkgCompilation = project.currentPackage().getCompilation();
+            JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(pkgCompilation, JvmTarget.JAVA_17);
+
+            List<Diagnostic> diagnostics = new ArrayList<>();
+
+            long start = 0;
+            if (project.buildOptions().dumpBuildTime()) { //TODO: change to dumpTestBuildTime??
+                start = System.currentTimeMillis();
+            }
+
+            for(ModuleDescriptor moduleDescriptor :
+                    project.currentPackage().moduleDependencyGraph().toTopologicallySortedList()) {
+
+                Module module = project.currentPackage().module(moduleDescriptor.name());
+                Path testExecutablePath = getTestExecutablePath(target, module);
+                emitResult = jBallerinaBackend.emit(JBallerinaBackend.OutputType.TEST, testExecutablePath, module.moduleName());
+                diagnostics.addAll(emitResult.diagnostics().diagnostics());
+            }
+
+            if (project.buildOptions().dumpBuildTime()) {
+                BuildTime.getInstance().emitArtifactDuration = System.currentTimeMillis() - start;
+                BuildTime.getInstance().compile = false;
+            }
+
+            // Print warnings for conflicted jars
+            if (!jBallerinaBackend.conflictedJars().isEmpty()) {
+                out.println("\twarning: Detected conflicting jar files:");
+                for (JBallerinaBackend.JarConflict conflict : jBallerinaBackend.conflictedJars()) {
+                    out.println(conflict.getWarning(project.buildOptions().listConflictedClasses()));
+                }
+            }
+
+            if (!diagnostics.isEmpty()) {
+                //  TODO: When deprecating the lifecycle compiler plugin, we can remove this check for duplicates
+                //   in JBallerinaBackend diagnostics and the diagnostics added to EmitResult.
+                diagnostics = diagnostics.stream()
+                        .filter(diagnostic -> !jBallerinaBackend.diagnosticResult().diagnostics().contains(diagnostic))
+                        .collect(Collectors.toList());
+                if (!diagnostics.isEmpty()) {
+                    diagnostics.forEach(d -> out.println("\n" + d.toString()));
+                }
+            }
+        }
+        catch(ProjectException e) {
+            throw createLauncherException(e.getMessage());
+        }
+        // notify plugin
+        // todo following call has to be refactored after introducing new plugin architecture
+        notifyPlugins(project, target);
+    }
+    private Path getTestExecutablePath(Target target, Module module) {
+        Path executablePath;
+        try{
+            executablePath = target.getTestExecutablePath(module).toAbsolutePath().normalize();
+        }
+        catch(IOException e){
+            throw createLauncherException(e.getMessage());
+        }
+        return executablePath;
+    }
+}

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateTestExecutableTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateTestExecutableTask.java
@@ -1,14 +1,19 @@
 package io.ballerina.cli.task;
 
 import io.ballerina.cli.utils.BuildTime;
-import io.ballerina.projects.*;
+import io.ballerina.projects.EmitResult;
+import io.ballerina.projects.JBallerinaBackend;
+import io.ballerina.projects.JvmTarget;
 import io.ballerina.projects.Module;
+import io.ballerina.projects.ModuleDescriptor;
+import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.Project;
+import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.internal.model.Target;
 import io.ballerina.tools.diagnostics.Diagnostic;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -19,7 +24,7 @@ import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
 import static io.ballerina.projects.util.ProjectConstants.USER_DIR;
 
 public class CreateTestExecutableTask extends CreateExecutableTask {
-    private RunTestsTask runTestsTask;
+    private final RunTestsTask runTestsTask;
 
     public CreateTestExecutableTask(PrintStream out, String output, RunTestsTask runTestsTask) {
         super(out, output);
@@ -34,7 +39,7 @@ public class CreateTestExecutableTask extends CreateExecutableTask {
         Target target = getTarget(project);
         EmitResult emitResult;
 
-        try{
+        try {
             PackageCompilation pkgCompilation = project.currentPackage().getCompilation();
             JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(pkgCompilation, JvmTarget.JAVA_17);
 
@@ -45,7 +50,7 @@ public class CreateTestExecutableTask extends CreateExecutableTask {
                 start = System.currentTimeMillis();
             }
 
-            for(ModuleDescriptor moduleDescriptor :
+            for (ModuleDescriptor moduleDescriptor :
                     project.currentPackage().moduleDependencyGraph().toTopologicallySortedList()) {
 
                 Module module = project.currentPackage().module(moduleDescriptor.name());
@@ -86,8 +91,7 @@ public class CreateTestExecutableTask extends CreateExecutableTask {
                     diagnostics.forEach(d -> out.println("\n" + d.toString()));
                 }
             }
-        }
-        catch(ProjectException e) {
+        } catch (ProjectException e) {
             throw createLauncherException(e.getMessage());
         }
         // notify plugin
@@ -96,10 +100,9 @@ public class CreateTestExecutableTask extends CreateExecutableTask {
     }
     private Path getTestExecutablePath(Target target, Module module) {
         Path executablePath;
-        try{
+        try {
             executablePath = target.getTestExecutablePath(module).toAbsolutePath().normalize();
-        }
-        catch(IOException e){
+        } catch (IOException e) {
             throw createLauncherException(e.getMessage());
         }
         return executablePath;

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -34,6 +34,7 @@ import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.ResolvedPackageDependency;
 import io.ballerina.projects.internal.model.Target;
+import io.ballerina.projects.util.ProjectConstants;
 import org.ballerinalang.test.runtime.entity.ModuleStatus;
 import org.ballerinalang.test.runtime.entity.TestReport;
 import org.ballerinalang.test.runtime.entity.TestSuite;
@@ -193,91 +194,117 @@ public class RunTestsTask implements Task {
             Module module = project.currentPackage().module(moduleDescriptor.name());
             ModuleName moduleName = module.moduleName();
 
-            TestSuite suite = testProcessor.testSuite(module).orElse(null);
-            if (suite == null) {
+            //get the created uber jar files for each module in CreateTestExecutableTask
+            Path testExecutablePath = target.path().resolve("bin").resolve("tests")
+                        .resolve(moduleName.toString() + ProjectConstants.TEST_UBER_JAR_SUFFIX + ProjectConstants.BLANG_COMPILED_JAR_EXT);
+
+            out.println("test executable path: " + testExecutablePath.toString());
+            if (!Files.exists(testExecutablePath)) {
+                out.println("\t" + moduleName + ": no tests found");
                 continue;
             }
 
-            //Set 'hasTests' flag if there are any tests available in the package
-            if (!hasTests) {
-                hasTests = true;
-            }
-
-            if (!isRerunTestExecution) {
-                clearFailedTestsJson(target.path());
-            }
-            if (project.kind() == ProjectKind.SINGLE_FILE_PROJECT) {
-                suite.setSourceFileName(project.sourceRoot().getFileName().toString());
-            }
-            suite.setReportRequired(report || coverage);
-            String resolvedModuleName =
-                    module.isDefaultModule() ? moduleName.toString() : module.moduleName().moduleNamePart();
-            testSuiteMap.put(resolvedModuleName, suite);
-            moduleNamesList.add(resolvedModuleName);
-            Map<String, String> mockFunctionMap = suite.getMockFunctionNamesMap();
-            for (Map.Entry<String, String> entry : mockFunctionMap.entrySet()) {
-                String key = entry.getKey();
-                String functionToMockClassName;
-                // Find the first delimiter and compare the indexes
-                // The first index should always be a delimiter. Which ever one that is denotes the mocking type
-                if (key.indexOf(MOCK_LEGACY_DELIMITER) == -1) {
-                    functionToMockClassName = key.substring(0, key.indexOf(MOCK_FN_DELIMITER));
-                } else if (key.indexOf(MOCK_FN_DELIMITER) == -1) {
-                    functionToMockClassName = key.substring(0, key.indexOf(MOCK_LEGACY_DELIMITER));
-                } else {
-                    if (key.indexOf(MOCK_FN_DELIMITER) < key.indexOf(MOCK_LEGACY_DELIMITER)) {
-                        functionToMockClassName = key.substring(0, key.indexOf(MOCK_FN_DELIMITER));
-                    } else {
-                        functionToMockClassName = key.substring(0, key.indexOf(MOCK_LEGACY_DELIMITER));
-                    }
-                }
-                mockClassNames.add(functionToMockClassName);
-            }
-        }
-
-        writeToTestSuiteJson(testSuiteMap, testsCachePath);
-
-        if (hasTests) {
-            int testResult;
+            List<String> cmdArgs = getInitialCmdArgs();
+            cmdArgs.add("-jar");
+            cmdArgs.add(testExecutablePath.toString());
+            cmdArgs.addAll(getTestRunnerCmdArgs());
+            ProcessBuilder processBuilder = new ProcessBuilder(cmdArgs).inheritIO();
+            Process proc;
             try {
-                Set<String> exclusionClassList = new HashSet<>();
-                testResult = runTestSuite(target, project.currentPackage(), jBallerinaBackend, mockClassNames,
-                             exclusionClassList);
-
-                if (report || coverage) {
-                    for (String moduleName : moduleNamesList) {
-                        ModuleStatus moduleStatus = loadModuleStatusFromFile(
-                                testsCachePath.resolve(moduleName).resolve(TesterinaConstants.STATUS_FILE));
-                        if (moduleStatus == null) {
-                            continue;
-                        }
-
-                        if (!moduleName.equals(project.currentPackage().packageName().toString())) {
-                            moduleName = ModuleName.from(project.currentPackage().packageName(), moduleName).toString();
-                        }
-                        testReport.addModuleStatus(moduleName, moduleStatus);
-                    }
-                    try {
-                        generateCoverage(project, testReport, jBallerinaBackend, this.includesInCoverage,
-                                this.coverageReportFormat, this.coverageModules, exclusionClassList);
-                        generateTesterinaReports(project, testReport, this.out, target);
-                    } catch (IOException e) {
-                        cleanTempCache(project, cachesRoot);
-                        throw createLauncherException("error occurred while generating test report :", e);
-                    }
-                }
-            } catch (IOException | InterruptedException | ClassNotFoundException e) {
-                cleanTempCache(project, cachesRoot);
+                proc = processBuilder.start();
+                proc.waitFor();
+            } catch (IOException | InterruptedException e) {
                 throw createLauncherException("error occurred while running tests", e);
             }
 
-            if (testResult != 0) {
-                cleanTempCache(project, cachesRoot);
+            if (proc.exitValue() != 0) {
                 throw createLauncherException("there are test failures");
             }
-        } else {
-            out.println("\tNo tests found");
+//            TestSuite suite = testProcessor.testSuite(module).orElse(null);
+//            if (suite == null) {
+//                continue;
+//            }
+//
+//            //Set 'hasTests' flag if there are any tests available in the package
+//            if (!hasTests) {
+//                hasTests = true;
+//            }
+//
+//            if (!isRerunTestExecution) {
+//                clearFailedTestsJson(target.path());
+//            }
+//            if (project.kind() == ProjectKind.SINGLE_FILE_PROJECT) {
+//                suite.setSourceFileName(project.sourceRoot().getFileName().toString());
+//            }
+//            suite.setReportRequired(report || coverage);
+//            String resolvedModuleName =
+//                    module.isDefaultModule() ? moduleName.toString() : module.moduleName().moduleNamePart();
+//            testSuiteMap.put(resolvedModuleName, suite);
+//            moduleNamesList.add(resolvedModuleName);
+//            Map<String, String> mockFunctionMap = suite.getMockFunctionNamesMap();
+//            for (Map.Entry<String, String> entry : mockFunctionMap.entrySet()) {
+//                String key = entry.getKey();
+//                String functionToMockClassName;
+//                // Find the first delimiter and compare the indexes
+//                // The first index should always be a delimiter. Which ever one that is denotes the mocking type
+//                if (key.indexOf(MOCK_LEGACY_DELIMITER) == -1) {
+//                    functionToMockClassName = key.substring(0, key.indexOf(MOCK_FN_DELIMITER));
+//                } else if (key.indexOf(MOCK_FN_DELIMITER) == -1) {
+//                    functionToMockClassName = key.substring(0, key.indexOf(MOCK_LEGACY_DELIMITER));
+//                } else {
+//                    if (key.indexOf(MOCK_FN_DELIMITER) < key.indexOf(MOCK_LEGACY_DELIMITER)) {
+//                        functionToMockClassName = key.substring(0, key.indexOf(MOCK_FN_DELIMITER));
+//                    } else {
+//                        functionToMockClassName = key.substring(0, key.indexOf(MOCK_LEGACY_DELIMITER));
+//                    }
+//                }
+//                mockClassNames.add(functionToMockClassName);
+//            }
         }
+
+//        writeToTestSuiteJson(testSuiteMap, testsCachePath);
+//
+//        if (hasTests) {
+//            int testResult;
+//            try {
+//                Set<String> exclusionClassList = new HashSet<>();
+//                testResult = runTestSuite(target, project.currentPackage(), jBallerinaBackend, mockClassNames,
+//                             exclusionClassList);
+//
+//                if (report || coverage) {
+//                    for (String moduleName : moduleNamesList) {
+//                        ModuleStatus moduleStatus = loadModuleStatusFromFile(
+//                                testsCachePath.resolve(moduleName).resolve(TesterinaConstants.STATUS_FILE));
+//                        if (moduleStatus == null) {
+//                            continue;
+//                        }
+//
+//                        if (!moduleName.equals(project.currentPackage().packageName().toString())) {
+//                            moduleName = ModuleName.from(project.currentPackage().packageName(), moduleName).toString();
+//                        }
+//                        testReport.addModuleStatus(moduleName, moduleStatus);
+//                    }
+//                    try {
+//                        generateCoverage(project, testReport, jBallerinaBackend, this.includesInCoverage,
+//                                this.coverageReportFormat, this.coverageModules, exclusionClassList);
+//                        generateTesterinaReports(project, testReport, this.out, target);
+//                    } catch (IOException e) {
+//                        cleanTempCache(project, cachesRoot);
+//                        throw createLauncherException("error occurred while generating test report :", e);
+//                    }
+//                }
+//            } catch (IOException | InterruptedException | ClassNotFoundException e) {
+//                cleanTempCache(project, cachesRoot);
+//                throw createLauncherException("error occurred while running tests", e);
+//            }
+//
+//            if (testResult != 0) {
+//                cleanTempCache(project, cachesRoot);
+//                throw createLauncherException("there are test failures");
+//            }
+//        } else {
+//            out.println("\tNo tests found");
+//        }
 
         // Cleanup temp cache for SingleFileProject
         cleanTempCache(project, cachesRoot);
@@ -298,8 +325,8 @@ public class RunTestsTask implements Task {
         cmdArgs.add("-XX:HeapDumpPath=" + System.getProperty(USER_DIR));
 
         String mainClassName = TesterinaConstants.TESTERINA_LAUNCHER_CLASS_NAME;
-        String jacocoAgentJarPath = Paths.get(System.getProperty(BALLERINA_HOME)).resolve(BALLERINA_HOME_BRE)
-                .resolve(BALLERINA_HOME_LIB).resolve(TesterinaConstants.AGENT_FILE_NAME).toString();
+        String jacocoAgentJarPath = getJacocoAgentJarPath();
+
         if (coverage) {
             if (!mockClassNames.isEmpty()) {
                 // If we have mock function we need to use jacoco offline instrumentation since jacoco doesn't
@@ -356,6 +383,35 @@ public class RunTestsTask implements Task {
         ProcessBuilder processBuilder = new ProcessBuilder(cmdArgs).inheritIO();
         Process proc = processBuilder.start();
         return proc.waitFor();
+    }
+
+    private String getJacocoAgentJarPath() {
+        return Paths.get(System.getProperty(BALLERINA_HOME)).resolve(BALLERINA_HOME_BRE)
+                .resolve(BALLERINA_HOME_LIB).resolve(TesterinaConstants.AGENT_FILE_NAME).toString();
+    }
+
+    private List<String> getInitialCmdArgs() {
+        List<String> cmdArgs = new ArrayList<>();
+        cmdArgs.add(System.getProperty("java.command"));
+        cmdArgs.add("-XX:+HeapDumpOnOutOfMemoryError");
+        cmdArgs.add("-XX:HeapDumpPath=" + System.getProperty(USER_DIR));
+        return cmdArgs;
+    }
+
+    private List<String> getTestRunnerCmdArgs(){
+        List<String> cmdArgs = new ArrayList<>();
+        //cmdArgs.add(getJacocoAgentJarPath());
+        cmdArgs.add(Boolean.toString(report));
+        cmdArgs.add(Boolean.toString(coverage));
+        cmdArgs.add(this.groupList != null ? this.groupList : "");
+        cmdArgs.add(this.disableGroupList != null ? this.disableGroupList : "");
+        cmdArgs.add(this.singleExecTests != null ? this.singleExecTests : "");
+        cmdArgs.add(Boolean.toString(isRerunTestExecution));
+        cmdArgs.add(Boolean.toString(listGroups));
+        cliArgs.forEach((arg) -> {
+            cmdArgs.add(arg);
+        });
+        return cmdArgs;
     }
 
     private List<Path> getAllSourceFilePaths(String projectRootString) throws IOException {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -68,12 +68,7 @@ import static io.ballerina.cli.utils.TestUtils.loadModuleStatusFromFile;
 import static io.ballerina.cli.utils.TestUtils.writeToTestSuiteJson;
 import static io.ballerina.projects.util.ProjectConstants.GENERATED_MODULES_ROOT;
 import static io.ballerina.projects.util.ProjectConstants.MODULES_ROOT;
-import static org.ballerinalang.test.runtime.util.TesterinaConstants.FULLY_QULAIFIED_MODULENAME_SEPRATOR;
-import static org.ballerinalang.test.runtime.util.TesterinaConstants.IGNORE_PATTERN;
-import static org.ballerinalang.test.runtime.util.TesterinaConstants.MOCK_FN_DELIMITER;
-import static org.ballerinalang.test.runtime.util.TesterinaConstants.MOCK_LEGACY_DELIMITER;
-import static org.ballerinalang.test.runtime.util.TesterinaConstants.STANDALONE_SRC_PACKAGENAME;
-import static org.ballerinalang.test.runtime.util.TesterinaConstants.WILDCARD;
+import static org.ballerinalang.test.runtime.util.TesterinaConstants.*;
 import static org.ballerinalang.test.runtime.util.TesterinaUtils.getQualifiedClassName;
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME;
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME_BRE;
@@ -184,36 +179,30 @@ public class RunTestsTask implements Task {
         List<String> mockClassNames = new ArrayList<>();
         for (ModuleDescriptor moduleDescriptor :
                 project.currentPackage().moduleDependencyGraph().toTopologicallySortedList()) {
+            int testResult = 0;
             Module module = project.currentPackage().module(moduleDescriptor.name());
             ModuleName moduleName = module.moduleName();
-
             //get the created uber jar files for each module in CreateTestExecutableTask
             Path testExecutablePath = target.path().resolve("bin").resolve("tests")
-                        .resolve(moduleName.toString() + ProjectConstants.TEST_UBER_JAR_SUFFIX + ProjectConstants.BLANG_COMPILED_JAR_EXT);
+                    .resolve(moduleName.toString() + ProjectConstants.TEST_UBER_JAR_SUFFIX + ProjectConstants.BLANG_COMPILED_JAR_EXT);
 
-            out.println("test executable path: " + testExecutablePath.toString());
+            //out.println("test executable path: " + testExecutablePath.toString());
             if (!Files.exists(testExecutablePath)) {
                 out.println("\t" + moduleName + ": no tests found");
-                continue;
+            }
+            else{
+                try {
+                    testResult = runTestModule(project, testExecutablePath, moduleDescriptor);
+                } catch (IOException | InterruptedException | ClassNotFoundException  e) {
+                    throw createLauncherException("error occurred while running tests", e);
+                }
+
+                if (testResult != 0) {
+                    throw createLauncherException("there are test failures");
+                }
             }
 
-            List<String> cmdArgs = getInitialCmdArgs();
-            cmdArgs.add("-jar");
-            cmdArgs.add(testExecutablePath.toString());
-            cmdArgs.addAll(getTestRunnerCmdArgs(target, project.currentPackage().packageName().toString(),
-                    moduleName.toString()));
-            ProcessBuilder processBuilder = new ProcessBuilder(cmdArgs).inheritIO();
-            Process proc;
-            try {
-                proc = processBuilder.start();
-                proc.waitFor();
-            } catch (IOException | InterruptedException e) {
-                throw createLauncherException("error occurred while running tests", e);
-            }
 
-            if (proc.exitValue() != 0) {
-                throw createLauncherException("there are test failures");
-            }
 //            TestSuite suite = testProcessor.testSuite(module).orElse(null);
 //            if (suite == null) {
 //                continue;
@@ -307,6 +296,26 @@ public class RunTestsTask implements Task {
         }
     }
 
+    private int runTestModule(Project project,Path testExecutablePath, ModuleDescriptor moduleDescriptor) throws IOException, InterruptedException, ClassNotFoundException {
+
+        List<String> cmdArgs = getInitialCmdArgs();
+        cmdArgs.add("-jar");
+        cmdArgs.add(testExecutablePath.toString()); //this will start the jar file which has the BTestMain as the initial main class in the manifest
+
+        String testPackageID = TestProcessor.getTestModuleName(project.currentPackage().module(moduleDescriptor.name()));
+        String org = moduleDescriptor.org().toString();
+        String version = moduleDescriptor.version().toString();
+
+        cmdArgs.add(testPackageID);
+        cmdArgs.add(org);
+        cmdArgs.add(version);
+
+        ProcessBuilder processBuilder = new ProcessBuilder(cmdArgs).inheritIO();
+        Process proc = processBuilder.start();
+
+        return proc.waitFor();
+    }
+
     private int runTestSuite(Target target, Package currentPackage, JBallerinaBackend jBallerinaBackend,
                              List<String> mockClassNames, Set<String> exclusionClassList) throws IOException,
             InterruptedException, ClassNotFoundException {
@@ -389,15 +398,21 @@ public class RunTestsTask implements Task {
         cmdArgs.add(System.getProperty("java.command"));
         cmdArgs.add("-XX:+HeapDumpOnOutOfMemoryError");
         cmdArgs.add("-XX:HeapDumpPath=" + System.getProperty(USER_DIR));
+
+        if (isInDebugMode()) {
+            cmdArgs.add(getDebugArgs(this.err));
+        }
+
         return cmdArgs;
     }
 
-    private List<String> getTestRunnerCmdArgs(Target target, String packageName, String moduleName){
+    public List<String> getTestRunnerCmdArgs(Target target, String packageName, String moduleName){
         List<String> cmdArgs = new ArrayList<>();
+        cmdArgs.add(getJacocoAgentJarPath());
+
         cmdArgs.add(target.path().toString());
         cmdArgs.add(packageName);
         cmdArgs.add(moduleName);
-        //cmdArgs.add(getJacocoAgentJarPath());
         cmdArgs.add(Boolean.toString(report));
         cmdArgs.add(Boolean.toString(coverage));
         cmdArgs.add(this.groupList != null ? this.groupList : "");

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -35,6 +35,7 @@ import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.ResolvedPackageDependency;
 import io.ballerina.projects.internal.model.Target;
 import io.ballerina.projects.util.ProjectConstants;
+import org.ballerinalang.test.runtime.entity.ModuleStatus;
 import org.ballerinalang.test.runtime.entity.TestReport;
 import org.ballerinalang.test.runtime.entity.TestSuite;
 import org.ballerinalang.test.runtime.util.JacocoInstrumentUtils;
@@ -67,6 +68,9 @@ import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
 import static io.ballerina.cli.utils.DebugUtils.getDebugArgs;
 import static io.ballerina.cli.utils.DebugUtils.isInDebugMode;
 import static io.ballerina.cli.utils.TestUtils.cleanTempCache;
+import static io.ballerina.cli.utils.TestUtils.generateCoverage;
+import static io.ballerina.cli.utils.TestUtils.generateTesterinaReports;
+import static io.ballerina.cli.utils.TestUtils.loadModuleStatusFromFile;
 import static io.ballerina.projects.util.ProjectConstants.GENERATED_MODULES_ROOT;
 import static io.ballerina.projects.util.ProjectConstants.MODULES_ROOT;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.FULLY_QULAIFIED_MODULENAME_SEPRATOR;
@@ -168,36 +172,36 @@ public class RunTestsTask implements Task {
             throw createLauncherException("error while creating target directory: ", e);
         }
 
-        boolean hasTests = false;
-
         PackageCompilation packageCompilation = project.currentPackage().getCompilation();
         JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(packageCompilation, JvmTarget.JAVA_17);
         JarResolver jarResolver = jBallerinaBackend.jarResolver();
         TestProcessor testProcessor = new TestProcessor(jarResolver);
-        List<String> moduleNamesList = new ArrayList<>();
-        Map<String, TestSuite> testSuiteMap = new HashMap<>();
-        List<String> updatedSingleExecTests;
+        List<ModuleName> moduleNamesList = new ArrayList<>();
+        HashSet<String> exclusionClassList = new HashSet<>();
+
         // Only tests in packages are executed so default packages i.e. single bal files which has the package name
         // as "." are ignored. This is to be consistent with the "bal test" command which only executes tests
         // in packages.
-        List<String> mockClassNames = new ArrayList<>();
+
         for (ModuleDescriptor moduleDescriptor :
                 project.currentPackage().moduleDependencyGraph().toTopologicallySortedList()) {
             int testResult = 0;
             Module module = project.currentPackage().module(moduleDescriptor.name());
             ModuleName moduleName = module.moduleName();
+            moduleNamesList.add(moduleName);
             //get the created uber jar files for each module in CreateTestExecutableTask
             Path testExecutablePath = target.path().resolve("bin").resolve("tests")
                     .resolve(moduleName.toString() +
                             ProjectConstants.TEST_UBER_JAR_SUFFIX +
                             ProjectConstants.BLANG_COMPILED_JAR_EXT);
 
-            //out.println("test executable path: " + testExecutablePath.toString());
             if (!Files.exists(testExecutablePath)) {
                 out.println("\t" + moduleName + ": no tests found");
             } else {
                 try {
-                    testResult = runTestModule(testExecutablePath);
+                    testResult = runTestModule(testExecutablePath, target, project.currentPackage(),
+                            exclusionClassList, getJacocoAgentJarPath(), project.currentPackage().packageName().toString(),
+                            project.currentPackage().packageOrg().toString());
                 } catch (IOException | InterruptedException | ClassNotFoundException  e) {
                     throw createLauncherException("error occurred while running tests", e);
                 }
@@ -206,94 +210,34 @@ public class RunTestsTask implements Task {
                     throw createLauncherException("there are test failures");
                 }
             }
-
-
-//            TestSuite suite = testProcessor.testSuite(module).orElse(null);
-//            if (suite == null) {
-//                continue;
-//            }
-//
-//            //Set 'hasTests' flag if there are any tests available in the package
-//            if (!hasTests) {
-//                hasTests = true;
-//            }
-//
-//            if (!isRerunTestExecution) {
-//                clearFailedTestsJson(target.path());
-//            }
-//            if (project.kind() == ProjectKind.SINGLE_FILE_PROJECT) {
-//                suite.setSourceFileName(project.sourceRoot().getFileName().toString());
-//            }
-//            suite.setReportRequired(report || coverage);
-//            String resolvedModuleName =
-//                    module.isDefaultModule() ? moduleName.toString() : module.moduleName().moduleNamePart();
-//            testSuiteMap.put(resolvedModuleName, suite);
-//            moduleNamesList.add(resolvedModuleName);
-//            Map<String, String> mockFunctionMap = suite.getMockFunctionNamesMap();
-//            for (Map.Entry<String, String> entry : mockFunctionMap.entrySet()) {
-//                String key = entry.getKey();
-//                String functionToMockClassName;
-//                // Find the first delimiter and compare the indexes
-//                // The first index should always be a delimiter. Which ever one that is denotes the mocking type
-//                if (key.indexOf(MOCK_LEGACY_DELIMITER) == -1) {
-//                    functionToMockClassName = key.substring(0, key.indexOf(MOCK_FN_DELIMITER));
-//                } else if (key.indexOf(MOCK_FN_DELIMITER) == -1) {
-//                    functionToMockClassName = key.substring(0, key.indexOf(MOCK_LEGACY_DELIMITER));
-//                } else {
-//                    if (key.indexOf(MOCK_FN_DELIMITER) < key.indexOf(MOCK_LEGACY_DELIMITER)) {
-//                        functionToMockClassName = key.substring(0, key.indexOf(MOCK_FN_DELIMITER));
-//                    } else {
-//                        functionToMockClassName = key.substring(0, key.indexOf(MOCK_LEGACY_DELIMITER));
-//                    }
-//                }
-//                mockClassNames.add(functionToMockClassName);
-//            }
         }
 
-//        writeToTestSuiteJson(testSuiteMap, testsCachePath);
-//
-//        if (hasTests) {
-//            int testResult;
-//            try {
-//                Set<String> exclusionClassList = new HashSet<>();
-//                testResult = runTestSuite(target, project.currentPackage(), jBallerinaBackend, mockClassNames,
-//                             exclusionClassList);
-//
-//                if (report || coverage) {
-//                    for (String moduleName : moduleNamesList) {
-//                        ModuleStatus moduleStatus = loadModuleStatusFromFile(
-//                                testsCachePath.resolve(moduleName).resolve(TesterinaConstants.STATUS_FILE));
-//                        if (moduleStatus == null) {
-//                            continue;
-//                        }
-//
-//                        if (!moduleName.equals(project.currentPackage().packageName().toString())) {
-//                            moduleName = ModuleName.from(project.currentPackage().packageName(), moduleName)
-//                            .toString();
-//                        }
-//                        testReport.addModuleStatus(moduleName, moduleStatus);
-//                    }
-//                    try {
-//                        generateCoverage(project, testReport, jBallerinaBackend, this.includesInCoverage,
-//                                this.coverageReportFormat, this.coverageModules, exclusionClassList);
-//                        generateTesterinaReports(project, testReport, this.out, target);
-//                    } catch (IOException e) {
-//                        cleanTempCache(project, cachesRoot);
-//                        throw createLauncherException("error occurred while generating test report :", e);
-//                    }
-//                }
-//            } catch (IOException | InterruptedException | ClassNotFoundException e) {
-//                cleanTempCache(project, cachesRoot);
-//                throw createLauncherException("error occurred while running tests", e);
-//            }
-//
-//            if (testResult != 0) {
-//                cleanTempCache(project, cachesRoot);
-//                throw createLauncherException("there are test failures");
-//            }
-//        } else {
-//            out.println("\tNo tests found");
-//        }
+        if (report || coverage) {
+            for(ModuleName moduleName : moduleNamesList) {
+                try {
+                    ModuleStatus moduleStatus = loadModuleStatusFromFile(
+                            testsCachePath.resolve(moduleName.toString()).resolve(TesterinaConstants.STATUS_FILE));
+                    if (moduleStatus == null) {
+                        continue;
+                    }
+
+                    if (!moduleName.toString().equals(project.currentPackage().packageName().toString())) {
+                        moduleName = ModuleName.from(project.currentPackage().packageName(), moduleName.moduleNamePart());
+                    }
+                    testReport.addModuleStatus(moduleName.toString(), moduleStatus);
+                } catch (IOException e) {
+                    throw createLauncherException("error occurred while generating test report :", e);
+                }
+            }
+
+            try {
+                generateCoverage(project, testReport, jBallerinaBackend, this.includesInCoverage,
+                        this.coverageReportFormat, this.coverageModules, exclusionClassList);
+                generateTesterinaReports(project, testReport, this.out, target);
+            } catch (IOException e) {
+                throw createLauncherException("error occurred while generating test report :", e);
+            }
+        }
 
         // Cleanup temp cache for SingleFileProject
         cleanTempCache(project, cachesRoot);
@@ -302,10 +246,24 @@ public class RunTestsTask implements Task {
         }
     }
 
-    private int runTestModule(Path testExecutablePath)
+    private int runTestModule(Path testExecutablePath, Target target, Package currentPackage,
+                              Set<String> exclusionClassList, String jacocoAgentJarPath,
+                              String packageName, String orgName)
             throws IOException, InterruptedException, ClassNotFoundException {
 
         List<String> cmdArgs = getInitialCmdArgs();
+
+        if (coverage) {
+            String agentCommand = getAgentCommand(target, currentPackage, exclusionClassList,
+                    jacocoAgentJarPath, packageName, orgName);
+
+            cmdArgs.add(agentCommand);
+        }
+
+        if (isInDebugMode()) {
+            cmdArgs.add(getDebugArgs(this.err));
+        }
+
         cmdArgs.add("-jar");
         cmdArgs.add(testExecutablePath.toString());
         //this will start the jar file which has the BTestMain as the initial main class in the manifest
@@ -339,26 +297,7 @@ public class RunTestsTask implements Task {
                         .resolve(TesterinaConstants.JACOCO_INSTRUMENTED_DIR);
                 JacocoInstrumentUtils.instrumentOffline(jarUrlList, instrumentDir, mockClassNames);
             }
-            String agentCommand = "-javaagent:"
-                    + jacocoAgentJarPath
-                    + "=destfile="
-                    + target.getTestsCachePath().resolve(TesterinaConstants.COVERAGE_DIR)
-                    .resolve(TesterinaConstants.EXEC_FILE_NAME);
-            if (!STANDALONE_SRC_PACKAGENAME.equals(packageName) && this.includesInCoverage == null) {
-                // add user defined classes for generating the jacoco exec file
-                agentCommand += ",includes=" + orgName + ".*";
-            } else {
-                agentCommand += ",includes=" + this.includesInCoverage;
-            }
-
-            if (!STANDALONE_SRC_PACKAGENAME.equals(packageName) && this.excludesInCoverage != null) {
-                if (!this.excludesInCoverage.equals("")) {
-                    List<String> exclusionSourceList = new ArrayList<>(List.of((this.excludesInCoverage).
-                            split(",")));
-                    getclassFromSourceFilePath(exclusionSourceList, currentPackage, exclusionClassList);
-                    agentCommand += ",excludes=" + String.join(":", exclusionClassList);
-                }
-            }
+            String agentCommand = getAgentCommand(target, currentPackage, exclusionClassList, jacocoAgentJarPath, packageName, orgName);
 
             cmdArgs.add(agentCommand);
         }
@@ -388,6 +327,30 @@ public class RunTestsTask implements Task {
         return proc.waitFor();
     }
 
+    private String getAgentCommand(Target target, Package currentPackage, Set<String> exclusionClassList, String jacocoAgentJarPath, String packageName, String orgName) throws IOException {
+        String agentCommand = "-javaagent:"
+                + jacocoAgentJarPath
+                + "=destfile="
+                + target.getTestsCachePath().resolve(TesterinaConstants.COVERAGE_DIR)
+                .resolve(TesterinaConstants.EXEC_FILE_NAME);
+        if (!STANDALONE_SRC_PACKAGENAME.equals(packageName) && this.includesInCoverage == null) {
+            // add user defined classes for generating the jacoco exec file
+            agentCommand += ",includes=" + orgName + ".*";
+        } else {
+            agentCommand += ",includes=" + this.includesInCoverage;
+        }
+
+        if (!STANDALONE_SRC_PACKAGENAME.equals(packageName) && this.excludesInCoverage != null) {
+            if (!this.excludesInCoverage.equals("")) {
+                List<String> exclusionSourceList = new ArrayList<>(List.of((this.excludesInCoverage).
+                        split(",")));
+                getclassFromSourceFilePath(exclusionSourceList, currentPackage, exclusionClassList);
+                agentCommand += ",excludes=" + String.join(":", exclusionClassList);
+            }
+        }
+        return agentCommand;
+    }
+
     private String getJacocoAgentJarPath() {
         return Paths.get(System.getProperty(BALLERINA_HOME)).resolve(BALLERINA_HOME_BRE)
                 .resolve(BALLERINA_HOME_LIB).resolve(TesterinaConstants.AGENT_FILE_NAME).toString();
@@ -398,10 +361,6 @@ public class RunTestsTask implements Task {
         cmdArgs.add(System.getProperty("java.command"));
         cmdArgs.add("-XX:+HeapDumpOnOutOfMemoryError");
         cmdArgs.add("-XX:HeapDumpPath=" + System.getProperty(USER_DIR));
-
-        if (isInDebugMode()) {
-            cmdArgs.add(getDebugArgs(this.err));
-        }
 
         return cmdArgs;
     }
@@ -447,6 +406,10 @@ public class RunTestsTask implements Task {
 
     //first 3 args are required for loading the test class
     public List<String> getAllTestArgs(Target target, String packageName, String moduleName, Project project, ModuleDescriptor moduleDescriptor) {
+        //set test report and coverage report from the project
+        report = project.buildOptions().testReport();
+        coverage = project.buildOptions().codeCoverage();
+
         List<String> allArgs = getArgsRequiredForLoadingTestClass(project, moduleDescriptor);
 
         allArgs.addAll(getTestRunnerCmdArgs(target, packageName, moduleName));

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -35,7 +35,6 @@ import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.ResolvedPackageDependency;
 import io.ballerina.projects.internal.model.Target;
 import io.ballerina.projects.util.ProjectConstants;
-import org.ballerinalang.test.runtime.entity.ModuleStatus;
 import org.ballerinalang.test.runtime.entity.TestReport;
 import org.ballerinalang.test.runtime.entity.TestSuite;
 import org.ballerinalang.test.runtime.util.JacocoInstrumentUtils;
@@ -52,7 +51,14 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -61,14 +67,12 @@ import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
 import static io.ballerina.cli.utils.DebugUtils.getDebugArgs;
 import static io.ballerina.cli.utils.DebugUtils.isInDebugMode;
 import static io.ballerina.cli.utils.TestUtils.cleanTempCache;
-import static io.ballerina.cli.utils.TestUtils.clearFailedTestsJson;
-import static io.ballerina.cli.utils.TestUtils.generateCoverage;
-import static io.ballerina.cli.utils.TestUtils.generateTesterinaReports;
-import static io.ballerina.cli.utils.TestUtils.loadModuleStatusFromFile;
-import static io.ballerina.cli.utils.TestUtils.writeToTestSuiteJson;
 import static io.ballerina.projects.util.ProjectConstants.GENERATED_MODULES_ROOT;
 import static io.ballerina.projects.util.ProjectConstants.MODULES_ROOT;
-import static org.ballerinalang.test.runtime.util.TesterinaConstants.*;
+import static org.ballerinalang.test.runtime.util.TesterinaConstants.FULLY_QULAIFIED_MODULENAME_SEPRATOR;
+import static org.ballerinalang.test.runtime.util.TesterinaConstants.STANDALONE_SRC_PACKAGENAME;
+import static org.ballerinalang.test.runtime.util.TesterinaConstants.WILDCARD;
+import static org.ballerinalang.test.runtime.util.TesterinaConstants.IGNORE_PATTERN;
 import static org.ballerinalang.test.runtime.util.TesterinaUtils.getQualifiedClassName;
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME;
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME_BRE;
@@ -184,13 +188,14 @@ public class RunTestsTask implements Task {
             ModuleName moduleName = module.moduleName();
             //get the created uber jar files for each module in CreateTestExecutableTask
             Path testExecutablePath = target.path().resolve("bin").resolve("tests")
-                    .resolve(moduleName.toString() + ProjectConstants.TEST_UBER_JAR_SUFFIX + ProjectConstants.BLANG_COMPILED_JAR_EXT);
+                    .resolve(moduleName.toString() +
+                            ProjectConstants.TEST_UBER_JAR_SUFFIX +
+                            ProjectConstants.BLANG_COMPILED_JAR_EXT);
 
             //out.println("test executable path: " + testExecutablePath.toString());
             if (!Files.exists(testExecutablePath)) {
                 out.println("\t" + moduleName + ": no tests found");
-            }
-            else{
+            } else {
                 try {
                     testResult = runTestModule(project, testExecutablePath, moduleDescriptor);
                 } catch (IOException | InterruptedException | ClassNotFoundException  e) {
@@ -263,7 +268,8 @@ public class RunTestsTask implements Task {
 //                        }
 //
 //                        if (!moduleName.equals(project.currentPackage().packageName().toString())) {
-//                            moduleName = ModuleName.from(project.currentPackage().packageName(), moduleName).toString();
+//                            moduleName = ModuleName.from(project.currentPackage().packageName(), moduleName)
+//                            .toString();
 //                        }
 //                        testReport.addModuleStatus(moduleName, moduleStatus);
 //                    }
@@ -296,13 +302,17 @@ public class RunTestsTask implements Task {
         }
     }
 
-    private int runTestModule(Project project,Path testExecutablePath, ModuleDescriptor moduleDescriptor) throws IOException, InterruptedException, ClassNotFoundException {
+    private int runTestModule(Project project, Path testExecutablePath, ModuleDescriptor moduleDescriptor)
+            throws IOException, InterruptedException, ClassNotFoundException {
 
         List<String> cmdArgs = getInitialCmdArgs();
         cmdArgs.add("-jar");
-        cmdArgs.add(testExecutablePath.toString()); //this will start the jar file which has the BTestMain as the initial main class in the manifest
+        cmdArgs.add(testExecutablePath.toString());
+        //this will start the jar file which has the BTestMain as the initial main class in the manifest
 
-        String testPackageID = TestProcessor.getTestModuleName(project.currentPackage().module(moduleDescriptor.name()));
+        String testPackageID = TestProcessor.getTestModuleName(
+                project.currentPackage().module(moduleDescriptor.name())
+        );
         String org = moduleDescriptor.org().toString();
         String version = moduleDescriptor.version().toString();
 
@@ -406,7 +416,7 @@ public class RunTestsTask implements Task {
         return cmdArgs;
     }
 
-    public List<String> getTestRunnerCmdArgs(Target target, String packageName, String moduleName){
+    public List<String> getTestRunnerCmdArgs(Target target, String packageName, String moduleName) {
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add(getJacocoAgentJarPath());
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -67,16 +67,11 @@ import java.util.stream.Stream;
 import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
 import static io.ballerina.cli.utils.DebugUtils.getDebugArgs;
 import static io.ballerina.cli.utils.DebugUtils.isInDebugMode;
-import static io.ballerina.cli.utils.TestUtils.cleanTempCache;
-import static io.ballerina.cli.utils.TestUtils.generateCoverage;
-import static io.ballerina.cli.utils.TestUtils.generateTesterinaReports;
-import static io.ballerina.cli.utils.TestUtils.loadModuleStatusFromFile;
+import static io.ballerina.cli.utils.TestUtils.*;
+import static io.ballerina.cli.utils.TestUtils.writeToTestSuiteJson;
 import static io.ballerina.projects.util.ProjectConstants.GENERATED_MODULES_ROOT;
 import static io.ballerina.projects.util.ProjectConstants.MODULES_ROOT;
-import static org.ballerinalang.test.runtime.util.TesterinaConstants.FULLY_QULAIFIED_MODULENAME_SEPRATOR;
-import static org.ballerinalang.test.runtime.util.TesterinaConstants.STANDALONE_SRC_PACKAGENAME;
-import static org.ballerinalang.test.runtime.util.TesterinaConstants.WILDCARD;
-import static org.ballerinalang.test.runtime.util.TesterinaConstants.IGNORE_PATTERN;
+import static org.ballerinalang.test.runtime.util.TesterinaConstants.*;
 import static org.ballerinalang.test.runtime.util.TesterinaUtils.getQualifiedClassName;
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME;
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME_BRE;
@@ -104,6 +99,7 @@ public class RunTestsTask implements Task {
     private Map<String, Module> coverageModules;
     private boolean listGroups;
     private final List<String> cliArgs;
+    private boolean emitTestExecutable;
 
     TestReport testReport;
     private static final Boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.getDefault())
@@ -150,6 +146,7 @@ public class RunTestsTask implements Task {
 
         report = project.buildOptions().testReport();
         coverage = project.buildOptions().codeCoverage();
+        emitTestExecutable = project.buildOptions().emitTestExecutable();
 
         if (report || coverage) {
             testReport = new TestReport();
@@ -172,17 +169,133 @@ public class RunTestsTask implements Task {
             throw createLauncherException("error while creating target directory: ", e);
         }
 
+        boolean hasTests = false;
+
         PackageCompilation packageCompilation = project.currentPackage().getCompilation();
         JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(packageCompilation, JvmTarget.JAVA_17);
         JarResolver jarResolver = jBallerinaBackend.jarResolver();
-        TestProcessor testProcessor = new TestProcessor(jarResolver);
-        List<ModuleName> moduleNamesList = new ArrayList<>();
-        HashSet<String> exclusionClassList = new HashSet<>();
 
         // Only tests in packages are executed so default packages i.e. single bal files which has the package name
         // as "." are ignored. This is to be consistent with the "bal test" command which only executes tests
         // in packages.
 
+        if (emitTestExecutable) {
+            HashSet<String> exclusionClassList = new HashSet<>();
+            List<ModuleName> moduleNamesList = new ArrayList<>();
+            runTestsUsingEmits(project, moduleNamesList, target, exclusionClassList, testsCachePath, jBallerinaBackend);
+        }
+        else {
+            runTestsUsingSuiteJSON(project, jarResolver, hasTests, target, testsCachePath, jBallerinaBackend, cachesRoot);
+        }
+
+
+        // Cleanup temp cache for SingleFileProject
+        cleanTempCache(project, cachesRoot);
+        if (project.buildOptions().dumpBuildTime()) {
+            BuildTime.getInstance().testingExecutionDuration = System.currentTimeMillis() - start;
+        }
+    }
+
+    private void runTestsUsingSuiteJSON(Project project, JarResolver jarResolver, boolean hasTests, Target target, Path testsCachePath, JBallerinaBackend jBallerinaBackend, Path cachesRoot) {
+        TestProcessor testProcessor = new TestProcessor(jarResolver);
+        List<String> moduleNamesList = new ArrayList<>();
+        Map<String, TestSuite> testSuiteMap = new HashMap<>();
+        List<String> updatedSingleExecTests;
+        List<String> mockClassNames = new ArrayList<>();
+
+        for (ModuleDescriptor moduleDescriptor :
+                project.currentPackage().moduleDependencyGraph().toTopologicallySortedList()) {
+            Module module = project.currentPackage().module(moduleDescriptor.name());
+            ModuleName moduleName = module.moduleName();
+
+            TestSuite suite = testProcessor.testSuite(module).orElse(null);
+            if (suite == null) {
+                continue;
+            }
+
+            //Set 'hasTests' flag if there are any tests available in the package
+            if (!hasTests) {
+                hasTests = true;
+            }
+
+            if (!isRerunTestExecution) {
+                clearFailedTestsJson(target.path());
+            }
+            if (project.kind() == ProjectKind.SINGLE_FILE_PROJECT) {
+                suite.setSourceFileName(project.sourceRoot().getFileName().toString());
+            }
+            suite.setReportRequired(report || coverage);
+            String resolvedModuleName =
+                    module.isDefaultModule() ? moduleName.toString() : module.moduleName().moduleNamePart();
+            testSuiteMap.put(resolvedModuleName, suite);
+            moduleNamesList.add(resolvedModuleName);
+            Map<String, String> mockFunctionMap = suite.getMockFunctionNamesMap();
+            for (Map.Entry<String, String> entry : mockFunctionMap.entrySet()) {
+                String key = entry.getKey();
+                String functionToMockClassName;
+                // Find the first delimiter and compare the indexes
+                // The first index should always be a delimiter. Which ever one that is denotes the mocking type
+                if (key.indexOf(MOCK_LEGACY_DELIMITER) == -1) {
+                    functionToMockClassName = key.substring(0, key.indexOf(MOCK_FN_DELIMITER));
+                } else if (key.indexOf(MOCK_FN_DELIMITER) == -1) {
+                    functionToMockClassName = key.substring(0, key.indexOf(MOCK_LEGACY_DELIMITER));
+                } else {
+                    if (key.indexOf(MOCK_FN_DELIMITER) < key.indexOf(MOCK_LEGACY_DELIMITER)) {
+                        functionToMockClassName = key.substring(0, key.indexOf(MOCK_FN_DELIMITER));
+                    } else {
+                        functionToMockClassName = key.substring(0, key.indexOf(MOCK_LEGACY_DELIMITER));
+                    }
+                }
+                mockClassNames.add(functionToMockClassName);
+            }
+        }
+
+        writeToTestSuiteJson(testSuiteMap, testsCachePath);
+
+        if (hasTests) {
+            int testResult;
+            try {
+                Set<String> exclusionClassList = new HashSet<>();
+                testResult = runTestSuite(target, project.currentPackage(), jBallerinaBackend, mockClassNames,
+                        exclusionClassList);
+
+                if (report || coverage) {
+                    for (String moduleName : moduleNamesList) {
+                        ModuleStatus moduleStatus = loadModuleStatusFromFile(
+                                testsCachePath.resolve(moduleName).resolve(TesterinaConstants.STATUS_FILE));
+                        if (moduleStatus == null) {
+                            continue;
+                        }
+
+                        if (!moduleName.equals(project.currentPackage().packageName().toString())) {
+                            moduleName = ModuleName.from(project.currentPackage().packageName(), moduleName).toString();
+                        }
+                        testReport.addModuleStatus(moduleName, moduleStatus);
+                    }
+                    try {
+                        generateCoverage(project, testReport, jBallerinaBackend, this.includesInCoverage,
+                                this.coverageReportFormat, this.coverageModules, exclusionClassList);
+                        generateTesterinaReports(project, testReport, this.out, target);
+                    } catch (IOException e) {
+                        cleanTempCache(project, cachesRoot);
+                        throw createLauncherException("error occurred while generating test report :", e);
+                    }
+                }
+            } catch (IOException | InterruptedException | ClassNotFoundException e) {
+                cleanTempCache(project, cachesRoot);
+                throw createLauncherException("error occurred while running tests", e);
+            }
+
+            if (testResult != 0) {
+                cleanTempCache(project, cachesRoot);
+                throw createLauncherException("there are test failures");
+            }
+        } else {
+            out.println("\tNo tests found");
+        }
+    }
+
+    private void runTestsUsingEmits(Project project, List<ModuleName> moduleNamesList, Target target, HashSet<String> exclusionClassList, Path testsCachePath, JBallerinaBackend jBallerinaBackend) {
         for (ModuleDescriptor moduleDescriptor :
                 project.currentPackage().moduleDependencyGraph().toTopologicallySortedList()) {
             int testResult = 0;
@@ -237,12 +350,6 @@ public class RunTestsTask implements Task {
             } catch (IOException e) {
                 throw createLauncherException("error occurred while generating test report :", e);
             }
-        }
-
-        // Cleanup temp cache for SingleFileProject
-        cleanTempCache(project, cachesRoot);
-        if (project.buildOptions().dumpBuildTime()) {
-            BuildTime.getInstance().testingExecutionDuration = System.currentTimeMillis() - start;
         }
     }
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -52,14 +52,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringJoiner;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -207,7 +200,8 @@ public class RunTestsTask implements Task {
             List<String> cmdArgs = getInitialCmdArgs();
             cmdArgs.add("-jar");
             cmdArgs.add(testExecutablePath.toString());
-            cmdArgs.addAll(getTestRunnerCmdArgs());
+            cmdArgs.addAll(getTestRunnerCmdArgs(target, project.currentPackage().packageName().toString(),
+                    moduleName.toString()));
             ProcessBuilder processBuilder = new ProcessBuilder(cmdArgs).inheritIO();
             Process proc;
             try {
@@ -398,8 +392,11 @@ public class RunTestsTask implements Task {
         return cmdArgs;
     }
 
-    private List<String> getTestRunnerCmdArgs(){
+    private List<String> getTestRunnerCmdArgs(Target target, String packageName, String moduleName){
         List<String> cmdArgs = new ArrayList<>();
+        cmdArgs.add(target.path().toString());
+        cmdArgs.add(packageName);
+        cmdArgs.add(moduleName);
         //cmdArgs.add(getJacocoAgentJarPath());
         cmdArgs.add(Boolean.toString(report));
         cmdArgs.add(Boolean.toString(coverage));

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
@@ -35,9 +35,12 @@ public class BuildOptions {
     private Boolean exportComponentModel;
     private String graalVMBuildOptions;
 
+    private Boolean emitTestExecutable;
+
     BuildOptions(Boolean testReport, Boolean codeCoverage, Boolean dumpBuildTime, Boolean skipTests,
                  CompilationOptions compilationOptions, String targetPath, Boolean enableCache,
-                 Boolean nativeImage, Boolean exportComponentModel, String graalVMBuildOptions) {
+                 Boolean nativeImage, Boolean exportComponentModel,
+                 String graalVMBuildOptions, Boolean emitTestExecutable) {
         this.testReport = testReport;
         this.codeCoverage = codeCoverage;
         this.dumpBuildTime = dumpBuildTime;
@@ -48,6 +51,7 @@ public class BuildOptions {
         this.nativeImage = nativeImage;
         this.exportComponentModel = exportComponentModel;
         this.graalVMBuildOptions = graalVMBuildOptions;
+        this.emitTestExecutable = emitTestExecutable;
 
     }
 
@@ -125,6 +129,10 @@ public class BuildOptions {
 
     public String graalVMBuildOptions() {
         return Objects.requireNonNullElse(this.graalVMBuildOptions, "");
+    }
+
+    public boolean emitTestExecutable() {
+        return toBooleanDefaultIfNull(this.emitTestExecutable);
     }
 
     /**
@@ -263,6 +271,7 @@ public class BuildOptions {
         private Boolean nativeImage;
         private Boolean exportComponentModel;
         private String graalVMBuildOptions;
+        private Boolean emitTestExecutable;
 
 
         private BuildOptionsBuilder() {
@@ -311,6 +320,11 @@ public class BuildOptions {
 
         public BuildOptionsBuilder setGraalVMBuildOptions(String value) {
             graalVMBuildOptions = value;
+            return this;
+        }
+
+        public BuildOptionsBuilder setEmitTestExecutable(Boolean value) {
+            emitTestExecutable = value;
             return this;
         }
 
@@ -390,7 +404,7 @@ public class BuildOptions {
         public BuildOptions build() {
             CompilationOptions compilationOptions = compilationOptionsBuilder.build();
             return new BuildOptions(testReport, codeCoverage, dumpBuildTime, skipTests, compilationOptions,
-                    targetPath, enableCache, nativeImage, exportComponentModel, graalVMBuildOptions);
+                    targetPath, enableCache, nativeImage, exportComponentModel, graalVMBuildOptions, emitTestExecutable);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -558,10 +558,6 @@ public class JBallerinaBackend extends CompilerBackend {
                 return false;
             }
 
-            if(entryName.equals("ballerina/lang$0046error/0/$_init$SignalListener.class")){
-                System.out.println("copying the lang error class which is causing the conflict");
-            }
-
             // Skip already copied files or excluded extensions.
             if (isCopiedEntry(entryName, copiedEntries)) {
                 addConflictedJars(jarLibrary, copiedEntries, entryName);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -242,6 +242,35 @@ public class JBallerinaBackend extends CompilerBackend {
         return new EmitResult(true, new DefaultDiagnosticResult(allDiagnostics), generatedArtifact);
     }
 
+    public EmitResult emit(OutputType outputType, Path filePath, ModuleName moduleName) {
+        Path generatedArtifact = null;
+
+        if (diagnosticResult.hasErrors()) {
+            return new EmitResult(false, diagnosticResult, generatedArtifact);
+        }
+
+        if(outputType == OutputType.TEST) {
+            generatedArtifact = emitTest(filePath, moduleName);
+        }
+        else{
+            throw new RuntimeException("Unexpected output type: " + outputType);
+        }
+
+        ArrayList<Diagnostic> diagnostics = new ArrayList<>(diagnosticResult.allDiagnostics);
+        List<Diagnostic> pluginDiagnostics = packageCompilation.notifyCompilationCompletion(filePath);
+        if (!pluginDiagnostics.isEmpty()) {
+            diagnostics.addAll(pluginDiagnostics);
+        }
+        diagnosticResult = new DefaultDiagnosticResult(diagnostics);
+
+        List<Diagnostic> allDiagnostics = new ArrayList<>(diagnostics);
+        jarResolver().diagnosticResult().diagnostics().stream().forEach(
+                diagnostic -> allDiagnostics.add(diagnostic));
+
+        // TODO handle the EmitResult properly
+        return new EmitResult(true, new DefaultDiagnosticResult(allDiagnostics), generatedArtifact);
+    }
+
     private Path emitBala(Path filePath) {
         JBallerinaBalaWriter writer = new JBallerinaBalaWriter(this);
         return writer.write(filePath);
@@ -447,6 +476,28 @@ public class JBallerinaBackend extends CompilerBackend {
         return manifest;
     }
 
+    private Manifest createTestManifest(ModuleName moduleName){
+        // Getting the jarFileName of the root module of this executable
+        PlatformLibrary rootModuleJarFile = codeGeneratedTestLibrary(packageContext.packageId(), moduleName);
+
+        String mainClassName;
+        //mainClassName = "org.ballerinalang.test.runtime.BTestMain";
+        try (JarInputStream jarStream = new JarInputStream(Files.newInputStream(rootModuleJarFile.path()))) {
+            Manifest mf = jarStream.getManifest();
+            mainClassName = (String) mf.getMainAttributes().get(Attributes.Name.MAIN_CLASS);
+        } catch (IOException e) {
+            throw new RuntimeException("Generated jar file cannot be found for the module: " +
+                    packageContext.defaultModuleContext().moduleName());
+        }
+
+        Manifest manifest = new Manifest();
+        Attributes mainAttributes = manifest.getMainAttributes();
+        //System.out.println(mainClassName);
+        mainAttributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        mainAttributes.put(Attributes.Name.MAIN_CLASS, mainClassName);
+        return manifest;
+    }
+
     /**
      * Copies a given jar file into the executable fat jar.
      *
@@ -457,7 +508,7 @@ public class JBallerinaBackend extends CompilerBackend {
      * @throws IOException If jar file copying is failed.
      */
     private void copyJar(ZipArchiveOutputStream outStream, JarLibrary jarLibrary,
-            HashMap<String, JarLibrary> copiedEntries, HashMap<String, StringBuilder> services) throws IOException {
+                         HashMap<String, JarLibrary> copiedEntries, HashMap<String, StringBuilder> services) throws IOException {
 
         ZipFile zipFile = new ZipFile(jarLibrary.path().toFile());
         ZipArchiveEntryPredicate predicate = entry -> {
@@ -537,6 +588,19 @@ public class JBallerinaBackend extends CompilerBackend {
     private Path emitExecutable(Path executableFilePath) {
         Manifest manifest = createManifest();
         Collection<JarLibrary> jarLibraries = jarResolver.getJarFilePathsRequiredForExecution();
+
+        try {
+            assembleExecutableJar(executableFilePath, manifest, jarLibraries);
+        } catch (IOException e) {
+            throw new ProjectException("error while creating the executable jar file for package '" +
+                    this.packageContext.packageName().toString() + "' : " + e.getMessage(), e);
+        }
+        return executableFilePath;
+    }
+
+    private Path emitTest(Path executableFilePath, ModuleName moduleName) {
+        Manifest manifest = createTestManifest(moduleName);
+        Collection<JarLibrary> jarLibraries = jarResolver.getJarFilePathsRequiredForTestExecution(moduleName);
 
         try {
             assembleExecutableJar(executableFilePath, manifest, jarLibraries);
@@ -699,7 +763,8 @@ public class JBallerinaBackend extends CompilerBackend {
     public enum OutputType {
         EXEC("exec"),
         BALA("bala"),
-        GRAAL_EXEC("graal_exec")
+        GRAAL_EXEC("graal_exec"),
+        TEST("test")
         ;
 
         private String value;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -249,10 +249,9 @@ public class JBallerinaBackend extends CompilerBackend {
             return new EmitResult(false, diagnosticResult, generatedArtifact);
         }
 
-        if(outputType == OutputType.TEST) {
+        if (outputType == OutputType.TEST) {
             generatedArtifact = emitTest(filePath, moduleName, cmdArgs);
-        }
-        else{
+        } else {
             throw new RuntimeException("Unexpected output type: " + outputType);
         }
 
@@ -448,12 +447,12 @@ public class JBallerinaBackend extends CompilerBackend {
             }
 
             //create a txt file within the jar to store the main arguments if it is a test jar
-            if(cmdArgs != null){
+            if (cmdArgs != null) {
                 JarArchiveEntry e = new JarArchiveEntry(ProjectConstants.TEST_RUNTIME_MAIN_ARGS_FILE);
                 outStream.putArchiveEntry(e);
 
                 //write the arguments to the file
-                for(String arg : cmdArgs){
+                for (String arg : cmdArgs) {
                     outStream.write(arg.getBytes(StandardCharsets.UTF_8));
                     outStream.write("\n".getBytes(StandardCharsets.UTF_8));
                 }
@@ -491,10 +490,7 @@ public class JBallerinaBackend extends CompilerBackend {
         return manifest;
     }
 
-    private Manifest createTestManifest(ModuleName moduleName){
-        // Getting the jarFileName of the root module of this executable
-        PlatformLibrary rootModuleJarFile = codeGeneratedTestLibrary(packageContext.packageId(), moduleName);
-
+    private Manifest createTestManifest() {
         String mainClassName;
         mainClassName = "org.ballerinalang.test.runtime.BTestMain";
 //        try (JarInputStream jarStream = new JarInputStream(Files.newInputStream(rootModuleJarFile.path()))) {
@@ -507,7 +503,6 @@ public class JBallerinaBackend extends CompilerBackend {
 
         Manifest manifest = new Manifest();
         Attributes mainAttributes = manifest.getMainAttributes();
-        //System.out.println(mainClassName);
         mainAttributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
         mainAttributes.put(Attributes.Name.MAIN_CLASS, mainClassName);
         return manifest;
@@ -523,7 +518,8 @@ public class JBallerinaBackend extends CompilerBackend {
      * @throws IOException If jar file copying is failed.
      */
     private void copyJar(ZipArchiveOutputStream outStream, JarLibrary jarLibrary,
-                         HashMap<String, JarLibrary> copiedEntries, HashMap<String, StringBuilder> services) throws IOException {
+                         HashMap<String, JarLibrary> copiedEntries, HashMap<String,
+            StringBuilder> services) throws IOException {
 
         ZipFile zipFile = new ZipFile(jarLibrary.path().toFile());
         ZipArchiveEntryPredicate predicate = entry -> {
@@ -614,7 +610,7 @@ public class JBallerinaBackend extends CompilerBackend {
     }
 
     private Path emitTest(Path executableFilePath, ModuleName moduleName, List<String> cmdArgs) {
-        Manifest manifest = createTestManifest(moduleName);
+        Manifest manifest = createTestManifest();
         Collection<JarLibrary> jarLibraries = jarResolver.getJarFilePathsRequiredForTestExecution(moduleName);
 
         try {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Target.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Target.java
@@ -135,12 +135,7 @@ public class Target {
         if (outputPath != null) {
             return outputPath;
         }
-        String name;
-        if(module.moduleName().moduleNamePart() == null){
-            name = module.moduleName().packageName().value();
-        } else {
-            name = module.moduleName().moduleNamePart();
-        }
+        String name = module.moduleName().toString();
         return getTestBinPath().resolve(name + ProjectConstants.TEST_UBER_JAR_SUFFIX + ProjectConstants.BLANG_COMPILED_JAR_EXT);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Target.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Target.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.projects.internal.model;
 
+import io.ballerina.projects.Module;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.projects.util.ProjectUtils;
@@ -130,6 +131,19 @@ public class Target {
         return getBinPath().resolve(ProjectUtils.getExecutableName(pkg));
     }
 
+    public Path getTestExecutablePath(Module module) throws IOException {
+        if (outputPath != null) {
+            return outputPath;
+        }
+        String name;
+        if(module.moduleName().moduleNamePart() == null){
+            name = module.moduleName().packageName().value();
+        } else {
+            name = module.moduleName().moduleNamePart();
+        }
+        return getTestBinPath().resolve(name + ProjectConstants.TEST_UBER_JAR_SUFFIX + ProjectConstants.BLANG_COMPILED_JAR_EXT);
+    }
+
     /**
      * Returns the bin directory path.
      *
@@ -138,6 +152,11 @@ public class Target {
     public Path getBinPath() throws IOException {
         Files.createDirectories(binPath);
         return binPath;
+    }
+
+    public Path getTestBinPath() throws IOException {
+        Files.createDirectories(binPath.resolve(ProjectConstants.TEST_DIR_NAME));
+        return binPath.resolve(ProjectConstants.TEST_DIR_NAME);
     }
 
     public Path getReportPath() throws IOException {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
@@ -111,6 +111,8 @@ public class ProjectConstants {
     // Test framework related constants
     public static final String TEST_RUNTIME_JAR_PREFIX = "testerina-runtime-";
     public static final String TEST_CORE_JAR_PREFIX = "testerina-core-";
+    public static final String TEST_UBER_JAR_SUFFIX = "-testable";
+
     public static final String TEST_SUITE = "test_suite";
 
     public static final String JACOCO_CORE_JAR = "org.jacoco.core-0.8.10.jar";

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
@@ -112,6 +112,8 @@ public class ProjectConstants {
     public static final String TEST_RUNTIME_JAR_PREFIX = "testerina-runtime-";
     public static final String TEST_CORE_JAR_PREFIX = "testerina-core-";
     public static final String TEST_UBER_JAR_SUFFIX = "-testable";
+    public static final String TEST_RUNTIME_MAIN_ARGS_FILE_DIR = "/";
+    public static final String TEST_RUNTIME_MAIN_ARGS_FILE = "mainArgs.txt";
 
     public static final String TEST_SUITE = "test_suite";
 

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
@@ -147,8 +147,7 @@ public class TestProcessor {
      * @return TestSuite
      */
     private TestSuite generateTestSuite(Module module, JarResolver jarResolver) {
-        PackageID packageID = module.descriptor().moduleTestCompilationId();
-        String testModuleName = packageID.isTestPkg ? packageID.name.value + Names.TEST_PACKAGE : packageID.name.value;
+        String testModuleName = getTestModuleName(module);
         TestSuite testSuite = new TestSuite(module.descriptor().name().toString(), testModuleName,
                 module.descriptor().packageName().toString(), module.descriptor().org().value(),
                 module.descriptor().version().toString(), getExecutePath(module));
@@ -169,6 +168,11 @@ public class TestProcessor {
         addUtilityFunctions(module, testSuite);
         populateMockFunctionNamesMap(module, testSuite);
         return testSuite;
+    }
+
+    public static String getTestModuleName(Module module) {
+        PackageID packageID = module.descriptor().moduleTestCompilationId();
+        return packageID.isTestPkg ? packageID.name.value + Names.TEST_PACKAGE : packageID.name.value;
     }
 
     /**

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestMain.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestMain.java
@@ -97,10 +97,6 @@ public class BTestMain {
                 boolean report = Boolean.parseBoolean(argsArr[3]);
                 boolean coverage = Boolean.parseBoolean(argsArr[4]);
 
-                if(report || coverage) {
-                    testReport = new TestReport();
-                }
-
                 out.println();
                 out.print("Running Tests");
                 if (coverage) {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestMain.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestMain.java
@@ -69,13 +69,18 @@ public class BTestMain {
         int exitStatus = 0;
         int result;
 
-        if(args.length == 3) {
+        if(args.length == 0) {
             List<String> mainArgs = new ArrayList<>();
 
             try (InputStream in = BTestMain.class.getResourceAsStream(ProjectConstants.TEST_RUNTIME_MAIN_ARGS_FILE_DIR + ProjectConstants.TEST_RUNTIME_MAIN_ARGS_FILE);
                  //make sure that the path start with a leading slash (/)
                  BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
                 // Use resource
+
+                //read first 3 lines to get the packageID, orgName and version
+                String packageID = reader.readLine();
+                String org = reader.readLine();
+                String version = reader.readLine();
 
                 //read just one line to get the jacoco agent jar path
                 String jacocoAgentJarPath = reader.readLine();
@@ -110,7 +115,7 @@ public class BTestMain {
                         (moduleName.equals(TesterinaConstants.DOT) ? packageName : moduleName)
                         : packageName + TesterinaConstants.DOT + moduleName));
 
-                result = startTestExecution(classLoader, argsArr, args[0], args[1], args[2]);
+                result = startTestExecution(classLoader, argsArr, packageID, org, version);
 
                 exitStatus = (result == 1) ? result : exitStatus;
             }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestMain.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestMain.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.runtime;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import io.ballerina.projects.Resource;
 import io.ballerina.projects.util.ProjectConstants;
 import org.ballerinalang.test.runtime.entity.MockFunctionReplaceVisitor;
 import org.ballerinalang.test.runtime.entity.ModuleStatus;
@@ -33,15 +34,7 @@ import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintStream;
-import java.io.Writer;
+import java.io.*;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -76,7 +69,58 @@ public class BTestMain {
         int exitStatus = 0;
         int result;
 
-        if (args.length >= 4) {
+        if(args.length == 3) {
+            List<String> mainArgs = new ArrayList<>();
+
+            try (InputStream in = BTestMain.class.getResourceAsStream(ProjectConstants.TEST_RUNTIME_MAIN_ARGS_FILE_DIR + ProjectConstants.TEST_RUNTIME_MAIN_ARGS_FILE);
+                 //make sure that the path start with a leading slash (/)
+                 BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+                // Use resource
+
+                //read just one line to get the jacoco agent jar path
+                String jacocoAgentJarPath = reader.readLine();
+
+                //read the rest of the lines to get the args
+                String line;
+                while((line = reader.readLine()) != null){
+                    mainArgs.add(line);
+                }
+
+                classLoader = createURLClassLoader(new ArrayList<String>());
+
+                String[] argsArr = mainArgs.toArray(new String[0]);
+                boolean report = Boolean.parseBoolean(argsArr[3]);
+                boolean coverage = Boolean.parseBoolean(argsArr[4]);
+
+                if(report || coverage) {
+                    testReport = new TestReport();
+                }
+
+                out.println();
+                out.print("Running Tests");
+                if (coverage) {
+                    out.print(" with Coverage");
+                }
+                out.println();
+
+                String packageName = argsArr[1];
+                String moduleName = argsArr[2];
+
+                out.println("\n\t" + (moduleName.equals(packageName) ?
+                        (moduleName.equals(TesterinaConstants.DOT) ? packageName : moduleName)
+                        : packageName + TesterinaConstants.DOT + moduleName));
+
+                result = startTestExecution(classLoader, argsArr, args[0], args[1], args[2]);
+
+                exitStatus = (result == 1) ? result : exitStatus;
+            }
+            catch(NullPointerException e){
+                System.out.println("no file found");
+                exitStatus = 1;
+            }
+            Runtime.getRuntime().exit(exitStatus);
+        }
+        else if (args.length >= 4) {
             Path targetPath = Paths.get(args[0]);
             Path testCache = targetPath.resolve(ProjectConstants.CACHES_DIR_NAME)
                             .resolve(ProjectConstants.TESTS_CACHE_DIR_NAME);
@@ -149,6 +193,14 @@ public class BTestMain {
                                      String[] args) {
         try {
             return TesterinaUtils.executeTests(sourceRootPath, testSuite, classLoader, args, out);
+        } catch (RuntimeException e) {
+            return 1;
+        }
+    }
+
+    private static  int startTestExecution(ClassLoader classLoader, String[] args,String packageID, String org, String version) {
+        try{
+            return TesterinaUtils.executeTests(packageID, org, version, classLoader, args, out);
         } catch (RuntimeException e) {
             return 1;
         }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestMain.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestMain.java
@@ -34,7 +34,16 @@ import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.Writer;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -69,7 +78,7 @@ public class BTestMain {
         int exitStatus = 0;
         int result;
 
-        if(args.length == 0) {
+        if(args.length == 0) { //running using the uber jar
             List<String> mainArgs = new ArrayList<>();
 
             try (InputStream in = BTestMain.class.getResourceAsStream(ProjectConstants.TEST_RUNTIME_MAIN_ARGS_FILE_DIR + ProjectConstants.TEST_RUNTIME_MAIN_ARGS_FILE);
@@ -121,7 +130,7 @@ public class BTestMain {
             }
             Runtime.getRuntime().exit(exitStatus);
         }
-        else if (args.length >= 4) {
+        else if (args.length >= 4) { //running using the suite json
             Path targetPath = Paths.get(args[0]);
             Path testCache = targetPath.resolve(ProjectConstants.CACHES_DIR_NAME)
                             .resolve(ProjectConstants.TESTS_CACHE_DIR_NAME);

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaUtils.java
@@ -103,6 +103,20 @@ public class TesterinaUtils {
         }
     }
 
+    public static int executeTests(String testPackageID, String orgName, String version, ClassLoader classLoader,
+                                   String[] args, PrintStream out) throws RuntimeException {
+        try {
+            return execute(testPackageID, orgName, version, classLoader, args, out);
+        } catch (BallerinaTestException e) {
+            if (e.getMessage() != null) {
+                errStream.println("error: " + e.getMessage());
+            }
+            throw e;
+        } catch (Throwable e) {
+            throw new RuntimeException("test execution failed due to runtime exception");
+        }
+    }
+
     private static int execute(TestSuite suite, ClassLoader classLoader, String[] args, PrintStream out) {
         String initClassName = TesterinaUtils.getQualifiedClassName(suite.getOrgName(),
                 suite.getTestPackageID(),
@@ -118,6 +132,23 @@ public class TesterinaUtils {
         if (suiteExecuteFilePath.equals("")) {
             out.println("\tNo tests found");
             return 0;
+        }
+
+        // This will run the main method of the test module.
+        startSuite(initClazz, args);
+        return getTestExecutionState(initClazz);
+    }
+
+    private static int execute(String testPackageID, String orgName, String version, ClassLoader classLoader,
+                               String[] args, PrintStream out) {
+        String initClassName = TesterinaUtils.getQualifiedClassName(orgName, testPackageID, version,
+                MODULE_INIT_CLASS_NAME);
+        Class<?> initClazz;
+
+        try {
+            initClazz = classLoader.loadClass(initClassName);
+        } catch (Throwable e) {
+            throw new BallerinaTestException("failed to load init class :" + initClassName);
         }
 
         // This will run the main method of the test module.


### PR DESCRIPTION
## Purpose
> Creates Uber JARs for each test module and execute those in a ballerina project when 'bal test --emit' command is executed. bal test still works as it is (By using the test suit JSON).

Fixes #41036

## Approach
> Add a new command line option to choose between test suite JSON and Uber JAR creation (Will be useful to extending it to the cloud flag). Made relevant changes to the BuildOptions.
> Create a new task called CreateTestExecutableTask by extending the CreateExecutableTask class.
> Get the modules in topologically sorted order to emit the uber jars for each test module.
> Get the relevant command line args that will be passed to BTestMain and write them to a file in the JAR.
> to run the standalone JAR, (to support java -jar execution) BTestMain as the initial main class of the JAR (in manifest) shouldn't accept any arguments. It is checked inside main method of BTestMain.



## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
