### PR TITLE
Fix resolving const value in the array size of array type definitions 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantTypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantTypeChecker.java
@@ -79,7 +79,6 @@ import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.SimpleBLangNodeAnalyzer;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangBinaryExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstant;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangListConstructorExpr;
@@ -314,8 +313,8 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
             varRefExpr.symbol = symTable.notFoundSymbol;
             dlog.error(varRefExpr.pos, DiagnosticErrorCode.UNDEFINED_MODULE, varRefExpr.pkgAlias);
         } else {
-            BSymbol symbol =
-                    getSymbolOfVarRef(varRefExpr.pos, data.env, names.fromIdNode(varRefExpr.pkgAlias), varName, data);
+            BSymbol symbol = typeResolver.getSymbolOfVarRef(
+                    varRefExpr.pos, data.env, names.fromIdNode(varRefExpr.pkgAlias), varName);
 
             if (symbol == symTable.notFoundSymbol) {
                 data.resultType = symTable.semanticError;
@@ -375,8 +374,8 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
         }
 
         if (varRefExpr.pkgSymbol != symTable.notFoundSymbol) {
-            BSymbol symbol =
-                    getSymbolOfVarRef(varRefExpr.pos, data.env, names.fromIdNode(varRefExpr.pkgAlias), varName, data);
+            BSymbol symbol = typeResolver.getSymbolOfVarRef(varRefExpr.pos, data.env,
+                    names.fromIdNode(varRefExpr.pkgAlias), varName);
 
             if (symbol == symTable.notFoundSymbol) {
                 data.resultType = symTable.semanticError;
@@ -2013,24 +2012,6 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
         }
 
         return BUnionType.create(null, memberTypes);
-    }
-
-    private BSymbol getSymbolOfVarRef(Location pos, SymbolEnv env, Name pkgAlias, Name varName, AnalyzerData data) {
-        if (pkgAlias == Names.EMPTY && data.modTable.containsKey(varName.value)) {
-            // modTable contains the available constants in current module.
-            BLangNode node = data.modTable.get(varName.value);
-            if (node.getKind() == NodeKind.CONSTANT) {
-                if (!typeResolver.resolvedConstants.contains((BLangConstant) node)) {
-                    typeResolver.resolveConstant(data.env, data.modTable, (BLangConstant) node);
-                }
-            } else {
-                dlog.error(pos, DiagnosticErrorCode.EXPRESSION_IS_NOT_A_CONSTANT_EXPRESSION);
-                return symTable.notFoundSymbol;
-            }
-        }
-
-        // Search and get the referenced variable from different module.
-        return symResolver.lookupMainSpaceSymbolInPackage(pos, env, pkgAlias, varName);
     }
 
     private boolean addFields(LinkedHashMap<String, BField> fields, BType keyValueType, String key, Location pos,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantTypeTest.java
@@ -54,7 +54,8 @@ public class ConstantTypeTest {
            "testConstTypesInline",
            "testInvalidRuntimeUpdateOfConstMaps",
            "testResolvingConstValForConstantsOfUserDefinedTypes",
-           "testConstByteArrLiteral"
+           "testConstByteArrLiteral",
+           "testDefiningArrayTypesWithConstSizes"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/constant-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/constant-type.bal
@@ -370,6 +370,20 @@ function testConstByteArrLiteral() {
     assertEqual(data10[1], 187);
 }
 
+const BEFORE_TYPE_DEF_1 = 1;
+const int[BEFORE_TYPE_DEF_1] TYPE_DEF_1 = [1];
+const int[AFTER_TYPE_DEF_2] TYPE_DEF_2 = [1];
+const AFTER_TYPE_DEF_2 = 1;
+type Array int[AFTER_TYPE_DEF_3];
+const AFTER_TYPE_DEF_3 = 4;
+
+function testDefiningArrayTypesWithConstSizes() {
+    assertEqual(TYPE_DEF_1, [1]);
+    assertEqual(TYPE_DEF_2, [1]);
+    Array array = [1, 2, 3, 4];
+    assertEqual(array, [1, 2, 3, 4]);
+}
+
 function assertInvalidUpdateError(error? res, string expectedDetailMessage) {
     assertTrue(res is error);
     error err = <error> res;


### PR DESCRIPTION
## Purpose
$subject

Fixes #41978

## Approach
Transfer the constant symbol resolving logic from the constant type checker to the type resolver and employ this method for resolving the array size.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
