### PR TITLE
 Fix `readonly` intersection with type reference for readonly

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -2443,11 +2443,11 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
 
     public BType getPotentialIntersection(Types.IntersectionContext intersectionContext,
                                            BType lhsType, BType rhsType, SymbolEnv env) {
-        if (lhsType == symTable.readonlyType) {
+        if (Types.getImpliedType(lhsType) == symTable.readonlyType) {
             return rhsType;
         }
 
-        if (rhsType == symTable.readonlyType) {
+        if (Types.getImpliedType(rhsType) == symTable.readonlyType) {
             return lhsType;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -1457,6 +1457,13 @@ public class TypeResolver {
         }
 
         while (iterator.hasNext()) {
+            bLangEffectiveImpliedType = Types.getImpliedType(effectiveType);
+            if (bLangEffectiveImpliedType.tag == TypeTags.READONLY) {
+                intersectionType.flags = intersectionType.flags | TypeTags.READONLY;
+                effectiveType = iterator.next();
+                bLangEffectiveType = bLangTypeItr.next();
+                continue;
+            }
             BType type = iterator.next();
             BLangType bLangType = bLangTypeItr.next();
             BType typeReferenceType = Types.getImpliedType(type);
@@ -1464,7 +1471,6 @@ public class TypeResolver {
                 intersectionType.flags = intersectionType.flags | TypeTags.READONLY;
                 continue;
             }
-            bLangEffectiveImpliedType = Types.getImpliedType(effectiveType);
             effectiveType = calculateEffectiveType(td, bLangEffectiveType, bLangType, effectiveType, type,
                     bLangEffectiveImpliedType, typeReferenceType);
             if (effectiveType.tag == TypeTags.SEMANTIC_ERROR) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -1449,8 +1449,8 @@ public class TypeResolver {
         Iterator<BType> iterator = intersectionType.getConstituentTypes().iterator();
         BType effectiveType = iterator.next();
         BLangType bLangEffectiveType = bLangTypeItr.next();
-        BType effectiveTypeReferenceType = Types.getImpliedType(effectiveType);
-        if (effectiveTypeReferenceType.tag == TypeTags.READONLY && iterator.hasNext()) {
+        BType effectiveImpliedTypeReferenceType = Types.getImpliedType(effectiveType);
+        if (effectiveImpliedTypeReferenceType.tag == TypeTags.READONLY && iterator.hasNext()) {
             intersectionType.flags = intersectionType.flags | TypeTags.READONLY;
             effectiveType = iterator.next();
             bLangEffectiveType = bLangTypeItr.next();
@@ -1464,9 +1464,9 @@ public class TypeResolver {
                 intersectionType.flags = intersectionType.flags | TypeTags.READONLY;
                 continue;
             }
-            effectiveTypeReferenceType = Types.getImpliedType(effectiveType);
+            effectiveImpliedTypeReferenceType = Types.getImpliedType(effectiveType);
             effectiveType = calculateEffectiveType(td, bLangEffectiveType, bLangType, effectiveType, type,
-                    effectiveTypeReferenceType, typeReferenceType);
+                    effectiveImpliedTypeReferenceType, typeReferenceType);
             if (effectiveType.tag == TypeTags.SEMANTIC_ERROR) {
                 intersectionType.effectiveType = symTable.semanticError;
                 return;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -1449,15 +1449,9 @@ public class TypeResolver {
         Iterator<BType> iterator = intersectionType.getConstituentTypes().iterator();
         BType effectiveType = iterator.next();
         BLangType bLangEffectiveType = bLangTypeItr.next();
-        BType bLangEffectiveImpliedType = Types.getImpliedType(effectiveType);
-        if (bLangEffectiveImpliedType.tag == TypeTags.READONLY && iterator.hasNext()) {
-            intersectionType.flags = intersectionType.flags | TypeTags.READONLY;
-            effectiveType = iterator.next();
-            bLangEffectiveType = bLangTypeItr.next();
-        }
 
         while (iterator.hasNext()) {
-            bLangEffectiveImpliedType = Types.getImpliedType(effectiveType);
+            BType bLangEffectiveImpliedType = Types.getImpliedType(effectiveType);
             if (bLangEffectiveImpliedType.tag == TypeTags.READONLY) {
                 intersectionType.flags = intersectionType.flags | TypeTags.READONLY;
                 effectiveType = iterator.next();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -1449,8 +1449,8 @@ public class TypeResolver {
         Iterator<BType> iterator = intersectionType.getConstituentTypes().iterator();
         BType effectiveType = iterator.next();
         BLangType bLangEffectiveType = bLangTypeItr.next();
-        BType effectiveImpliedTypeReferenceType = Types.getImpliedType(effectiveType);
-        if (effectiveImpliedTypeReferenceType.tag == TypeTags.READONLY && iterator.hasNext()) {
+        BType bLangEffectiveImpliedType = Types.getImpliedType(effectiveType);
+        if (bLangEffectiveImpliedType.tag == TypeTags.READONLY && iterator.hasNext()) {
             intersectionType.flags = intersectionType.flags | TypeTags.READONLY;
             effectiveType = iterator.next();
             bLangEffectiveType = bLangTypeItr.next();
@@ -1464,9 +1464,9 @@ public class TypeResolver {
                 intersectionType.flags = intersectionType.flags | TypeTags.READONLY;
                 continue;
             }
-            effectiveImpliedTypeReferenceType = Types.getImpliedType(effectiveType);
+            bLangEffectiveImpliedType = Types.getImpliedType(effectiveType);
             effectiveType = calculateEffectiveType(td, bLangEffectiveType, bLangType, effectiveType, type,
-                    effectiveImpliedTypeReferenceType, typeReferenceType);
+                    bLangEffectiveImpliedType, typeReferenceType);
             if (effectiveType.tag == TypeTags.SEMANTIC_ERROR) {
                 intersectionType.effectiveType = symTable.semanticError;
                 return;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -417,9 +417,8 @@ public class TypeResolver {
     }
 
     private BType calculateEffectiveType(BLangType typeNode, BLangType bLangTypeOne,
-                                         BLangType bLangTypeTwo, BType typeOne, BType typeTwo) {
-        BType typeOneReference = Types.getImpliedType(typeOne);
-        BType typeTwoReference = Types.getImpliedType(typeTwo);
+                                         BLangType bLangTypeTwo, BType typeOne, BType typeTwo,
+                                         BType typeOneReference, BType typeTwoReference) {
 
         if (typeOneReference.tag != TypeTags.ERROR || typeTwoReference.tag != TypeTags.ERROR) {
             dlog.error(typeNode.pos, DiagnosticErrorCode.UNSUPPORTED_TYPE_INTERSECTION);
@@ -1450,7 +1449,8 @@ public class TypeResolver {
         Iterator<BType> iterator = intersectionType.getConstituentTypes().iterator();
         BType effectiveType = iterator.next();
         BLangType bLangEffectiveType = bLangTypeItr.next();
-        if (Types.getImpliedType(effectiveType).tag == TypeTags.READONLY && iterator.hasNext()) {
+        BType effectiveTypeReferenceType = Types.getImpliedType(effectiveType);
+        if (effectiveTypeReferenceType.tag == TypeTags.READONLY && iterator.hasNext()) {
             intersectionType.flags = intersectionType.flags | TypeTags.READONLY;
             effectiveType = iterator.next();
             bLangEffectiveType = bLangTypeItr.next();
@@ -1459,12 +1459,14 @@ public class TypeResolver {
         while (iterator.hasNext()) {
             BType type = iterator.next();
             BLangType bLangType = bLangTypeItr.next();
-            if (Types.getImpliedType(type).tag == TypeTags.READONLY) {
+            BType typeReferenceType = Types.getImpliedType(type);
+            if (typeReferenceType.tag == TypeTags.READONLY) {
                 intersectionType.flags = intersectionType.flags | TypeTags.READONLY;
                 continue;
             }
-
-            effectiveType = calculateEffectiveType(td, bLangEffectiveType, bLangType, effectiveType, type);
+            effectiveTypeReferenceType = Types.getImpliedType(effectiveType);
+            effectiveType = calculateEffectiveType(td, bLangEffectiveType, bLangType, effectiveType, type,
+                    effectiveTypeReferenceType, typeReferenceType);
             if (effectiveType.tag == TypeTags.SEMANTIC_ERROR) {
                 intersectionType.effectiveType = symTable.semanticError;
                 return;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -1450,7 +1450,7 @@ public class TypeResolver {
         Iterator<BType> iterator = intersectionType.getConstituentTypes().iterator();
         BType effectiveType = iterator.next();
         BLangType bLangEffectiveType = bLangTypeItr.next();
-        if (effectiveType.tag == TypeTags.READONLY && iterator.hasNext()) {
+        if (Types.getImpliedType(effectiveType).tag == TypeTags.READONLY && iterator.hasNext()) {
             intersectionType.flags = intersectionType.flags | TypeTags.READONLY;
             effectiveType = iterator.next();
             bLangEffectiveType = bLangTypeItr.next();
@@ -1459,7 +1459,7 @@ public class TypeResolver {
         while (iterator.hasNext()) {
             BType type = iterator.next();
             BLangType bLangType = bLangTypeItr.next();
-            if (type.tag == TypeTags.READONLY) {
+            if (Types.getImpliedType(type).tag == TypeTags.READONLY) {
                 intersectionType.flags = intersectionType.flags | TypeTags.READONLY;
                 continue;
             }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
@@ -86,6 +86,8 @@ public class IntersectionTypeTest {
         validateError(result, index++, "invalid intersection type '(Baz & readonly)': no intersection", 32,
                       45);
         validateError(result, index++, "incompatible types: 'Y' is not a record", 42, 6);
+        validateError(result, index++, "invalid intersection type " +
+                        "'ImmutableTypeRef & READONLY_REF1': no intersection", 49, 9);
 
         assertEquals(result.getErrorCount(), index);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
@@ -87,7 +87,7 @@ public class IntersectionTypeTest {
                       45);
         validateError(result, index++, "incompatible types: 'Y' is not a record", 42, 6);
         validateError(result, index++, "invalid intersection type " +
-                        "'ImmutableTypeRef & READONLY_REF1': no intersection", 49, 9);
+                        "'ImmutableType & ReadonlyType': no intersection", 49, 9);
 
         assertEquals(result.getErrorCount(), index);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
@@ -88,6 +88,7 @@ public class IntersectionTypeTest {
         validateError(result, index++, "incompatible types: 'Y' is not a record", 42, 6);
         validateError(result, index++, "invalid intersection type " +
                         "'MutableType & ReadonlyType': no intersection", 49, 9);
+        validateError(result, index++, "cannot update 'readonly' value of type '(string[] & readonly)'", 53, 5);
 
         assertEquals(result.getErrorCount(), index);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
@@ -87,7 +87,7 @@ public class IntersectionTypeTest {
                       45);
         validateError(result, index++, "incompatible types: 'Y' is not a record", 42, 6);
         validateError(result, index++, "invalid intersection type " +
-                        "'ImmutableType & ReadonlyType': no intersection", 49, 9);
+                        "'MutableType & ReadonlyType': no intersection", 49, 9);
 
         assertEquals(result.getErrorCount(), index);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
@@ -87,8 +87,10 @@ public class IntersectionTypeTest {
                       45);
         validateError(result, index++, "incompatible types: 'Y' is not a record", 42, 6);
         validateError(result, index++, "invalid intersection type " +
-                        "'MutableType & ReadonlyType': no intersection", 49, 9);
+                        "'FutureType & ReadonlyType': no intersection", 49, 9);
         validateError(result, index++, "cannot update 'readonly' value of type '(string[] & readonly)'", 53, 5);
+        validateError(result, index++, "incompatible types: expected '(int[] & readonly)', found 'int[]'", 63, 30);
+        validateError(result, index++, "incompatible types: expected '(Foo & readonly)', found 'Foo'", 65, 28);
 
         assertEquals(result.getErrorCount(), index);
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
@@ -263,16 +263,16 @@ function testRuntimeTypeNameOfIntersectionType() {
 
 type Error error<record { string message; }>;
 
-type READONLY_REF1 readonly;
-type READONLY_REF2 readonly;
-type READONLY_REF3 readonly;
+type ReadonlyTypeDef1 readonly;
+type ReadonlyTypeDef2 readonly;
+type ReadonlyTypeDef3 readonly;
 
 type ReadonlyObjectType1 object {
     int atb1;
     function call() returns int;
 };
 
-type IntersectionType1 READONLY_REF3 & record {|
+type IntersectionType1 ReadonlyTypeDef3 & record {|
     int a;
 |};
 
@@ -280,10 +280,10 @@ type FooType record {|
     int a;
 |};
 
-type IntersectionType2 READONLY_REF3 & FooType;
-type IntersectionType3 FooType & READONLY_REF3;
-type IntersectionType4 READONLY_REF3 & ReadonlyObjectType1;
-type IntersectionType5 ReadonlyObjectType1 & READONLY_REF3;
+type IntersectionType2 ReadonlyTypeDef3 & FooType;
+type IntersectionType3 FooType & ReadonlyTypeDef3;
+type IntersectionType4 ReadonlyTypeDef3 & ReadonlyObjectType1;
+type IntersectionType5 ReadonlyObjectType1 & ReadonlyTypeDef3;
 
 function assertError(any|error value, string errorMessage, string expDetailMessage) {
     if value is Error {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
@@ -263,14 +263,16 @@ function testRuntimeTypeNameOfIntersectionType() {
 
 type Error error<record { string message; }>;
 
-type ReadonlyTypeDef3 readonly;
+type ReadonlyTypeDef1 readonly;
+type ReadonlyTypeDef2 readonly;
+
 
 type ReadonlyObjectType1 object {
     int atb1;
     function call() returns int;
 };
 
-type IntersectionType1 ReadonlyTypeDef3 & record {|
+type IntersectionType1 ReadonlyTypeDef1 & record {|
     int a;
 |};
 
@@ -278,10 +280,17 @@ type FooType record {|
     int a;
 |};
 
-type IntersectionType2 ReadonlyTypeDef3 & FooType;
-type IntersectionType3 FooType & ReadonlyTypeDef3;
-type IntersectionType4 ReadonlyTypeDef3 & ReadonlyObjectType1;
-type IntersectionType5 ReadonlyObjectType1 & ReadonlyTypeDef3;
+type BarType record {|
+    byte a;
+|};
+
+type IntersectionType2 ReadonlyTypeDef1 & FooType;
+type IntersectionType3 FooType & ReadonlyTypeDef1;
+type IntersectionType4 ReadonlyTypeDef1 & ReadonlyObjectType1;
+type IntersectionType5 ReadonlyObjectType1 & ReadonlyTypeDef1;
+type IntersectionType6 ReadonlyTypeDef1 & ReadonlyTypeDef2 & FooType;
+type IntersectionType7 ReadonlyTypeDef1 & FooType & ReadonlyTypeDef2;
+type ErrIntersection ReadonlyTypeDef1 & error<FooType> & error<BarType>;
 
 function testReadonlyIntersection() {
     IntersectionType1 foo1 = {a: 1};
@@ -304,6 +313,16 @@ function testReadonlyIntersection() {
         function call() returns int => 1;
     };
     assertTrue(<any>obj2 is readonly);
+
+    IntersectionType6 foo4 = {a: 1};
+    assertTrue(<any>foo4 is readonly);
+
+    IntersectionType7 foo5 = {a: 1};
+    assertTrue(<any>foo5 is readonly);
+
+    ErrIntersection err = error("Error", a=12);
+    assertTrue(<any|error>err is readonly);
+    assertTrue(<any>err.detail().a is byte);
 }
 
 function assertError(any|error value, string errorMessage, string expDetailMessage) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
@@ -263,8 +263,6 @@ function testRuntimeTypeNameOfIntersectionType() {
 
 type Error error<record { string message; }>;
 
-type ReadonlyTypeDef1 readonly;
-type ReadonlyTypeDef2 readonly;
 type ReadonlyTypeDef3 readonly;
 
 type ReadonlyObjectType1 object {
@@ -286,11 +284,26 @@ type IntersectionType4 ReadonlyTypeDef3 & ReadonlyObjectType1;
 type IntersectionType5 ReadonlyObjectType1 & ReadonlyTypeDef3;
 
 function testReadonlyIntersection() {
-    assertTrue(IntersectionType1 is readonly);
-    assertTrue(IntersectionType2 is readonly);
-    assertTrue(IntersectionType3 is ReadonlyTypeDef1);
-    assertTrue(IntersectionType4 is ReadonlyTypeDef2);
-    assertTrue(IntersectionType5 is ReadonlyTypeDef3);
+    IntersectionType1 foo1 = {a: 1};
+    assertTrue(<any>foo1 is readonly);
+
+    IntersectionType2 foo2 = {a: 1};
+    assertTrue(<any>foo2 is readonly);
+
+    IntersectionType3 foo3 = {a: 1};
+    assertTrue(<any>foo3 is readonly);
+
+    IntersectionType4 obj1 = object {
+        int atb1 = 1;
+        function call() returns int => 1;
+    };
+    assertTrue(<any>obj1 is readonly);
+
+    IntersectionType5 obj2 = object {
+        int atb1 = 1;
+        function call() returns int => 1;
+    };
+    assertTrue(<any>obj2 is readonly);
 }
 
 function assertError(any|error value, string errorMessage, string expDetailMessage) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
@@ -263,6 +263,28 @@ function testRuntimeTypeNameOfIntersectionType() {
 
 type Error error<record { string message; }>;
 
+type READONLY_REF1 readonly;
+type READONLY_REF2 readonly;
+type READONLY_REF3 readonly;
+
+type ReadonlyObjectType1 object {
+    int atb1;
+    function call() returns int;
+};
+
+type IntersectionType1 READONLY_REF3 & record {|
+    int a;
+|};
+
+type FooType record {|
+    int a;
+|};
+
+type IntersectionType2 READONLY_REF3 & FooType;
+type IntersectionType3 FooType & READONLY_REF3;
+type IntersectionType4 READONLY_REF3 & ReadonlyObjectType1;
+type IntersectionType5 ReadonlyObjectType1 & READONLY_REF3;
+
 function assertError(any|error value, string errorMessage, string expDetailMessage) {
     if value is Error {
         if (value.message() != errorMessage) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
@@ -266,13 +266,12 @@ type Error error<record { string message; }>;
 type ReadonlyTypeDef1 readonly;
 type ReadonlyTypeDef2 readonly;
 
-
-type ReadonlyObjectType1 object {
+type ObjectType object {
     int atb1;
     function call() returns int;
 };
 
-type IntersectionType1 ReadonlyTypeDef1 & record {|
+type ReadonlyRecordIntersectionType1 ReadonlyTypeDef1 & record {|
     int a;
 |};
 
@@ -284,45 +283,57 @@ type BarType record {|
     byte a;
 |};
 
-type IntersectionType2 ReadonlyTypeDef1 & FooType;
-type IntersectionType3 FooType & ReadonlyTypeDef1;
-type IntersectionType4 ReadonlyTypeDef1 & ReadonlyObjectType1;
-type IntersectionType5 ReadonlyObjectType1 & ReadonlyTypeDef1;
-type IntersectionType6 ReadonlyTypeDef1 & ReadonlyTypeDef2 & FooType;
-type IntersectionType7 ReadonlyTypeDef1 & FooType & ReadonlyTypeDef2;
-type ErrIntersection ReadonlyTypeDef1 & error<FooType> & error<BarType>;
+type ReadonlyRecordIntersectionType2 ReadonlyTypeDef1 & FooType;
+type ReadonlyRecordIntersectionType3 FooType & ReadonlyTypeDef1;
+type ReadonlyObjectIntersectionType1 ReadonlyTypeDef1 & ObjectType;
+type ReadonlyObjectIntersectionType2 ObjectType & ReadonlyTypeDef1;
+type IntersectionWithMultipleReadonlyType1 ReadonlyTypeDef1 & ReadonlyTypeDef2 & FooType;
+type IntersectionWithMultipleReadonlyType2 ReadonlyTypeDef1 & FooType & ReadonlyTypeDef2;
+type ReadonlyErrorIntersectionType ReadonlyTypeDef1 & error<FooType> & error<BarType>;
 
 function testReadonlyIntersection() {
-    IntersectionType1 foo1 = {a: 1};
+    ReadonlyRecordIntersectionType1 foo1 = {a: 1};
     assertTrue(<any>foo1 is readonly);
 
-    IntersectionType2 foo2 = {a: 1};
+    ReadonlyRecordIntersectionType2 foo2 = {a: 1};
     assertTrue(<any>foo2 is readonly);
 
-    IntersectionType3 foo3 = {a: 1};
+    ReadonlyRecordIntersectionType3 foo3 = {a: 1};
     assertTrue(<any>foo3 is readonly);
 
-    IntersectionType4 obj1 = object {
+    ReadonlyObjectIntersectionType1 obj1 = object {
         int atb1 = 1;
         function call() returns int => 1;
     };
     assertTrue(<any>obj1 is readonly);
 
-    IntersectionType5 obj2 = object {
+    ReadonlyObjectIntersectionType2 obj2 = object {
         int atb1 = 1;
         function call() returns int => 1;
     };
     assertTrue(<any>obj2 is readonly);
 
-    IntersectionType6 foo4 = {a: 1};
+    IntersectionWithMultipleReadonlyType1 foo4 = {a: 1};
     assertTrue(<any>foo4 is readonly);
 
-    IntersectionType7 foo5 = {a: 1};
+    IntersectionWithMultipleReadonlyType2 foo5 = {a: 1};
     assertTrue(<any>foo5 is readonly);
 
-    ErrIntersection err = error("Error", a=12);
+    ReadonlyErrorIntersectionType err = error("Error", a = 12);
     assertTrue(<any|error>err is readonly);
     assertTrue(<any>err.detail().a is byte);
+
+    ReadonlyTypeDef1 & string value1 = "abc";
+    assertTrue(<any>value1 is readonly);
+
+    ReadonlyTypeDef1 & string[] value2 = ["1", "2", "3"];
+    assertTrue(<any>value2 is readonly);
+
+    ReadonlyTypeDef1 & map<string> value3 = {"a": "1", "b": "2"};
+    assertTrue(<any>value3 is readonly);
+
+    ReadonlyTypeDef1 & ReadonlyTypeDef2 & map<string> value4 = {"a": "1", "b": "2"};
+    assertTrue(<any>value4 is readonly);
 }
 
 function assertError(any|error value, string errorMessage, string expDetailMessage) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
@@ -328,12 +328,17 @@ function testReadonlyIntersection() {
 
     ReadonlyTypeDef1 & string[] value2 = ["1", "2", "3"];
     assertTrue(<any>value2 is readonly);
+    assertTrue(<any>value2 is ReadonlyTypeDef1 & string[]);
 
     ReadonlyTypeDef1 & map<string> value3 = {"a": "1", "b": "2"};
     assertTrue(<any>value3 is readonly);
+    assertTrue(<any>value3 is ReadonlyTypeDef1 & map<string>);
 
     ReadonlyTypeDef1 & ReadonlyTypeDef2 & map<string> value4 = {"a": "1", "b": "2"};
     assertTrue(<any>value4 is readonly);
+
+    string[] value5 = ["1", "2", "3"];
+    assertFalse(<any>value4 is ReadonlyTypeDef1 & string[]);
 }
 
 function assertError(any|error value, string errorMessage, string expDetailMessage) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
@@ -285,6 +285,14 @@ type IntersectionType3 FooType & ReadonlyTypeDef3;
 type IntersectionType4 ReadonlyTypeDef3 & ReadonlyObjectType1;
 type IntersectionType5 ReadonlyObjectType1 & ReadonlyTypeDef3;
 
+function testReadonlyIntersection() {
+    assertTrue(IntersectionType1 is readonly);
+    assertTrue(IntersectionType2 is readonly);
+    assertTrue(IntersectionType3 is ReadonlyTypeDef1);
+    assertTrue(IntersectionType4 is ReadonlyTypeDef2);
+    assertTrue(IntersectionType5 is ReadonlyTypeDef3);
+}
+
 function assertError(any|error value, string errorMessage, string expDetailMessage) {
     if value is Error {
         if (value.message() != errorMessage) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type_negative.bal
@@ -44,6 +44,6 @@ type Z record {
     Y y;
 };
 
-type READONLY_REF1 readonly;
-type ImmutableTypeRef future<int>;
-type T2 ImmutableTypeRef & READONLY_REF1;
+type ReadonlyType readonly;
+type ImmutableType future<int>;
+type T2 ImmutableType & ReadonlyType;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type_negative.bal
@@ -47,3 +47,8 @@ type Z record {
 type ReadonlyType readonly;
 type MutableType future<int>;
 type T2 MutableType & ReadonlyType;
+
+function testReadonlyIntersectionImmutability() {
+    ReadonlyType & string[] arr = ["a", "b", "c"];
+    arr.push("d");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type_negative.bal
@@ -45,10 +45,22 @@ type Z record {
 };
 
 type ReadonlyType readonly;
-type MutableType future<int>;
-type T2 MutableType & ReadonlyType;
+type FutureType future<int>;
+type T2 FutureType & ReadonlyType;
 
 function testReadonlyIntersectionImmutability() {
     ReadonlyType & string[] arr = ["a", "b", "c"];
     arr.push("d");
+}
+
+type Foo record {
+    string p1;
+    int p2?;
+};
+
+function testAssigningMutableValuesToReadonlyIntersectionsWithTypeRefForReadonly() {
+    int[] numArray = [1, 2, 3, 4];
+    ReadonlyType & int[] _ = numArray;
+    Foo foo = {p1: "P1"};
+    Foo & ReadonlyType _ = foo;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type_negative.bal
@@ -43,3 +43,7 @@ type Z record {
     X x;
     Y y;
 };
+
+type READONLY_REF1 readonly;
+type ImmutableTypeRef future<int>;
+type T2 ImmutableTypeRef & READONLY_REF1;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type_negative.bal
@@ -45,5 +45,5 @@ type Z record {
 };
 
 type ReadonlyType readonly;
-type ImmutableType future<int>;
-type T2 ImmutableType & ReadonlyType;
+type MutableType future<int>;
+type T2 MutableType & ReadonlyType;


### PR DESCRIPTION
## Purpose
$subject
With this PR we will support having intersection for type reference type with readonly.

Fixes #41916

## Approach
In the type resolver when resolving effective intersection type we are not taking the referred type for type reference types.

## Samples
> Provide high-level details about the samples related to this feature.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
