### PR TITLE
Include description-section in API docs generation

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -560,7 +560,8 @@ public class Generator {
                     isIsolated, isService);
         } else if (containsToken(classDefinitionNode.classTypeQualifiers(), SyntaxKind.LISTENER_KEYWORD)
                 || isListenerModel(functions)) {
-            return new Listener(name, description, descriptionSections, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
+            return new Listener(name, description, descriptionSections, isDeprecated, fields, functions, isReadOnly,
+                    isIsolated, isService);
         } else {
             return new BClass(name, description, descriptionSections, isDeprecated, fields, functions, isReadOnly,
                     isIsolated, isService);
@@ -946,7 +947,8 @@ public class Generator {
         if (docLines != null) {
             for (Node docLine : docLines.documentationLines()) {
                 if (docLine instanceof MarkdownDocumentationLineNode) {
-                    String docLineString = getDocLineString(((MarkdownDocumentationLineNode) docLine).documentElements());
+                    String docLineString = getDocLineString(((MarkdownDocumentationLineNode) docLine).
+                            documentElements());
                     if (docLineString.startsWith(DOC_HEADER_PREFIX)) {
                         break;
                     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -108,6 +108,7 @@ public class Generator {
     public static final String LISTENER_DETACH_METHOD_NAME = "detach";
     public static final String LISTENER_IMMEDIATE_STOP_METHOD_NAME = "immediateStop";
     public static final String LISTENER_GRACEFUL_STOP_METHOD_NAME = "gracefulStop";
+    public static final String DOC_HEADER_PREFIX = "# ";
 
     /**
      * Generate/Set the module constructs model(docerina model) when the syntax tree for the module is given.
@@ -201,7 +202,8 @@ public class Generator {
                     (type.category != null && type.category.equals("errors")) ||
                             (type.category != null && type.category.equals("builtin")) &&
                                     type.name.equals("error"))) {
-                module.errors.add(new Error(typeName, getDocFromMetadata(metaDataNode), isDeprecated(metaDataNode),
+                module.errors.add(new Error(typeName, getDocFromMetadata(metaDataNode),
+                        getDescSectionsDocFromMetaDataList(metaDataNode), isDeprecated(metaDataNode),
                         Type.fromNode(typeDefinition.typeDescriptor(), semanticModel, module)));
             } else {
                 module.unionTypes.add(getUnionTypeModel(typeDefinition.typeDescriptor(),
@@ -211,8 +213,8 @@ public class Generator {
                 syntaxKind.equals(SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
             Type refType = Type.fromNode(typeDefinition.typeDescriptor(), semanticModel, module);
             if (refType.category.equals("errors")) {
-                module.errors.add(new Error(typeName, getDocFromMetadata(metaDataNode), isDeprecated(metaDataNode),
-                        refType));
+                module.errors.add(new Error(typeName, getDocFromMetadata(metaDataNode),
+                        getDescSectionsDocFromMetaDataList(metaDataNode), isDeprecated(metaDataNode), refType));
             } else {
                 module.simpleNameReferenceTypes.add(getUnionTypeModel(typeDefinition.typeDescriptor(), typeName,
                         metaDataNode, semanticModel, module));
@@ -227,7 +229,8 @@ public class Generator {
                 detailType = Type.fromNode(parameterizedTypeDescNode.typeParamNode().get().typeNode(), semanticModel,
                         module);
             }
-            Error err = new Error(typeName, getDocFromMetadata(metaDataNode), isDeprecated(metaDataNode), detailType);
+            Error err = new Error(typeName, getDocFromMetadata(metaDataNode),
+                    getDescSectionsDocFromMetaDataList(metaDataNode), isDeprecated(metaDataNode), detailType);
             err.isDistinct = true;
             module.errors.add(err);
         } else if (syntaxKind.equals(SyntaxKind.DISTINCT_TYPE_DESC) &&
@@ -250,7 +253,8 @@ public class Generator {
             ParenthesisedTypeDescriptorNode parenthesisedTypeDescriptorNode = (ParenthesisedTypeDescriptorNode)
                     ((DistinctTypeDescriptorNode) (typeDefinition.typeDescriptor())).typeDescriptor();
             Type detailType = Type.fromNode(parenthesisedTypeDescriptorNode, semanticModel, module);
-            Error err = new Error(typeName, getDocFromMetadata(metaDataNode), isDeprecated(metaDataNode), detailType);
+            Error err = new Error(typeName, getDocFromMetadata(metaDataNode),
+                    getDescSectionsDocFromMetaDataList(metaDataNode), isDeprecated(metaDataNode), detailType);
             err.isDistinct = true;
             module.errors.add(err);
         } else if (syntaxKind.equals(SyntaxKind.DISTINCT_TYPE_DESC) &&
@@ -259,14 +263,15 @@ public class Generator {
             Type refType = Type.fromNode(((DistinctTypeDescriptorNode) (typeDefinition.typeDescriptor()))
                     .typeDescriptor(), semanticModel, module);
             if (refType.category.equals("errors")) {
-                Error err = new Error(typeName, getDocFromMetadata(metaDataNode), isDeprecated(metaDataNode), refType);
+                Error err = new Error(typeName, getDocFromMetadata(metaDataNode),
+                        getDescSectionsDocFromMetaDataList(metaDataNode), isDeprecated(metaDataNode), refType);
                 err.isDistinct = true;
                 module.errors.add(err);
             } else {
                 List<Type> memberTypes = new ArrayList<>();
                 memberTypes.add(refType);
-                BType bType = new BType(typeName, getDocFromMetadata(metaDataNode), isDeprecated(metaDataNode),
-                        memberTypes);
+                BType bType = new BType(typeName, getDocFromMetadata(metaDataNode),
+                        getDescSectionsDocFromMetaDataList(metaDataNode), isDeprecated(metaDataNode), memberTypes);
                 bType.isAnonymousUnionType = true;
                 module.types.add(bType);
             }
@@ -278,7 +283,8 @@ public class Generator {
                 type = Type.fromNode(parameterizedTypeDescNode.typeParamNode().get().typeNode(),
                         semanticModel, module);
             }
-            module.errors.add(new Error(typeName, getDocFromMetadata(metaDataNode), isDeprecated(metaDataNode), type));
+            module.errors.add(new Error(typeName, getDocFromMetadata(metaDataNode),
+                    getDescSectionsDocFromMetaDataList(metaDataNode), isDeprecated(metaDataNode), type));
         } else if (syntaxKind.equals(SyntaxKind.TUPLE_TYPE_DESC)) {
             module.tupleTypes.add(getTupleTypeModel((TupleTypeDescriptorNode) typeDefinition.typeDescriptor(),
                     typeName, metaDataNode, semanticModel, module));
@@ -360,10 +366,12 @@ public class Generator {
                 if (doc.equals("")) {
                     doc = getParameterDocFromMetadataList(memberName, enumDeclaration.metadata());
                 }
-                members.add(new Construct(memberName, doc, false));
+                List<String> descSections = getDescSectionsDocFromMetaDataList(enumDeclaration.metadata());
+                members.add(new Construct(memberName, doc, descSections, false));
             }
         });
         return new Enum(enumName, getDocFromMetadata(enumDeclaration.metadata()),
+                getDescSectionsDocFromMetaDataList(enumDeclaration.metadata()),
                 isDeprecated(enumDeclaration.metadata()), members);
     }
 
@@ -380,6 +388,7 @@ public class Generator {
         Type dataType = annotationDeclaration.typeDescriptor().isPresent() ? Type.fromNode(annotationDeclaration.
                 typeDescriptor().get(), semanticModel, module) : null;
         return new Annotation(annotationName, getDocFromMetadata(annotationDeclaration.metadata()),
+                getDescSectionsDocFromMetaDataList(annotationDeclaration.metadata()),
                 isDeprecated(annotationDeclaration.metadata()), dataType, attachPointJoiner.toString());
     }
 
@@ -388,6 +397,7 @@ public class Generator {
         String constantName = constantNode.variableName().text();
         String value = constantNode.initializer().toString();
         String desc = getDocFromMetadata(constantNode.metadata());
+        List<String> descriptionSections = getDescSectionsDocFromMetaDataList(constantNode.metadata());
         Type type;
         if (constantNode.typeDescriptor().isPresent()) {
             type = Type.fromNode(constantNode.typeDescriptor().get(), semanticModel, module);
@@ -408,7 +418,8 @@ public class Generator {
             }
             type = new Type(dataType);
         }
-        return new Constant(constantName, desc, isDeprecated(constantNode.metadata()), type, value);
+        return new Constant(constantName, desc, descriptionSections, isDeprecated(constantNode.metadata()), type,
+                value);
     }
 
     private static void addIntersectionTypeModel(IntersectionTypeDescriptorNode typeDescriptor, String typeName,
@@ -436,7 +447,8 @@ public class Generator {
         List<Type> memberTypes = new ArrayList<>();
         Type.addIntersectionMemberTypes(typeDescriptor, semanticModel, memberTypes, module);
         BType bType = new BType(typeName, getDocFromMetadata(optionalMetadataNode),
-                isDeprecated(optionalMetadataNode), memberTypes);
+                getDescSectionsDocFromMetaDataList(optionalMetadataNode), isDeprecated(optionalMetadataNode),
+                memberTypes);
         bType.isIntersectionType = true;
         module.intersectionTypes.add(bType);
     }
@@ -448,7 +460,8 @@ public class Generator {
         memberTypes.addAll(typeDescriptor.memberTypeDesc().stream().map(type ->
                 Type.fromNode(type, semanticModel, module)).collect(Collectors.toList()));
         BType bType = new BType(tupleTypeName, getDocFromMetadata(optionalMetadataNode),
-                isDeprecated(optionalMetadataNode), memberTypes);
+                getDescSectionsDocFromMetaDataList(optionalMetadataNode), isDeprecated(optionalMetadataNode),
+                memberTypes);
         bType.isTuple = true;
         return bType;
     }
@@ -460,8 +473,8 @@ public class Generator {
         if (typeDescriptor.typeParamNode().isPresent()) {
             type = Type.fromNode(typeDescriptor.typeParamNode().get().typeNode(), semanticModel, module);
         }
-        BType bType = new BType(typeName, getDocFromMetadata(optionalMetadataNode), isDeprecated(optionalMetadataNode),
-                null);
+        BType bType = new BType(typeName, getDocFromMetadata(optionalMetadataNode),
+                getDescSectionsDocFromMetaDataList(optionalMetadataNode), isDeprecated(optionalMetadataNode), null);
         bType.isTypeDesc = true;
         bType.version = BallerinaDocGenerator.getBallerinaShortVersion();
         bType.elementType = type;
@@ -474,6 +487,7 @@ public class Generator {
         List<Type> memberTypes = new ArrayList<>();
         Type.addUnionMemberTypes(unionTypeDescriptor, semanticModel, memberTypes, module);
         BType bType = new BType(unionName, getDocFromMetadata(optionalMetadataNode),
+                                getDescSectionsDocFromMetaDataList(optionalMetadataNode),
                                 isDeprecated(optionalMetadataNode), memberTypes);
         bType.isAnonymousUnionType = true;
         return bType;
@@ -486,7 +500,7 @@ public class Generator {
                 ? null : Type.fromNode(typeDescriptor, semanticModel, module);
 
         return new MapType(typeName, getDocFromMetadata(optionalMetadataNode),
-                isDeprecated(optionalMetadataNode), type);
+                getDescSectionsDocFromMetaDataList(optionalMetadataNode), isDeprecated(optionalMetadataNode), type);
     }
 
     private static TableType getTableTypeModel(TableTypeDescriptorNode typeDescriptor, String typeName,
@@ -498,7 +512,8 @@ public class Generator {
                 ? null : Type.fromNode(typeDescriptor.keyConstraintNode().get(), semanticModel, module);
 
         return new TableType(typeName, getDocFromMetadata(optionalMetadataNode),
-                isDeprecated(optionalMetadataNode), rowParameterType, keyConstraintType);
+                getDescSectionsDocFromMetaDataList(optionalMetadataNode), isDeprecated(optionalMetadataNode),
+                rowParameterType, keyConstraintType);
     }
 
     private static BClass getClassModel(ClassDefinitionNode classDefinitionNode, SemanticModel semanticModel,
@@ -507,6 +522,7 @@ public class Generator {
         List<Function> includedFunctions = new ArrayList<>();
         String name = classDefinitionNode.className().text();
         String description = getDocFromMetadata(classDefinitionNode.metadata());
+        List<String> descriptionSections = getDescSectionsDocFromMetaDataList(classDefinitionNode.metadata());
         boolean isDeprecated = isDeprecated(classDefinitionNode.metadata());
         boolean isReadOnly = containsToken(classDefinitionNode.classTypeQualifiers(), SyntaxKind.READONLY_KEYWORD);
         boolean isIsolated = containsToken(classDefinitionNode.classTypeQualifiers(), SyntaxKind.ISOLATED_KEYWORD);
@@ -540,12 +556,14 @@ public class Generator {
         functions.addAll(classFunctions);
 
         if (containsToken(classDefinitionNode.classTypeQualifiers(), SyntaxKind.CLIENT_KEYWORD)) {
-            return new Client(name, description, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
+            return new Client(name, description, descriptionSections, isDeprecated, fields, functions, isReadOnly,
+                    isIsolated, isService);
         } else if (containsToken(classDefinitionNode.classTypeQualifiers(), SyntaxKind.LISTENER_KEYWORD)
                 || isListenerModel(functions)) {
-            return new Listener(name, description, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
+            return new Listener(name, description, descriptionSections, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
         } else {
-            return new BClass(name, description, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
+            return new BClass(name, description, descriptionSections, isDeprecated, fields, functions, isReadOnly,
+                    isIsolated, isService);
         }
     }
 
@@ -581,6 +599,7 @@ public class Generator {
         List<Function> includedFunctions = new ArrayList<>();
 
         String description = getDocFromMetadata(optionalMetadataNode);
+        List<String> descriptionSections = getDescSectionsDocFromMetaDataList(optionalMetadataNode);
         boolean isDeprecated = isDeprecated(optionalMetadataNode);
 
         List<DefaultableVariable> fields = getDefaultableVariableList(typeDescriptorNode.members(),
@@ -630,7 +649,8 @@ public class Generator {
                     }
 
                     objectFunctions.add(new Function(methodName, accessor, resourcePath,
-                            getDocFromMetadata(methodNode.metadata()), functionKind, false,
+                            getDocFromMetadata(methodNode.metadata()),
+                            getDescSectionsDocFromMetaDataList(methodNode.metadata()), functionKind, false,
                             isDeprecated(methodNode.metadata()), containsToken(methodNode.qualifierList(),
                             SyntaxKind.ISOLATED_KEYWORD), parameters, returnParams));
                 }
@@ -652,7 +672,7 @@ public class Generator {
 
         functions.addAll(objectFunctions);
 
-        return new BObjectType(objectName, description, isDeprecated, fields, functions);
+        return new BObjectType(objectName, description, descriptionSections, isDeprecated, fields, functions);
     }
 
     private static List<Function> mapFunctionTypesToFunctions(List<FunctionType> functionTypes, Type originType) {
@@ -669,8 +689,9 @@ public class Generator {
             }
 
             Function function = new Function(functionType.name, functionType.accessor, functionType.resourcePath,
-                    functionType.description, functionType.functionKind, functionType.isExtern,
-                    functionType.isDeprecated, functionType.isIsolated, parameters, returnParameters);
+                    functionType.description, functionType.descriptionSections, functionType.functionKind,
+                    functionType.isExtern, functionType.isDeprecated, functionType.isIsolated, parameters,
+                    returnParameters);
             function.inclusionType = originType.isPublic ? originType : null;
             functions.add(function);
         }
@@ -720,6 +741,7 @@ public class Generator {
         }
 
         return new Function(functionName, accessor, resourcePath, getDocFromMetadata(functionDefinitionNode.metadata()),
+                getDescSectionsDocFromMetaDataList(functionDefinitionNode.metadata()),
                 functionKind, isExtern, isDeprecated(functionDefinitionNode.metadata()),
                 containsToken(functionDefinitionNode.qualifierList(), SyntaxKind.ISOLATED_KEYWORD), parameters,
                 returnParams, annotationAttachments);
@@ -739,6 +761,7 @@ public class Generator {
             fields.add(restVariable);
         }
         return new Record(recordName, getDocFromMetadata(optionalMetadataNode),
+                          getDescSectionsDocFromMetaDataList(optionalMetadataNode),
                           isDeprecated(optionalMetadataNode), isClosed, fields);
     }
 
@@ -860,7 +883,7 @@ public class Generator {
             }
             final ModuleID id = symbol.getModule().get().id();
             annotationAttachments.add(
-                    new AnnotationAttachment(symbol.getName().orElse(""), "", false,
+                    new AnnotationAttachment(symbol.getName().orElse(""), "", null, false,
                             id.orgName(), id.moduleName(), id.version()));
         }));
         return annotationAttachments;
@@ -876,7 +899,7 @@ public class Generator {
             }
             final ModuleID id = symbol.getModule().get().id();
             annotationAttachments.add(
-                    new AnnotationAttachment(symbol.getName().orElse(""), "", false,
+                    new AnnotationAttachment(symbol.getName().orElse(""), "", null, false,
                             id.orgName(), id.moduleName(), id.version()));
         });
         return annotationAttachments;
@@ -923,6 +946,10 @@ public class Generator {
         if (docLines != null) {
             for (Node docLine : docLines.documentationLines()) {
                 if (docLine instanceof MarkdownDocumentationLineNode) {
+                    String docLineString = getDocLineString(((MarkdownDocumentationLineNode) docLine).documentElements());
+                    if (docLineString.startsWith(DOC_HEADER_PREFIX)) {
+                        break;
+                    }
                     doc.append(!((MarkdownDocumentationLineNode) docLine).documentElements().isEmpty() ?
                             getDocLineString(((MarkdownDocumentationLineNode) docLine).documentElements()) : "\n");
                 } else if (docLine instanceof MarkdownCodeBlockNode) {
@@ -957,12 +984,64 @@ public class Generator {
                         lookForMoreLines = false;
                     }
                 } else if (lookForMoreLines && docLine instanceof MarkdownDocumentationLineNode) {
-                    parameterDoc.append(getDocLineString(((MarkdownDocumentationLineNode) docLine).documentElements()));
+                    String docLineString = getDocLineString(((MarkdownDocumentationLineNode) docLine)
+                            .documentElements());
+                    if (!docLineString.isEmpty()) {
+                        parameterDoc.append(docLineString);
+                    } else {
+                        lookForMoreLines = false;
+                    }
                 }
             }
         }
 
         return parameterDoc.toString();
+    }
+
+    private static List<String> getDescSectionsDocFromMetaDataList(Optional<MetadataNode> optionalMetadataNode) {
+        if (optionalMetadataNode.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<String> descSections = new ArrayList<>();
+        MarkdownDocumentationNode docLines = optionalMetadataNode.get().documentationString().isPresent() ?
+                (MarkdownDocumentationNode) optionalMetadataNode.get().documentationString().get() : null;
+        if (docLines != null) {
+            StringBuilder sectionDoc = new StringBuilder();
+            boolean lookForMoreLines = false;
+            for (Node docLine : docLines.documentationLines()) {
+                if (docLine instanceof MarkdownDocumentationLineNode) {
+                    String docLineString = getDocLineString(((MarkdownDocumentationLineNode) docLine)
+                            .documentElements());
+                    if (!docLineString.isEmpty()) {
+                        if (docLineString.startsWith(DOC_HEADER_PREFIX)) {
+                            sectionDoc = new StringBuilder();
+                            sectionDoc.append(docLineString);
+                            lookForMoreLines = true;
+                        } else if (lookForMoreLines) {
+                            sectionDoc.append(docLineString);
+                        }
+                    } else {
+                        if (sectionDoc != null && !sectionDoc.toString().isEmpty()) {
+                            descSections.add(sectionDoc.toString());
+                            sectionDoc = null;
+                        }
+                        lookForMoreLines = false;
+                    }
+                } else {
+                    if (sectionDoc != null && !sectionDoc.toString().isEmpty()) {
+                        descSections.add(sectionDoc.toString());
+                        sectionDoc = null;
+                    }
+                    lookForMoreLines = false;
+                }
+            }
+            if (sectionDoc != null && !sectionDoc.toString().isEmpty()) {
+                descSections.add(sectionDoc.toString());
+            }
+        }
+
+        return descSections;
     }
 
     private static String getDocLineString(NodeList<Node> documentElements) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Annotation.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Annotation.java
@@ -17,6 +17,8 @@ package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
 
+import java.util.List;
+
 /**
  * Represent documentation for an Annotation.
  */
@@ -26,8 +28,8 @@ public class Annotation extends Construct {
     @Expose
     public String attachmentPoints;
 
-    public Annotation(String name, String description, boolean isDeprecated, Type type, String attachmentPoints) {
-        super(name, description, isDeprecated);
+    public Annotation(String name, String description, List<String> descriptionSections, boolean isDeprecated, Type type, String attachmentPoints) {
+        super(name, description, descriptionSections, isDeprecated);
         this.type = type;
         this.attachmentPoints = attachmentPoints;
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Annotation.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Annotation.java
@@ -28,7 +28,8 @@ public class Annotation extends Construct {
     @Expose
     public String attachmentPoints;
 
-    public Annotation(String name, String description, List<String> descriptionSections, boolean isDeprecated, Type type, String attachmentPoints) {
+    public Annotation(String name, String description, List<String> descriptionSections, boolean isDeprecated,
+                      Type type, String attachmentPoints) {
         super(name, description, descriptionSections, isDeprecated);
         this.type = type;
         this.attachmentPoints = attachmentPoints;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/AnnotationAttachment.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/AnnotationAttachment.java
@@ -17,6 +17,8 @@ package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
 
+import java.util.List;
+
 /**
  * Represent documentation for an Annotation Attachment.
  */
@@ -28,9 +30,10 @@ public class AnnotationAttachment extends Construct {
     @Expose
     public String version;
 
-    public AnnotationAttachment(String name, String description, boolean isDeprecated, String orgName,
+    public AnnotationAttachment(String name, String description, List<String> descriptionSections,
+                                boolean isDeprecated, String orgName,
                                 String moduleName, String version) {
-        super(name, description, isDeprecated);
+        super(name, description, descriptionSections, isDeprecated);
         this.orgName = orgName;
         this.version = version;
         this.moduleName = moduleName;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BClass.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BClass.java
@@ -41,9 +41,9 @@ public class BClass extends Construct {
     @Expose
     public boolean isService;
 
-    public BClass(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,
+    public BClass(String name, String description, List<String> descriptionSections, boolean isDeprecated, List<DefaultableVariable> fields,
                   List<Function> methods, boolean isReadOnly, boolean isIsolated, boolean isService) {
-        super(name, description, isDeprecated);
+        super(name, description, descriptionSections, isDeprecated);
         this.fields = fields;
         this.methods = methods;
         Optional<Function> initMethod = getInitMethod(methods);

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BClass.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BClass.java
@@ -41,8 +41,9 @@ public class BClass extends Construct {
     @Expose
     public boolean isService;
 
-    public BClass(String name, String description, List<String> descriptionSections, boolean isDeprecated, List<DefaultableVariable> fields,
-                  List<Function> methods, boolean isReadOnly, boolean isIsolated, boolean isService) {
+    public BClass(String name, String description, List<String> descriptionSections, boolean isDeprecated,
+                  List<DefaultableVariable> fields, List<Function> methods, boolean isReadOnly, boolean isIsolated,
+                  boolean isService) {
         super(name, description, descriptionSections, isDeprecated);
         this.fields = fields;
         this.methods = methods;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BObjectType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BObjectType.java
@@ -32,9 +32,10 @@ public class BObjectType extends Construct {
     @Expose
     public boolean isDistinct = false;
 
-    public BObjectType(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,
+    public BObjectType(String name, String description, List<String> descriptionSections, boolean isDeprecated,
+                       List<DefaultableVariable> fields,
                        List<Function> methods) {
-        super(name, description, isDeprecated);
+        super(name, description, descriptionSections, isDeprecated);
         this.fields = fields;
         this.methods = methods;
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BType.java
@@ -21,7 +21,8 @@ import java.util.List;
  * Represents ballerina types.
  */
 public class BType extends Type {
-    public BType(String name, String description, List<String> descriptionSections, boolean isDeprecated, List<Type> memberTypes) {
+    public BType(String name, String description, List<String> descriptionSections, boolean isDeprecated,
+                 List<Type> memberTypes) {
         super(name, description, descriptionSections, isDeprecated);
         this.memberTypes = memberTypes;
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BType.java
@@ -21,8 +21,8 @@ import java.util.List;
  * Represents ballerina types.
  */
 public class BType extends Type {
-    public BType(String name, String description, boolean isDeprecated, List<Type> memberTypes) {
-        super(name, description, isDeprecated);
+    public BType(String name, String description, List<String> descriptionSections, boolean isDeprecated, List<Type> memberTypes) {
+        super(name, description, descriptionSections, isDeprecated);
         this.memberTypes = memberTypes;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
@@ -30,9 +30,10 @@ public class Client extends BClass {
     @Expose
     public List<Function> resourceMethods;
 
-    public Client(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,
-            List<Function> methods, boolean isReadOnly, boolean isIsolated, boolean isService) {
-        super(name, description, isDeprecated, fields, methods, isReadOnly, isIsolated, isService);
+    public Client(String name, String description, List<String> descriptionSections, boolean isDeprecated,
+                  List<DefaultableVariable> fields, List<Function> methods, boolean isReadOnly, boolean isIsolated,
+                  boolean isService) {
+        super(name, description, descriptionSections, isDeprecated, fields, methods, isReadOnly, isIsolated, isService);
         this.remoteMethods = getRemoteMethods();
         this.resourceMethods = getResourceMethods();
         this.otherMethods = getOtherMethods(methods);

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Constant.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Constant.java
@@ -28,7 +28,8 @@ public class Constant extends Construct {
     @Expose
     public String value;
 
-    public Constant(String name, String description, List<String> descriptionSections, boolean isDeprecated, Type type, String value) {
+    public Constant(String name, String description, List<String> descriptionSections, boolean isDeprecated,
+                    Type type, String value) {
         super(name, description, descriptionSections, isDeprecated);
         this.type = type;
         this.value = value;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Constant.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Constant.java
@@ -17,6 +17,8 @@ package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
 
+import java.util.List;
+
 /**
  * Represent documentation for a Constant.
  */
@@ -26,8 +28,8 @@ public class Constant extends Construct {
     @Expose
     public String value;
 
-    public Constant(String name, String description, boolean isDeprecated, Type type, String value) {
-        super(name, description, isDeprecated);
+    public Constant(String name, String description, List<String> descriptionSections, boolean isDeprecated, Type type, String value) {
+        super(name, description, descriptionSections, isDeprecated);
         this.type = type;
         this.value = value;
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Construct.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Construct.java
@@ -36,6 +36,12 @@ public class Construct {
     @Expose
     public boolean isReadOnly;
 
+    public Construct(String name, String description, boolean isDeprecated) {
+        this.name = name;
+        this.description = description;
+        this.isDeprecated = isDeprecated;
+    }
+
     public Construct(String name, String description, List<String> descriptionSections, boolean isDeprecated) {
         this.name = name;
         this.description = description;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Construct.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Construct.java
@@ -17,6 +17,8 @@ package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
 
+import java.util.List;
+
 /**
  * Represents a language construct in a Ballerina module.
  */
@@ -26,15 +28,18 @@ public class Construct {
     @Expose
     public String description;
     @Expose
+    public List<String> descriptionSections;
+    @Expose
     public boolean isDeprecated;
     @Expose
     public Type inclusionType = null;
     @Expose
     public boolean isReadOnly;
 
-    public Construct(String name, String description, boolean isDeprecated) {
+    public Construct(String name, String description, List<String> descriptionSections, boolean isDeprecated) {
         this.name = name;
         this.description = description;
+        this.descriptionSections = descriptionSections;
         this.isDeprecated = isDeprecated;
     }
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Enum.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Enum.java
@@ -27,7 +27,8 @@ public class Enum extends Construct {
     @Expose
     public List<Construct> members;
 
-    public Enum(String name, String description, List<String> descriptionSections, boolean isDeprecated, List<Construct> members) {
+    public Enum(String name, String description, List<String> descriptionSections, boolean isDeprecated,
+                List<Construct> members) {
         super(name, description, descriptionSections, isDeprecated);
         this.members = members;
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Enum.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Enum.java
@@ -27,8 +27,8 @@ public class Enum extends Construct {
     @Expose
     public List<Construct> members;
 
-    public Enum(String name, String description, boolean isDeprecated, List<Construct> members) {
-        super(name, description, isDeprecated);
+    public Enum(String name, String description, List<String> descriptionSections, boolean isDeprecated, List<Construct> members) {
+        super(name, description, descriptionSections, isDeprecated);
         this.members = members;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Error.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Error.java
@@ -17,6 +17,8 @@ package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
 
+import java.util.List;
+
 /**
  * Represent documentation for an Error.
  */
@@ -26,8 +28,8 @@ public class Error extends Construct {
     @Expose
     public boolean isDistinct;
 
-    public Error(String name, String description, boolean isDeprecated, Type detailType) {
-        super(name, description, isDeprecated);
+    public Error(String name, String description, List<String> descriptionSections, boolean isDeprecated, Type detailType) {
+        super(name, description, descriptionSections, isDeprecated);
         this.detailType = detailType;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Error.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Error.java
@@ -28,7 +28,8 @@ public class Error extends Construct {
     @Expose
     public boolean isDistinct;
 
-    public Error(String name, String description, List<String> descriptionSections, boolean isDeprecated, Type detailType) {
+    public Error(String name, String description, List<String> descriptionSections, boolean isDeprecated,
+                 Type detailType) {
         super(name, description, descriptionSections, isDeprecated);
         this.detailType = detailType;
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
@@ -42,10 +42,10 @@ public class Function extends Construct {
     @Expose
     List<AnnotationAttachment> annotationAttachments;
 
-    public Function(String name, String description, FunctionKind functionKind, boolean isExtern, boolean isDeprecated,
-                    boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters,
-                    List<AnnotationAttachment> annotationAttachments) {
-        super(name, description, isDeprecated);
+    public Function(String name, String description, List<String> descriptionSections, FunctionKind functionKind,
+                    boolean isExtern, boolean isDeprecated, boolean isIsolated, List<DefaultableVariable> parameters,
+                    List<Variable> returnParameters, List<AnnotationAttachment> annotationAttachments) {
+        super(name, description, descriptionSections, isDeprecated);
         this.isRemote = checkRemote(functionKind);
         this.isResource = checkResource(functionKind);
         this.isExtern = isExtern;
@@ -55,10 +55,11 @@ public class Function extends Construct {
         this.annotationAttachments = annotationAttachments;
     }
 
-    public Function(String name, String accessor, String resourcePath, String description, FunctionKind functionKind,
-                    boolean isExtern, boolean isDeprecated, boolean isIsolated, List<DefaultableVariable> parameters,
+    public Function(String name, String accessor, String resourcePath, String description,
+                    List<String> descriptionSections, FunctionKind functionKind, boolean isExtern,
+                    boolean isDeprecated, boolean isIsolated, List<DefaultableVariable> parameters,
                     List<Variable> returnParameters, List<AnnotationAttachment> annotationAttachments) {
-        super(name, description, isDeprecated);
+        super(name, description, descriptionSections, isDeprecated);
         this.accessor = accessor;
         this.resourcePath = resourcePath;
         this.isRemote = checkRemote(functionKind);
@@ -70,9 +71,10 @@ public class Function extends Construct {
         this.annotationAttachments = annotationAttachments;
     }
 
-    public Function(String name, String description, FunctionKind functionKind, boolean isExtern, boolean isDeprecated,
-                    boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters) {
-        super(name, description, isDeprecated);
+    public Function(String name, String description, List<String> descriptionSections, FunctionKind functionKind,
+                    boolean isExtern, boolean isDeprecated, boolean isIsolated, List<DefaultableVariable> parameters,
+                    List<Variable> returnParameters) {
+        super(name, description, descriptionSections, isDeprecated);
         this.isRemote = checkRemote(functionKind);
         this.isResource = checkResource(functionKind);
         this.isExtern = isExtern;
@@ -81,10 +83,11 @@ public class Function extends Construct {
         this.isIsolated = isIsolated;
     }
 
-    public Function(String name, String accessor, String resourcePath, String description, FunctionKind functionKind,
-                    boolean isExtern, boolean isDeprecated, boolean isIsolated, List<DefaultableVariable> parameters,
+    public Function(String name, String accessor, String resourcePath, String description,
+                    List<String> descriptionSections, FunctionKind functionKind, boolean isExtern,
+                    boolean isDeprecated, boolean isIsolated, List<DefaultableVariable> parameters,
                     List<Variable> returnParameters) {
-        super(name, description, isDeprecated);
+        super(name, description, descriptionSections, isDeprecated);
         this.accessor = accessor;
         this.resourcePath = resourcePath;
         this.isRemote = checkRemote(functionKind);

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Listener.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Listener.java
@@ -28,9 +28,10 @@ public class Listener extends BClass {
     @Expose
     public List<Function> lifeCycleMethods;
 
-    public Listener(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,
-            List<Function> methods, boolean isReadOnly, boolean isIsolated, boolean isService) {
-        super(name, description, isDeprecated, fields, methods, isReadOnly, isIsolated, isService);
+    public Listener(String name, String description, List<String> descriptionSections, boolean isDeprecated,
+                    List<DefaultableVariable> fields, List<Function> methods, boolean isReadOnly, boolean isIsolated,
+                    boolean isService) {
+        super(name, description, descriptionSections, isDeprecated, fields, methods, isReadOnly, isIsolated, isService);
         this.lifeCycleMethods = getLCMethods(methods);
         this.otherMethods = getOtherMethods(methods);
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/MapType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/MapType.java
@@ -19,6 +19,8 @@ package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
 
+import java.util.List;
+
 /**
  * Represents Ballerina Map Type.
  */
@@ -26,8 +28,9 @@ public class MapType extends Construct {
     @Expose
     public Type mapParameterType;
 
-    public MapType(String name, String description, boolean isDeprecated, Type mapParameterType) {
-        super(name, description, isDeprecated);
+    public MapType(String name, String description, List<String> descriptionSections, boolean isDeprecated,
+                   Type mapParameterType) {
+        super(name, description, descriptionSections, isDeprecated);
         this.mapParameterType = mapParameterType;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Record.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Record.java
@@ -29,9 +29,9 @@ public class Record extends Construct {
     @Expose
     public boolean isClosed;
 
-    public Record(String name, String description, boolean isDeprecated, boolean isClosed,
-                  List<DefaultableVariable> fields) {
-        super(name, description, isDeprecated);
+    public Record(String name, String description, List<String> descriptionSections, boolean isDeprecated,
+                  boolean isClosed, List<DefaultableVariable> fields) {
+        super(name, description, descriptionSections, isDeprecated);
         this.isClosed = isClosed;
         this.fields = fields;
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/TableType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/TableType.java
@@ -19,6 +19,8 @@ package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
 
+import java.util.List;
+
 /**
  * Represents Ballerina Table Type.
  */
@@ -28,9 +30,9 @@ public class TableType extends Construct {
     @Expose
     public Type keyConstraint;
 
-    public TableType(String name, String description, boolean isDeprecated, Type rowParameterType,
-                  Type keyConstraint) {
-        super(name, description, isDeprecated);
+    public TableType(String name, String description, List<String> descriptionSections, boolean isDeprecated,
+                     Type rowParameterType, Type keyConstraint) {
+        super(name, description, descriptionSections, isDeprecated);
         this.rowParameterType = rowParameterType;
         this.keyConstraint = keyConstraint;
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -95,6 +95,8 @@ public class Type {
     @Expose
     public String description;
     @Expose
+    public List<String> descriptionSections;
+    @Expose
     public String category;
     @Expose
     public boolean isAnonymousUnionType;
@@ -626,9 +628,10 @@ public class Type {
         this.category = "builtin";
     }
 
-    public Type(String name, String description, boolean isDeprecated) {
+    public Type(String name, String description, List<String> descriptionSections, boolean isDeprecated) {
         this.name = name;
         this.description = description;
+        this.descriptionSections = descriptionSections;
         this.isDeprecated = isDeprecated;
     }
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Variable.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Variable.java
@@ -17,8 +17,6 @@ package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
 
-import java.util.List;
-
 /**
  * Represents a variable.
  */

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Variable.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Variable.java
@@ -17,6 +17,8 @@ package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
 
+import java.util.List;
+
 /**
  * Represents a variable.
  */
@@ -24,8 +26,9 @@ public class Variable extends Construct {
     @Expose
     public Type type;
 
-    public Variable(String name, String description, boolean isDeprecated, Type type) {
-        super(name, description, isDeprecated);
+    public Variable(String name, String description, boolean isDeprecated,
+                    Type type) {
+        super(name, description, null, isDeprecated);
         this.type = type;
     }
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Variable.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Variable.java
@@ -26,7 +26,7 @@ public class Variable extends Construct {
 
     public Variable(String name, String description, boolean isDeprecated,
                     Type type) {
-        super(name, description, null, isDeprecated);
+        super(name, description, isDeprecated);
         this.type = type;
     }
 


### PR DESCRIPTION
## Purpose
Include description sections in API docs generation.

Fixes #41928

## Approach
Design for the implementation for description section and the specification has been mentioned in https://github.com/ballerina-platform/ballerina-lang/issues/41928
