### PR TITLE
Filter configurable variables under separate category in API docs generation

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -167,8 +167,14 @@ public class Generator {
                         ((ModuleVariableDeclarationNode) node).visibilityQualifier().isPresent() &&
                         ((ModuleVariableDeclarationNode) node).visibilityQualifier().get().kind()
                                 .equals(SyntaxKind.PUBLIC_KEYWORD)) {
-                    module.variables.add(getModuleVariable((ModuleVariableDeclarationNode) node, semanticModel,
-                            module));
+                    DefaultableVariable defaultableVariable = getModuleVariable((ModuleVariableDeclarationNode) node,
+                            semanticModel, module);
+                    if (containsToken(((ModuleVariableDeclarationNode) node).qualifiers(),
+                            SyntaxKind.CONFIGURABLE_KEYWORD)) {
+                        module.configurables.add(defaultableVariable);
+                    } else {
+                        module.variables.add(defaultableVariable);
+                    }
                 }
             }
         }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Module.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Module.java
@@ -76,7 +76,7 @@ public class Module extends ModuleMetaData {
     public List<BType> anyDataTypes = new ArrayList<>();
     @Expose
     public List<BType> anyTypes = new ArrayList<>();
-
+    @Expose
     public List<BType> stringTypes = new ArrayList<>();
     @Expose
     public List<BType> integerTypes = new ArrayList<>();
@@ -88,6 +88,8 @@ public class Module extends ModuleMetaData {
     public List<Enum> enums = new ArrayList<>();
     @Expose
     public List<DefaultableVariable> variables = new ArrayList<>();
-
+    @Expose
+    public List<DefaultableVariable> configurables = new ArrayList<>();
+    @Expose
     public List<Path> resources = new ArrayList<>();
 }


### PR DESCRIPTION
## Purpose
Currently the configurable variables are shown as variables in the API docs generation. But it should be filtered as `Configurables` in a different category.

Fixes https://github.com/ballerina-platform/ballerina-dev-tools/issues/323

## Approach
It has been explained in https://github.com/ballerina-platform/ballerina-dev-tools/issues/323.

## Samples
<img width="548" alt="Screenshot 2024-01-26 at 22 33 42" src="https://github.com/ballerina-platform/ballerina-lang/assets/51471998/39d30de2-da54-45af-831f-e97b8ec7419d">

