### PR TITLE
[Worker Change] Add `error:NoMessage` iff all receives have it in the alternate receive

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -2736,7 +2736,6 @@ public class QueryDesugar extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangWorkerReceive workerReceiveNode) {
-        workerReceiveNode.sendExpression = rewrite(workerReceiveNode.sendExpression);
         result = workerReceiveNode;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -285,7 +285,7 @@ import static org.wso2.ballerinalang.compiler.util.Constants.WORKER_LAMBDA_VAR_P
 public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerData> {
 
     private static final CompilerContext.Key<CodeAnalyzer> CODE_ANALYZER_KEY = new CompilerContext.Key<>();
-    private static final String NO_MESSAGE_ERROR_TYPE = "NoMessageError";
+    private static final String NO_MESSAGE_ERROR_TYPE = "NoMessage";
 
     private final SymbolResolver symResolver;
     private final SymbolTable symTable;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWorkerAsyncSendExpr.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWorkerAsyncSendExpr.java
@@ -17,13 +17,7 @@
 */
 package org.wso2.ballerinalang.compiler.tree.expressions;
 
-import org.ballerinalang.model.tree.IdentifierNode;
 import org.ballerinalang.model.tree.NodeKind;
-import org.ballerinalang.model.tree.expressions.WorkerSendExpressionNode;
-import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
-import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
-import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeAnalyzer;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeTransformer;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
@@ -33,33 +27,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
  *
  * @since 0.94
  */
-public class BLangWorkerAsyncSendExpr extends BLangWorkerSendReceiveExpr implements WorkerSendExpressionNode {
-
-    // BLangNodes
-    public BLangExpression expr;
-    public BLangIdentifier workerIdentifier;
-
-    // Semantic Data
-    public BLangWorkerReceive receive;
-    public SymbolEnv env;
-    public BSymbol workerSymbol;
-    public BType workerType;
-    public BType sendType;
-
-    @Override
-    public BLangExpression getExpression() {
-        return expr;
-    }
-
-    @Override
-    public BLangIdentifier getWorkerName() {
-        return workerIdentifier;
-    }
-
-    @Override
-    public void setWorkerName(IdentifierNode identifierNode) {
-        this.workerIdentifier = (BLangIdentifier) identifierNode;
-    }
+public class BLangWorkerAsyncSendExpr extends BLangWorkerSendExpr {
 
     @Override
     public NodeKind getKind() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWorkerReceive.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWorkerReceive.java
@@ -20,8 +20,6 @@ package org.wso2.ballerinalang.compiler.tree.expressions;
 import org.ballerinalang.model.tree.IdentifierNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.statements.WorkerReceiveNode;
-import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
-import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeAnalyzer;
@@ -35,14 +33,8 @@ import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
  */
 public class BLangWorkerReceive extends BLangWorkerSendReceiveExpr implements WorkerReceiveNode {
 
-    // BLangNodes
-    public BLangIdentifier workerIdentifier;
-
     // Semantic Data
-    public BLangExpression sendExpression; // TODO: #AST_CLEAN - No Transformer ?
-    public BSymbol workerSymbol; // TODO: 22/11/23 Seems no usage. Clean.
-    public SymbolEnv env;
-    public BType workerType;
+    public BLangWorkerSendExpr send;
     public BType matchingSendsError;
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWorkerSendExpr.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWorkerSendExpr.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.ballerinalang.compiler.tree.expressions;
+
+import org.ballerinalang.model.tree.IdentifierNode;
+import org.ballerinalang.model.tree.expressions.WorkerSendExpressionNode;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
+
+/**
+ * Represents commons in worker async-send and sync-send.
+ *
+ * @since 2201.9.0
+ */
+public abstract class BLangWorkerSendExpr extends BLangWorkerSendReceiveExpr implements WorkerSendExpressionNode {
+
+    // BLangNodes
+    public BLangExpression expr;
+
+    // Semantic Data
+    public BLangWorkerReceive receive;
+    public BType sendType;
+
+    // For alternate receive type inference
+    public boolean noMessagePossible;
+    public BType sendTypeWithNoMsgIgnored;
+
+    @Override
+    public BLangExpression getExpression() {
+        return expr;
+    }
+
+    @Override
+    public BLangIdentifier getWorkerName() {
+        return workerIdentifier;
+    }
+
+    @Override
+    public void setWorkerName(IdentifierNode identifierNode) {
+        this.workerIdentifier = (BLangIdentifier) identifierNode;
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWorkerSendReceiveExpr.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWorkerSendReceiveExpr.java
@@ -17,6 +17,11 @@
  */
 package org.wso2.ballerinalang.compiler.tree.expressions;
 
+import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
+
 /**
  * Represents commons in worker async-send, sync-send and single-receive.
  *
@@ -24,6 +29,10 @@ package org.wso2.ballerinalang.compiler.tree.expressions;
  */
 public abstract class BLangWorkerSendReceiveExpr extends BLangExpression {
 
+    public SymbolEnv env;
+    public BSymbol workerSymbol;
+    public BType workerType;
+    public BLangIdentifier workerIdentifier;
     private Channel channel;
 
     public Channel getChannel() {
@@ -34,16 +43,7 @@ public abstract class BLangWorkerSendReceiveExpr extends BLangExpression {
         this.channel = channel;
     }
 
-    public static final class Channel {
-        public final String sender;
-        public final String receiver;
-        public final int eventIndex;
-
-        public Channel(String sender, String receiver, int eventIndex) {
-            this.sender = sender;
-            this.receiver = receiver;
-            this.eventIndex = eventIndex;
-        }
+    public record Channel(String sender, String receiver, int eventIndex) {
 
         public String workerPairId() {
             return workerPairId(sender, receiver);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWorkerSyncSendExpr.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWorkerSyncSendExpr.java
@@ -17,14 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.tree.expressions;
 
-import org.ballerinalang.model.tree.IdentifierNode;
 import org.ballerinalang.model.tree.NodeKind;
-import org.ballerinalang.model.tree.expressions.ExpressionNode;
-import org.ballerinalang.model.tree.expressions.WorkerSendExpressionNode;
-import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
-import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
-import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeAnalyzer;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeTransformer;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
@@ -34,18 +27,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
  *
  * @since 0.985
  */
-public class BLangWorkerSyncSendExpr extends BLangWorkerSendReceiveExpr implements WorkerSendExpressionNode {
-
-    // BLangNodes
-    public BLangIdentifier workerIdentifier;
-    public BLangExpression expr;
-
-    // Semantic Data
-    public BLangWorkerReceive receive;
-    public BSymbol workerSymbol;
-    public SymbolEnv env;
-    public BType workerType;
-    public BType sendType;
+public class BLangWorkerSyncSendExpr extends BLangWorkerSendExpr {
 
     @Override
     public NodeKind getKind() {
@@ -65,21 +47,6 @@ public class BLangWorkerSyncSendExpr extends BLangWorkerSendReceiveExpr implemen
     @Override
     public <T, R> R apply(BLangNodeTransformer<T, R> modifier, T props) {
         return modifier.transform(this, props);
-    }
-
-    @Override
-    public ExpressionNode getExpression() {
-        return expr;
-    }
-
-    @Override
-    public IdentifierNode getWorkerName() {
-        return workerIdentifier;
-    }
-
-    @Override
-    public void setWorkerName(IdentifierNode identifierNode) {
-        this.workerIdentifier = (BLangIdentifier) identifierNode;
     }
 
     public String toActionString() {

--- a/langlib/lang.error/src/main/ballerina/error.bal
+++ b/langlib/lang.error/src/main/ballerina/error.bal
@@ -17,7 +17,7 @@
 import ballerina/jballerina.java;
 
 # Error type representing the no message error in worker interactions.
-public type NoMessageError distinct error;
+public type NoMessage distinct error;
 
 # Type for value that can be cloned.
 # This is the same as in lang.value, but is copied here to avoid a dependency.

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerAlternateReceiveTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerAlternateReceiveTest.java
@@ -15,9 +15,9 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-
 package org.ballerinalang.test.worker;
 
+import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
@@ -32,12 +32,13 @@ import org.testng.annotations.Test;
  */
 public class WorkerAlternateReceiveTest {
 
-    private CompileResult result;
+    private CompileResult result, negativeResult;
 
     @BeforeClass
     public void setup() {
-        this.result = BCompileUtil.compile("test-src/workers/workers_alt_receive.bal");
+        result = BCompileUtil.compile("test-src/workers/workers_alt_receive.bal");
         Assert.assertEquals(result.getErrorCount(), 0);
+        negativeResult = BCompileUtil.compile("test-src/workers/workers_alt_receive_negative.bal");
     }
 
     @Test(dataProvider = "functionProvider")
@@ -66,8 +67,29 @@ public class WorkerAlternateReceiveTest {
         };
     }
 
+    @Test(description = "Test negative scenarios of alternate receive action.")
+    public void testAltWorkerReceiveNegative() {
+        int index = 0;
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'string', found 'int'", 53,
+                20);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'string', found '" +
+                "(int|ballerina/lang.error:0.0.0:NoMessage)'", 54, 20);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'string', found 'int'", 55,
+                20);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'string', found 'int'", 56,
+                20);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'string', found 'int'", 57,
+                20);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'string', found '" +
+                "(decimal|string|int|boolean)'", 58, 20);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'string', found '" +
+                "(decimal|string|int|boolean|ballerina/lang.error:0.0.0:NoMessage)'", 59, 20);
+        Assert.assertEquals(negativeResult.getErrorCount(), index);
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;
+        negativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers_alt_receive_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers_alt_receive_negative.bal
@@ -1,0 +1,63 @@
+function testAltReceiveNoMessageErrorType(boolean b) {
+    worker w1 {
+        // case 1
+        1 -> w2;
+        2 -> w2;
+
+        // case 2
+        if b {
+            3 -> w2;
+            4 -> w2;
+        }
+
+        // case 3
+        if b {
+            5 -> w2;
+        }
+        6 -> w2;
+
+        // case 4
+        7 -> w2;
+        if b {
+            8 -> w2;
+        }
+
+        // case 5
+        9 -> w2;
+        10 -> w2;
+        if b {
+            11 -> w2;
+        }
+        12 -> w2;
+
+        // case 5
+        13.3d -> w2;
+        if b {
+            "xx" -> w2;
+            14 -> w2;
+            true -> w2;
+        }
+
+        // case 6
+        if !b {
+            13.3d -> w2;
+        }
+        if b {
+            "xx" -> w2;
+            14 -> w2;
+            true -> w2;
+        }
+    }
+
+    worker w2 {
+        string _ = <- w1|w1; // found 'int'
+        string _ = <- w1|w1; // found 'int|error:NoMessage'
+        string _ = <- w1|w1; // found 'int'
+        string _ = <- w1|w1; // found 'int'
+        string _ = <- w1|w1|w1|w1; // found 'int'
+        string _ = <- w1|w1|w1|w1; // found 'decimal|string|int|boolean'
+        string _ = <- w1|w1|w1|w1; // found 'decimal|string|int|boolean|error:NoMessage'
+    }
+
+    _ = wait {a: w1, b: w2};
+}


### PR DESCRIPTION
## Purpose
$subject.

Fixes #41968

## Approach
n/a

## Samples
```bal
function foobar() {
    boolean foo = true;

    worker w1 {
        if foo {
            10 -> w2;
        }
        20 -> w2;
    }

    worker w2 {
        int a = <- w1|w1; // LHS type does not require error:NoMessage now
    }

    _ = wait {a: w1, b: w2};
}
```

## Remarks
n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
