### PR TITLE
Fix let expression usage inside query actions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -2103,8 +2103,8 @@ public class QueryDesugar extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangLetExpression letExpr) {
-        letExpr.expr = rewrite(letExpr.expr);
         letExpr.letVarDeclarations.forEach(var -> this.acceptNode((BLangNode) var.definitionNode));
+        letExpr.expr = rewrite(letExpr.expr);
         result = letExpr;
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryActionOrExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryActionOrExprTest.java
@@ -80,7 +80,8 @@ public class QueryActionOrExprTest {
                 "testQueryActionOrExpressionWithUnionRecordResultType",
                 "testQueryActionOrExprWithAnyOrErrResultType",
                 "testNestedQueryActionOrExprWithClientResourceAccessAction",
-                "testQueryActionWithQueryExpression"
+                "testQueryActionWithQueryExpression",
+                "testQueryActionWithLetExpression"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_action_or_expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_action_or_expr.bal
@@ -1019,8 +1019,7 @@ function testQueryActionWithLetExpression() {
             float gpaVal = let var sGpa = gpa in sGpa;
             actualGpaList.push(gpaVal);
         };
-    float[] expectedGpaList = [3.5, 1.9, 3.7, 4.0];
-    assertEquality(expectedGpaList, actualGpaList);
+    assertEquality([3.5, 1.9, 3.7, 4.0], actualGpaList);
 
     int[] actualValues = [];
     int weight = 2;
@@ -1029,8 +1028,7 @@ function testQueryActionWithLetExpression() {
             int gpaVal = let var sGpa = i in weight * i;
             actualValues.push(gpaVal);
         };
-    int[] expectedValues = [2, 4, 6, 8];
-    assertEquality(actualValues, expectedValues);
+    assertEquality([2, 4, 6, 8], actualValues);
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_action_or_expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_action_or_expr.bal
@@ -988,11 +988,7 @@ type Student record {
 function calGraduationYear(int year) returns int => year + 5;
 
 function getBestStudents() returns any|error {
-    Student s1 = {firstName: "Martin", lastName: "Sadler", intakeYear: 1990, gpa: 3.5};
-    Student s2 = {firstName: "Ranjan", lastName: "Fonseka", intakeYear: 2001, gpa: 1.9};
-    Student s3 = {firstName: "Michelle", lastName: "Guthrie", intakeYear: 2002, gpa: 3.7};
-    Student s4 = {firstName: "George", lastName: "Fernando", intakeYear: 2005, gpa: 4.0};
-    Student[] studentList = [s1, s2, s3];
+    Student[] studentList = getStudents();
 
     return from var student in studentList
         where student.gpa >= 2.0
@@ -1004,6 +1000,37 @@ function getBestStudents() returns any|error {
 
 function testQueryActionOrExprWithAnyOrErrResultType() {
     assertTrue(getBestStudents() is record {|string name; string degree; int graduationYear;|}[]);
+}
+
+function getStudents() returns Student[] {
+    return [
+        {firstName: "Martin", lastName: "Sadler", intakeYear: 1990, gpa: 3.5},
+        {firstName: "Ranjan", lastName: "Fonseka", intakeYear: 2001, gpa: 1.9},
+        {firstName: "Michelle", lastName: "Guthrie", intakeYear: 2002, gpa: 3.7},
+        {firstName: "George", lastName: "Fernando", intakeYear: 2005, gpa: 4.0}
+    ];
+}
+
+function testQueryActionWithLetExpression() {
+    Student[] studentList = getStudents();
+    float[] actualGpaList = [];
+    _ = from var {gpa} in studentList
+        do {
+            float gpaVal = let var sGpa = gpa in sGpa;
+            actualGpaList.push(gpaVal);
+        };
+    float[] expectedGpaList = [3.5, 1.9, 3.7, 4.0];
+    assertEquality(expectedGpaList, actualGpaList);
+
+    int[] actualValues = [];
+    int weight = 2;
+    _ = from var i in [1, 2, 3, 4]
+        do {
+            int gpaVal = let var sGpa = i in weight * i;
+            actualValues.push(gpaVal);
+        };
+    int[] expectedValues = [2, 4, 6, 8];
+    assertEquality(actualValues, expectedValues);
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";


### PR DESCRIPTION
## Purpose
$subject

Fixes #40229

## Approach
In the query desugar we were desugaring the expression of the let expression before desugaring the let variable declaration. Because of that there were unwanted statements added at the query desugar level resulted in compiler crash. Changing the desuaging order will fixed the issue.


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
