### PR TITLE
Support `create function` CA for workers and explicitly defined anonymous functions

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
@@ -407,8 +407,8 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
 
     @Override
     public void visit(NamedWorkerDeclarationNode namedWorkerDeclarationNode) {
-        Optional<Symbol> symbol = semanticModel.symbol(namedWorkerDeclarationNode);
-        symbol.ifPresent(value -> checkAndSetTypeResult(((WorkerSymbol) value).returnType()));
+        semanticModel.symbol(namedWorkerDeclarationNode)
+                .ifPresent(value -> checkAndSetTypeResult(((WorkerSymbol) value).returnType()));
     }
 
     @Override
@@ -420,7 +420,12 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
 
         // Get function type symbol and get return type descriptor from it
         returnStatementNode.parent().accept(this);
-        if (resultFound && returnTypeSymbol.typeKind() == TypeDescKind.FUNCTION) {
+
+        if (!resultFound) {
+            resetResult();
+            return;
+        }
+        if (returnTypeSymbol.typeKind() == TypeDescKind.FUNCTION) {
             FunctionTypeSymbol functionTypeSymbol = (FunctionTypeSymbol) returnTypeSymbol;
             functionTypeSymbol.returnTypeDescriptor().ifPresentOrElse(this::checkAndSetTypeResult, this::resetResult);
         }
@@ -521,8 +526,7 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
 
     @Override
     public void visit(ExplicitAnonymousFunctionExpressionNode explicitAnonymousFunctionExpressionNode) {
-        Optional<TypeSymbol> typeSymbol = semanticModel.typeOf(explicitAnonymousFunctionExpressionNode);
-        typeSymbol.ifPresent(this::checkAndSetTypeResult);
+        semanticModel.typeOf(explicitAnonymousFunctionExpressionNode).ifPresent(this::checkAndSetTypeResult);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateFunctionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateFunctionTest.java
@@ -191,11 +191,13 @@ public class CreateFunctionTest extends AbstractCodeActionTest {
                 {"create_function_in_worker2.json"},
                 {"create_function_in_worker3.json"},
                 {"create_function_in_worker4.json"},
+                {"create_function_in_worker5.json"},
 
                 {"create_function_in_explicit_anonymous_function1.json"},
                 {"create_function_in_explicit_anonymous_function2.json"},
                 {"create_function_in_explicit_anonymous_function3.json"},
-                {"create_function_in_explicit_anonymous_function4.json"}
+                {"create_function_in_explicit_anonymous_function4.json"},
+                {"create_function_in_explicit_anonymous_function5.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateFunctionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateFunctionTest.java
@@ -186,6 +186,16 @@ public class CreateFunctionTest extends AbstractCodeActionTest {
 
                 {"create_function_in_anonymous_function1.json"},
                 {"create_function_in_anonymous_function2.json"},
+
+                {"create_function_in_worker1.json"},
+                {"create_function_in_worker2.json"},
+                {"create_function_in_worker3.json"},
+                {"create_function_in_worker4.json"},
+
+                {"create_function_in_explicit_anonymous_function1.json"},
+                {"create_function_in_explicit_anonymous_function2.json"},
+                {"create_function_in_explicit_anonymous_function3.json"},
+                {"create_function_in_explicit_anonymous_function4.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function1.json
@@ -1,0 +1,57 @@
+{
+  "position": {
+    "line": 4,
+    "character": 16
+  },
+  "source": "create_function_in_explicit_anonymous_function.bal",
+  "expected": [
+    {
+      "title": "Create function 'foo(...)'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 19,
+              "character": 1
+            },
+            "end": {
+              "line": 19,
+              "character": 1
+            }
+          },
+          "newText": "\n\nfunction foo() returns int {\n    return 0;\n}"
+        }
+      ],
+      "resolvable": true,
+      "data": {
+        "extName": "org.ballerinalang.langserver.codeaction.BallerinaCodeActionExtension",
+        "codeActionName": "Create Function",
+        "fileUri": "create_function_in_explicit_anonymous_function.bal",
+        "range": {
+          "start": {
+            "line": 4,
+            "character": 15
+          },
+          "end": {
+            "line": 4,
+            "character": 20
+          }
+        },
+        "actionData": {
+          "key": "node.range",
+          "value": {
+            "start": {
+              "line": 4.0,
+              "character": 15.0
+            },
+            "end": {
+              "line": 4.0,
+              "character": 20.0
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function1.json
@@ -12,11 +12,11 @@
         {
           "range": {
             "start": {
-              "line": 19,
+              "line": 25,
               "character": 1
             },
             "end": {
-              "line": 19,
+              "line": 25,
               "character": 1
             }
           },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function2.json
@@ -1,0 +1,57 @@
+{
+  "position": {
+    "line": 8,
+    "character": 10
+  },
+  "source": "create_function_in_explicit_anonymous_function.bal",
+  "expected": [
+    {
+      "title": "Create function 'foo(...)'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 19,
+              "character": 1
+            },
+            "end": {
+              "line": 19,
+              "character": 1
+            }
+          },
+          "newText": "\n\nfunction foo(int i) {\n    \n}"
+        }
+      ],
+      "resolvable": true,
+      "data": {
+        "extName": "org.ballerinalang.langserver.codeaction.BallerinaCodeActionExtension",
+        "codeActionName": "Create Function",
+        "fileUri": "create_function_in_explicit_anonymous_function.bal",
+        "range": {
+          "start": {
+            "line": 8,
+            "character": 8
+          },
+          "end": {
+            "line": 8,
+            "character": 15
+          }
+        },
+        "actionData": {
+          "key": "node.range",
+          "value": {
+            "start": {
+              "line": 8.0,
+              "character": 8.0
+            },
+            "end": {
+              "line": 8.0,
+              "character": 15.0
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function2.json
@@ -12,11 +12,11 @@
         {
           "range": {
             "start": {
-              "line": 19,
+              "line": 25,
               "character": 1
             },
             "end": {
-              "line": 19,
+              "line": 25,
               "character": 1
             }
           },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function3.json
@@ -1,0 +1,57 @@
+{
+  "position": {
+    "line": 13,
+    "character": 17
+  },
+  "source": "create_function_in_explicit_anonymous_function.bal",
+  "expected": [
+    {
+      "title": "Create function 'foo(...)'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 19,
+              "character": 1
+            },
+            "end": {
+              "line": 19,
+              "character": 1
+            }
+          },
+          "newText": "\n\nfunction foo() {\n    \n}"
+        }
+      ],
+      "resolvable": true,
+      "data": {
+        "extName": "org.ballerinalang.langserver.codeaction.BallerinaCodeActionExtension",
+        "codeActionName": "Create Function",
+        "fileUri": "create_function_in_explicit_anonymous_function.bal",
+        "range": {
+          "start": {
+            "line": 13,
+            "character": 15
+          },
+          "end": {
+            "line": 13,
+            "character": 20
+          }
+        },
+        "actionData": {
+          "key": "node.range",
+          "value": {
+            "start": {
+              "line": 13.0,
+              "character": 15.0
+            },
+            "end": {
+              "line": 13.0,
+              "character": 20.0
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function3.json
@@ -12,11 +12,11 @@
         {
           "range": {
             "start": {
-              "line": 19,
+              "line": 25,
               "character": 1
             },
             "end": {
-              "line": 19,
+              "line": 25,
               "character": 1
             }
           },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function4.json
@@ -1,0 +1,57 @@
+{
+  "position": {
+    "line": 17,
+    "character": 17
+  },
+  "source": "create_function_in_explicit_anonymous_function.bal",
+  "expected": [
+    {
+      "title": "Create function 'foo(...)'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 19,
+              "character": 1
+            },
+            "end": {
+              "line": 19,
+              "character": 1
+            }
+          },
+          "newText": "\n\nfunction foo() returns module1:TestRecord2 {\n    return {};\n}"
+        }
+      ],
+      "resolvable": true,
+      "data": {
+        "extName": "org.ballerinalang.langserver.codeaction.BallerinaCodeActionExtension",
+        "codeActionName": "Create Function",
+        "fileUri": "create_function_in_explicit_anonymous_function.bal",
+        "range": {
+          "start": {
+            "line": 17,
+            "character": 15
+          },
+          "end": {
+            "line": 17,
+            "character": 20
+          }
+        },
+        "actionData": {
+          "key": "node.range",
+          "value": {
+            "start": {
+              "line": 17.0,
+              "character": 15.0
+            },
+            "end": {
+              "line": 17.0,
+              "character": 20.0
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_explicit_anonymous_function5.json
@@ -1,7 +1,7 @@
 {
   "position": {
-    "line": 17,
-    "character": 17
+    "line": 22,
+    "character": 22
   },
   "source": "create_function_in_explicit_anonymous_function.bal",
   "expected": [
@@ -20,7 +20,7 @@
               "character": 1
             }
           },
-          "newText": "\n\nfunction foo() returns module1:TestRecord2 {\n    return {};\n}"
+          "newText": "\n\nfunction foo() returns int {\n    return 0;\n}"
         }
       ],
       "resolvable": true,
@@ -30,24 +30,24 @@
         "fileUri": "create_function_in_explicit_anonymous_function.bal",
         "range": {
           "start": {
-            "line": 17,
-            "character": 15
+            "line": 22,
+            "character": 19
           },
           "end": {
-            "line": 17,
-            "character": 20
+            "line": 22,
+            "character": 24
           }
         },
         "actionData": {
           "key": "node.range",
           "value": {
             "start": {
-              "line": 17.0,
-              "character": 15.0
+              "line": 22.0,
+              "character": 19.0
             },
             "end": {
-              "line": 17.0,
-              "character": 20.0
+              "line": 22.0,
+              "character": 24.0
             }
           }
         }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker1.json
@@ -1,0 +1,57 @@
+{
+  "position": {
+    "line": 4,
+    "character": 16
+  },
+  "source": "create_function_in_worker.bal",
+  "expected": [
+    {
+      "title": "Create function 'foo(...)'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 19,
+              "character": 1
+            },
+            "end": {
+              "line": 19,
+              "character": 1
+            }
+          },
+          "newText": "\n\nfunction foo() returns int {\n    return 0;\n}"
+        }
+      ],
+      "resolvable": true,
+      "data": {
+        "extName": "org.ballerinalang.langserver.codeaction.BallerinaCodeActionExtension",
+        "codeActionName": "Create Function",
+        "fileUri": "create_function_in_worker.bal",
+        "range": {
+          "start": {
+            "line": 4,
+            "character": 15
+          },
+          "end": {
+            "line": 4,
+            "character": 20
+          }
+        },
+        "actionData": {
+          "key": "node.range",
+          "value": {
+            "start": {
+              "line": 4.0,
+              "character": 15.0
+            },
+            "end": {
+              "line": 4.0,
+              "character": 20.0
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker1.json
@@ -12,11 +12,11 @@
         {
           "range": {
             "start": {
-              "line": 19,
+              "line": 25,
               "character": 1
             },
             "end": {
-              "line": 19,
+              "line": 25,
               "character": 1
             }
           },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker2.json
@@ -12,11 +12,11 @@
         {
           "range": {
             "start": {
-              "line": 19,
+              "line": 25,
               "character": 1
             },
             "end": {
-              "line": 19,
+              "line": 25,
               "character": 1
             }
           },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker2.json
@@ -1,0 +1,57 @@
+{
+  "position": {
+    "line": 8,
+    "character": 10
+  },
+  "source": "create_function_in_worker.bal",
+  "expected": [
+    {
+      "title": "Create function 'foo(...)'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 19,
+              "character": 1
+            },
+            "end": {
+              "line": 19,
+              "character": 1
+            }
+          },
+          "newText": "\n\nfunction foo(int i) {\n    \n}"
+        }
+      ],
+      "resolvable": true,
+      "data": {
+        "extName": "org.ballerinalang.langserver.codeaction.BallerinaCodeActionExtension",
+        "codeActionName": "Create Function",
+        "fileUri": "create_function_in_worker.bal",
+        "range": {
+          "start": {
+            "line": 8,
+            "character": 8
+          },
+          "end": {
+            "line": 8,
+            "character": 15
+          }
+        },
+        "actionData": {
+          "key": "node.range",
+          "value": {
+            "start": {
+              "line": 8.0,
+              "character": 8.0
+            },
+            "end": {
+              "line": 8.0,
+              "character": 15.0
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker3.json
@@ -1,0 +1,57 @@
+{
+  "position": {
+    "line": 13,
+    "character": 17
+  },
+  "source": "create_function_in_worker.bal",
+  "expected": [
+    {
+      "title": "Create function 'foo(...)'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 19,
+              "character": 1
+            },
+            "end": {
+              "line": 19,
+              "character": 1
+            }
+          },
+          "newText": "\n\nfunction foo() {\n    \n}"
+        }
+      ],
+      "resolvable": true,
+      "data": {
+        "extName": "org.ballerinalang.langserver.codeaction.BallerinaCodeActionExtension",
+        "codeActionName": "Create Function",
+        "fileUri": "create_function_in_worker.bal",
+        "range": {
+          "start": {
+            "line": 13,
+            "character": 15
+          },
+          "end": {
+            "line": 13,
+            "character": 20
+          }
+        },
+        "actionData": {
+          "key": "node.range",
+          "value": {
+            "start": {
+              "line": 13.0,
+              "character": 15.0
+            },
+            "end": {
+              "line": 13.0,
+              "character": 20.0
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker3.json
@@ -12,11 +12,11 @@
         {
           "range": {
             "start": {
-              "line": 19,
+              "line": 25,
               "character": 1
             },
             "end": {
-              "line": 19,
+              "line": 25,
               "character": 1
             }
           },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker4.json
@@ -1,0 +1,57 @@
+{
+  "position": {
+    "line": 17,
+    "character": 17
+  },
+  "source": "create_function_in_worker.bal",
+  "expected": [
+    {
+      "title": "Create function 'foo(...)'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 19,
+              "character": 1
+            },
+            "end": {
+              "line": 19,
+              "character": 1
+            }
+          },
+          "newText": "\n\nfunction foo() returns module1:TestRecord2 {\n    return {};\n}"
+        }
+      ],
+      "resolvable": true,
+      "data": {
+        "extName": "org.ballerinalang.langserver.codeaction.BallerinaCodeActionExtension",
+        "codeActionName": "Create Function",
+        "fileUri": "create_function_in_worker.bal",
+        "range": {
+          "start": {
+            "line": 17,
+            "character": 15
+          },
+          "end": {
+            "line": 17,
+            "character": 20
+          }
+        },
+        "actionData": {
+          "key": "node.range",
+          "value": {
+            "start": {
+              "line": 17.0,
+              "character": 15.0
+            },
+            "end": {
+              "line": 17.0,
+              "character": 20.0
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker4.json
@@ -12,11 +12,11 @@
         {
           "range": {
             "start": {
-              "line": 19,
+              "line": 25,
               "character": 1
             },
             "end": {
-              "line": 19,
+              "line": 25,
               "character": 1
             }
           },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/create_function_in_worker5.json
@@ -1,9 +1,9 @@
 {
   "position": {
-    "line": 17,
-    "character": 17
+    "line": 22,
+    "character": 22
   },
-  "source": "create_function_in_explicit_anonymous_function.bal",
+  "source": "create_function_in_worker.bal",
   "expected": [
     {
       "title": "Create function 'foo(...)'",
@@ -20,34 +20,34 @@
               "character": 1
             }
           },
-          "newText": "\n\nfunction foo() returns module1:TestRecord2 {\n    return {};\n}"
+          "newText": "\n\nfunction foo() returns int {\n    return 0;\n}"
         }
       ],
       "resolvable": true,
       "data": {
         "extName": "org.ballerinalang.langserver.codeaction.BallerinaCodeActionExtension",
         "codeActionName": "Create Function",
-        "fileUri": "create_function_in_explicit_anonymous_function.bal",
+        "fileUri": "create_function_in_worker.bal",
         "range": {
           "start": {
-            "line": 17,
-            "character": 15
+            "line": 22,
+            "character": 19
           },
           "end": {
-            "line": 17,
-            "character": 20
+            "line": 22,
+            "character": 24
           }
         },
         "actionData": {
           "key": "node.range",
           "value": {
             "start": {
-              "line": 17.0,
-              "character": 15.0
+              "line": 22.0,
+              "character": 19.0
             },
             "end": {
-              "line": 17.0,
-              "character": 20.0
+              "line": 22.0,
+              "character": 24.0
             }
           }
         }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/create_function_in_explicit_anonymous_function.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/create_function_in_explicit_anonymous_function.bal
@@ -17,4 +17,10 @@ function createFunctionInWorker() {
     var fn4 = function() returns module1:TestRecord2 {
         return foo();
     };
+
+    var fn5 = function() returns function () returns int {
+        return function () returns int {
+            return foo();
+        };
+    };
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/create_function_in_explicit_anonymous_function.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/create_function_in_explicit_anonymous_function.bal
@@ -1,0 +1,20 @@
+import ballerina/module1;
+
+function createFunctionInWorker() {
+    var fn1 = function() returns int {
+        return foo();
+    };
+
+    var fn2 = function() returns string {
+        foo(32);
+        return "bar";
+    };
+
+    var fn3 = function() {
+        return foo();
+    };
+
+    var fn4 = function() returns module1:TestRecord2 {
+        return foo();
+    };
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/create_function_in_worker.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/create_function_in_worker.bal
@@ -17,4 +17,10 @@ function createFunctionInWorker() {
     worker D returns module1:TestRecord2 {
         return foo();
     }
+
+    fork {
+        worker E returns int {
+            return foo();
+        }
+    }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/create_function_in_worker.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/create_function_in_worker.bal
@@ -1,0 +1,20 @@
+import ballerina/module1;
+
+function createFunctionInWorker() {
+    worker A returns int {
+        return foo();
+    }
+
+    worker B returns string {
+        foo(32);
+        return "bar";
+    }
+
+    worker C {
+        return foo();
+    }
+
+    worker D returns module1:TestRecord2 {
+        return foo();
+    }
+}


### PR DESCRIPTION
## Purpose
The `create function` CA uses the `FunctionCallExpressionTypeFinder`, which determines the expected type of a function call. The implementation of this type finder does not have the logic to handle workers and explicit anonymous functions; thus, these are not supported with the `create function` CA.

Fixes #42013

## Approach
The PR modifies the `FunctionCallExpressionTypeFinder` to support determining the expected type of function calls within workers and explicit anonymous function calls.

## Samples
![image](https://github.com/ballerina-platform/ballerina-lang/assets/59343084/127dfd13-f29d-495f-a798-0389e8b55569)
<img width="307" alt="image" src="https://github.com/ballerina-platform/ballerina-lang/assets/59343084/2078d079-b1db-42c3-b536-91243b5a0c4f">


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
