### PR TITLE
Add the locations to the field in an intersected record

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -5619,7 +5619,7 @@ public class Types {
                                                    intersectionFieldType, newTypeSymbol, lhsRecordField.pos, SOURCE);
             }
 
-            newTypeFields.put(key, new BField(name, null, recordFieldSymbol));
+            newTypeFields.put(key, new BField(name, recordFieldSymbol.pos, recordFieldSymbol));
             newTypeSymbol.scope.define(name,  recordFieldSymbol);
         }
         return true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -5616,7 +5616,7 @@ public class Types {
                 invokableSymbol.flags = tsymbol.flags;
             } else {
                 recordFieldSymbol = new BVarSymbol(intersectionFlags, name, env.enclPkg.packageID,
-                                                   intersectionFieldType, newTypeSymbol, lhsRecordField.pos, SOURCE);
+                        intersectionFieldType, newTypeSymbol, lhsRecordField.symbol.pos, SOURCE);
             }
 
             newTypeFields.put(key, new BField(name, recordFieldSymbol.pos, recordFieldSymbol));

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ErrorTypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ErrorTypeSymbolTest.java
@@ -19,10 +19,15 @@
 package io.ballerina.semantic.api.test.symbols;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.impl.symbols.BallerinaErrorTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaIntersectionTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaRecordTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaTypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.Documentable;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
@@ -41,6 +46,7 @@ import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
@@ -130,6 +136,46 @@ public class ErrorTypeSymbolTest {
                 {41, 4, "EmailError"},
                 {42, 4, "CancelledError"},
                 {43, 4, "IntersectionError"}
+        };
+    }
+
+    @Test(dataProvider = "IntersectionErrorTypeProvider")
+    public void testFieldDescriptorsOfErrorIntersection(int line, int offset, String expectedErrorType,
+                                                        List<String> expectedFieldNames) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, offset));
+        assertTrue(symbol.isPresent());
+
+        Symbol ballerinaTypeDefinitionSymbol = symbol.get();
+        assertEquals(ballerinaTypeDefinitionSymbol.kind(), SymbolKind.TYPE);
+        assertTrue(ballerinaTypeDefinitionSymbol.getName().isPresent());
+        assertEquals(ballerinaTypeDefinitionSymbol.getName().get(), expectedErrorType);
+
+        TypeSymbol ballerinaIntersectionTypeSymbol =
+                ((BallerinaTypeReferenceTypeSymbol) ballerinaTypeDefinitionSymbol).typeDescriptor();
+        assertEquals(ballerinaIntersectionTypeSymbol.kind(), SymbolKind.TYPE);
+
+        TypeSymbol ballerinaErrorTypeSymbol =
+                ((BallerinaIntersectionTypeSymbol) ballerinaIntersectionTypeSymbol).effectiveTypeDescriptor();
+        assertEquals(ballerinaErrorTypeSymbol.kind(), SymbolKind.TYPE);
+
+        TypeSymbol ballerinaRecordTypeSymbol =
+                ((BallerinaErrorTypeSymbol) ballerinaErrorTypeSymbol).detailTypeDescriptor();
+        assertEquals(ballerinaRecordTypeSymbol.kind(), SymbolKind.TYPE);
+
+        Map<String, RecordFieldSymbol> stringRecordFieldSymbolMap =
+                ((BallerinaRecordTypeSymbol) ballerinaRecordTypeSymbol).fieldDescriptors();
+        List<String> actualFieldNames = stringRecordFieldSymbolMap.keySet().stream().toList();
+        assertEquals(actualFieldNames.size(), expectedFieldNames.size());
+        for (int i = 0; i < actualFieldNames.size(); i++) {
+            assertEquals(actualFieldNames.get(i), expectedFieldNames.get(i));
+        }
+    }
+
+    @DataProvider(name = "IntersectionErrorTypeProvider")
+    public Object[][] getIntersectionErrorType() {
+        return new Object[][]{
+                {62, 4, "SimpleIntersectionError", List.of("msg", "value")},
+                {63, 4, "MultipleIntersectionError", List.of("flag", "msg", "value")}
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/error_type_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/error_type_symbol_test.bal
@@ -43,3 +43,23 @@ function test() {
     CancelledError distinctErr;
     IntersectionError intersectionErr;
 }
+
+type ErrorDetail1 record {
+    string msg;
+    int value?;
+};
+
+type ErrorDetail2 record {|
+    *ErrorDetail1;
+    boolean flag;
+|};
+
+type SimpleError error<ErrorDetail1>;
+type InclusionError error<ErrorDetail2>;
+
+type SimpleIntersectionError distinct error & error<ErrorDetail1> & error<ErrorDetail1>;
+type MultipleIntersectionError InclusionError & error<ErrorDetail1> & SimpleError & error<ErrorDetail2>;
+function testMultipleIntersectionError() {
+    SimpleIntersectionError simpleErr;
+    MultipleIntersectionError multipleErr;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/error_type_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/error_type_symbol_test.bal
@@ -51,7 +51,7 @@ type ErrorDetail1 record {
 
 type ErrorDetail2 record {|
     *ErrorDetail1;
-    boolean flag;
+    boolean|int flag;
 |};
 
 type SimpleError error<ErrorDetail1>;


### PR DESCRIPTION
## Purpose
The current implementation sets `null` as the location when adding the fields to the new intersected record. This impacts the `fieldDescriptors` API as it is unable to detect the line range when initializing the symbols.

Fixes #42094

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
