### PR TITLE
Fix xml navigation on xml union type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -732,7 +732,6 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
 
     CONTINUE_NOT_ALLOWED("BCE3992", "continue.not.allowed"),
     BREAK_NOT_ALLOWED("BCE3993", "break.not.allowed"),
-    TYPE_DOES_NOT_SUPPORT_XML_NAVIGATION_ACCESS("BCE3994", "type.does.not.support.xml.navigation.access"),
     XML_FUNCTION_DOES_NOT_SUPPORT_ARGUMENT_TYPE("BCE3995", "xml.function.does.not.support.argument.type"),
 
     INTERSECTION_NOT_ALLOWED_WITH_TYPE("BCE3996", "intersection.not.allowed.with.type"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -470,12 +470,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         if (xmlNavigation.childIndex != null) {
             checkExpr(xmlNavigation.childIndex, symTable.intType, data);
         }
-        BType exprType = checkExpr(xmlNavigation.expr, symTable.xmlType, data);
-
-        if (Types.getImpliedType(exprType).tag == TypeTags.UNION) {
-            dlog.error(xmlNavigation.pos, DiagnosticErrorCode.TYPE_DOES_NOT_SUPPORT_XML_NAVIGATION_ACCESS,
-                       xmlNavigation.expr.getBType());
-        }
+        checkExpr(xmlNavigation.expr, symTable.xmlType, data);
 
         BType actualType = xmlNavigation.navAccessType == XMLNavigationAccess.NavAccessType.CHILDREN
                 ? symTable.xmlType : symTable.xmlElementSeqType;

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -709,9 +709,6 @@ error.invalid.namespace.declaration=\
 error.cannot.update.xml.sequence=\
   cannot update an xml sequence
 
-error.type.does.not.support.xml.navigation.access=\
-  invalid operation: union type ''{0}'' does not support xml navigation access
-
 error.xml.function.does.not.support.argument.type=\
   xml langlib functions does not support union types as their arguments
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -280,8 +280,8 @@ public class XMLAccessTest {
     }
 
     @Test
-    public void testXMLNavigationWithUnionType() {
-        BRunUtil.invoke(navigation, "testXMLNavigationWithUnionType");
+    public void testXmlNavigationWithUnionType() {
+        BRunUtil.invoke(navigation, "testXmlNavigationWithUnionType");
     }
 
     @Test
@@ -327,6 +327,42 @@ public class XMLAccessTest {
         BAssertUtil.validateError(navigationFilterNegative, index++,
                 "cannot find xml namespace prefix 'foo'", 13, 16);
         Assert.assertEquals(navigationFilterNegative.getErrorCount(), index);
+    }
+
+    @Test
+    void testXmlStepExprWithUnionTypeNegative() {
+        CompileResult navigationStepExprNegative =
+                BCompileUtil.compile("test-src/types/xml/xml_step_expr_negative.bal");
+        int index = 0;
+        BAssertUtil.validateError(navigationStepExprNegative, index++,
+                "incompatible types: expected 'xml', found '(xml<xml:Element>|int)'", 23, 9);
+        BAssertUtil.validateError(navigationStepExprNegative, index++,
+                "incompatible types: expected 'xml', found '(xml<xml:Element>|int)'", 24, 9);
+        BAssertUtil.validateError(navigationStepExprNegative, index++,
+                "incompatible types: expected 'xml', found '(xml:Comment|string)'", 27, 9);
+        BAssertUtil.validateError(navigationStepExprNegative, index++,
+                "incompatible types: expected 'xml', found '(xml:Comment|string)'", 28, 9);
+        BAssertUtil.validateError(navigationStepExprNegative, index++,
+                "incompatible types: expected 'xml', found '(xml:Element|xml:ProcessingInstruction|record {| xml x; " +
+                        "|})'", 31, 9);
+        BAssertUtil.validateError(navigationStepExprNegative, index++,
+                "incompatible types: expected 'xml', found '(xml:Element|xml:ProcessingInstruction|record {| xml x; " +
+                        "|})'", 32, 9);
+        BAssertUtil.validateError(navigationStepExprNegative, index++,
+                "incompatible types: expected 'xml', found '(xml:Text|xml:ProcessingInstruction|boolean)'", 35, 9);
+        BAssertUtil.validateError(navigationStepExprNegative, index++,
+                "incompatible types: expected 'xml', found '(xml:Text|xml:ProcessingInstruction|boolean)'", 36, 9);
+        BAssertUtil.validateError(navigationStepExprNegative, index++,
+                "incompatible types: expected 'xml', found 'XCE'", 39, 9);
+        BAssertUtil.validateError(navigationStepExprNegative, index++,
+                "incompatible types: expected 'xml', found 'XCE'", 40, 9);
+        BAssertUtil.validateError(navigationStepExprNegative, index++,
+                "incompatible types: expected 'xml', found '" +
+                        "(xml<xml:Element>|xml<xml:Comment>|xml<xml:ProcessingInstruction>|xml:Text|int)'", 43, 9);
+        BAssertUtil.validateError(navigationStepExprNegative, index++,
+                "incompatible types: expected 'xml', found '" +
+                        "(xml<xml:Element>|xml<xml:Comment>|xml<xml:ProcessingInstruction>|xml:Text|int)'", 44, 9);
+        Assert.assertEquals(navigationStepExprNegative.getErrorCount(), index);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -280,6 +280,11 @@ public class XMLAccessTest {
     }
 
     @Test
+    public void testXMLNavigationWithUnionType() {
+        BRunUtil.invoke(navigation, "testXMLNavigationWithUnionType");
+    }
+
+    @Test
     public void testXMLNavExpressionNegative() {
         String methodInvocMessage = "method invocations are not yet supported within XML navigation expressions, " +
                 "use a grouping expression (parenthesis) " +

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
@@ -174,7 +174,7 @@ type XC xml:Comment;
 type XE xml:Element;
 type XCE XC|XE;
 
-function testXMLNavigationWithUnionType() {
+function testXmlNavigationWithUnionType() {
     xml<xml:Element>|xml<xml:Comment> x1 = xml `<a><b><c><e>foo</e></c></b><d><g>bar</g></d></a>`;
     assert(x1.<a>, xml `<a><b><c><e>foo</e></c></b><d><g>bar</g></d></a>`);
     assert(x1/*, xml `<b><c><e>foo</e></c></b><d><g>bar</g></d>`);
@@ -202,7 +202,7 @@ function testXMLNavigationWithUnionType() {
     assert(x4/**/<e>, xml ``);
     assert(x4/<f>, xml ``);
 
-    XC|XE x5 = xml `<foo><bar>b</bar></foo>`;
+    XCE x5 = xml `<foo><bar>b</bar></foo>`;
     assert(x5.<foo>, xml `<foo><bar>b</bar></foo>`);
     assert(x5/*, xml `<bar>b</bar>`);
     assert(x5/*.<bar>, xml `<bar>b</bar>`);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
@@ -170,6 +170,34 @@ function testXMLNavigationWithEscapeCharacter() {
     assert(x7, xml `<home-address>some address</home-address>`);
 }
 
+function testXMLNavigationWithUnionType() {
+    xml<'xml:Element>|xml<'xml:Comment> x1 = xml `<a><!-- comment--><b><c><e>foo</e></c></b><d><g>bar</g></d></a>`;
+    assert(x1/*, xml `<!-- comment--><b><c><e>foo</e></c></b><d><g>bar</g></d>`);
+    assert(x1/*.<b>, xml `<b><c><e>foo</e></c></b>`);
+    assert(x1/**/<c>, xml `<c><e>foo</e></c>`);
+    assert((x1/**/<c>)/*.<e>, xml `<e>foo</e>`);
+    assert(x1/<d>, xml `<d><g>bar</g></d>`);
+    assert((x1/<d>)/*.<g>, xml `<g>bar</g>`);
+
+    xml<'xml:Element>|xml<'xml:Comment> x2 = xml `<!-- comment node-->`;
+    assert(x2/*, xml ``);
+    assert(x2/*.<a>, xml ``);
+    assert(x2/**/<a>, xml ``);
+    assert(x2/<b>, xml ``);
+
+    xml<'xml:Element>|xml<'xml:ProcessingInstruction> x3 = xml `<?target data?>`;
+    assert(x3/*, xml ``);
+    assert(x3/*.<b>, xml ``);
+    assert(x3/**/<c>, xml ``);
+    assert(x3/<d>, xml ``);
+
+    xml<'xml:Text>|xml<'xml:ProcessingInstruction> x4 = xml `test xml text`;
+    assert(x4/*, xml ``);
+    assert(x4/*.<d>, xml ``);
+    assert(x4/**/<e>, xml ``);
+    assert(x4/<f>, xml ``);
+}
+
 function assert(anydata actual, anydata expected) {
     if (expected != actual) {
         string reason = "expected `" + expected.toString() + "`, but found `" + actual.toString() + "`";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
@@ -170,7 +170,6 @@ function testXMLNavigationWithEscapeCharacter() {
     assert(x7, xml `<home-address>some address</home-address>`);
 }
 
-
 type XC xml:Comment;
 type XE xml:Element;
 type XCE XC|XE;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
@@ -170,32 +170,50 @@ function testXMLNavigationWithEscapeCharacter() {
     assert(x7, xml `<home-address>some address</home-address>`);
 }
 
+
+type XC xml:Comment;
+type XE xml:Element;
+type XCE XC|XE;
+
 function testXMLNavigationWithUnionType() {
-    xml<'xml:Element>|xml<'xml:Comment> x1 = xml `<a><!-- comment--><b><c><e>foo</e></c></b><d><g>bar</g></d></a>`;
-    assert(x1/*, xml `<!-- comment--><b><c><e>foo</e></c></b><d><g>bar</g></d>`);
+    xml<xml:Element>|xml<xml:Comment> x1 = xml `<a><b><c><e>foo</e></c></b><d><g>bar</g></d></a>`;
+    assert(x1.<a>, xml `<a><b><c><e>foo</e></c></b><d><g>bar</g></d></a>`);
+    assert(x1/*, xml `<b><c><e>foo</e></c></b><d><g>bar</g></d>`);
     assert(x1/*.<b>, xml `<b><c><e>foo</e></c></b>`);
     assert(x1/**/<c>, xml `<c><e>foo</e></c>`);
     assert((x1/**/<c>)/*.<e>, xml `<e>foo</e>`);
     assert(x1/<d>, xml `<d><g>bar</g></d>`);
     assert((x1/<d>)/*.<g>, xml `<g>bar</g>`);
 
-    xml<'xml:Element>|xml<'xml:Comment> x2 = xml `<!-- comment node-->`;
+    xml:Element|xml:Comment x2 = xml `<!-- comment node-->`;
     assert(x2/*, xml ``);
     assert(x2/*.<a>, xml ``);
     assert(x2/**/<a>, xml ``);
     assert(x2/<b>, xml ``);
 
-    xml<'xml:Element>|xml<'xml:ProcessingInstruction> x3 = xml `<?target data?>`;
+    xml:Element|xml:ProcessingInstruction x3 = xml `<?target data?>`;
     assert(x3/*, xml ``);
     assert(x3/*.<b>, xml ``);
     assert(x3/**/<c>, xml ``);
     assert(x3/<d>, xml ``);
 
-    xml<'xml:Text>|xml<'xml:ProcessingInstruction> x4 = xml `test xml text`;
+    xml:Text|xml:ProcessingInstruction x4 = xml `test xml text`;
     assert(x4/*, xml ``);
     assert(x4/*.<d>, xml ``);
     assert(x4/**/<e>, xml ``);
     assert(x4/<f>, xml ``);
+
+    XC|XE x5 = xml `<foo><bar>b</bar></foo>`;
+    assert(x5.<foo>, xml `<foo><bar>b</bar></foo>`);
+    assert(x5/*, xml `<bar>b</bar>`);
+    assert(x5/*.<bar>, xml `<bar>b</bar>`);
+    assert(x5/**/<bar>, xml `<bar>b</bar>`);
+
+    xml<xml:Element>|xml<xml:Comment>|xml<xml:ProcessingInstruction>|xml:Text x6 = xml `<l><m><n></n></m></l>`;
+    assert(x6/*, xml `<m><n></n></m>`);
+    assert(x6/*.<m>, xml `<m><n></n></m>`);
+    assert(x6/**/<n>, xml `<n></n>`);
+    assert(x6/<m>, xml `<m><n></n></m>`);
 }
 
 function assert(anydata actual, anydata expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_step_expr_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_step_expr_negative.bal
@@ -1,0 +1,45 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type XC xml:Comment;
+type XE xml:Element;
+type XCE XC|XE|int;
+
+function testXmlStepExprWithUnionTypeNegative() {
+    xml<xml:Element>|int x1 = xml `<a><b><c><e>foo</e></c></b><d><g>bar</g></d></a>`;
+    _ = x1/*;
+    _ = x1/<d>;
+
+    xml:Comment|string x2 = xml `<!-- comment node-->`;
+    _ = x2/*;
+    _ = x2/*.<a>;
+
+    xml:Element|xml:ProcessingInstruction|record {|xml x;|} x3 = xml `<?target data?>`;
+    _ = x3/*;
+    _ = x3/*.<b>;
+
+    xml:Text|xml:ProcessingInstruction|boolean x4 = xml `test xml text`;
+    _ = x4/*;
+    _ = x4/*.<d>;
+
+    XCE x5 = xml `<foo><bar>b</bar></foo>`;
+    _ = x5/*.<bar>;
+    _ = x5/**/<bar>;
+
+    xml<xml:Element>|xml<xml:Comment>|xml<xml:ProcessingInstruction>|xml:Text|int x6 = xml `<l><m><n></n></m></l>`;
+    _ = x6/*;
+    _ = x6/*.<m>;
+}


### PR DESCRIPTION
## Purpose
Fixes #28692 

## Approach
Remove the check for union type in the TypeChecker for the xml navigation expression, because union type is allowed here in the `checkExpr` call for the `expr` in the navigationExpr guarantee that the expr is of the subtype `xml`.

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
