### PR TITLE
Fix incorrect import CAs provided for expressions with multiple possible imports

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/ImportModuleCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/ImportModuleCodeAction.java
@@ -36,12 +36,14 @@ import org.ballerinalang.langserver.commons.CodeActionContext;
 import org.ballerinalang.langserver.commons.codeaction.spi.DiagBasedPositionDetails;
 import org.ballerinalang.langserver.commons.codeaction.spi.DiagnosticBasedCodeActionProvider;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
+import org.ballerinalang.model.Name;
 import org.ballerinalang.util.diagnostic.DiagnosticErrorCode;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
+import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -79,7 +81,7 @@ public class ImportModuleCodeAction implements DiagnosticBasedCodeActionProvider
         // Find the qualified name reference node within the diagnostic location
         Range diagRange = PositionUtil.toRange(diagnostic.location().lineRange());
         NonTerminalNode node = CommonUtil.findNode(diagRange, context.currentSyntaxTree().get());
-        QNameRefFinder finder = new QNameRefFinder();
+        QNameRefFinder finder = new QNameRefFinder(diagnostic.properties().get(0).value());
         node.accept(finder);
         Optional<QualifiedNameReferenceNode> qNameReferenceNode = finder.getQNameReferenceNode();
         if (qNameReferenceNode.isEmpty()) {
@@ -169,12 +171,25 @@ public class ImportModuleCodeAction implements DiagnosticBasedCodeActionProvider
      * A visitor to find the qualified name reference node within an expression.
      */
     static class QNameRefFinder extends NodeVisitor {
+        private final String moduleName;
+
+        public QNameRefFinder(Object nameObj) {
+            if (nameObj instanceof Name name) {
+                this.moduleName = name.getValue();
+            } else if (nameObj instanceof BLangIdentifier identifier) {
+                this.moduleName = identifier.getValue();
+            } else {
+                this.moduleName = nameObj.toString();
+            }
+        }
 
         private QualifiedNameReferenceNode qualifiedNameReferenceNode;
 
         @Override
         public void visit(QualifiedNameReferenceNode qualifiedNameReferenceNode) {
-            this.qualifiedNameReferenceNode = qualifiedNameReferenceNode;
+            if (qualifiedNameReferenceNode.modulePrefix().text().equals(moduleName)) {
+                this.qualifiedNameReferenceNode = qualifiedNameReferenceNode;
+            }
         }
 
         Optional<QualifiedNameReferenceNode> getQNameReferenceNode() {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ImportModuleCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ImportModuleCodeActionTest.java
@@ -67,7 +67,13 @@ public class ImportModuleCodeActionTest extends AbstractCodeActionTest {
                 {"importModuleWithLicenceHeader1.json"},
                 {"importModuleWithLicenceHeader2.json"},
                 {"importModuleWithIgnoredImport.json"},
-                {"importModuleWithTopLevelComment.json"}
+                {"importModuleWithTopLevelComment.json"},
+                {"importMultipleModules1.json"},
+                {"importMultipleModules2.json"},
+                {"importMultipleModules3.json"},
+                {"importMultipleModules4.json"},
+                {"importMultipleModules5.json"},
+                {"importMultipleModules6.json"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/config/importMultipleModules1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/config/importMultipleModules1.json
@@ -1,0 +1,69 @@
+{
+  "position": {
+    "line": 2,
+    "character": 30
+  },
+  "source": "project/importMultipleModules1.bal",
+  "expected": [
+    {
+      "title": "Import module 'ballerina/lang.array'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.array;\n"
+        }
+      ],
+      "resolvable": false
+    },
+    {
+      "title": "Import module 'project.array'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import project.array;\n"
+        }
+      ],
+      "resolvable": false
+    },
+    {
+      "title": "Import module 'project.module2'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import project.module2;\n"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/config/importMultipleModules2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/config/importMultipleModules2.json
@@ -1,0 +1,69 @@
+{
+  "position": {
+    "line": 6,
+    "character": 32
+  },
+  "source": "project/importMultipleModules1.bal",
+  "expected": [
+    {
+      "title": "Import module 'ballerina/module1'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1;\n"
+        }
+      ],
+      "resolvable": false
+    },
+    {
+      "title": "Import module 'project.module1'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import project.module1;\n"
+        }
+      ],
+      "resolvable": false
+    },
+    {
+      "title": "Import module 'project.module2'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import project.module2;\n"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/config/importMultipleModules3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/config/importMultipleModules3.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 3,
+    "character": 30
+  },
+  "source": "project/importMultipleModules2.bal",
+  "expected": [
+    {
+      "title": "Import module 'project.module2'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 0
+            },
+            "end": {
+              "line": 1,
+              "character": 0
+            }
+          },
+          "newText": "import project.module2;\n"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/config/importMultipleModules4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/config/importMultipleModules4.json
@@ -1,0 +1,49 @@
+{
+  "position": {
+    "line": 3,
+    "character": 30
+  },
+  "source": "project/importMultipleModules3.bal",
+  "expected": [
+    {
+      "title": "Import module 'ballerina/module1'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 0
+            },
+            "end": {
+              "line": 1,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1;\n"
+        }
+      ],
+      "resolvable": false
+    },
+    {
+      "title": "Import module 'project.module1'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 0
+            },
+            "end": {
+              "line": 1,
+              "character": 0
+            }
+          },
+          "newText": "import project.module1;\n"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/config/importMultipleModules5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/config/importMultipleModules5.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 2,
+    "character": 25
+  },
+  "source": "project/importMultipleModules4.bal",
+  "expected": [
+    {
+      "title": "Import module 'project.module2'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import project.module2;\n"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/config/importMultipleModules6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/config/importMultipleModules6.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 3,
+    "character": 25
+  },
+  "source": "project/importMultipleModules4.bal",
+  "expected": [
+    {
+      "title": "Import module 'project.module2'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import project.module2;\n"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/source/project/importMultipleModules1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/source/project/importMultipleModules1.bal
@@ -1,0 +1,8 @@
+
+function testSubModuleWithNoImports() {
+   _ = module2:isIntArray(array:size());
+}
+
+function testExternalModuleWithNoImports() {
+   _ = module2:isIntArray(module1:function1());
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/source/project/importMultipleModules2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/source/project/importMultipleModules2.bal
@@ -1,0 +1,5 @@
+import project.array;
+
+function testSubModuleWithOneImport() {
+   _ = module2:isIntArray(array:size());
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/source/project/importMultipleModules3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/source/project/importMultipleModules3.bal
@@ -1,0 +1,5 @@
+import project.module2;
+
+function testExternalModuleWithOneImport() {
+    _ = module2:isIntArray(module1:function1());
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/source/project/importMultipleModules4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/source/project/importMultipleModules4.bal
@@ -1,0 +1,5 @@
+
+public function testLangLib() {
+    module2:assertEquals(<int:Signed16>3, 3);
+    module2:assertEquals(<string:Char>"x", "x");
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/source/project/modules/module2/mod.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/import-module/source/project/modules/module2/mod.bal
@@ -1,0 +1,5 @@
+public function first(int[] arr) returns int => arr[0];
+
+public function assertEquals(anydata expected, anydata actual) {}
+
+public function isIntArray(any value) returns boolean => value is int[];


### PR DESCRIPTION
## Purpose
The current implementation of the `import module` CA does not account for the module provided in the diagnostic but rather creates the import on the most nested module prefix. Hence, invalid CAs are provided when there are multiple module imports.

Fixes #42086
Fixes #41596

## Approach
The PR modifies the `import module` CA to detect the `QualifiedNameReferenceNode` with the module prefix specified in the diagnostic.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
