### PR TITLE
Fix indexed access on xml union type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -2818,7 +2818,7 @@ public class BIRGen extends BLangNodeVisitor {
             if (astIndexBasedAccessExpr.getKind() == NodeKind.XML_ATTRIBUTE_ACCESS_EXPR) {
                 insKind = InstructionKind.XML_ATTRIBUTE_LOAD;
                 keyRegIndex = getQNameOP(astIndexBasedAccessExpr.indexExpr, keyRegIndex);
-            } else if (TypeTags.isXMLTypeTag(astAccessExprExprType.tag)) {
+            } else if (types.isAssignable(astAccessExprExprType, symTable.xmlType)) {
                 generateXMLAccess((BLangXMLAccessExpr) astIndexBasedAccessExpr, tempVarRef, varRefRegIndex,
                         keyRegIndex);
                 this.varAssignment = variableStore;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
@@ -754,7 +754,7 @@ public class MethodGen {
                 mv.visitFieldInsn(GETFIELD, frameName, localVar.jvmVarName,
                         GET_BSTRING);
                 mv.visitVarInsn(ASTORE, index);
-            } else if (TypeTags.isXMLTypeTag(bType.tag)) {
+            } else if (types.isAssignable(bType, symbolTable.xmlType)) {
                 mv.visitFieldInsn(GETFIELD, frameName, localVar.jvmVarName,
                         GET_XML);
                 mv.visitVarInsn(ASTORE, index);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -6433,7 +6433,7 @@ public class Desugar extends BLangNodeVisitor {
         } else if (types.isSubTypeOfList(varRefType)) {
             targetVarRef = new BLangArrayAccessExpr(indexAccessExpr.pos, indexAccessExpr.expr,
                                                     indexAccessExpr.indexExpr);
-        } else if (TypeTags.isXMLTypeTag(varRefType.tag)) {
+        } else if (types.isAssignable(varRefType, symTable.xmlType)) {
             targetVarRef = new BLangXMLAccessExpr(indexAccessExpr.pos, indexAccessExpr.expr,
                     indexAccessExpr.indexExpr);
         } else if (types.isAssignable(varRefType, symTable.stringType)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -8639,7 +8639,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
             indexBasedAccessExpr.originalType = symTable.charStringType;
             actualType = symTable.charStringType;
-        } else if (TypeTags.isXMLTypeTag(varRefType.tag)) {
+        } else if (types.isAssignable(varRefType, symTable.xmlType)) {
             if (indexBasedAccessExpr.isLValue) {
                 indexExpr.setBType(symTable.semanticError);
                 dlog.error(indexBasedAccessExpr.pos, DiagnosticErrorCode.CANNOT_UPDATE_XML_SEQUENCE);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -260,6 +260,11 @@ public class XMLAccessTest {
     }
 
     @Test
+    public void testInvalidXMLUnionAccessWithNegativeIndex() {
+        BRunUtil.invoke(result, "testInvalidXMLUnionAccessWithNegativeIndex");
+    }
+
+    @Test
     public void testInvalidXMLAccessWithNegativeIndex() {
         BRunUtil.invoke(result, "testInvalidXMLAccessWithNegativeIndex");
     }
@@ -267,6 +272,11 @@ public class XMLAccessTest {
     @Test
     public void testXmlAccessWithLargerIndex() {
         BRunUtil.invoke(result, "testXmlAccessWithLargerIndex");
+    }
+
+    @Test
+    public void testXmlIndexedAccessWithUnionType() {
+        BRunUtil.invoke(result, "testXmlIndexedAccessWithUnionType");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-indexed-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-indexed-access.bal
@@ -451,36 +451,92 @@ type XmlType2 xml<xml:Element|xml:ProcessingInstruction>;
 type XmlType3 XmlType1|XmlType2;
 
 function testXmlIndexedAccessWithUnionType() {
+    xml value;
     xml:Element|xml:Comment x1 = xml `<a>abc</a>`;
-    assert(x1[0], xml `<a>abc</a>`);
-    assert(x1[1], xml ``);
+    value = x1[0];
+    assert(value, xml `<a>abc</a>`);
+    assertTrue(typeof value is typedesc<xml:Element>);
+    value = x1[1];
+    assert(value, xml ``);
+    assertTrue(typeof value is typedesc<xml:Text>);
+
     xml:Element|xml:Text x2 = xml `Hello World`;
-    assert(x2[0], xml `Hello World`);
-    assert(x2[0][1], xml ``);
+    value = x2[0];
+    assert(value, xml `Hello World`);
+    assertTrue(typeof value is typedesc<xml:Text>);
+    value = x2[0][1];
+    assert(value, xml ``);
+    assertTrue(typeof value is typedesc<xml:Text>);
+
     xml:Element|xml:ProcessingInstruction x3 = xml `<?target data?>`;
-    assert(x3[0], xml `<?target data?>`);
-    assert(x3[1][100], xml ``);
+    value = x3[0];
+    assert(value, xml `<?target data?>`);
+    assertTrue(typeof value is typedesc<xml:ProcessingInstruction>);
+    value = x3[1][100];
+    assert(value, xml ``);
+    assertTrue(typeof value is typedesc<xml:Text>);
+
     xml:Element|xml:Comment x4 = xml `<!-- comment node-->`;
-    assert(x4[0], xml `<!-- comment node-->`);
-    assert(x4[50], xml ``);
+    value = x4[0];
+    assert(value, xml `<!-- comment node-->`);
+    assertTrue(typeof value is typedesc<xml:Comment>);
+    value = x4[10];
+    assert(value, xml ``);
+    assertTrue(typeof value is typedesc<xml:Text>);
+
     xml:Text|xml:Comment x5 = xml `<!-- comment node 2 -->`;
-    assert(x5[0], xml `<!-- comment node 2 -->`);
+    value = x5[0];
+    assert(value, xml `<!-- comment node 2 -->`);
+    assertTrue(typeof value is typedesc<xml:Comment>);
+
     xml:ProcessingInstruction|xml:Comment x6 = xml `<?target test?>`;
-    assert(x6[0], xml `<?target test?>`);
+    value = x6[0];
+    assert(value, xml `<?target test?>`);
+    assertTrue(typeof value is typedesc<xml:ProcessingInstruction>);
+
     xml:ProcessingInstruction|xml:Text x7 = xml `Test Text`;
-    assert(x7[0], xml `Test Text`);
+    value = x7[0];
+    assert(value, xml `Test Text`);
+    assertTrue(typeof value is typedesc<xml:Text>);
+
     xml|xml:Comment x8 = xml `<a>abc</a><b>def</b>`;
-    assert(x8[0], xml `<a>abc</a>`);
+    value = x8[0];
+    assert(value, xml `<a>abc</a>`);
+    assertTrue(typeof value is typedesc<xml:Element>);
+
     xml|xml x9 = xml `<c>ghi</c><d>jkl</d>`;
-    assert(x9[0], xml `<c>ghi</c>`);
+    value = x9[0];
+    assert(value, xml `<c>ghi</c>`);
+    assertTrue(typeof value is typedesc<xml:Element>);
+
     xml<xml:Text|xml:Comment>|xml<xml:ProcessingInstruction|xml:Element> x10 = xml `<name>Dan Brown</name>`;
-    assert(x10[0], xml `<name>Dan Brown</name>`);
-    assert(x10[50], xml ``);
+    value = x10[0];
+    assert(value, xml `<name>Dan Brown</name>`);
+    assertTrue(typeof value is typedesc<xml:Element>);
+    value = x10[1];
+    assert(value, xml ``);
+    assertTrue(typeof value is typedesc<xml:Text>);
+
     XmlType1 x11 = xml `Hello!`;
-    assert(x11[0], xml `Hello!`);
-    XmlType3 x12 = xml `<name>Sherlock Holmes</name>`;
-    assert(x12[0], xml `<name>Sherlock Holmes</name>`);
-    assert(x12[50][1], xml ``);
+    value = x11[0];
+    assert(value, xml `Hello!`);
+    assertTrue(typeof value is typedesc<xml:Text>);
+
+    XmlType2 x12 = xml `<name>Sherlock Holmes</name><work>Detective</work>`;
+    value = x12[0];
+    assert(value, xml `<name>Sherlock Holmes</name>`);
+    assertTrue(typeof value is typedesc<xml:Element>);
+    value = x12[1];
+    assert(value, xml `<work>Detective</work>`);
+    assertTrue(typeof value is typedesc<xml:Element>);
+
+    XmlType3 x13 = xml `<name>Sherlock Holmes</name>`;
+    value = x13[0];
+    assert(value, xml `<name>Sherlock Holmes</name>`);
+    assertTrue(typeof value is typedesc<xml:Element>);
+    value = x13[50][1];
+    assert(value, xml ``);
+    assertTrue(typeof value is typedesc<xml:Text>);
 }
 
 function testInvalidXMLUnionAccessWithNegativeIndex() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-indexed-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-indexed-access.bal
@@ -444,6 +444,94 @@ function testXmlAccessWithLargerIndex() {
     assert(xmlValue, xml ``);
 }
 
+type XmlType1 xml:Text|xml:Comment;
+
+type XmlType2 xml<xml:Element|xml:ProcessingInstruction>;
+
+type XmlType3 XmlType1|XmlType2;
+
+function testXmlIndexedAccessWithUnionType() {
+    xml:Element|xml:Comment x1 = xml `<a>abc</a>`;
+    assert(x1[0], xml `<a>abc</a>`);
+    assert(x1[1], xml ``);
+    xml:Element|xml:Text x2 = xml `Hello World`;
+    assert(x2[0], xml `Hello World`);
+    assert(x2[0][1], xml ``);
+    xml:Element|xml:ProcessingInstruction x3 = xml `<?target data?>`;
+    assert(x3[0], xml `<?target data?>`);
+    assert(x3[1][100], xml ``);
+    xml:Element|xml:Comment x4 = xml `<!-- comment node-->`;
+    assert(x4[0], xml `<!-- comment node-->`);
+    assert(x4[50], xml ``);
+    xml:Text|xml:Comment x5 = xml `<!-- comment node 2 -->`;
+    assert(x5[0], xml `<!-- comment node 2 -->`);
+    xml:ProcessingInstruction|xml:Comment x6 = xml `<?target test?>`;
+    assert(x6[0], xml `<?target test?>`);
+    xml:ProcessingInstruction|xml:Text x7 = xml `Test Text`;
+    assert(x7[0], xml `Test Text`);
+    xml|xml:Comment x8 = xml `<a>abc</a><b>def</b>`;
+    assert(x8[0], xml `<a>abc</a>`);
+    xml|xml x9 = xml `<c>ghi</c><d>jkl</d>`;
+    assert(x9[0], xml `<c>ghi</c>`);
+    xml<xml:Text|xml:Comment>|xml<xml:ProcessingInstruction|xml:Element> x10 = xml `<name>Dan Brown</name>`;
+    assert(x10[0], xml `<name>Dan Brown</name>`);
+    assert(x10[50], xml ``);
+    XmlType1 x11 = xml `Hello!`;
+    assert(x11[0], xml `Hello!`);
+    XmlType3 x12 = xml `<name>Sherlock Holmes</name>`;
+    assert(x12[0], xml `<name>Sherlock Holmes</name>`);
+    assert(x12[50][1], xml ``);
+}
+
+function testInvalidXMLUnionAccessWithNegativeIndex() {
+    int a = -1;
+    xml:Element|xml:Comment x1 = xml `<a>abc</a>`;
+    string errorMessage = "xml sequence index out of range. Length: '1' requested: '-1'";
+
+    xml|error e = trap x1[-1];
+    assertTrue(e is error);
+    assert((<error> e).message(), errorMessage);
+    e = trap x1[a];
+    assertTrue(e is error);
+    assert((<error> e).message(), errorMessage);
+    e = trap x1[i];
+    assertTrue(e is error);
+    assert((<error> e).message(), errorMessage);
+
+    xml<xml:Text|xml:Comment>|xml<xml:ProcessingInstruction|xml:Element> x2 = xml `<name>Dan Brown</name>`;
+    e = trap x2[-1];
+    assertTrue(e is error);
+    assert((<error> e).message(), errorMessage);
+    e = trap x2[a];
+    assertTrue(e is error);
+    assert((<error> e).message(), errorMessage);
+    e = trap x2[i];
+    assertTrue(e is error);
+    assert((<error> e).message(), errorMessage);
+
+    XmlType1 x3 = xml `Hello!`;
+    e = trap x3[-1];
+    assertTrue(e is error);
+    assert((<error> e).message(), errorMessage);
+    e = trap x3[a];
+    assertTrue(e is error);
+    assert((<error> e).message(), errorMessage);
+    e = trap x3[i];
+    assertTrue(e is error);
+    assert((<error> e).message(), errorMessage);
+
+    XmlType3 x4 = xml `<name>Sherlock Holmes</name>`;
+    e = trap x4[-1];
+    assertTrue(e is error);
+    assert((<error> e).message(), errorMessage);
+    e = trap x4[a];
+    assertTrue(e is error);
+    assert((<error> e).message(), errorMessage);
+    e = trap x4[i];
+    assertTrue(e is error);
+    assert((<error> e).message(), errorMessage);
+}
+
 function assert(anydata actual, anydata expected) {
     if (expected != actual) {
         typedesc<anydata> expT = typeof expected;


### PR DESCRIPTION
## Purpose
Fixes #35008 

## Approach
Use `isAssignable` check to allow xml union types instead of checking using the xml type tag which does not cover union types.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
