### PR TITLE
Remove the `function must return a result` diagnostic after unreachable code

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/reachability/ReachabilityAnalysisTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/reachability/ReachabilityAnalysisTest.java
@@ -221,7 +221,6 @@ public class ReachabilityAnalysisTest {
         validateHint(result, i++, HINT_UNNECESSARY_CONDITION, 268, 16);
         validateHint(result, i++, HINT_UNNECESSARY_CONDITION, 285, 12);
         validateError(result, i++, ERROR_UNREACHABLE_CODE, 289, 5);
-        validateError(result, i++, ERROR_MUST_RETURN_A_RESULT, 290, 1);
         validateError(result, i++, ERROR_UNREACHABLE_CODE, 294, 5);
         validateHint(result, i++, HINT_UNNECESSARY_CONDITION, 307, 12);
         validateError(result, i++, ERROR_UNREACHABLE_CODE, 311, 9);
@@ -653,7 +652,23 @@ public class ReachabilityAnalysisTest {
         validateError(result, i++, ERROR_UNREACHABLE_CODE, 1142, 17);
         validateHint(result, i++, ALWAYS_FALSE_CONDITION, 1152, 19);
         validateError(result, i++, ERROR_UNREACHABLE_CODE, 1153, 17);
-        
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1205, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1218, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1227, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1240, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1256, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1272, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1280, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1295, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1306, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1314, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1327, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1335, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1355, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1363, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1376, 5);
+        validateError(result, i++, ERROR_UNREACHABLE_CODE, 1387, 5);
+
         Assert.assertEquals(result.getErrorCount(), i - 24);
         Assert.assertEquals(result.getHintCount(), 24);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/dostatement/DoStmtsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/dostatement/DoStmtsTest.java
@@ -67,7 +67,6 @@ public class DoStmtsTest {
         BAssertUtil.validateWarning(negativeRes, index++, "unused variable 'e'", 57, 12);
         BAssertUtil.validateError(negativeRes, index++, "unreachable code", 60, 7);
         BAssertUtil.validateError(negativeRes, index++, "unreachable code", 72, 3);
-        BAssertUtil.validateError(negativeRes, index++, "this function must return a result", 73, 1);
         Assert.assertEquals(negativeRes.getDiagnostics().length, index);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/reachability-analysis/unreachability_test2.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/reachability-analysis/unreachability_test2.bal
@@ -1194,6 +1194,200 @@ function testUnreachabilityInsideMatchBlockWithWhileStmt() {
 
 // }
 
+function testUnreachabilityAfterTerminatedIfBlock1(int a) returns int {
+    if a > 10 {
+        return a + 1;
+    } else if a > 12 {
+        return a - 1;
+    } else {
+        return -a;
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedIfBlock2(int a) returns int {
+    if a > 10 {
+        if a > 12 {
+            return a;
+        }
+        return a - 1;
+    } else {
+        return -a;
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedIfBlock3(int a) returns int {
+    if a > 10 {
+        return a;
+    }
+    return -a;
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedMatchBlock1(int a) returns int {
+    match a {
+        1 => {
+            return a + 1;
+        }
+        _ => {
+            return a - 1;
+        }
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedMatchBlock2(int a) returns int {
+    match a {
+        var x if a > 10 => {
+            if x % 2 == 0 {
+                return a * 2;
+            }
+            return x + 1;
+        }
+        _ => {
+            return a - 1;
+        }
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedMatchBlock3(int a) returns int {
+    match a {
+        2|3 => {
+            check functionReturnsNilOrError();
+            return a + 1;
+        }
+        _ => {
+            return a - 1;
+        }
+    } on fail {
+    	return -1;
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedDoBlock1() returns int {
+    do {
+        return 10;
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedDoBlock2(int a) returns int {
+    do {
+        if a > 10 {
+            if a > 12 {
+                return a + 1;
+            }
+            return a - 1;
+        } else {
+            return -a;
+        }
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedDoBlock3(int a) returns int {
+    do {
+        check functionReturnsNilOrError();
+        return 10;
+    } on fail {
+        return -1;
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedWhileBlock1() returns int {
+    while true {
+        
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedWhileBlock2() returns int {
+    while true {
+        int|string a = 12;
+        if a is int {
+            return -1;
+        }
+        string _ = a;
+        panic error("Error");
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedLockBlock1(int a) returns int {
+    lock {
+        return 1;
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedLockBlock2(int a) returns int {
+    lock {
+        do {
+            if a > 10 {
+                if a > 12 {
+                    check functionReturnsNilOrError();
+                    return 10;
+                }
+                return a - 1;
+            } else {
+                return -a;
+            }
+        } on fail {
+            return -1;
+        }
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedBlock1() returns int {
+    {
+        return 1;
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedBlock2() returns int {
+    {
+        int|string a = 12;
+        if a is int {
+            return -1;
+        }
+        string _ = a;
+        panic error("Error");
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
+function testUnreachabilityAfterTerminatedBlock3(int a) returns int {
+    if a > 10 {
+        return a;
+    }
+    {
+        return -a;
+    }
+    int _ = 1; // unreachable code
+    int _ = 2;
+}
+
 function trapFuc() returns never {
     panic error("Timeout");
 }


### PR DESCRIPTION
## Purpose
The current implementation produces the diagnostic `function must return a result` after unreachable code, which is not useful for the context. The analyzer should consider such scenarios and opt out from generating such diagnostics.

Fixes #41000 

## Approach
The PR introduces two new state variables to the `AnalyzerData` in the `ReachabilityAnalyzer` class: `hasFunctionTerminated`, which determines if the function has already terminated, and `isBlockUnreachable` to check if the given block has unreachable statements at a given state.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
