### PR TITLE
[2201.8.x] Exclude cli and picocli from childfirst loading in CustomToolClassLoader

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/launcher/CustomToolClassLoader.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/launcher/CustomToolClassLoader.java
@@ -46,8 +46,13 @@ public class CustomToolClassLoader extends URLClassLoader {
         Class<?> loadedClass = findLoadedClass(name);
         if (loadedClass == null) {
             try {
-                // First, try to load the class from the URLs
-                loadedClass = findClass(name);
+                // Load from parent if cli or picocli classes. This is to avoid SPI and class loading issues
+                if (name.startsWith("io.ballerina.cli") || name.startsWith("picocli")) {
+                    loadedClass = super.loadClass(name, resolve);
+                } else {
+                    // First, try to load the class from the URLs
+                    loadedClass = findClass(name);
+                }
             } catch (ClassNotFoundException e) {
                 try {
                     // If not found, delegate to the parent


### PR DESCRIPTION
## Purpose
8.x PR of https://github.com/ballerina-platform/ballerina-lang/pull/42161

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
