### PR TITLE
Expose options toml node locations in ToolContext for build tools

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/buildtools/CodeGeneratorTool.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/buildtools/CodeGeneratorTool.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package io.ballerina.projects.buildtools;
 
 /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/buildtools/ToolContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/buildtools/ToolContext.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -20,6 +20,8 @@ package io.ballerina.projects.buildtools;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.PackageManifest;
 import io.ballerina.toml.semantic.ast.TomlTableNode;
+import io.ballerina.toml.semantic.ast.TopLevelNode;
+import io.ballerina.toml.semantic.diagnostics.TomlNodeLocation;
 import io.ballerina.tools.diagnostics.Diagnostic;
 
 import java.nio.file.Path;
@@ -43,7 +45,7 @@ public class ToolContext {
     private final String toolId;
     private final String filePath;
     private final String targetModule;
-    private final Map<String, Object> options;
+    private final Map<String, Option> options;
     private final List<Diagnostic> diagnostics = new ArrayList<>();
 
     ToolContext(Package currentPackage, String toolId, String filePath,
@@ -93,7 +95,7 @@ public class ToolContext {
      *
      * @return a map of the optional tool configurations.
      */
-    public Map<String, Object> options() {
+    public Map<String, Option> options() {
         return this.options;
     }
 
@@ -148,15 +150,48 @@ public class ToolContext {
         diagnostics.add(diagnostic);
     }
 
-    private Map<String, Object> getOptions(TomlTableNode optionsTable) {
-        Map<String, Object> options = new HashMap<>();
+    private Map<String, Option> getOptions(TomlTableNode optionsTable) {
+        Map<String, Option> options = new HashMap<>();
         if (null == optionsTable) {
             return options;
         }
         for (String option: optionsTable.entries().keySet()) {
-            options.put(option, optionsTable.entries().get(option).toNativeObject());
+            options.put(option, new Option(optionsTable.entries().get(option)));
         }
         return options;
+    }
+
+    /**
+     * Represents a single option Toml node in Ballerina.toml file.
+     *
+     * @since 2201.9.0
+     */
+    public static class Option {
+        private final Object value;
+        private final TomlNodeLocation location;
+
+        public Option(TopLevelNode optionNode) {
+            this.value = optionNode.toNativeObject();
+            this.location = optionNode.location();
+        }
+
+        /**
+         * Returns the value of the option.
+         *
+         * @return the option value.
+         */
+        public Object value() {
+            return value;
+        }
+
+        /**
+         * Returns the location of the option node in Ballerina.toml.
+         *
+         * @return the option location.
+         */
+        public TomlNodeLocation location() {
+            return location;
+        }
     }
 }
 


### PR DESCRIPTION
## Purpose
> With a recent change, the optional build tool configurations provided in `Ballerina.toml` were exposed to the tool developer as a `Map<String, Object>`. But this does not allow the developer to access the location of the option toml nodes.

Addresses the limitation mentioned in https://github.com/ballerina-platform/ballerina-library/issues/4932#issuecomment-1945716859

## Approach
> Tool developer will be provided with a `Map<String, Option>` where `Option` will contain both the option value and its toml node location.
Check https://github.com/ShammiL/sample-build-tool for usage examples

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
