### PR TITLE
Fix XML navigation result when namespace is declared in a statement after the the expression 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -8308,25 +8308,16 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private ArrayList<BLangExpression> expandFilters(List<BLangXMLElementFilter> filters) {
-        Map<Name, BXMLNSSymbol> nameBXMLNSSymbolMap = symResolver.resolveAllNamespaces(env);
-        BXMLNSSymbol defaultNSSymbol = nameBXMLNSSymbolMap.get(names.fromString(XMLConstants.DEFAULT_NS_PREFIX));
-        String defaultNS = defaultNSSymbol != null ? defaultNSSymbol.namespaceURI : null;
-
         ArrayList<BLangExpression> args = new ArrayList<>();
         for (BLangXMLElementFilter filter : filters) {
-            BSymbol nsSymbol = symResolver.lookupSymbolInPrefixSpace(env, names.fromString(filter.namespace));
-            if (nsSymbol == symTable.notFoundSymbol) {
-                if (defaultNS != null && !filter.name.equals("*")) {
-                    String expandedName = createExpandedQName(defaultNS, filter.name);
-                    args.add(createStringLiteral(filter.elemNamePos, expandedName));
-                } else {
-                    args.add(createStringLiteral(filter.elemNamePos, filter.name));
-                }
+            BSymbol nsSymbol = filter.namespaceSymbol;
+            String filterName = filter.name;
+            if (nsSymbol != null &&
+                    !(filter.namespace.equals(XMLConstants.DEFAULT_NS_PREFIX) && filterName.equals("*"))) {
+                String expandedName = createExpandedQName(((BXMLNSSymbol) nsSymbol).namespaceURI, filterName);
+                args.add(createStringLiteral(filter.elemNamePos, expandedName));
             } else {
-                BXMLNSSymbol bxmlnsSymbol = (BXMLNSSymbol) nsSymbol;
-                String expandedName = createExpandedQName(bxmlnsSymbol.namespaceURI, filter.name);
-                BLangLiteral stringLiteral = createStringLiteral(filter.elemNamePos, expandedName);
-                args.add(stringLiteral);
+                args.add(createStringLiteral(filter.elemNamePos, filterName));
             }
         }
         return args;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -486,7 +486,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
     private void checkXMLNamespacePrefixes(List<BLangXMLElementFilter> filters, AnalyzerData data) {
         Map<Name, BXMLNSSymbol> nameBXMLNSSymbolMap = symResolver.resolveAllNamespaces(data.env);
         BXMLNSSymbol defaultNSSymbol = nameBXMLNSSymbolMap.get(Names.fromString(XMLConstants.DEFAULT_NS_PREFIX));
-
+        boolean hasDefaultNS = defaultNSSymbol != null;
         for (BLangXMLElementFilter filter : filters) {
             String namespace = filter.namespace;
             if (!namespace.isEmpty()) {
@@ -496,7 +496,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     dlog.error(filter.nsPos, DiagnosticErrorCode.CANNOT_FIND_XML_NAMESPACE, nsName);
                 }
                 filter.namespaceSymbol = nsSymbol;
-            } else {
+            } else if (hasDefaultNS) {
                 filter.namespaceSymbol = defaultNSSymbol;
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -484,14 +484,20 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
     }
 
     private void checkXMLNamespacePrefixes(List<BLangXMLElementFilter> filters, AnalyzerData data) {
+        Map<Name, BXMLNSSymbol> nameBXMLNSSymbolMap = symResolver.resolveAllNamespaces(data.env);
+        BXMLNSSymbol defaultNSSymbol = nameBXMLNSSymbolMap.get(names.fromString(XMLConstants.DEFAULT_NS_PREFIX));
+
         for (BLangXMLElementFilter filter : filters) {
-            if (!filter.namespace.isEmpty()) {
-                Name nsName = names.fromString(filter.namespace);
-                BSymbol nsSymbol = symResolver.lookupSymbolInPrefixSpace(data.env, nsName);
-                filter.namespaceSymbol = nsSymbol;
-                if (nsSymbol.getKind() != SymbolKind.XMLNS) {
+            String namespace = filter.namespace;
+            if (!namespace.isEmpty()) {
+                Name nsName = names.fromString(namespace);
+                BXMLNSSymbol nsSymbol = nameBXMLNSSymbolMap.get(nsName);
+                if (nsSymbol == null) {
                     dlog.error(filter.nsPos, DiagnosticErrorCode.CANNOT_FIND_XML_NAMESPACE, nsName);
                 }
+                filter.namespaceSymbol = nsSymbol;
+            } else {
+                filter.namespaceSymbol = defaultNSSymbol;
             }
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -485,12 +485,12 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
     private void checkXMLNamespacePrefixes(List<BLangXMLElementFilter> filters, AnalyzerData data) {
         Map<Name, BXMLNSSymbol> nameBXMLNSSymbolMap = symResolver.resolveAllNamespaces(data.env);
-        BXMLNSSymbol defaultNSSymbol = nameBXMLNSSymbolMap.get(names.fromString(XMLConstants.DEFAULT_NS_PREFIX));
+        BXMLNSSymbol defaultNSSymbol = nameBXMLNSSymbolMap.get(Names.fromString(XMLConstants.DEFAULT_NS_PREFIX));
 
         for (BLangXMLElementFilter filter : filters) {
             String namespace = filter.namespace;
             if (!namespace.isEmpty()) {
-                Name nsName = names.fromString(namespace);
+                Name nsName = Names.fromString(namespace);
                 BXMLNSSymbol nsSymbol = nameBXMLNSSymbolMap.get(nsName);
                 if (nsSymbol == null) {
                     dlog.error(filter.nsPos, DiagnosticErrorCode.CANNOT_FIND_XML_NAMESPACE, nsName);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -284,8 +284,8 @@ public class XMLAccessTest {
     }
 
     @Test
-    public void testXmlNavigationWithDefaultNamespaceDefinedLater() {
-        BRunUtil.invoke(navigation, "testXmlNavigationWithDefaultNamespaceDefinedLater");
+    public void testXmlNavigationWithDefaultNamespaceDefinedAfter() {
+        BRunUtil.invoke(navigation, "testXmlNavigationWithDefaultNamespaceDefinedAfter");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -163,9 +163,8 @@ public class XMLAccessTest {
                 "<child xmlns=\"foo\">A</child><child xmlns=\"foo\" xmlns:ns=\"foo\">B</child><k:child xmlns=\"foo\" " +
                         "xmlns:k=\"bar\">C</k:child><it-child xmlns=\"foo\">D</it-child>TEXT");
         Assert.assertEquals(returns.get(2).toString(),
-                "<child xmlns=\"foo\">A</child>" +
-                        "<child xmlns=\"foo\" xmlns:ns=\"foo\">B</child>" +
-                        "<it-child xmlns=\"foo\">D</it-child>");
+                "<child xmlns=\"foo\">A</child><child xmlns=\"foo\" xmlns:ns=\"foo\">B</child><k:child xmlns=\"foo\" " +
+                        "xmlns:k=\"bar\">C</k:child><it-child xmlns=\"foo\">D</it-child>");
         Assert.assertEquals(returns.get(3).toString(),
                 "<child xmlns=\"foo\">A</child><child xmlns=\"foo\" xmlns:ns=\"foo\">B</child>");
         Assert.assertEquals(returns.get(4).toString(),
@@ -180,8 +179,8 @@ public class XMLAccessTest {
                 "<child xmlns=\"foo\">A</child><child xmlns=\"foo\" xmlns:ns=\"foo\">B</child>" +
                         "<child2 xmlns=\"foo\">D</child2>");
         Assert.assertEquals(returns.get(2).toString(),
-                "<child xmlns=\"foo\">A</child><child xmlns=\"foo\" xmlns:ns=\"foo\">B</child>" +
-                        "<child2 xmlns=\"foo\">D</child2>");
+                "<child xmlns=\"foo\">A</child><child xmlns=\"foo\" xmlns:ns=\"foo\">B</child><k:child xmlns=\"foo\" " +
+                        "xmlns:k=\"bar\">C</k:child><child2 xmlns=\"foo\">D</child2>");
         Assert.assertEquals(returns.get(3).toString(),
                 "<child xmlns=\"foo\">A</child><child xmlns=\"foo\" xmlns:ns=\"foo\">B</child><k:child xmlns=\"foo\" " +
                         "xmlns:k=\"bar\">C</k:child><child2 xmlns=\"foo\">D</child2>");
@@ -282,6 +281,11 @@ public class XMLAccessTest {
     @Test
     public void testXmlNavigationWithUnionType() {
         BRunUtil.invoke(navigation, "testXmlNavigationWithUnionType");
+    }
+
+    @Test
+    public void testXmlNavigationWithDefaultNamespaceDefinedLater() {
+        BRunUtil.invoke(navigation, "testXmlNavigationWithDefaultNamespaceDefinedLater");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
@@ -216,22 +216,28 @@ function testXmlNavigationWithUnionType() {
 }
 
 function testXmlNavigationWithDefaultNamespaceDefinedLater() {
+    xml[] results = [];
     xml x1 = xml `<a>a<b>b<c>c</c></b><d>d</d></a><f/>`;
-
-    assert((x1.<a>).toString(), "<a>a<b>b<c>c</c></b><d>d</d></a>");
-    assert((x1/*).toString(), "a<b>b<c>c</c></b><d>d</d>");
-    assert((x1/<b>).toString(), "<b>b<c>c</c></b>");
-    assert((x1/<*>).toString(), "<b>b<c>c</c></b><d>d</d>");
-    assert((x1/**/<c>).toString(), "<c>c</c>");
+    results.push(x1.<a>, (x1/*), (x1/<b>), (x1/<*>), (x1/**/<c>));
 
     xml x2 = xml `<e>e<f><g>f</g></f><h>h</h></e><j/>`;
     xmlns "http://example.com/";
+    results.push(x2.<e>, (x2/*), (x2/<f>), (x2/<*>), (x2/**/<g>));
 
-    assert((x2.<e>).toString(), "");
-    assert((x2/*).toString(), "e<f><g>f</g></f><h>h</h>");
-    assert((x2/<f>).toString(), "");
-    assert((x2/<*>).toString(), "<f><g>f</g></f><h>h</h>");
-    assert((x2/**/<g>).toString(), "");
+    assertXmlNavigationWithDefaultNamespaceDefinedLater(results);
+}
+
+function assertXmlNavigationWithDefaultNamespaceDefinedLater(xml[] results) {
+    assert(results[0], xml `<a>a<b>b<c>c</c></b><d>d</d></a>`);
+    assert(results[1], xml `a<b>b<c>c</c></b><d>d</d>`);
+    assert(results[2], xml `<b>b<c>c</c></b>`);
+    assert(results[3], xml `<b>b<c>c</c></b><d>d</d>`);
+    assert(results[4], xml `<c>c</c>`);
+    assert(results[5], xml ``);
+    assert(results[6], xml `e<f><g>f</g></f><h>h</h>`);
+    assert(results[7], xml ``);
+    assert(results[8], xml `<f><g>f</g></f><h>h</h>`);
+    assert(results[9], xml ``);
 }
 
 function assert(anydata actual, anydata expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
@@ -218,28 +218,41 @@ function testXmlNavigationWithUnionType() {
 function testXmlNavigationWithDefaultNamespaceDefinedAfter() {
     xml[] results = [];
     xml x1 = xml `<a>a<b>b<c>c</c></b><d>d</d></a><f/>`;
-    results.push(x1.<a>, (x1/*), (x1/<b>), (x1/<*>), (x1/**/<c>));
+    results[0] = x1.<a>;
+    results[1] = x1/*;
+    results[2] = x1/<b>;
+    results[3] = x1/<*>;
+    results[4] = x1/**/<c>;
 
     xmlns "http://example2.com/" as p1;
     xml x2 = xml `<l>l<m>m<n>n</n></m><p1:q>q1</p1:q><q>q2</q></l>`;
     {
         xmlns "http://example2.com/";
     }
-    results.push(x2.<l>, (x2/<m>), (x2/<q>), (x2/**/<n>));
+    results[5] = x2.<l>;
+    results[6] = x2/<m>;
+    results[7] = x2/<q>;
+    results[8] = x2/**/<n>;
 
     {
         xmlns "http://example2.com/";
         {
-            results.push(x2.<l>, (x2/<q>));
+            results[9] = x2.<l>;
+            results[10] = x2/<q>;
         }
     }
     xmlns "http://example.com/" as p2;
     xml x3 = xml `<e>no-ns</e><f/><p2:e>with-ns</p2:e>`;
-    results.push(x3.<e>);
+    results[11] = x3.<e>;
 
     xml x4 = xml `<e>e<f><g>f</g></f><h>h</h></e><j/>`;
     xmlns "http://example.com/";
-    results.push(x3.<e>, x4.<e>, (x4/*), (x4/<f>), (x4/<*>), (x4/**/<g>));
+    results[12] = x3.<e>;
+    results[13] = x4.<e>;
+    results[14] = x4/*;
+    results[15] = x4/<f>;
+    results[16] = x4/<*>;
+    results[17] = x4/**/<g>;
 
     assertXmlNavigationWithDefaultNamespaceDefinedAfter(results);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
@@ -215,29 +215,54 @@ function testXmlNavigationWithUnionType() {
     assert(x6/<m>, xml `<m><n></n></m>`);
 }
 
-function testXmlNavigationWithDefaultNamespaceDefinedLater() {
+function testXmlNavigationWithDefaultNamespaceDefinedAfter() {
     xml[] results = [];
     xml x1 = xml `<a>a<b>b<c>c</c></b><d>d</d></a><f/>`;
     results.push(x1.<a>, (x1/*), (x1/<b>), (x1/<*>), (x1/**/<c>));
 
-    xml x2 = xml `<e>e<f><g>f</g></f><h>h</h></e><j/>`;
-    xmlns "http://example.com/";
-    results.push(x2.<e>, (x2/*), (x2/<f>), (x2/<*>), (x2/**/<g>));
+    xmlns "http://example2.com/" as p1;
+    xml x2 = xml `<l>l<m>m<n>n</n></m><p1:q>q1</p1:q><q>q2</q></l>`;
+    {
+        xmlns "http://example2.com/";
+    }
+    results.push(x2.<l>, (x2/<m>), (x2/<q>), (x2/**/<n>));
 
-    assertXmlNavigationWithDefaultNamespaceDefinedLater(results);
+    {
+        xmlns "http://example2.com/";
+        {
+            results.push(x2.<l>, (x2/<q>));
+        }
+    }
+    xmlns "http://example.com/" as p2;
+    xml x3 = xml `<e>no-ns</e><f/><p2:e>with-ns</p2:e>`;
+    results.push(x3.<e>);
+
+    xml x4 = xml `<e>e<f><g>f</g></f><h>h</h></e><j/>`;
+    xmlns "http://example.com/";
+    results.push(x3.<e>, x4.<e>, (x4/*), (x4/<f>), (x4/<*>), (x4/**/<g>));
+
+    assertXmlNavigationWithDefaultNamespaceDefinedAfter(results);
 }
 
-function assertXmlNavigationWithDefaultNamespaceDefinedLater(xml[] results) {
+function assertXmlNavigationWithDefaultNamespaceDefinedAfter(xml[] results) {
     assert(results[0], xml `<a>a<b>b<c>c</c></b><d>d</d></a>`);
     assert(results[1], xml `a<b>b<c>c</c></b><d>d</d>`);
     assert(results[2], xml `<b>b<c>c</c></b>`);
     assert(results[3], xml `<b>b<c>c</c></b><d>d</d>`);
     assert(results[4], xml `<c>c</c>`);
-    assert(results[5], xml ``);
-    assert(results[6], xml `e<f><g>f</g></f><h>h</h>`);
-    assert(results[7], xml ``);
-    assert(results[8], xml `<f><g>f</g></f><h>h</h>`);
+    assert(results[5], xml `<l>l<m>m<n>n</n></m><p1:q xmlns:p1="http://example2.com/">q1</p1:q><q>q2</q></l>`);
+    assert(results[6], xml `<m>m<n>n</n></m>`);
+    assert(results[7], xml `<q>q2</q>`);
+    assert(results[8], xml `<n>n</n>`);
     assert(results[9], xml ``);
+    assert(results[10], xml `<p1:q xmlns:p1="http://example2.com/">q1</p1:q>`);
+    assert(results[11], xml `<e>no-ns</e>`);
+    assert(results[12], xml `<p2:e xmlns:p2="http://example.com/">with-ns</p2:e>`);
+    assert(results[13], xml ``);
+    assert(results[14], xml `e<f><g>f</g></f><h>h</h>`);
+    assert(results[15], xml ``);
+    assert(results[16], xml `<f><g>f</g></f><h>h</h>`);
+    assert(results[17], xml ``);
 }
 
 function assert(anydata actual, anydata expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
@@ -215,6 +215,25 @@ function testXmlNavigationWithUnionType() {
     assert(x6/<m>, xml `<m><n></n></m>`);
 }
 
+function testXmlNavigationWithDefaultNamespaceDefinedLater() {
+    xml x1 = xml `<a>a<b>b<c>c</c></b><d>d</d></a><f/>`;
+
+    assert((x1.<a>).toString(), "<a>a<b>b<c>c</c></b><d>d</d></a>");
+    assert((x1/*).toString(), "a<b>b<c>c</c></b><d>d</d>");
+    assert((x1/<b>).toString(), "<b>b<c>c</c></b>");
+    assert((x1/<*>).toString(), "<b>b<c>c</c></b><d>d</d>");
+    assert((x1/**/<c>).toString(), "<c>c</c>");
+
+    xml x2 = xml `<e>e<f><g>f</g></f><h>h</h></e><j/>`;
+    xmlns "http://example.com/";
+
+    assert((x2.<e>).toString(), "");
+    assert((x2/*).toString(), "e<f><g>f</g></f><h>h</h>");
+    assert((x2/<f>).toString(), "");
+    assert((x2/<*>).toString(), "<f><g>f</g></f><h>h</h>");
+    assert((x2/**/<g>).toString(), "");
+}
+
 function assert(anydata actual, anydata expected) {
     if (expected != actual) {
         string reason = "expected `" + expected.toString() + "`, but found `" + actual.toString() + "`";


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #42185 
Fixes #42200

## Approach
Save the namespace symbol of the `BLangXMLElementFilter` expression in the TypeChecker phase using the set of visible namespaces and use that information in the Desugar phase to expand the filter name. Accessing the set of namespaces in the Desugar phase provides namespaces that are defined after the filter expression declaration.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
