### PR TITLE
Fix invalid subtyping relationship in xml

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -4473,7 +4473,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         // If the type node is available, we get the type from it.
         BType typeNodeType = symResolver.resolveTypeNode(variableNode.typeNode, blockEnv);
         // Checking whether the RHS type is assignable to LHS type.
-        if (types.isAssignable(varType, typeNodeType)) {
+        if (types.constituentTypesAssignable(varType, typeNodeType)) {
             if (onFail && varType == symTable.neverType) {
                 varType = typeNodeType;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1457,7 +1457,7 @@ public class Types {
                 boolean isTypeParam = TypeParamAnalyzer.isTypeParam(targetParam);
 
                 if (isTypeParam) {
-                    if (!isAssignable(sourceParam, targetParam)) {
+                    if (!constituentTypesAssignable(sourceParam, targetParam)) {
                         return false;
                     }
                 } else {
@@ -1480,6 +1480,17 @@ public class Types {
         // Source param types should be contravariant with target param types. Hence s and t switched when checking
         // assignability.
         return checkFunctionTypeEquality(source, target, unresolvedTypes, (s, t, ut) -> isAssignable(t, s, ut));
+    }
+
+    public boolean constituentTypesAssignable(BType varType, BType typeNodeType) {
+        if (varType.tag == TypeTags.XML) {
+            typeNodeType = getReferredType(typeNodeType);
+            if (typeNodeType.tag == TypeTags.UNION) {
+                return isAssignable(symTable.xmlItemType, typeNodeType);
+            }
+            return typeNodeType.tag == TypeTags.XML;
+        }
+        return isAssignable(varType, typeNodeType);
     }
 
     public boolean isInherentlyImmutableType(BType type) {
@@ -3678,11 +3689,6 @@ public class Types {
                 continue;
             }
             if (sMember.tag == TypeTags.FINITE && isAssignable(sMember, target, unresolvedTypes)) {
-                sourceIterator.remove();
-                continue;
-            }
-            if (sMember.tag == TypeTags.XML &&
-                    isAssignableToUnionType(expandedXMLBuiltinSubtypes, target, unresolvedTypes)) {
                 sourceIterator.remove();
                 continue;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -178,9 +178,10 @@ public class SymbolTable {
     public final BRegexpType regExpType = new BRegexpType(TypeTags.REGEXP, Names.REGEXP_TYPE);
     public final BType xmlNeverType = new BXMLType(neverType,  null);
     public final BType xmlElementSeqType = new BXMLType(xmlElementType, null);
+    public final BType xmlItemType = BUnionType.create(null, xmlElementType, xmlCommentType,
+            xmlPIType, xmlTextType);
 
-    public final BType xmlType = new BXMLType(BUnionType.create(null, xmlElementType, xmlCommentType,
-            xmlPIType, xmlTextType),  null);
+    public final BType xmlType = new BXMLType(xmlItemType,  null);
 
     public BAnydataType anydataType;
     public BArrayType arrayAnydataType;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
@@ -213,6 +213,17 @@ public class XMLLiteralTest {
                 "'(xml<xml<xml:Text>>|xml<xml<xml:Comment>>)', found 'xml'", 150, 54);
         BAssertUtil.validateError(negativeResult, index++, "missing gt token", 154, 22);
         BAssertUtil.validateError(negativeResult, index++, "missing gt token", 155, 28);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'UX', found 'X'", 166, 12);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'UX', found 'X'", 169, 12);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'UX', found 'X'", 172, 12);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'UX', found 'X'", 175, 12);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'UX', found 'X'", 178, 12);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'UX', found 'X'", 181, 12);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'UX', found 'X'", 184, 12);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'UX', found 'X'", 187, 12);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'UX', found 'X'", 190, 12);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'UX', found 'X'", 193, 12);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'UX', found 'X'", 196, 12);
         Assert.assertEquals(index, negativeResult.getErrorCount());
     }
 
@@ -454,6 +465,11 @@ public class XMLLiteralTest {
     @Test
     public void testXMLLiteralWithConditionExpr() {
         BRunUtil.invoke(result, "testXMLLiteralWithConditionExpr");
+    }
+
+    @Test
+    public void testXMLSubtype() {
+        BRunUtil.invoke(result, "testXMLSubtype");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals-negative.bal
@@ -154,3 +154,44 @@ function testMissingClosingGTToken() {
     xml x1 = xml `<a/a>`;
     xml x2 = xml `<a n="a"/a>`;
 }
+
+type X xml;
+type XE xml<xml:Element>;
+type XP xml<xml:ProcessingInstruction>;
+type XC xml<xml:Comment>;
+type UX XE|XP|XC|xml:Text;
+
+function testXMLInvalidSubtype() {
+    X x1 = xml `<a></a><b></b>`;
+    UX _ = x1;
+
+    X x2 = xml `<?target instructions?><?a data?>`;
+    UX _ = x2;
+
+    X x3 = xml `<!--comment one--><!--comment two-->`;
+    UX _ = x3;
+
+    X x4 = xml `random sequence of text`;
+    UX _ = x4;
+
+    X x5 = xml `<a></a><b></b><?target instructions?><?c data?>`;
+    UX _ = x5;
+
+    X x6 = xml `<a></a><b></b><!--comment one--><!--comment two-->`;
+    UX _ = x6;
+
+    X x7 = xml `<a></a><b></b>random text`;
+    UX _ = x7;
+
+    X x8 = xml `<?target instructions?><?a data?>text`;
+    UX _ = x8;
+
+    X x9 = xml `<?target instructions?><?a data?><!--comment one--><!--comment two-->`;
+    UX _ = x9;
+
+    X x10 = xml `<!--comment one--><!--comment two-->text`;
+    UX _ = x10;
+
+    X x11 = xml `<a></a><b></b><?d data?><?c data?>?><!--comment--><!--comment-->text`;
+    UX _ = x11;
+}


### PR DESCRIPTION
## Purpose
Fixes #34779 

## Approach
Update `isAssignable` to not to allow assigning of value with static type`xml` to value with static type `xml:Comment|xml:Element|xml:ProcessingInstruction|xml:Text`. But this assignment is allowed in the type binding pattern in the`foreach` loops. Thus in order to handle this case new function is introduced  `constituentTypesAssignable`. 

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
