### PR TITLE
Fix service fill value returning null

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -3398,6 +3398,7 @@ public class TypeChecker {
             case TypeTags.FINITE_TYPE_TAG:
                 return checkFillerValue((BFiniteType) type);
             case TypeTags.OBJECT_TYPE_TAG:
+            case TypeTags.SERVICE_TAG:
                 return checkFillerValue((BObjectType) type);
             case TypeTags.RECORD_TYPE_TAG:
                 return checkFillerValue((BRecordType) type, unanalyzedTypes);
@@ -3557,20 +3558,17 @@ public class TypeChecker {
     }
 
     private static boolean checkFillerValue(BObjectType type) {
-        if (type.getTag() == TypeTags.SERVICE_TAG) {
+        MethodType generatedInitMethod = type.getGeneratedInitMethod();
+        if (generatedInitMethod == null) {
+            // abstract objects doesn't have a filler value.
             return false;
-        } else {
-            MethodType generatedInitMethod = type.getGeneratedInitMethod();
-            if (generatedInitMethod == null) {
-                // abstract objects doesn't have a filler value.
-                return false;
-            }
-            FunctionType initFuncType = generatedInitMethod.getType();
-            // Todo: check defaultable params of the init func as well
-            boolean noParams = initFuncType.getParameters().length == 0;
-            boolean nilReturn = getImpliedType(initFuncType.getReturnType()).getTag() == TypeTags.NULL_TAG;
-            return noParams && nilReturn;
         }
+        FunctionType initFuncType = generatedInitMethod.getType();
+        // Todo: check defaultable params of the init func as well
+        boolean noParams = initFuncType.getParameters().length == 0;
+        boolean nilReturn = getImpliedType(initFuncType.getReturnType()).getTag() == TypeTags.NULL_TAG;
+        return noParams && nilReturn;
+
     }
 
     private static boolean checkFillerValue(BFiniteType type) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array_fill_runtime_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array_fill_runtime_test.bal
@@ -244,6 +244,7 @@ public function main() {
     tesOneDimensionalArrayWithConstantSizeReferenceFill();
     tesTwoDimensionalArrayWithConstantSizeReferenceFill();
     testAnonRecordTypeWithDefaultValueFill();
+    testServiceClassArrayFilling();
     // testObjectArrayFillingWithDefaultValues();
 }
 
@@ -251,4 +252,15 @@ function assertEqualPanic(anydata expected, anydata actual, string message = "Va
     if (expected != actual) {
         panic error(message + " Expected : " + expected.toString() + " Actual : " + actual.toString());
     }
+}
+
+service class Class1 {}
+
+service class Class2 {}
+
+public function testServiceClassArrayFilling() {
+    [Class1, Class2] interceptors = [];
+    assertEqualPanic(2, interceptors.length());
+    assertEqualPanic(true, interceptors[0] is Class1);
+    assertEqualPanic(true, interceptors[1] is Class2);
 }


### PR DESCRIPTION
## Purpose
$subject
Fixes #42237 

## Approach
Remove unnecessary validations in `TypeChecker`.

## Samples
```ballerina

import ballerina/io;

service class Class1 {}

service class Class2 {}

public function main() {
    [Class1, Class2] interceptors = [];
    io:println(interceptors.length());
    io:println(interceptors); // [null,null] 
}
```
## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
