### PR TITLE
Improve fast run by modifying module and preventing shrink

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/RunExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/RunExecutor.java
@@ -70,7 +70,7 @@ public class RunExecutor implements LSCommandExecutor {
         try { // Can't use resource style due to SpotBugs bug.
             byte[] buffer = new byte[1024];
             int count;
-            while ((count = in.read(buffer)) > 0) {
+            while ((count = in.read(buffer)) >= 0) {
                 String str = new String(buffer, 0, count, StandardCharsets.UTF_8);
                 client.logTrace(new LogTraceParams(str, channel));
             }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/TestWorkspaceManager.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/TestWorkspaceManager.java
@@ -17,7 +17,13 @@
  */
 package org.ballerinalang.langserver.workspace;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
@@ -25,6 +31,7 @@ import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.util.ProjectConstants;
 import org.apache.commons.io.FileUtils;
+import org.ballerinalang.diagramutil.DiagramUtil;
 import org.ballerinalang.langserver.command.executors.RunExecutor;
 import org.ballerinalang.langserver.command.executors.StopExecutor;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
@@ -35,6 +42,7 @@ import org.ballerinalang.langserver.commons.command.LSCommandExecutorException;
 import org.ballerinalang.langserver.commons.eventsync.exceptions.EventSyncException;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.contexts.LanguageServerContextImpl;
+import org.ballerinalang.langserver.extensions.ballerina.document.ExecutorPositionsUtil;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.FileChangeType;
@@ -549,8 +557,69 @@ public class TestWorkspaceManager {
 
     @Test
     public void testWSRunStopProject()
-            throws WorkspaceDocumentException, EventSyncException, IOException, LSCommandExecutorException {
-        Path filePath = RESOURCE_DIRECTORY.resolve("long_running").resolve("main.bal").toAbsolutePath();
+            throws WorkspaceDocumentException, EventSyncException, LSCommandExecutorException, IOException {
+        Path projectPath = RESOURCE_DIRECTORY.resolve("long_running");
+        Path filePath = projectPath.resolve("main.bal");
+        ExecuteCommandContext execContext = runViaLs(filePath);
+        stopViaLs(execContext, projectPath);
+    }
+
+    @Test
+    public void testSemanticApiAfterWSRun()
+            throws WorkspaceDocumentException, EventSyncException, LSCommandExecutorException {
+        Path projectPath = RESOURCE_DIRECTORY.resolve("hello_service");
+        Path filePath = projectPath.resolve("main.bal");
+        ExecuteCommandContext execContext = runViaLs(filePath);
+
+        // Test syntax tree api
+        JsonElement syntaxTreeJSON = DiagramUtil.getSyntaxTreeJSON(workspaceManager.document(filePath).orElseThrow(),
+                workspaceManager.semanticModel(filePath).orElseThrow());
+        // 0 = func def 1 = func def 2 = class def, 3 = listener decl, 4 = service decl
+        JsonObject service = syntaxTreeJSON.getAsJsonObject().get("members").getAsJsonArray().get(4).getAsJsonObject();
+        Assert.assertEquals(service.get("kind").getAsString(), "ServiceDeclaration");
+
+        // test executor positions api
+        JsonArray execPositions = ExecutorPositionsUtil.getExecutorPositions(workspaceManager, filePath);
+        Assert.assertEquals(execPositions.getAsJsonArray().get(0).getAsJsonObject().get("name").getAsString(),
+                "hello");
+
+        stopViaLs(execContext, projectPath);
+    }
+
+    @Test
+    public void testSemanticApiAfterWSRunMultiMod()
+            throws WorkspaceDocumentException, EventSyncException, LSCommandExecutorException, IOException {
+        Path projectPath = RESOURCE_DIRECTORY.resolve("multimod");
+        Path filePath = projectPath.resolve("main.bal");
+
+        DidOpenTextDocumentParams params = new DidOpenTextDocumentParams();
+        TextDocumentItem textDocument = new TextDocumentItem();
+        textDocument.setUri(filePath.toUri().toString());
+        textDocument.setText(new String(Files.readAllBytes(filePath)));
+        params.setTextDocument(textDocument);
+        workspaceManager.didOpen(filePath, params);
+
+        SemanticModel semanticModelPreExec = workspaceManager.semanticModel(filePath).orElseThrow();
+        JsonElement syntaxTreeJSONPreExec = DiagramUtil.getSyntaxTreeJSON(
+                workspaceManager.document(filePath).orElseThrow(),
+                semanticModelPreExec);
+
+        ExecuteCommandContext execContext = runViaLs(filePath);
+
+        SemanticModel semanticModelPostExec = workspaceManager.semanticModel(filePath).orElseThrow();
+        JsonElement syntaxTreeJSONPostExec = DiagramUtil.getSyntaxTreeJSON(
+                workspaceManager.document(filePath).orElseThrow(),
+                semanticModelPostExec);
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Assert.assertEquals(gson.toJson(syntaxTreeJSONPreExec), gson.toJson(syntaxTreeJSONPostExec));
+
+        stopViaLs(execContext, projectPath);
+    }
+
+
+    private ExecuteCommandContext runViaLs(Path filePath)
+            throws WorkspaceDocumentException, EventSyncException, LSCommandExecutorException {
         System.setProperty("java.command", guessJavaPath());
         System.setProperty(BALLERINA_HOME, "./build");
         workspaceManager.loadProject(filePath);
@@ -567,13 +636,17 @@ public class TestWorkspaceManager {
         Boolean didRan = runExecutor.execute(execContext);
         Assert.assertTrue(didRan);
         Assert.assertEquals(reduceToOutString(logCaptor), "Hello, World!" + System.lineSeparator());
+        return execContext;
+    }
 
+    private static void stopViaLs(ExecuteCommandContext execContext, Path projectPath)
+            throws LSCommandExecutorException {
         StopExecutor stopExecutor = new StopExecutor();
         Boolean didStop = stopExecutor.execute(execContext);
         Assert.assertTrue(didStop);
 
-        Path target = RESOURCE_DIRECTORY.resolve("long_running").resolve("target");
-        FileUtils.deleteDirectory(target.toFile());
+        Path target = projectPath.resolve("target");
+        FileUtils.deleteQuietly(target.toFile());
     }
 
     private static String reduceToOutString(ArgumentCaptor<LogTraceParams> logCaptor) {

--- a/language-server/modules/langserver-core/src/test/resources/project/hello_service/Ballerina.toml
+++ b/language-server/modules/langserver-core/src/test/resources/project/hello_service/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "baltest"
+name = "long_running"
+version = "0.1.0"

--- a/language-server/modules/langserver-core/src/test/resources/project/hello_service/main.bal
+++ b/language-server/modules/langserver-core/src/test/resources/project/hello_service/main.bal
@@ -1,0 +1,43 @@
+import ballerina/jballerina.java;
+
+function system_out() returns handle = @java:FieldGet {
+    name: "out",
+    'class: "java.lang.System"
+} external;
+
+function println(handle receiver, handle arg0) = @java:Method {
+    name: "println",
+    'class: "java.io.PrintStream",
+    paramTypes: ["java.lang.String"]
+} external;
+
+
+public class Listener {
+    public isolated function 'start() returns error? {
+    }
+    public isolated function gracefulStop() returns error? {
+    }
+    public isolated function immediateStop() returns error? {
+    }
+    public isolated function detach(service object {} s) returns error? {
+    }
+    public isolated function attach(service object {} s, string[]|string? name = ()) returns error? {
+        return self.register(s, name);
+    }
+    isolated function register(service object {} s, string[]|string? name) returns error? {
+        return ();
+    }
+}
+
+listener Listener lsn = new;
+
+service /hello on lsn {
+
+    function init() {
+        println(system_out(), java:fromString("Hello, World!"));
+    }
+
+    resource function get foo() returns int {
+        return 1;
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/project/multimod/Ballerina.toml
+++ b/language-server/modules/langserver-core/src/test/resources/project/multimod/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "baltest"
+name = "multimod"
+version = "0.1.0"

--- a/language-server/modules/langserver-core/src/test/resources/project/multimod/main.bal
+++ b/language-server/modules/langserver-core/src/test/resources/project/multimod/main.bal
@@ -1,0 +1,23 @@
+import multimod.submod;
+import ballerina/jballerina.java;
+import ballerina/lang.runtime;
+
+function system_out() returns handle = @java:FieldGet {
+    name: "out",
+    'class: "java.lang.System"
+} external;
+
+function println(handle receiver, handle arg0) = @java:Method {
+    name: "println",
+    'class: "java.io.PrintStream",
+    paramTypes: ["java.lang.String"]
+} external;
+
+function print(String str) {
+    println(system_out(), java:fromString(str));
+}
+
+public function main() {
+    println(system_out(), java:fromString(submod:hello("World")));
+    runtime:sleep(2000);
+}

--- a/language-server/modules/langserver-core/src/test/resources/project/multimod/modules/submod/submod.bal
+++ b/language-server/modules/langserver-core/src/test/resources/project/multimod/modules/submod/submod.bal
@@ -1,0 +1,3 @@
+public function hello(string name) returns string {
+    return "Hello, " + name + "!";
+}

--- a/language-server/modules/langserver-core/src/test/resources/project/multimod/types.bal
+++ b/language-server/modules/langserver-core/src/test/resources/project/multimod/types.bal
@@ -1,0 +1,1 @@
+type String string;


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/ballerina-vscode/issues/503
part of https://github.com/ballerina-platform/ballerina-lang/issues/39939

## Approach
After a fast run, all documents are marked modified. This will avoid any issues due to changes done to the model by the backend.

But for this to work, we need to be able to recreate modules back from the source, so we disable the shrink feature that deletes the source to save memory.

## Remarks
Known issues:
- Fast run fails with large sources like open health care libraries.
- Fails when some changes are done to the source without the knowledge of LS, eg run bla persist modifications via cli