### PR TITLE
Provide code actions to fix invalid non-private mutable field

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddPrivateQualifierCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddPrivateQualifierCodeAction.java
@@ -43,14 +43,14 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Code Action for changing isolated field to private.
+ * Code Action for adding the private visibility qualifier ƒor an object field.
  *
  * @since 2201.9.0
  */
 @JavaSPIService("org.ballerinalang.langserver.commons.codeaction.spi.LSCodeActionProvider")
-public class ChangeIsolatedFieldPrivateCodeAction implements DiagnosticBasedCodeActionProvider {
+public class AddPrivateQualifierCodeAction implements DiagnosticBasedCodeActionProvider {
 
-    private static final String NAME = "Change isolated field to private";
+    private static final String NAME = "Add private visibility qualifier";
     private static final String DIAGNOSTIC_CODE = "BCE3956";
 
     @Override
@@ -69,7 +69,7 @@ public class ChangeIsolatedFieldPrivateCodeAction implements DiagnosticBasedCode
         }
 
         return Collections.singletonList(CodeActionUtil.createCodeAction(
-                CommandConstants.CHANGE_ISOLATED_FIELD_PRIVATE,
+                CommandConstants.ADD_PRIVATE_QUALIFIER,
                 List.of(getTextEdit((ObjectFieldNode) cursorNode)),
                 context.fileUri(),
                 CodeActionKind.QuickFix

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddPrivateQualifierCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddPrivateQualifierCodeAction.java
@@ -65,6 +65,7 @@ public class AddPrivateQualifierCodeAction implements DiagnosticBasedCodeActionP
                                            CodeActionContext context) {
         Node cursorNode = positionDetails.matchedNode();
         if (cursorNode.kind() != SyntaxKind.OBJECT_FIELD) {
+            assert false : "This line is unreachable as the diagnostic is only generated for an object field.";
             return Collections.emptyList();
         }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ChangeIsolatedFieldPrivateCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ChangeIsolatedFieldPrivateCodeAction.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.codeaction.providers;
+
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.codeaction.CodeActionNodeValidator;
+import org.ballerinalang.langserver.codeaction.CodeActionUtil;
+import org.ballerinalang.langserver.common.constants.CommandConstants;
+import org.ballerinalang.langserver.common.utils.PositionUtil;
+import org.ballerinalang.langserver.commons.CodeActionContext;
+import org.ballerinalang.langserver.commons.codeaction.spi.DiagBasedPositionDetails;
+import org.ballerinalang.langserver.commons.codeaction.spi.DiagnosticBasedCodeActionProvider;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Code Action for changing isolated field to private.
+ *
+ * @since 2201.9.0
+ */
+@JavaSPIService("org.ballerinalang.langserver.commons.codeaction.spi.LSCodeActionProvider")
+public class ChangeIsolatedFieldPrivateCodeAction implements DiagnosticBasedCodeActionProvider {
+
+    private static final String NAME = "Change isolated field to private";
+    private static final String DIAGNOSTIC_CODE = "BCE3956";
+
+    @Override
+    public boolean validate(Diagnostic diagnostic, DiagBasedPositionDetails positionDetails,
+                            CodeActionContext context) {
+        return DIAGNOSTIC_CODE.equals(diagnostic.diagnosticInfo().code())
+                && CodeActionNodeValidator.validate(context.nodeAtRange());
+    }
+
+    @Override
+    public List<CodeAction> getCodeActions(Diagnostic diagnostic, DiagBasedPositionDetails positionDetails,
+                                           CodeActionContext context) {
+        Node cursorNode = positionDetails.matchedNode();
+        LinePosition startLinePosition = cursorNode.lineRange().startLine();
+        Position startPosition = PositionUtil.toPosition(startLinePosition);
+        Position endPosition = PositionUtil.toPosition(cursorNode.lineRange().endLine());
+
+        String editText = "private " + cursorNode.toSourceCode().substring(startLinePosition.offset());
+        TextEdit makePrivateTextEdit = new TextEdit(new Range(startPosition, endPosition), editText);
+
+        return Collections.singletonList(CodeActionUtil.createCodeAction(
+                CommandConstants.CHANGE_ISOLATED_FIELD_PRIVATE,
+                List.of(makePrivateTextEdit),
+                context.fileUri(),
+                CodeActionKind.QuickFix
+        ));
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ChangeIsolatedFieldPrivateCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ChangeIsolatedFieldPrivateCodeAction.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.langserver.codeaction.providers;
 
 import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.annotation.JavaSPIService;
@@ -60,12 +61,11 @@ public class ChangeIsolatedFieldPrivateCodeAction implements DiagnosticBasedCode
     public List<CodeAction> getCodeActions(Diagnostic diagnostic, DiagBasedPositionDetails positionDetails,
                                            CodeActionContext context) {
         Node cursorNode = positionDetails.matchedNode();
-        LinePosition startLinePosition = cursorNode.lineRange().startLine();
-        Position startPosition = PositionUtil.toPosition(startLinePosition);
-        Position endPosition = PositionUtil.toPosition(cursorNode.lineRange().endLine());
+        LinePosition linePosition = cursorNode.lineRange().startLine();
+        Position position = PositionUtil.toPosition(linePosition);
 
-        String editText = "private " + cursorNode.toSourceCode().substring(startLinePosition.offset());
-        TextEdit makePrivateTextEdit = new TextEdit(new Range(startPosition, endPosition), editText);
+        String editText = SyntaxKind.PRIVATE_KEYWORD.stringValue() + " ";
+        TextEdit makePrivateTextEdit = new TextEdit(new Range(position, position), editText);
 
         return Collections.singletonList(CodeActionUtil.createCodeAction(
                 CommandConstants.CHANGE_ISOLATED_FIELD_PRIVATE,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/MakeVariableImmutableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/MakeVariableImmutableCodeAction.java
@@ -47,7 +47,6 @@ import org.eclipse.lsp4j.TextEdit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -73,7 +72,7 @@ public class MakeVariableImmutableCodeAction implements DiagnosticBasedCodeActio
                                            CodeActionContext context) {
         NonTerminalNode cursorNode = positionDetails.matchedNode();
 
-        // The current implementation of the CA only supports object fields.
+        // The current implementation of the CA only supports object fields
         if (cursorNode.kind() != SyntaxKind.OBJECT_FIELD) {
             return Collections.emptyList();
         }
@@ -111,7 +110,7 @@ public class MakeVariableImmutableCodeAction implements DiagnosticBasedCodeActio
 
         // Generate and return the code action
         return Collections.singletonList(CodeActionUtil.createCodeAction(
-                String.format(CommandConstants.CHANGE_VARIABLE_TO_IMMUTABLE, getTitleText(isFinal, isReadonly)),
+                String.format(CommandConstants.MAKE_VARIABLE_IMMUTABLE, getTitleText(isFinal, isReadonly)),
                 textEdits,
                 context.fileUri(),
                 CodeActionKind.QuickFix));
@@ -119,7 +118,7 @@ public class MakeVariableImmutableCodeAction implements DiagnosticBasedCodeActio
 
     private static Optional<TypeSymbol> getTypeSymbol(Symbol symbol) {
         TypeSymbol typeSymbol;
-        if (Objects.requireNonNull(symbol.kind()) == SymbolKind.CLASS_FIELD) {
+        if (symbol.kind() == SymbolKind.CLASS_FIELD) {
             typeSymbol = ((ClassFieldSymbol) symbol).typeDescriptor();
         } else {
             assert false : "Unconsidered symbol type found: " + symbol.kind();
@@ -142,12 +141,14 @@ public class MakeVariableImmutableCodeAction implements DiagnosticBasedCodeActio
 
         if (isUnion) {
             Position startPosition = PositionUtil.toPosition(startLinePosition);
-            TextEdit startTextEdit = new TextEdit(new Range(startPosition, startPosition), "(");
+            TextEdit startTextEdit = new TextEdit(new Range(startPosition, startPosition),
+                    SyntaxKind.OPEN_PAREN_TOKEN.stringValue());
             textEdits.add(startTextEdit);
         }
 
         Position endPosition = PositionUtil.toPosition(endLinePosition);
-        String editText = (isUnion ? ")" : "") + " & " + SyntaxKind.READONLY_KEYWORD.stringValue();
+        String editText = (isUnion ? SyntaxKind.CLOSE_PAREN_TOKEN.stringValue() : "") + " & " +
+                SyntaxKind.READONLY_KEYWORD.stringValue();
         TextEdit endTextEdit = new TextEdit(new Range(endPosition, endPosition), editText);
         textEdits.add(endTextEdit);
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/MakeVariableImmutableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/MakeVariableImmutableCodeAction.java
@@ -1,0 +1,176 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.codeaction.providers;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.codeaction.CodeActionNodeValidator;
+import org.ballerinalang.langserver.codeaction.CodeActionUtil;
+import org.ballerinalang.langserver.common.constants.CommandConstants;
+import org.ballerinalang.langserver.common.utils.PositionUtil;
+import org.ballerinalang.langserver.commons.CodeActionContext;
+import org.ballerinalang.langserver.commons.codeaction.spi.DiagBasedPositionDetails;
+import org.ballerinalang.langserver.commons.codeaction.spi.DiagnosticBasedCodeActionProvider;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Code Action for making a variable immutable. This will ensure that the given variable is both final and readonly.
+ *
+ * @since 2201.9.0
+ */
+@JavaSPIService("org.ballerinalang.langserver.commons.codeaction.spi.LSCodeActionProvider")
+public class MakeVariableImmutableCodeAction implements DiagnosticBasedCodeActionProvider {
+
+    private static final String NAME = "Make variable immutable";
+    private static final String DIAGNOSTIC_CODE = "BCE3956";
+
+    @Override
+    public boolean validate(Diagnostic diagnostic, DiagBasedPositionDetails positionDetails,
+                            CodeActionContext context) {
+        return DIAGNOSTIC_CODE.equals(diagnostic.diagnosticInfo().code())
+                && CodeActionNodeValidator.validate(context.nodeAtRange());
+    }
+
+    @Override
+    public List<CodeAction> getCodeActions(Diagnostic diagnostic, DiagBasedPositionDetails positionDetails,
+                                           CodeActionContext context) {
+        NonTerminalNode cursorNode = positionDetails.matchedNode();
+        if (cursorNode.kind() != SyntaxKind.OBJECT_FIELD) {
+            return Collections.emptyList();
+        }
+
+        ObjectFieldNode objectFieldNode = (ObjectFieldNode) cursorNode;
+        Node typeNode = objectFieldNode.typeName();
+        List<TextEdit> textEdits = new ArrayList<>();
+
+        // Check if the type is final
+        boolean isFinal = objectFieldNode.qualifierList().stream()
+                .anyMatch(token -> token.kind().equals(SyntaxKind.FINAL_KEYWORD));
+        if (!isFinal) {
+            textEdits.add(getFinalTextEdit(typeNode));
+        }
+
+        // Check if the type is readonly
+        TypeSymbol typeSymbol, readonlyType;
+        try {
+            SemanticModel semanticModel = context.currentSemanticModel().orElseThrow();
+            readonlyType = semanticModel.types().READONLY;
+            Symbol symbol = semanticModel.symbol(cursorNode).orElseThrow();
+            typeSymbol = getTypeSymbol(symbol).orElseThrow();
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+        boolean isReadonly = typeSymbol.subtypeOf(readonlyType);
+        if (!isReadonly) {
+            textEdits.addAll(getReadonlyTextEdits(typeNode, typeSymbol.typeKind() == TypeDescKind.UNION));
+        }
+
+        // Check if the text edits are empty
+        if (textEdits.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // Generate and return the code action
+        return Collections.singletonList(CodeActionUtil.createCodeAction(
+                String.format(CommandConstants.CHANGE_VARIABLE_TO_IMMUTABLE, getTitleText(isFinal, isReadonly)),
+                textEdits,
+                context.fileUri(),
+                CodeActionKind.QuickFix));
+    }
+
+    private static Optional<TypeSymbol> getTypeSymbol(Symbol symbol) {
+        TypeSymbol typeSymbol;
+        if (Objects.requireNonNull(symbol.kind()) == SymbolKind.CLASS_FIELD) {
+            typeSymbol = ((ClassFieldSymbol) symbol).typeDescriptor();
+        } else {
+            assert false : "Unconsidered symbol type found: " + symbol.kind();
+            return Optional.empty();
+        }
+        return typeSymbol.typeKind() == TypeDescKind.COMPILATION_ERROR ? Optional.empty() : Optional.of(typeSymbol);
+    }
+
+    private static TextEdit getFinalTextEdit(Node typeNode) {
+        LinePosition linePosition = typeNode.lineRange().startLine();
+        Position position = PositionUtil.toPosition(linePosition);
+        String editText = SyntaxKind.FINAL_KEYWORD.stringValue() + " ";
+        return new TextEdit(new Range(position, position), editText);
+    }
+
+    private static List<TextEdit> getReadonlyTextEdits(Node typeNode, boolean isUnion) {
+        LinePosition startLinePosition = typeNode.lineRange().startLine();
+        LinePosition endLinePosition = typeNode.lineRange().endLine();
+        List<TextEdit> textEdits = new ArrayList<>();
+
+        if (isUnion) {
+            Position startPosition = PositionUtil.toPosition(startLinePosition);
+            TextEdit startTextEdit = new TextEdit(new Range(startPosition, startPosition), "(");
+            textEdits.add(startTextEdit);
+        }
+
+        Position endPosition = PositionUtil.toPosition(endLinePosition);
+        String editText = (isUnion ? ")" : "") + " & " + SyntaxKind.READONLY_KEYWORD.stringValue();
+        TextEdit endTextEdit = new TextEdit(new Range(endPosition, endPosition), editText);
+        textEdits.add(endTextEdit);
+
+        return textEdits;
+    }
+
+    private static String getTitleText(boolean isFinal, boolean isReadonly) {
+        StringBuilder result = new StringBuilder();
+
+        if (!isFinal) {
+            result.append("'").append(SyntaxKind.FINAL_KEYWORD.stringValue()).append("'");
+        }
+
+        if (!isReadonly) {
+            if (result.length() > 0) {
+                result.append(" and ");
+            }
+            result.append("'").append(SyntaxKind.READONLY_KEYWORD.stringValue()).append("'");
+        }
+
+        return result.toString();
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/MakeVariableImmutableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/MakeVariableImmutableCodeAction.java
@@ -74,6 +74,7 @@ public class MakeVariableImmutableCodeAction implements DiagnosticBasedCodeActio
 
         // The current implementation of the CA only supports object fields
         if (cursorNode.kind() != SyntaxKind.OBJECT_FIELD) {
+            assert false : "This line is unreachable as the diagnostic is only generated for an object field.";
             return Collections.emptyList();
         }
 
@@ -96,16 +97,13 @@ public class MakeVariableImmutableCodeAction implements DiagnosticBasedCodeActio
             Symbol symbol = semanticModel.symbol(cursorNode).orElseThrow();
             typeSymbol = getTypeSymbol(symbol).orElseThrow();
         } catch (RuntimeException e) {
+            assert false : "This line is unreachable because the semantic model cannot be empty, and the type " +
+                    "symbol does not contain errors.";
             return Collections.emptyList();
         }
         boolean isReadonly = typeSymbol.subtypeOf(readonlyType);
         if (!isReadonly) {
             textEdits.addAll(getReadonlyTextEdits(typeNode, typeSymbol.typeKind() == TypeDescKind.UNION));
-        }
-
-        // Check if the text edits are empty
-        if (textEdits.isEmpty()) {
-            return Collections.emptyList();
         }
 
         // Generate and return the code action
@@ -117,14 +115,11 @@ public class MakeVariableImmutableCodeAction implements DiagnosticBasedCodeActio
     }
 
     private static Optional<TypeSymbol> getTypeSymbol(Symbol symbol) {
-        TypeSymbol typeSymbol;
         if (symbol.kind() == SymbolKind.CLASS_FIELD) {
-            typeSymbol = ((ClassFieldSymbol) symbol).typeDescriptor();
-        } else {
-            assert false : "Unconsidered symbol type found: " + symbol.kind();
-            return Optional.empty();
+            return Optional.of(((ClassFieldSymbol) symbol).typeDescriptor());
         }
-        return typeSymbol.typeKind() == TypeDescKind.COMPILATION_ERROR ? Optional.empty() : Optional.of(typeSymbol);
+        assert false : "Unconsidered symbol type found: " + symbol.kind();
+        return Optional.empty();
     }
 
     private static TextEdit getFinalTextEdit(Node typeNode) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/MakeVariableImmutableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/MakeVariableImmutableCodeAction.java
@@ -72,6 +72,8 @@ public class MakeVariableImmutableCodeAction implements DiagnosticBasedCodeActio
     public List<CodeAction> getCodeActions(Diagnostic diagnostic, DiagBasedPositionDetails positionDetails,
                                            CodeActionContext context) {
         NonTerminalNode cursorNode = positionDetails.matchedNode();
+
+        // The current implementation of the CA only supports object fields.
         if (cursorNode.kind() != SyntaxKind.OBJECT_FIELD) {
             return Collections.emptyList();
         }
@@ -94,7 +96,7 @@ public class MakeVariableImmutableCodeAction implements DiagnosticBasedCodeActio
             readonlyType = semanticModel.types().READONLY;
             Symbol symbol = semanticModel.symbol(cursorNode).orElseThrow();
             typeSymbol = getTypeSymbol(symbol).orElseThrow();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Collections.emptyList();
         }
         boolean isReadonly = typeSymbol.subtypeOf(readonlyType);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
@@ -120,6 +120,8 @@ public class CommandConstants {
 
     public static final String CHANGE_PARAM_TYPE_TITLE = "Change parameter '%s' type to '%s'";
 
+    public static final String CHANGE_ISOLATED_FIELD_PRIVATE = "Change the field to private";
+
     public static final String CREATE_VAR_TYPE_GUARD_TITLE = "Create variable and type guard";
 
     public static final String TYPE_GUARD_TITLE = "Type guard variable '%s'";

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
@@ -122,6 +122,8 @@ public class CommandConstants {
 
     public static final String CHANGE_ISOLATED_FIELD_PRIVATE = "Change the field to private";
 
+    public static final String CHANGE_VARIABLE_TO_IMMUTABLE = "Add %s to the variable";
+
     public static final String CREATE_VAR_TYPE_GUARD_TITLE = "Create variable and type guard";
 
     public static final String TYPE_GUARD_TITLE = "Type guard variable '%s'";

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
@@ -120,9 +120,9 @@ public class CommandConstants {
 
     public static final String CHANGE_PARAM_TYPE_TITLE = "Change parameter '%s' type to '%s'";
 
-    public static final String CHANGE_ISOLATED_FIELD_PRIVATE = "Change the field to private";
+    public static final String ADD_PRIVATE_QUALIFIER = "Add private qualifier";
 
-    public static final String CHANGE_VARIABLE_TO_IMMUTABLE = "Add %s to the variable";
+    public static final String MAKE_VARIABLE_IMMUTABLE = "Add %s to the variable";
 
     public static final String CREATE_VAR_TYPE_GUARD_TITLE = "Create variable and type guard";
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddPrivateQualifierCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddPrivateQualifierCodeActionTest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  *
  * @since 2201.9.0
  */
-public class ChangeIsolatedFieldPrivateCodeActionTest extends AbstractCodeActionTest {
+public class AddPrivateQualifierCodeActionTest extends AbstractCodeActionTest {
 
     @Test(dataProvider = "codeaction-data-provider")
     @Override

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeIsolatedFieldPrivateCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeIsolatedFieldPrivateCodeActionTest.java
@@ -43,7 +43,10 @@ public class ChangeIsolatedFieldPrivateCodeActionTest extends AbstractCodeAction
         return new Object[][]{
                 {"change_field_private1.json"},
                 {"change_field_private2.json"},
-                {"change_field_private3.json"}
+                {"change_field_private3.json"},
+                {"change_field_private4.json"},
+                {"change_field_private5.json"},
+                {"change_field_private6.json"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeIsolatedFieldPrivateCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeIsolatedFieldPrivateCodeActionTest.java
@@ -25,7 +25,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 
 /**
- * Test class to test the change isolated field to private code action
+ * Test class to test the change isolated field to private code action.
  *
  * @since 2201.9.0
  */

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeIsolatedFieldPrivateCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeIsolatedFieldPrivateCodeActionTest.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.codeaction;
+
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+/**
+ * Test class to test the change isolated field to private code action
+ *
+ * @since 2201.9.0
+ */
+public class ChangeIsolatedFieldPrivateCodeActionTest extends AbstractCodeActionTest {
+
+    @Test(dataProvider = "codeaction-data-provider")
+    @Override
+    public void test(String config) throws IOException, WorkspaceDocumentException {
+        super.test(config);
+    }
+
+    @DataProvider(name = "codeaction-data-provider")
+    @Override
+    public Object[][] dataProvider() {
+        return new Object[][]{
+                {"change_field_private1.json"},
+                {"change_field_private2.json"},
+                {"change_field_private3.json"}
+        };
+    }
+
+    @Override
+    public String getResourceDir() {
+        return "change-field-private";
+    }
+}

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/MakeVariableImmutableCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/MakeVariableImmutableCodeActionTest.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.codeaction;
+
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+/**
+ * Test class to test the converting a variable to immutable code action.
+ *
+ * @since 2201.9.0
+ */
+public class MakeVariableImmutableCodeActionTest extends AbstractCodeActionTest {
+
+    @Test(dataProvider = "codeaction-data-provider")
+    @Override
+    public void test(String config) throws IOException, WorkspaceDocumentException {
+        super.test(config);
+    }
+
+    @DataProvider(name = "codeaction-data-provider")
+    @Override
+    public Object[][] dataProvider() {
+        return new Object[][]{
+                {"make_variable_immutable1.json"},
+                {"make_variable_immutable2.json"},
+                {"make_variable_immutable3.json"},
+                {"make_variable_immutable4.json"},
+                {"make_variable_immutable5.json"},
+                {"make_variable_immutable6.json"},
+                {"make_variable_immutable7.json"},
+                {"make_variable_immutable8.json"},
+                {"make_variable_immutable9.json"},
+                {"make_variable_immutable10.json"},
+                {"make_variable_immutable11.json"},
+                {"make_variable_immutable12.json"},
+                {"make_variable_immutable13.json"},
+                {"make_variable_immutable14.json"},
+                {"make_variable_immutable15.json"}
+        };
+    }
+
+    @Override
+    public String getResourceDir() {
+        return "make-variable-immutable";
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private1.json
@@ -1,0 +1,30 @@
+{
+  "position": {
+    "line": 1,
+    "character": 11
+  },
+  "source": "change_field_private1.bal",
+  "description": "Change the isolated field to private for a structured type",
+  "expected": [
+    {
+      "title": "Change the field to private",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 5,
+              "character": 6
+            }
+          },
+          "newText": "private map<string> isolatedField = {\n        a: \"1\",\n        b: \"2\",\n        c: \"3\"\n    };\n"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private1.json
@@ -7,7 +7,7 @@
   "description": "Change the isolated field to private for a structured type",
   "expected": [
     {
-      "title": "Change the field to private",
+      "title": "Add private qualifier",
       "kind": "quickfix",
       "edits": [
         {

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private2.json
@@ -7,7 +7,7 @@
   "description": "Change the isolated field to private for a simple type",
   "expected": [
     {
-      "title": "Change the field to private",
+      "title": "Add private qualifier",
       "kind": "quickfix",
       "edits": [
         {

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private2.json
@@ -18,10 +18,10 @@
             },
             "end": {
               "line": 1,
-              "character": 15
+              "character": 4
             }
           },
-          "newText": "private int i = 32;\n"
+          "newText": "private "
         }
       ],
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private2.json
@@ -1,0 +1,30 @@
+{
+  "position": {
+    "line": 1,
+    "character": 9
+  },
+  "source": "change_field_private2.bal",
+  "description": "Change the isolated field to private for a simple type",
+  "expected": [
+    {
+      "title": "Change the field to private",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 15
+            }
+          },
+          "newText": "private int i = 32;\n"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private3.json
@@ -17,11 +17,11 @@
               "character": 4
             },
             "end": {
-              "line": 4,
-              "character": 19
+              "line": 1,
+              "character": 4
             }
           },
-          "newText": "private record {|\n        int i;\n        string val;\n    |} isolatedRec;\n"
+          "newText": "private "
         }
       ],
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private3.json
@@ -7,7 +7,7 @@
   "description": "Change the isolated field to private for a multiline type",
   "expected": [
     {
-      "title": "Change the field to private",
+      "title": "Add private qualifier",
       "kind": "quickfix",
       "edits": [
         {

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private3.json
@@ -1,0 +1,30 @@
+{
+  "position": {
+    "line": 1,
+    "character": 10
+  },
+  "source": "change_field_private3.bal",
+  "description": "Change the isolated field to private for a multiline type",
+  "expected": [
+    {
+      "title": "Change the field to private",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 4,
+              "character": 19
+            }
+          },
+          "newText": "private record {|\n        int i;\n        string val;\n    |} isolatedRec;\n"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private4.json
@@ -1,10 +1,10 @@
 {
   "position": {
     "line": 1,
-    "character": 11
+    "character": 25
   },
-  "source": "change_field_private1.bal",
-  "description": "Change the isolated field to private for a structured type",
+  "source": "change_field_private4.bal",
+  "description": "Change the isolated field to private for a public type",
   "expected": [
     {
       "title": "Change the field to private",
@@ -18,10 +18,10 @@
             },
             "end": {
               "line": 1,
-              "character": 4
+              "character": 10
             }
           },
-          "newText": "private "
+          "newText": "private"
         }
       ],
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private4.json
@@ -7,7 +7,7 @@
   "description": "Change the isolated field to private for a public type",
   "expected": [
     {
-      "title": "Change the field to private",
+      "title": "Add private qualifier",
       "kind": "quickfix",
       "edits": [
         {

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private5.json
@@ -7,7 +7,7 @@
   "description": "Change the isolated field to private for a final type",
   "expected": [
     {
-      "title": "Change the field to private",
+      "title": "Add private qualifier",
       "kind": "quickfix",
       "edits": [
         {

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private5.json
@@ -1,10 +1,10 @@
 {
   "position": {
     "line": 1,
-    "character": 11
+    "character": 10
   },
-  "source": "change_field_private1.bal",
-  "description": "Change the isolated field to private for a structured type",
+  "source": "change_field_private5.bal",
+  "description": "Change the isolated field to private for a final type",
   "expected": [
     {
       "title": "Change the field to private",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private6.json
@@ -7,7 +7,7 @@
   "description": "Change the isolated field to private for a documented type",
   "expected": [
     {
-      "title": "Change the field to private",
+      "title": "Add private qualifier",
       "kind": "quickfix",
       "edits": [
         {

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/config/change_field_private6.json
@@ -1,10 +1,10 @@
 {
   "position": {
-    "line": 1,
-    "character": 11
+    "line": 2,
+    "character": 8
   },
-  "source": "change_field_private1.bal",
-  "description": "Change the isolated field to private for a structured type",
+  "source": "change_field_private6.bal",
+  "description": "Change the isolated field to private for a documented type",
   "expected": [
     {
       "title": "Change the field to private",
@@ -13,11 +13,11 @@
         {
           "range": {
             "start": {
-              "line": 1,
+              "line": 2,
               "character": 4
             },
             "end": {
-              "line": 1,
+              "line": 2,
               "character": 4
             }
           },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/source/change_field_private1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/source/change_field_private1.bal
@@ -1,0 +1,8 @@
+isolated service class IsolatedClass {
+    map<string> isolatedField = {
+        a: "1",
+        b: "2",
+        c: "3"
+    };
+    int i = 32;
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/source/change_field_private2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/source/change_field_private2.bal
@@ -1,0 +1,3 @@
+isolated service class IsolatedClass {
+    int i = 32;
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/source/change_field_private3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/source/change_field_private3.bal
@@ -1,0 +1,6 @@
+isolated service class IsolatedClass {
+    record {|
+        int i;
+        string val;
+    |} isolatedRec;
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/source/change_field_private4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/source/change_field_private4.bal
@@ -1,0 +1,7 @@
+isolated service class IsolatedClass {
+    public final map<string> isolatedField = {
+        a: "1",
+        b: "2",
+        c: "3"
+    };
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/source/change_field_private5.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/source/change_field_private5.bal
@@ -1,0 +1,3 @@
+isolated service class IsolatedClass {
+    final string[] strArr = [];
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/source/change_field_private6.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-field-private/source/change_field_private6.bal
@@ -1,0 +1,4 @@
+isolated service class IsolatedClass {
+    # Documentation
+    final string[] strArr = [];
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable1.json
@@ -1,0 +1,30 @@
+{
+  "position": {
+    "line": 1,
+    "character": 7
+  },
+  "source": "make_variable_immutable1.bal",
+  "description": "Make immutable of a simple type variable",
+  "expected": [
+    {
+      "title": "Add 'final' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable10.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable10.json
@@ -1,0 +1,43 @@
+{
+  "position": {
+    "line": 7,
+    "character": 13
+  },
+  "source": "make_variable_immutable10.bal",
+  "description": "Make immutable of a object variable",
+  "expected": [
+    {
+      "title": "Add 'final' and 'readonly' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 4
+            },
+            "end": {
+              "line": 7,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 14
+            },
+            "end": {
+              "line": 7,
+              "character": 14
+            }
+          },
+          "newText": " & readonly"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable11.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable11.json
@@ -1,0 +1,30 @@
+{
+  "position": {
+    "line": 7,
+    "character": 10
+  },
+  "source": "make_variable_immutable11.bal",
+  "description": "Make immutable of a readonly object",
+  "expected": [
+    {
+      "title": "Add 'final' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 4
+            },
+            "end": {
+              "line": 7,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable12.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable12.json
@@ -1,0 +1,43 @@
+{
+  "position": {
+    "line": 1,
+    "character": 10
+  },
+  "source": "make_variable_immutable12.bal",
+  "description": "Make immutable of a variable",
+  "expected": [
+    {
+      "title": "Add 'final' and 'readonly' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 11
+            },
+            "end": {
+              "line": 1,
+              "character": 11
+            }
+          },
+          "newText": " & readonly"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable13.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable13.json
@@ -1,0 +1,56 @@
+{
+  "position": {
+    "line": 1,
+    "character": 8
+  },
+  "source": "make_variable_immutable13.bal",
+  "description": "Make immutable of a nullable mutable variable",
+  "expected": [
+    {
+      "title": "Add 'final' and 'readonly' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "("
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 16
+            },
+            "end": {
+              "line": 1,
+              "character": 16
+            }
+          },
+          "newText": ") & readonly"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable14.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable14.json
@@ -1,0 +1,43 @@
+{
+  "position": {
+    "line": 1,
+    "character": 11
+  },
+  "source": "make_variable_immutable14.bal",
+  "description": "Make immutable of a variable",
+  "expected": [
+    {
+      "title": "Add 'final' and 'readonly' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 11
+            },
+            "end": {
+              "line": 1,
+              "character": 11
+            }
+          },
+          "newText": "final "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 16
+            },
+            "end": {
+              "line": 1,
+              "character": 16
+            }
+          },
+          "newText": " & readonly"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable15.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable15.json
@@ -1,0 +1,30 @@
+{
+  "position": {
+    "line": 2,
+    "character": 9
+  },
+  "source": "make_variable_immutable15.bal",
+  "description": "Make immutable of a documented public variable",
+  "expected": [
+    {
+      "title": "Add 'final' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 4
+            },
+            "end": {
+              "line": 2,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable2.json
@@ -1,0 +1,43 @@
+{
+  "position": {
+    "line": 2,
+    "character": 12
+  },
+  "source": "make_variable_immutable2.bal",
+  "description": "Make immutable of a record variable",
+  "expected": [
+    {
+      "title": "Add 'final' and 'readonly' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 4,
+              "character": 6
+            },
+            "end": {
+              "line": 4,
+              "character": 6
+            }
+          },
+          "newText": " & readonly"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable3.json
@@ -1,0 +1,30 @@
+{
+  "position": {
+    "line": 4,
+    "character": 12
+  },
+  "source": "make_variable_immutable3.bal",
+  "description": "Make immutable of a readonly record variable",
+  "expected": [
+    {
+      "title": "Add 'final' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable4.json
@@ -1,0 +1,56 @@
+{
+  "position": {
+    "line": 1,
+    "character": 7
+  },
+  "source": "make_variable_immutable4.bal",
+  "description": "Make immutable of a union variable",
+  "expected": [
+    {
+      "title": "Add 'final' and 'readonly' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "("
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 19
+            },
+            "end": {
+              "line": 1,
+              "character": 19
+            }
+          },
+          "newText": ") & readonly"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable5.json
@@ -1,0 +1,30 @@
+{
+  "position": {
+    "line": 1,
+    "character": 7
+  },
+  "source": "make_variable_immutable5.bal",
+  "description": "Make immutable of a union variable",
+  "expected": [
+    {
+      "title": "Add 'final' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable6.json
@@ -1,0 +1,30 @@
+{
+  "position": {
+    "line": 1,
+    "character": 10
+  },
+  "source": "make_variable_immutable6.bal",
+  "description": "Make immutable of a union variable",
+  "expected": [
+    {
+      "title": "Add 'final' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable7.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable7.json
@@ -1,0 +1,56 @@
+{
+  "position": {
+    "line": 1,
+    "character": 14
+  },
+  "source": "make_variable_immutable7.bal",
+  "description": "Make immutable of a union variable",
+  "expected": [
+    {
+      "title": "Add 'final' and 'readonly' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "("
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 21
+            },
+            "end": {
+              "line": 1,
+              "character": 21
+            }
+          },
+          "newText": ") & readonly"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable8.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable8.json
@@ -1,0 +1,30 @@
+{
+  "position": {
+    "line": 1,
+    "character": 5
+  },
+  "source": "make_variable_immutable8.bal",
+  "description": "Make immutable of a singleton variable",
+  "expected": [
+    {
+      "title": "Add 'final' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable9.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/config/make_variable_immutable9.json
@@ -1,0 +1,30 @@
+{
+  "position": {
+    "line": 1,
+    "character": 10
+  },
+  "source": "make_variable_immutable9.bal",
+  "description": "Make immutable of a function variable",
+  "expected": [
+    {
+      "title": "Add 'final' to the variable",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "final "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable1.bal
@@ -1,0 +1,3 @@
+isolated class IsolatedClass {
+    int i = 2;
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable10.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable10.bal
@@ -1,0 +1,13 @@
+type ObjectName object {
+    int i;
+
+    function name();
+};
+
+isolated class IsolatedClass {
+    ObjectName myObj;
+
+    function init(ObjectName & readonly myObj) {
+        self.myObj = myObj;
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable11.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable11.bal
@@ -1,0 +1,13 @@
+type ObjectName object {
+    int i;
+
+    function name();
+} & readonly;
+
+isolated class IsolatedClass {
+    ObjectName myObj;
+
+    function init(ObjectName myObj) {
+        self.myObj = myObj;
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable12.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable12.bal
@@ -1,0 +1,7 @@
+isolated class IsolatedClass {
+    anydata val;
+
+    function init(string val) {
+        self.val = val;
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable13.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable13.bal
@@ -1,0 +1,3 @@
+isolated class IsolatedClass {
+    map<string>? mp = {};
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable14.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable14.bal
@@ -1,0 +1,3 @@
+isolated class IsolatedClass {
+    public int[] arr = [2];
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable15.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable15.bal
@@ -1,0 +1,4 @@
+isolated class IsolatedClass {
+    # Documented node
+    int i = 2;
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable2.bal
@@ -1,0 +1,10 @@
+isolated class IsolatedClass {
+    record {|
+        string id;
+        int count;
+    |} rec;
+
+    function init() {
+        self.rec = {count: 0, id: ""};
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable3.bal
@@ -1,0 +1,6 @@
+isolated class IsolatedClass {
+    record {|
+        string id;
+        int count;
+    |} & readonly rec = {count: 0, id: ""};
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable4.bal
@@ -1,0 +1,7 @@
+isolated class IsolatedClass {
+    int|map<string> val;
+
+    function init(int|map<string> & readonly val) {
+        self.val = val;
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable5.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable5.bal
@@ -1,0 +1,7 @@
+isolated class IsolatedClass {
+    int|string val;
+
+    function init(int|string val) {
+        self.val = val;
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable6.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable6.bal
@@ -1,0 +1,3 @@
+isolated class IsolatedClass {
+    map<string> & readonly|int|boolean val = false;
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable7.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable7.bal
@@ -1,0 +1,7 @@
+isolated class IsolatedClass {
+    int[]|map<string> val;
+
+    function init(int[]|map<string> val) {
+        self.val = val.cloneReadOnly();
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable8.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable8.bal
@@ -1,0 +1,3 @@
+isolated class IsolatedClass {
+    "Value" val = "Value";
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable9.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/make-variable-immutable/source/make_variable_immutable9.bal
@@ -1,0 +1,7 @@
+isolated class IsolatedClass {
+    function (int i) returns boolean fn;
+
+    function init(function (int i) returns boolean fn) {
+        self.fn = fn;
+    }
+}


### PR DESCRIPTION
## Purpose
The PR introduces two CAs as described [here](https://github.com/ballerina-platform/ballerina-lang/issues/42314#:~:text=Describe%20your%20solution(s)).

Fixes #42314

## Approach
The behavior of the two PRs can be summarized as follows:

1. The `Change isolated field to private` action simply modifies the visibility qualifier of the given field to `private`.
2. The `Make variable immutable` code action adds `final` and/or `readonly` based on what is needed for the variable.

## Samples
### 1. CA to make the field immutable.

https://github.com/ballerina-platform/ballerina-lang/assets/59343084/94f46de8-1808-4587-89cf-4be726d5dc09


### 2. CA to make the field private

https://github.com/ballerina-platform/ballerina-lang/assets/59343084/4549d117-cdb3-435c-892f-35e781820b58

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
