### PR TITLE
Increase the scope of the `Add isolated qualifier` code action

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddIsolatedQualifierCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddIsolatedQualifierCodeAction.java
@@ -56,10 +56,10 @@ import java.util.Set;
 public class AddIsolatedQualifierCodeAction implements DiagnosticBasedCodeActionProvider {
 
     public static final String NAME = "Add Isolated Qualifier";
-    private static final String NON_ISOLATED_WITHIN_LOCK_DIAGNOSTIC = "BCE3961";
+    private static final String DIAGNOSTIC_CODE_3961 = "BCE3961";
     private static final String ANONYMOUS_FUNCTION_EXPRESSION = "Anonymous function expression";
     private static final Set<String> DIAGNOSTIC_CODES =
-            Set.of("BCE3946", "BCE3947", "BCE3950", NON_ISOLATED_WITHIN_LOCK_DIAGNOSTIC);
+            Set.of("BCE3946", "BCE3947", "BCE3950", DIAGNOSTIC_CODE_3961);
 
     @Override
     public boolean validate(Diagnostic diagnostic,
@@ -156,7 +156,7 @@ public class AddIsolatedQualifierCodeAction implements DiagnosticBasedCodeAction
         return diagnostics.stream().anyMatch(diagnostic -> !currentDiagnostic.equals(diagnostic) &&
                 DIAGNOSTIC_CODES.contains(diagnostic.diagnosticInfo().code()) &&
                 PositionUtil.isWithinLineRange(diagnostic.location().lineRange(), node.lineRange())) &&
-                currentDiagnostic.diagnosticInfo().code().equals(NON_ISOLATED_WITHIN_LOCK_DIAGNOSTIC);
+                currentDiagnostic.diagnosticInfo().code().equals(DIAGNOSTIC_CODE_3961);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddIsolatedQualifierCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddIsolatedQualifierCodeAction.java
@@ -81,7 +81,7 @@ public class AddIsolatedQualifierCodeAction implements DiagnosticBasedCodeAction
         if (nonTerminalNode.kind() == SyntaxKind.EXPLICIT_ANONYMOUS_FUNCTION_EXPRESSION) {
             ExplicitAnonymousFunctionExpressionNode functionExpressionNode =
                     (ExplicitAnonymousFunctionExpressionNode) nonTerminalNode;
-            return getCodeAction(context, functionExpressionNode.functionKeyword(), ANONYMOUS_FUNCTION_EXPRESSION,
+            return getCodeAction(functionExpressionNode.functionKeyword(), ANONYMOUS_FUNCTION_EXPRESSION,
                     context.fileUri());
         }
 
@@ -117,12 +117,13 @@ public class AddIsolatedQualifierCodeAction implements DiagnosticBasedCodeAction
         }
         FunctionDefinitionNode functionDefinitionNode = (FunctionDefinitionNode) node.get();
 
-        return getCodeAction(context, functionDefinitionNode.functionKeyword(), symbol.get().getName().orElse(""),
+        return getCodeAction(functionDefinitionNode.functionKeyword(), symbol.get().getName().orElse(""),
                 filePath.get().toUri().toString());
     }
 
     private static Optional<Symbol> getReferredSymbol(CodeActionContext context, NonTerminalNode node) {
-        if (node.kind() == SyntaxKind.EXPLICIT_NEW_EXPRESSION || node.kind() == SyntaxKind.IMPLICIT_NEW_EXPRESSION) {
+        SyntaxKind kind = node.kind();
+        if (kind == SyntaxKind.EXPLICIT_NEW_EXPRESSION || kind == SyntaxKind.IMPLICIT_NEW_EXPRESSION) {
             try {
                 TypeReferenceTypeSymbol typeSymbol = (TypeReferenceTypeSymbol) context.currentSemanticModel()
                         .flatMap(semanticModel -> semanticModel.typeOf(node))
@@ -137,9 +138,7 @@ public class AddIsolatedQualifierCodeAction implements DiagnosticBasedCodeAction
         return context.currentSemanticModel().flatMap(semanticModel -> semanticModel.symbol(node));
     }
 
-    private static List<CodeAction> getCodeAction(CodeActionContext context, Token functionKeyword,
-                                                  String expressionName,
-                                                  String filePath) {
+    private static List<CodeAction> getCodeAction(Token functionKeyword, String expressionName, String filePath) {
         Position position = PositionUtil.toPosition(functionKeyword.lineRange().startLine());
         String editText = SyntaxKind.ISOLATED_KEYWORD.stringValue() + " ";
         TextEdit textEdit = new TextEdit(new Range(position, position), editText);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddIsolatedQualifierCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddIsolatedQualifierCodeActionTest.java
@@ -46,7 +46,16 @@ public class AddIsolatedQualifierCodeActionTest extends AbstractCodeActionTest {
                 {"add_isolated_qualifier_config1.json"},
                 {"add_isolated_qualifier_config2.json"},
                 {"add_isolated_qualifier_config3.json"},
-                {"add_isolated_qualifier_config4.json"}
+                {"add_isolated_qualifier_config4.json"},
+                {"add_isolated_qualifier_config5.json"},
+                {"add_isolated_qualifier_config6.json"},
+                {"add_isolated_qualifier_config7.json"},
+                {"add_isolated_qualifier_config8.json"},
+                {"add_isolated_qualifier_config9.json"},
+                {"add_isolated_qualifier_config10.json"},
+                {"add_isolated_qualifier_config11.json"},
+                {"add_isolated_qualifier_config12.json"},
+                {"add_isolated_qualifier_config13.json"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config10.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 35,
+    "character": 31
+  },
+  "source": "isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source2.bal",
+  "expected": [
+    {
+      "title": "Add isolated qualifier to 'init'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 11,
+              "character": 4
+            },
+            "end": {
+              "line": 11,
+              "character": 4
+            }
+          },
+          "newText": "isolated "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config11.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 38,
+    "character": 23
+  },
+  "source": "isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source2.bal",
+  "expected": [
+    {
+      "title": "Add isolated qualifier to 'init'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 11,
+              "character": 4
+            },
+            "end": {
+              "line": 11,
+              "character": 4
+            }
+          },
+          "newText": "isolated "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config12.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 40,
+    "character": 6
+  },
+  "source": "isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source2.bal",
+  "expected": [
+    {
+      "title": "Add isolated qualifier to 'fn'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 5,
+              "character": 4
+            },
+            "end": {
+              "line": 5,
+              "character": 4
+            }
+          },
+          "newText": "isolated "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config13.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 43,
+    "character": 15
+  },
+  "source": "isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source2.bal",
+  "expected": [
+    {
+      "title": "Add isolated qualifier to 'fn'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 15,
+              "character": 4
+            },
+            "end": {
+              "line": 15,
+              "character": 4
+            }
+          },
+          "newText": "isolated "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config5.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 9,
+    "character": 20
+  },
+  "source": "isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source2.bal",
+  "expected": [
+    {
+      "title": "Add isolated qualifier to 'testFunctionWithReturn'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 4,
+              "character": 0
+            },
+            "end": {
+              "line": 4,
+              "character": 0
+            }
+          },
+          "newText": "isolated "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config6.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 15,
+    "character": 15
+  },
+  "source": "isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source2.bal",
+  "expected": [
+    {
+      "title": "Add isolated qualifier to 'testFunctionWithReturn'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 4,
+              "character": 0
+            },
+            "end": {
+              "line": 4,
+              "character": 0
+            }
+          },
+          "newText": "isolated "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config7.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 21,
+    "character": 14
+  },
+  "source": "isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source2.bal",
+  "expected": [
+    {
+      "title": "Add isolated qualifier to 'testFunction'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "isolated "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config8.json
@@ -1,23 +1,23 @@
 {
   "position": {
-    "line": 6,
-    "character": 42
+    "line": 27,
+    "character": 24
   },
-  "source": "isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source4.bal",
+  "source": "isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source2.bal",
   "expected": [
     {
-      "title": "Add isolated qualifier to 'Anonymous function expression'",
+      "title": "Add isolated qualifier to 'testFunctionWithInput'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
               "line": 6,
-              "character": 36
+              "character": 14
             },
             "end": {
               "line": 6,
-              "character": 36
+              "character": 14
             }
           },
           "newText": "isolated "

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/config/add_isolated_qualifier_config9.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 32,
+    "character": 29
+  },
+  "source": "isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source2.bal",
+  "expected": [
+    {
+      "title": "Add isolated qualifier to 'init'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "isolated "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/source/isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/source/isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source2.bal
@@ -2,3 +2,45 @@ isolated function bar() {
     testFunction();
     return;
 }
+
+isolated int i = 1;
+
+function fn1() {
+    lock {
+        i = testFunctionWithReturn();
+    }
+}
+
+isolated function fn2() {
+    lock {
+        i = testFunctionWithReturn();
+    }
+}
+
+isolated function fn3() {
+    lock {
+        testFunction();
+    }
+}
+
+function fn4() {
+    lock {
+        i = testFunctionWithInput(i);
+    }
+}
+
+isolated function fn5() {
+    NonIsolatedClass cls1 = new;
+
+    lock {
+        IsolatedClass cls2 = new(i);
+    }
+
+    var cls3 = new IsolatedClass(i);
+
+    cls1.fn();
+    
+    lock {
+        cls3.fn(i);
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/source/isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source2_test.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/source/isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source2_test.bal
@@ -1,3 +1,7 @@
 function testFunction() {
     return;
 }
+
+function testFunctionWithReturn() returns int => 0;
+
+transactional function testFunctionWithInput(int i) returns int => i + 2;

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/source/isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/source/isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source4.bal
@@ -4,8 +4,8 @@ service / on new module1:Listener(9090) {
     private int[] items = [];
 
     isolated resource function name .() {
-        var isOdd = function(int n) returns boolean {
+        var isOdd = self.items.'map(function(int n) returns boolean {
             return n % 2 != 0;
-        };
+        });
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/source/isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source5.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-isolated-qualifier/source/isolatedFunctionCodeAction/modules/module2/add_isolated_qualifier_source5.bal
@@ -1,0 +1,19 @@
+class NonIsolatedClass {
+    function init() {
+
+    }
+
+    function fn() {
+        
+    }
+}
+
+isolated class IsolatedClass {
+    function init(int i) {
+
+    }
+
+    function fn(int i) {
+        
+    }
+}


### PR DESCRIPTION
## Purpose
Currently, the respective CA only supports text edits to fix the diagnostics: `BCE3946` and `BCE3947`. With this PR, the CA provides the necessary text edits to solve `BCE3950` and `BCE3961`, i.e.

1. Quick fix for using non-isolated functions within the `lock` statement.
2. Quick fix for using non-isolated initializers within an isolated function.

Fixes #42323

## Samples

### Fixing non-isolated functions within the `lock` statement
https://github.com/ballerina-platform/ballerina-lang/assets/59343084/76aeaba3-f870-4f56-b720-08e757efa135

### Fixing non-isolated initializers within an isolated function
https://github.com/ballerina-platform/ballerina-lang/assets/59343084/6bdf7a96-d794-4d08-8271-25546c2cd129

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
