### PR TITLE
Support `Change return type` code action for workers

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeVisitor.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeVisitor.java
@@ -47,6 +47,10 @@ public abstract class NodeVisitor {
         visitSyntaxNode(functionDefinitionNode);
     }
 
+    public void visit(NonTerminalNode nonTerminalNode) {
+        visitSyntaxNode(nonTerminalNode);
+    }
+
     public void visit(ImportDeclarationNode importDeclarationNode) {
         visitSyntaxNode(importDeclarationNode);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -666,7 +666,7 @@ public class CodeActionUtil {
      * {@link SyntaxKind#RESOURCE_ACCESSOR_DEFINITION}s
      *
      * @param matchedNode Node which is enclosed within a function
-     * @return Optional function defintion node
+     * @return Optional function definition node
      */
     public static Optional<FunctionDefinitionNode> getEnclosedFunction(Node matchedNode) {
         if (matchedNode == null) {
@@ -708,6 +708,36 @@ public class CodeActionUtil {
         }
 
         return Optional.ofNullable(functionDefNode);
+    }
+
+    /**
+     * Given a node, tries to find the {@link NonTerminalNode} which is enclosing the given node.
+     *
+     * @param matchedNode Node which is enclosed within a block
+     * @return Optional non terminal node
+     */
+    public static Optional<NonTerminalNode> getEnclosingBlock(Node matchedNode) {
+        Node parentNode = matchedNode;
+        while (parentNode.parent() != null) {
+            if ((parentNode.kind() == SyntaxKind.FUNCTION_DEFINITION &&
+                    parentNode.parent().kind() == SyntaxKind.MODULE_PART)
+            || (parentNode.kind() == SyntaxKind.OBJECT_METHOD_DEFINITION &&
+                    (parentNode.parent().kind() == SyntaxKind.CLASS_DEFINITION
+                            || parentNode.parent().kind() == SyntaxKind.SERVICE_DECLARATION
+                            || parentNode.parent().kind() == SyntaxKind.OBJECT_CONSTRUCTOR))
+            || parentNode.kind() == SyntaxKind.RESOURCE_ACCESSOR_DEFINITION &&
+                    (parentNode.parent().kind() == SyntaxKind.SERVICE_DECLARATION
+                            || (parentNode.parent().kind() == SyntaxKind.CLASS_DEFINITION &&
+                            ((ClassDefinitionNode) parentNode.parent())
+                                    .classTypeQualifiers().stream()
+                                    .anyMatch(qualifier-> qualifier.kind() == SyntaxKind.CLIENT_KEYWORD))
+                            || parentNode.parent().kind() == SyntaxKind.OBJECT_CONSTRUCTOR)
+            || parentNode.kind() == SyntaxKind.NAMED_WORKER_DECLARATION) {
+                return Optional.of((NonTerminalNode) parentNode);
+            }
+            parentNode = parentNode.parent();
+        }
+        return Optional.empty();
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
@@ -145,12 +145,13 @@ public class FixReturnTypeCodeAction implements DiagnosticBasedCodeActionProvide
 
             if (checkExprDiagnostic) {
                 types.add(Collections.singleton(returnTypeDescPresent ?
-                        ((ReturnTypeDescriptorNode)worker.returnTypeDesc().get()).type().toString().trim().concat("|")
+                        ((ReturnTypeDescriptorNode) worker.returnTypeDesc().get()).type().toString().trim().concat("|")
                                 .concat("error") : "error?"));
             } else {
                 types = getPossibleCombinations(getCombinedTypes(worker, context, importEdits), types);
             }
 
+            // Where to insert the edit: Depends on if a return statement already available or not
             Position start;
             Position end;
             if (returnTypeDescPresent) {
@@ -176,6 +177,7 @@ public class FixReturnTypeCodeAction implements DiagnosticBasedCodeActionProvide
                 types.add(Collections.singleton(returnTypeDescPresent ? funcDef.functionSignature().returnTypeDesc()
                         .get().type().toString().trim().concat("|").concat("error") : "error?"));
             } else {
+                // Not going to provide code action to change return type of the main() function
                 if (RuntimeConstants.MAIN_FUNCTION_NAME.equals(funcDef.functionName().text())) {
                     return Collections.emptyList();
                 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/FixReturnTypeTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/FixReturnTypeTest.java
@@ -80,7 +80,10 @@ public class FixReturnTypeTest extends AbstractCodeActionTest {
                 {"fixReturnTypeForQueryExpr1.json"},
                 {"fixReturnTypeForQueryExpr2.json"},
                 {"fixReturnTypeForQueryExpr3.json"},
-                {"fixReturnTypeForQueryExpr4.json"}
+                {"fixReturnTypeForQueryExpr4.json"},
+                {"fixReturnTypeForWorker.json"},
+                {"fixReturnTypeForWorker2.json"},
+                {"fixReturnTypeForWorker3.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/FixReturnTypeTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/FixReturnTypeTest.java
@@ -83,7 +83,9 @@ public class FixReturnTypeTest extends AbstractCodeActionTest {
                 {"fixReturnTypeForQueryExpr4.json"},
                 {"fixReturnTypeForWorker.json"},
                 {"fixReturnTypeForWorker2.json"},
-                {"fixReturnTypeForWorker3.json"}
+                {"fixReturnTypeForWorker3.json"},
+                {"fixReturnTypeForWorker4.json"},
+                {"fixReturnTypeForWorker5.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeForWorker.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeForWorker.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 2,
+    "character": 18
+  },
+  "source": "fixReturnTypeForWorker.bal",
+  "expected": [
+    {
+      "title": "Change return type to 'string'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 13
+            },
+            "end": {
+              "line": 1,
+              "character": 13
+            }
+          },
+          "newText": " returns string"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeForWorker2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeForWorker2.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 6,
+    "character": 18
+  },
+  "source": "fixReturnTypeForWorker.bal",
+  "expected": [
+    {
+      "title": "Change return type to 'string'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 5,
+              "character": 22
+            },
+            "end": {
+              "line": 5,
+              "character": 25
+            }
+          },
+          "newText": "string"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeForWorker3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeForWorker3.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 3,
+    "character": 15
+  },
+  "source": "fixReturnTypeForWorkerWithCheck.bal",
+  "expected": [
+    {
+      "title": "Change return type to 'string|error'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 22
+            },
+            "end": {
+              "line": 1,
+              "character": 28
+            }
+          },
+          "newText": "string|error"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeForWorker4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeForWorker4.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 13,
+    "character": 30
+  },
+  "source": "fixReturnTypeForWorker.bal",
+  "expected": [
+    {
+      "title": "Change return type to 'string'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 12,
+              "character": 34
+            },
+            "end": {
+              "line": 12,
+              "character": 37
+            }
+          },
+          "newText": "string"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeForWorker5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeForWorker5.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 17,
+    "character": 22
+  },
+  "source": "fixReturnTypeForWorker.bal",
+  "expected": [
+    {
+      "title": "Change return type to 'string'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 10,
+              "character": 17
+            },
+            "end": {
+              "line": 10,
+              "character": 17
+            }
+          },
+          "newText": " returns string"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeForWorker.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeForWorker.bal
@@ -1,0 +1,9 @@
+function testFunction() {
+    worker w3 {
+        return "test";
+    }
+
+    worker w4 returns int {
+        return "test";
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeForWorker.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeForWorker.bal
@@ -1,9 +1,21 @@
 function testFunction() {
-    worker w3 {
+    worker w1 {
         return "test";
     }
 
-    worker w4 returns int {
+    worker w2 returns int {
         return "test";
+    }
+
+    fork {
+        worker w3 {
+            fork {
+                worker w4 returns int {
+                    return "test";
+                }
+            }
+
+            return "test";
+        }
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeForWorkerWithCheck.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeForWorkerWithCheck.bal
@@ -1,0 +1,6 @@
+function testFunction() {
+    worker w2 returns string {
+        error|string e = error("test");
+        _ = check e;
+    }
+}


### PR DESCRIPTION
## Purpose
This PR adds the implementation to support the change return type code action for workers.

Fixes #41438

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples

https://github.com/ballerina-platform/ballerina-lang/assets/61020198/fadcf6b2-0bf9-48f2-851c-6dc603272506


## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
