### PR TITLE
[WIP] Support constant `spread-list-member` within the keys of a table

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -1441,8 +1441,12 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         } else if (node.getKind() == NodeKind.REG_EXP_TEMPLATE_LITERAL) {
             result = 31 * result +
                     generateHashForRegExp(((BLangRegExpTemplateLiteral) node).reDisjunction.sequenceList);
+        } else if (node.getKind() == NodeKind.LIST_CONSTRUCTOR_SPREAD_OP) {
+            result = 31 * result + hash(((BLangListConstructorExpr.BLangListConstructorSpreadOpExpr) node).expr);
+        } else if (node.getKind() == NodeKind.RECORD_LITERAL_SPREAD_OP) {
+            result = 31 * result + hash(((BLangRecordLiteral.BLangRecordSpreadOperatorField) node).expr);
         } else {
-            dlog.error(((BLangExpression) node).pos, DiagnosticErrorCode.EXPRESSION_IS_NOT_A_CONSTANT_EXPRESSION);
+            dlog.error(node.getPosition(), DiagnosticErrorCode.EXPRESSION_IS_NOT_A_CONSTANT_EXPRESSION);
         }
         return result;
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
@@ -123,9 +123,8 @@ const int[] INT_ARR = [22 , 44];
 function testListConstructorExprAsKeyValue() {
     table<Row4> key(k) tbl = table [
        {k: [12 , 13], value: 17},
-       {k: [12 , INT_VAL1], value: 17}
-    // Blocked by #41979
-    //    {k: [12 , ...INT_ARR], value: 17}
+       {k: [12 , INT_VAL1], value: 17},
+       {k: [12 , ...INT_ARR], value: 17}
     ];
 
     tbl.add({k: [13 , 14], value: 25});
@@ -134,7 +133,7 @@ function testListConstructorExprAsKeyValue() {
     var tbl2 = table key(k) [
         {k: [12, 13], value: 17},
         {k: [12, 55], value: 17},
-        // {k: [12, 22, 44], value: 17},
+        {k: [12, 22, 44], value: 17},
         {k: [13, 14], value: 25},
         {k: [13, 55], value: 25},
         {k: [13, 22, 44], value: 25}
@@ -193,28 +192,39 @@ type Row6 record {
 };
 const string STR_VAL1 = "X";
 const string STR_VAL2 = "Y";
+const map<anydata> MAP_VAL = {"X": 12, "Y": 22};
+const record {|int Z;|} REC_VAL = {Z: 32};
 
 function testMappingConstructorExprAsKeyValue() {
     table<Row6> key(k) tbl = table [
         {k: {"A": "a", "B": 12, "C": [13.5, 24.3]}, value: 17},
         {k: {"A": "a", "B": INT_VAL1, "C": [13.5, 24.3]}, value: 17},
         {k: {"A": "a", [STR_VAL1] : INT_VAL1, "C": [13.5, 24.3]}, value: 17},
-        {k: {"A": "a", STR_VAL1, "C": [13.5, 24.3]}, value: 17}
+        {k: {"A": "a", STR_VAL1, "C": [13.5, 24.3]}, value: 17},
+        {k: {"A": "a", ...MAP_VAL, "C": [13.5, 24.3]}, value: 17},
+        {k: {"A": "a", ...MAP_VAL, ...REC_VAL, "C": [13.5, 24.3]}, value: 17}
     ];
 
     tbl.add({k: {"A": "z", "B": 12, "C": [23.5, 65.3]}, value: 25});
     tbl.add({k: {"A": "z", "B": INT_VAL2, "C": [23.5, 65.3]}, value: 25});
     tbl.add({k: {"A": "z", [STR_VAL2] : INT_VAL2, "C": [23.5, 65.3]}, value: 25});
     tbl.add({k: {"A": "z", STR_VAL2, "C": [23.5, 65.3]}, value: 25});
+    tbl.add({k: {"A": "a", ...MAP_VAL, "C": [23.5, 65.3]}, value: 35});
+    tbl.add({k: {"A": "a", ...MAP_VAL, ...REC_VAL, "C": [23.5, 65.3]}, value: 35});
+
     var tbl2 = table key(k) [
         {k: {"A": "a", "B": 12, "C": [13.5, 24.3]}, value: 17},
         {k: {"A": "a", "B": 55, "C": [13.5, 24.3]}, value: 17},
         {k: {"A": "a", "X": 55, "C": [13.5, 24.3]}, value: 17},
         {k: {"A": "a", "STR_VAL1": "X", "C": [13.5, 24.3]}, value: 17},
+        {k: {"A": "a", "X": 12, "Y": 22, "C": [13.5, 24.3]}, value: 17},
+        {k: {"A": "a", "X": 12, "Y": 22, "Z": 32, "C": [13.5, 24.3]}, value: 17},
         {k: {"A": "z", "B": 12, "C": [23.5, 65.3]}, value: 25},
         {k: {"A": "z", "B": 22, "C": [23.5, 65.3]}, value: 25},
         {k: {"A": "z", "Y": 22, "C": [23.5, 65.3]}, value: 25},
-        {k: {"A": "z", "STR_VAL2": "Y", "C": [23.5, 65.3]}, value: 25}
+        {k: {"A": "z", "STR_VAL2": "Y", "C": [23.5, 65.3]}, value: 25},
+        {k: {"A": "a", "X": 12, "Y": 22, "C": [23.5, 65.3]}, value: 35},
+        {k: {"A": "a", "X": 12, "Y": 22, "Z": 32, "C": [23.5, 65.3]}, value: 35}
     ];
     assertEqual(tbl2, tbl);
 


### PR DESCRIPTION
## Purpose
As mentioned in the [spec](https://ballerina.io/spec/lang/master/#section_6.4), structural constructors are allowed as long as their subexpressions are also constant. However, as mentioned in https://github.com/ballerina-platform/ballerina-lang/issues/41979, an invalid diagnostic is produced when a `spread-list-member` is within such constructors.

Related to: https://github.com/ballerina-platform/ballerina-lang/pull/41992

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/41979

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
