### PR TITLE
Use thread context class loader for the compiler plugins

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/plugins/CompilerPlugins.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/plugins/CompilerPlugins.java
@@ -100,7 +100,7 @@ public class CompilerPlugins {
     private static ClassLoader createClassLoader(List<Path> jarDependencyPaths) {
         return AccessController.doPrivileged(
                 (PrivilegedAction<URLClassLoader>) () -> new URLClassLoader(getJarURLS(jarDependencyPaths),
-                        CompilerPlugins.class.getClassLoader())
+                        Thread.currentThread().getContextClassLoader())
         );
     }
 


### PR DESCRIPTION
## Purpose
$ subject

This will allow compiler plugins to be run within bal tools as per requirement in the below issue.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/42312

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
