### PR TITLE
Fix gradle task `:jballerina-unit-test:test` producing false negative test failures for master branch on Windows

### DIFF
--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
@@ -323,6 +323,7 @@ public class BRunUtil {
         String classPathString = System.getProperty("java.class.path") + classPath;
         // Create an argument file for Windows to mitigate the long classpath issue.
         if (IS_WINDOWS) {
+            classPathString = classPathString.replace(" ", "%20");
             String classPathArgs = "classPathArgs";
             try {
                 File classPathArgsFile = File.createTempFile(classPathArgs, ".txt");


### PR DESCRIPTION
## Purpose
> $title

Fixes #42424

## Approach
Replaced the whitespaces in `java -cp` argument JAR paths with `"%20"`. 

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
