### PR TITLE
[Master] Fix `error:NoMessage` for `worker-on-fail-clause`

### DIFF
--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/worker-on-fail-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/worker-on-fail-negative.bal
@@ -1,0 +1,74 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function testNoMessageErrorForOnFailAsyncSend() {
+    worker w1 {
+        0 -> w2;
+    } on fail {
+        1 -> w2;
+    }
+
+    worker w2 {
+        int _ = <- w1;
+        int _ = <- w1; // found 'int|error:NoMessage'
+    }
+
+    wait w2;
+}
+
+public function testNoMessageErrorForOnFailSyncSend() {
+    worker w1 {
+        0 ->> w2;
+    } on fail {
+        1 ->> w2;
+    }
+
+    worker w2 {
+        int _ = <- w1;
+        int _ = <- w1; // found 'int|error:NoMessage'
+    }
+
+    wait w1;
+}
+
+public function testNoMessageErrorWithWorkerOnFail() {
+    worker w1 {
+        boolean b = true;
+        check error("err");
+        0 -> w2;
+        if b {
+            1 -> w2;
+        }
+    } on fail {
+        boolean c = true;
+        2 -> w2;
+        if c {
+            3 ->> w2;
+        } else {
+            4 -> w2;
+        }
+    }
+
+    worker w2 {
+        int _ = <- w1; // found 'int|error:NoMessage'
+        int _ = <- w1; // found 'int|error:NoMessage'
+        int _ = <- w1; // found 'int|error:NoMessage'
+        int _ = <- w1; // found 'int|error:NoMessage'
+        int _ = <- w1; // found 'int|error:NoMessage'
+    }
+
+    wait w2;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/worker-on-fail.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/worker-on-fail.bal
@@ -103,3 +103,33 @@ function testWorkerOnFailWithSend() returns int {
 function returnOne() returns int => 1;
 
 function returnIntArr() returns int[] => [2, 3, 4, 5];
+
+public function testAsyncSendInsideWorkerOnFail() returns int|error {
+    worker w1 {
+        check error("err");
+    } on fail {
+        17 -> w2;
+    }
+
+    worker w2 returns int|error {
+        int x = check <- w1;
+        return x;
+    }
+
+    return wait w2;
+}
+
+public function testSyncSendInsideWorkerOnFail() returns int|error {
+    worker w1 {
+        check error("err");
+    } on fail {
+        -8 ->> w2;
+    }
+
+    worker w2 returns int|error {
+        int x = check <- w1;
+        return x;
+    }
+
+    return wait w2;
+}


### PR DESCRIPTION
## Purpose
$subject. 

Fixes #42499

## Approach
n/a

## Samples
```bal
public function testNoMessageErrorForOnFailAsyncSend() {
    worker w1 {
        0 -> w2;
    } on fail {
        1 -> w2;
    }

    worker w2 {
        int _ = <- w1;
        int _ = <- w1; // error: "incompatible types: expected 'int', found '(int|error:NoMessage)'"
    }

    wait w2;
}
```

## Remarks
n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
