### PR TITLE
Disallow error binding patterns in on fail clauses temporarily (for U9)

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -818,6 +818,7 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     EXPRESSION_OF_FUTURE_TYPE_EXPECTED("BCE4057", "future.expression.expected"),
     INSTANTIATION_ERROR("BCE4058", "instantiation.error"),
     INVALID_BINDING_PATTERN_IN_ON_FAIL("BCE4059", "invalid.binding.pattern.in.on.fail"),
+    ERROR_BINDING_PATTERN_NOT_YET_SUPPORTED_IN_ON_FAIL("BCE4060", "error.binding.pattern.not.yet.supported.in.on.fail")
     ;
 
     private String diagnosticId;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -3907,6 +3907,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
                                                               Names.fromString(anonModelHelper.getNextErrorVarKey(
                                                                       onFailEnv.enclPkg.packageID)),
                                                               onFailEnv, true);
+                dlog.error(errorVar.pos, DiagnosticErrorCode.ERROR_BINDING_PATTERN_NOT_YET_SUPPORTED_IN_ON_FAIL);
             }
         }
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -2031,3 +2031,6 @@ error.inferred.query.construct.type.as.stream=\
 
 error.invalid.binding.pattern.in.on.fail=\
   invalid binding pattern in ''on fail'' clause: only a capture binding pattern or an error binding pattern is allowed
+
+error.error.binding.pattern.not.yet.supported.in.on.fail=\
+  error binding patterns are not yet supported in ''on fail'' clauses

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachNegativeTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachNegativeTests.java
@@ -104,6 +104,8 @@ public class ForeachNegativeTests {
                 "mismatch with member type count", 342, 13);
         BAssertUtil.validateError(compile, index++, "invalid list binding pattern; member variable count " +
                 "mismatch with member type count", 346, 18);
+        BAssertUtil.validateError(compile, index++, "error binding patterns are not yet supported in " +
+                "'on fail' clauses", 374, 15);
         BAssertUtil.validateError(compile, index++, "invalid error variable; expecting an error type " +
                 "but found '(SampleComplexError|SampleError)' in type definition", 374, 15);
         Assert.assertEquals(compile.getErrorCount(), index);

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachOnFailTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachOnFailTests.java
@@ -87,7 +87,7 @@ public class ForeachOnFailTests {
         Assert.assertEquals(result.toString(), expected);
     }
 
-    @Test(dataProvider = "onFailClauseWithErrorBPTestDataProvider")
+    @Test(dataProvider = "onFailClauseWithErrorBPTestDataProvider", enabled = false)
     public void testOnFailWithErrorBP(String funcName) {
         BRunUtil.invoke(program, funcName);
     }

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-on-fail.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-on-fail.bal
@@ -94,449 +94,449 @@ function testNestedForeachLoopBreak() returns string {
     return result;
 }
 
-type SampleErrorData record {|
-    int code;
-    string reason;
-|};
+// type SampleErrorData record {|
+//     int code;
+//     string reason;
+// |};
 
-type SampleError error<SampleErrorData>;
+// type SampleError error<SampleErrorData>;
 
-function testSimpleOnFailWithErrorBP() {
-    string testMessage;
-    foreach var i in data {
-        fail error("error!");
-    } on fail error error(msg) {
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-}
+// function testSimpleOnFailWithErrorBP() {
+//     string testMessage;
+//     foreach var i in data {
+//         fail error("error!");
+//     } on fail error error(msg) {
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+// }
 
-function testSimpleOnFailWithErrorBPWithVar() {
-    string testMessage;
-    foreach var i in data {
-        fail error("error!");
-    } on fail var error(msg) {
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-}
+// function testSimpleOnFailWithErrorBPWithVar() {
+//     string testMessage;
+//     foreach var i in data {
+//         fail error("error!");
+//     } on fail var error(msg) {
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithError() {
-    int testErrorCode;
-    string testMessage;
-    string testErrorReason;
-    foreach var i in data {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithError() {
+//     int testErrorCode;
+//     string testMessage;
+//     string testErrorReason;
+//     foreach var i in data {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithVar() {
-    string testMessage;
-    int testErrorCode;
-    string testErrorReason;
-    foreach var i in data {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail var error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithVar() {
+//     string testMessage;
+//     int testErrorCode;
+//     string testErrorReason;
+//     foreach var i in data {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail var error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedType() {
-    string testMessage;
-    int testErrorCode;
-    string testErrorReason;
-    foreach var i in data {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail SampleError error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedType() {
+//     string testMessage;
+//     int testErrorCode;
+//     string testErrorReason;
+//     foreach var i in data {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail SampleError error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail1() {
-    string testMessage;
-    int testErrorCode;
-    string testErrorReason;
-    foreach var i in data {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<SampleErrorData> error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail1() {
+//     string testMessage;
+//     int testErrorCode;
+//     string testErrorReason;
+//     foreach var i in data {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<SampleErrorData> error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail2() {
-    int testErrorCode;
-    foreach var i in data {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<record {int code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail2() {
+//     int testErrorCode;
+//     foreach var i in data {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<record {int code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail3() {
-    int testErrorCode;
-    string testErrorReason;
-    foreach var i in data {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<record {int code;}> error(code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail3() {
+//     int testErrorCode;
+//     string testErrorReason;
+//     foreach var i in data {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<record {int code;}> error(code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail4() {
-    int testErrorCode;
-    foreach var i in data {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<record {int|string code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail4() {
+//     int testErrorCode;
+//     foreach var i in data {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<record {int|string code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecord() {
-    int testErrorCode;
-    foreach var i in data {
-        error<record {int code;}> errVar = error("error", code = 34);
-        fail errVar;
-    } on fail error<record {int code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecord() {
+//     int testErrorCode;
+//     foreach var i in data {
+//         error<record {int code;}> errVar = error("error", code = 34);
+//         fail errVar;
+//     } on fail error<record {int code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecordWithVar() {
-    int testErrorCode;
-    string testErrorReason;
-    foreach var i in data {
-        error<record {int code;}> errVar = error("error", code = 34);
-        fail errVar;
-    } on fail var error(msg, code = errCode) {
-        testErrorCode = errCode;
-        testErrorReason = msg;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-    assertEquality(testErrorReason, "error");
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecordWithVar() {
+//     int testErrorCode;
+//     string testErrorReason;
+//     foreach var i in data {
+//         error<record {int code;}> errVar = error("error", code = 34);
+//         fail errVar;
+//     } on fail var error(msg, code = errCode) {
+//         testErrorCode = errCode;
+//         testErrorReason = msg;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+//     assertEquality(testErrorReason, "error");
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecordWithUnionType() {
-    int testErrorCode;
-    foreach var i in data {
-        error<record {int code;}> errVar = error("error", code = 34);
-        fail errVar;
-    } on fail error<record {int|string code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecordWithUnionType() {
+//     int testErrorCode;
+//     foreach var i in data {
+//         error<record {int code;}> errVar = error("error", code = 34);
+//         fail errVar;
+//     } on fail error<record {int|string code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-type SampleComplexErrorData record {|
-    error cause;
-    int code;
-    int[2] pos;
-    record {string moreInfo;} infoDetails;
-|};
+// type SampleComplexErrorData record {|
+//     error cause;
+//     int code;
+//     int[2] pos;
+//     record {string moreInfo;} infoDetails;
+// |};
 
-type SampleComplexError error<SampleComplexErrorData>;
+// type SampleComplexError error<SampleComplexErrorData>;
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP1() {
-    string causeMsg;
-    int testErrorCode;
-    int testErrorPosRow;
-    int testErrorPosCol;
-    string testErrorMoreInfo;
-    foreach var i in data {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(_, cause = errCause, code = errCode, pos = errorPos, infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = errorPos[0];
-        testErrorPosCol = errorPos[1];
-        testErrorMoreInfo = errInfo.moreInfo;
-        causeMsg = errCause.message();
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(causeMsg, "Database Error");
-    assertEquality(causeMsg is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP1() {
+//     string causeMsg;
+//     int testErrorCode;
+//     int testErrorPosRow;
+//     int testErrorPosCol;
+//     string testErrorMoreInfo;
+//     foreach var i in data {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(_, cause = errCause, code = errCode, pos = errorPos, infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = errorPos[0];
+//         testErrorPosCol = errorPos[1];
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         causeMsg = errCause.message();
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(causeMsg, "Database Error");
+//     assertEquality(causeMsg is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP2() {
-    string testMessage;
-    int testErrorCode;
-    int testErrorPosRow;
-    int testErrorPosCol;
-    string testErrorMoreInfo;
-    foreach var i in data {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = errorPos, infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = errorPos[0];
-        testErrorPosCol = errorPos[1];
-        testErrorMoreInfo = errInfo.moreInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP2() {
+//     string testMessage;
+//     int testErrorCode;
+//     int testErrorPosRow;
+//     int testErrorPosCol;
+//     string testErrorMoreInfo;
+//     foreach var i in data {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = errorPos, infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = errorPos[0];
+//         testErrorPosCol = errorPos[1];
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP3() {
-    string testMessage;
-    int testErrorCode;
-    int testErrorPosRow;
-    int testErrorPosCol;
-    string testErrorMoreInfo;
-    foreach var i in data {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = [row, col], infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo.moreInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP3() {
+//     string testMessage;
+//     int testErrorCode;
+//     int testErrorPosRow;
+//     int testErrorPosCol;
+//     string testErrorMoreInfo;
+//     foreach var i in data {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = [row, col], infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP4() {
-    string testMessage;
-    int testErrorCode;
-    int testErrorPosRow;
-    int testErrorPosCol;
-    string testErrorMoreInfo;
-    foreach var i in data {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP4() {
+//     string testMessage;
+//     int testErrorCode;
+//     int testErrorPosRow;
+//     int testErrorPosCol;
+//     string testErrorMoreInfo;
+//     foreach var i in data {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP5() {
-    string testMessage;
-    int testErrorCode;
-    int testErrorPosRow;
-    int testErrorPosCol;
-    string testErrorMoreInfo;
-    foreach var i in data {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail var error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP5() {
+//     string testMessage;
+//     int testErrorCode;
+//     int testErrorPosRow;
+//     int testErrorPosCol;
+//     string testErrorMoreInfo;
+//     foreach var i in data {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail var error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testNestedOnFailWithErrorBP() {
-    string testMessage = "";
-    int testErrorCode = 0;
-    string testErrorReason = "";
-    int testErrorCodeNested = 0;
-    string testMessageNested = "";
-    string testErrorReasonNested = "";
-    foreach var i in data {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail var error(msg1, code = errCode1, reason = errReason1) {
-        if errCode1 == 20 {
-            foreach var j in data {
-                fail error SampleError("nested error!", code = 30, reason = "database error");
-            } on fail var error(msg2, code = errCode2, reason = errReason2) {
-                testErrorCode = errCode1;
-                testErrorCodeNested = errCode2;
-                testErrorReason = errReason1;
-                testErrorReasonNested = errReason2;
-                testMessage = msg1;
-                testMessageNested = msg2;
-            }
-        }
-    }
+// function testNestedOnFailWithErrorBP() {
+//     string testMessage = "";
+//     int testErrorCode = 0;
+//     string testErrorReason = "";
+//     int testErrorCodeNested = 0;
+//     string testMessageNested = "";
+//     string testErrorReasonNested = "";
+//     foreach var i in data {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//         if errCode1 == 20 {
+//             foreach var j in data {
+//                 fail error SampleError("nested error!", code = 30, reason = "database error");
+//             } on fail var error(msg2, code = errCode2, reason = errReason2) {
+//                 testErrorCode = errCode1;
+//                 testErrorCodeNested = errCode2;
+//                 testErrorReason = errReason1;
+//                 testErrorReasonNested = errReason2;
+//                 testMessage = msg1;
+//                 testMessageNested = msg2;
+//             }
+//         }
+//     }
 
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCodeNested, 30);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorReasonNested, "database error");
-    assertEquality(testMessage, "error!");
-    assertEquality(testMessageNested, "nested error!");
-}
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCodeNested, 30);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorReasonNested, "database error");
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testMessageNested, "nested error!");
+// }
 
-function testNestedOnFailWithErrorBPWithErrorArgsHavingBP() {
-    string testMessage = "";
-    int testErrorCode = 0;
-    int testErrorCodeNested = 0;
-    string testMessageNested = "";
-    int testErrorPosRow = 0;
-    int testErrorPosCol = 0;
-    string testErrorMoreInfo = "";
-    foreach var i in data {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail var error(msg1, code = errCode1, reason = errReason1) {
-        if errCode1 == 20 {
-            foreach var j in data {
-                fail error SampleComplexError("nested error!", cause = error("Database Error"), code = 30, pos = [35, 45], infoDetails = {moreInfo: "deadlock condition"});
-            } on fail SampleComplexError error(_, cause = error(msg2), code = errCode2, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-                testErrorCode = errCode1;
-                testErrorCodeNested = errCode2;
-                testMessage = msg1;
-                testMessageNested = msg2;
-                testErrorPosRow = row;
-                testErrorPosCol = col;
-                testErrorMoreInfo = errInfo;
-            }
-        }
-    }
+// function testNestedOnFailWithErrorBPWithErrorArgsHavingBP() {
+//     string testMessage = "";
+//     int testErrorCode = 0;
+//     int testErrorCodeNested = 0;
+//     string testMessageNested = "";
+//     int testErrorPosRow = 0;
+//     int testErrorPosCol = 0;
+//     string testErrorMoreInfo = "";
+//     foreach var i in data {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//         if errCode1 == 20 {
+//             foreach var j in data {
+//                 fail error SampleComplexError("nested error!", cause = error("Database Error"), code = 30, pos = [35, 45], infoDetails = {moreInfo: "deadlock condition"});
+//             } on fail SampleComplexError error(_, cause = error(msg2), code = errCode2, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//                 testErrorCode = errCode1;
+//                 testErrorCodeNested = errCode2;
+//                 testMessage = msg1;
+//                 testMessageNested = msg2;
+//                 testErrorPosRow = row;
+//                 testErrorPosCol = col;
+//                 testErrorMoreInfo = errInfo;
+//             }
+//         }
+//     }
 
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCodeNested, 30);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testMessage, "error!");
-    assertEquality(testMessageNested, "Database Error");
-    assertEquality(testErrorPosRow, 35);
-    assertEquality(testErrorPosCol, 45);
-}
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCodeNested, 30);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testMessageNested, "Database Error");
+//     assertEquality(testErrorPosRow, 35);
+//     assertEquality(testErrorPosCol, 45);
+// }
 
-function testMultiLevelOnFailWithErrorBP() {
-    string? testMessage = ();
-    int? testErrorCode = ();
-    string? testErrorReason = ();
-    string str = "";
-    int[] level1dData = [2];
-    int[] nestedData = [1];
+// function testMultiLevelOnFailWithErrorBP() {
+//     string? testMessage = ();
+//     int? testErrorCode = ();
+//     string? testErrorReason = ();
+//     string str = "";
+//     int[] level1dData = [2];
+//     int[] nestedData = [1];
 
-    foreach var i in level1dData {
-        foreach var j in nestedData {
-            str += " -> Iteration " + i.toString() + ", ";
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        } on fail var error(msg1, code = errCode1, reason = errReason1) {
-                str += " -> On Fail #" + i.toString();
-                testMessage = msg1;
-                testErrorCode = errCode1;
-                testErrorReason = errReason1;
-        }
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
-            str += " -> On Fail Final";
-    }
+//     foreach var i in level1dData {
+//         foreach var j in nestedData {
+//             str += " -> Iteration " + i.toString() + ", ";
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//                 str += " -> On Fail #" + i.toString();
+//                 testMessage = msg1;
+//                 testErrorCode = errCode1;
+//                 testErrorReason = errReason1;
+//         }
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
+//             str += " -> On Fail Final";
+//     }
 
-    assertEquality(" -> Iteration 2,  -> On Fail #2 -> On Fail Final", str);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testMessage, "error!");
-}
+//     assertEquality(" -> Iteration 2,  -> On Fail #2 -> On Fail Final", str);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+// }
 
-function testMultiLevelOnFailWithoutErrorInOneLevel() {
-    string str = "";
-    int[] nestedData = [1];
-    int[] level1dData = [2];
-    string? testMessage = ();
-    int? testErrorCode = ();
-    string? testErrorReason = ();
+// function testMultiLevelOnFailWithoutErrorInOneLevel() {
+//     string str = "";
+//     int[] nestedData = [1];
+//     int[] level1dData = [2];
+//     string? testMessage = ();
+//     int? testErrorCode = ();
+//     string? testErrorReason = ();
 
-    foreach var i in level1dData {
-        foreach var j in nestedData {
-            str += " -> Iteration " + i.toString() + ", ";
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        } on fail var error(msg1, code = errCode1, reason = errReason1) {
-                str += " -> On Fail #" + i.toString();
-                testMessage = msg1;
-                testErrorCode = errCode1;
-                testErrorReason = errReason1;
-        }
-    } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
-            str += " -> On Fail Final";
-    }
+//     foreach var i in level1dData {
+//         foreach var j in nestedData {
+//             str += " -> Iteration " + i.toString() + ", ";
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//                 str += " -> On Fail #" + i.toString();
+//                 testMessage = msg1;
+//                 testErrorCode = errCode1;
+//                 testErrorReason = errReason1;
+//         }
+//     } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
+//             str += " -> On Fail Final";
+//     }
 
-    assertEquality(" -> Iteration 2,  -> On Fail #2", str);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testMessage, "error!");
-}
+//     assertEquality(" -> Iteration 2,  -> On Fail #2", str);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+// }
 
 type AssertionError error;
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/UnusedVariableTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/UnusedVariableTest.java
@@ -110,13 +110,13 @@ public class UnusedVariableTest {
         validateWarning(result, i++, getUnusedVariableWarning("k"), 405, 9);
         validateWarning(result, i++, getUnusedVariableWarning("k1"), 418, 5);
         validateWarning(result, i++, getUnusedVariableWarning("k2"), 421, 5);
-        validateWarning(result, i++, getUnusedVariableWarning("msg1"), 432, 29);
-        validateWarning(result, i++, getUnusedVariableWarning("errCode1"), 432, 42);
-        validateWarning(result, i++, getUnusedVariableWarning("errReason1"), 432, 61);
-        validateWarning(result, i++, getUnusedVariableWarning("msg2"), 436, 33);
-        validateWarning(result, i++, getUnusedVariableWarning("cause"), 436, 39);
-        validateWarning(result, i++, getUnusedVariableWarning("errCode2"), 436, 53);
-        validateWarning(result, i++, getUnusedVariableWarning("errReason2"), 436, 72);
+//        validateWarning(result, i++, getUnusedVariableWarning("msg1"), 432, 29);
+//        validateWarning(result, i++, getUnusedVariableWarning("errCode1"), 432, 42);
+//        validateWarning(result, i++, getUnusedVariableWarning("errReason1"), 432, 61);
+//        validateWarning(result, i++, getUnusedVariableWarning("msg2"), 436, 33);
+//        validateWarning(result, i++, getUnusedVariableWarning("cause"), 436, 39);
+//        validateWarning(result, i++, getUnusedVariableWarning("errCode2"), 436, 53);
+//        validateWarning(result, i++, getUnusedVariableWarning("errReason2"), 436, 72);
         Assert.assertEquals(result.getWarnCount(), i);
         Assert.assertEquals(result.getErrorCount(), 0);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksWithOnFailTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksWithOnFailTest.java
@@ -74,7 +74,7 @@ public class LocksWithOnFailTest {
         BRunUtil.invoke(compileResult, "onFailLockWithinLockWithoutVariable");
     }
 
-    @Test(dataProvider = "onFailClauseWithErrorBPTestDataProvider")
+    @Test(dataProvider = "onFailClauseWithErrorBPTestDataProvider", enabled = false)
     public void testOnFailWithErrorBP(String funcName) {
         BRunUtil.invoke(compileResult, funcName);
     }
@@ -108,6 +108,8 @@ public class LocksWithOnFailTest {
     public void testNegative() {
         CompileResult resultNegative = BCompileUtil.compile("test-src/lock/lock-on-fail-negative.bal");
         int i = 0;
+        BAssertUtil.validateError(resultNegative, i++, "error binding patterns are not yet supported in " +
+                "'on fail' clauses", 39, 15);
         BAssertUtil.validateError(resultNegative, i++, "invalid error variable; expecting an " +
                 "error type but found '(SampleComplexError|SampleError)' in type definition", 39, 15);
         Assert.assertEquals(resultNegative.getErrorCount(), i);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStatementOnFailTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStatementOnFailTest.java
@@ -71,7 +71,7 @@ public class MatchStatementOnFailTest {
         BRunUtil.invoke(result, "testVarInMatchPatternWithinOnfail", new Object[]{});
     }
 
-    @Test(dataProvider = "onFailClauseWithErrorBPTestDataProvider")
+    @Test(dataProvider = "onFailClauseWithErrorBPTestDataProvider", enabled = false)
     public void testOnFailWithErrorBP(String funcName) {
         BRunUtil.invoke(result, funcName);
     }
@@ -112,6 +112,8 @@ public class MatchStatementOnFailTest {
                 "expected 'ErrorTypeA', found 'ErrorTypeB'", 59, 15);
         BAssertUtil.validateError(resultNegative, i++, "incompatible types: " +
                 "expected '(ErrorTypeA|ErrorTypeB)', found 'ErrorTypeB'", 94, 15);
+        BAssertUtil.validateError(resultNegative, i++, "error binding patterns are not yet supported in" +
+                " 'on fail' clauses", 125, 15);
         BAssertUtil.validateError(resultNegative, i++, "invalid error variable; expecting an error " +
                 "type but found '(SampleComplexError|SampleError)' in type definition", 125, 15);
         Assert.assertEquals(resultNegative.getErrorCount(), i);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/onfail/OnFailClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/onfail/OnFailClauseTest.java
@@ -58,53 +58,53 @@ public class OnFailClauseTest {
                 "test-src/statements/onfail/on-fail-clause-negative.bal");
         int i = 0;
         BAssertUtil.validateError(negativeResult, i++, "undefined symbol 'i'", 22, 55);
-        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'SampleError', " +
-                "found 'error<record {| string code; anydata...; |}>'", 49, 15);
-        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'SampleError', " +
-                "found 'SampleComplexError'", 56, 15);
-        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'SampleError', " +
-                "found 'int'", 63, 15);
-        BAssertUtil.validateError(negativeResult, i++, "invalid error variable; expecting an error " +
-                "type but found 'int' in type definition", 63, 15);
-        BAssertUtil.validateError(negativeResult, i++, "invalid error variable; expecting an error " +
-                "type but found 'int' in type definition", 63, 15);
-        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'error<record " +
-                "{| string code; anydata...; |}>', found 'error<record {| int code; anydata...; |}>'", 71, 15);
-        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'error', " +
-                "found 'anydata'", 78, 15);
-        BAssertUtil.validateError(negativeResult, i++, "invalid error variable; expecting an error " +
-                "type but found 'anydata' in type definition", 78, 15);
-        BAssertUtil.validateError(negativeResult, i++, "invalid error variable; expecting an error " +
-                "type but found 'anydata' in type definition", 78, 15);
-        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'error', " +
-                "found '[error]'", 85, 15);
-        BAssertUtil.validateError(negativeResult, i++, "invalid binding pattern in 'on fail' clause: " +
-                "only a capture binding pattern or an error binding pattern is allowed", 85, 15);
-        BAssertUtil.validateError(negativeResult, i++, "invalid error variable; expecting an error " +
-                "type but found '[error]' in type definition", 85, 15);
-        BAssertUtil.validateError(negativeResult, i++, "invalid binding pattern in 'on fail' clause: " +
-                "only a capture binding pattern or an error binding pattern is allowed", 92, 15);
-        BAssertUtil.validateError(negativeResult, i++, "invalid list binding pattern: attempted " +
-                "to infer a list type, but found 'error'", 92, 15);
-        BAssertUtil.validateError(negativeResult, i++, "a wildcard binding pattern can be used only " +
-                "with a value that belong to type 'any'", 99, 15);
-        BAssertUtil.validateError(negativeResult, i++, "invalid binding pattern in 'on fail' clause: " +
-                "only a capture binding pattern or an error binding pattern is allowed", 106, 15);
-        BAssertUtil.validateError(negativeResult, i++, "invalid record binding pattern " +
-                "with type 'error'", 106, 15);
-        BAssertUtil.validateError(negativeResult, i++, "unknown error detail arg 'cause' passed to " +
-                "closed error detail type 'SampleComplexErrorData'", 114, 66);
-        BAssertUtil.validateError(negativeResult, i++, "invalid error variable; expecting an error " +
-                "type but found '(SampleComplexError|SampleError)' in type definition", 117, 15);
-        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected '(Error2|error)', found " +
-                "'Error1'", 132, 15);
-        BAssertUtil.validateError(negativeResult, i++, "type 'int?' not allowed here; expected an 'error' or a " +
-                "subtype of 'error'", 141, 14);
-        BAssertUtil.validateError(negativeResult, i++, "type 'int?' not allowed here; expected an 'error' or a " +
-                "subtype of 'error'", 150, 14);
-        BAssertUtil.validateError(negativeResult, i++, "undefined symbol 'e'", 158, 14);
-        BAssertUtil.validateError(negativeResult, i++, "undefined symbol 'e'", 166, 14);
-        BAssertUtil.validateError(negativeResult, i++, "redeclared symbol 'm'", 176, 25);
+//        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'SampleError', " +
+//                "found 'error<record {| string code; anydata...; |}>'", 49, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'SampleError', " +
+//                "found 'SampleComplexError'", 56, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'SampleError', " +
+//                "found 'int'", 63, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "invalid error variable; expecting an error " +
+//                "type but found 'int' in type definition", 63, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "invalid error variable; expecting an error " +
+//                "type but found 'int' in type definition", 63, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'error<record " +
+//                "{| string code; anydata...; |}>', found 'error<record {| int code; anydata...; |}>'", 71, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'error', " +
+//                "found 'anydata'", 78, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "invalid error variable; expecting an error " +
+//                "type but found 'anydata' in type definition", 78, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "invalid error variable; expecting an error " +
+//                "type but found 'anydata' in type definition", 78, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'error', " +
+//                "found '[error]'", 85, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "invalid binding pattern in 'on fail' clause: " +
+//                "only a capture binding pattern or an error binding pattern is allowed", 85, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "invalid error variable; expecting an error " +
+//                "type but found '[error]' in type definition", 85, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "invalid binding pattern in 'on fail' clause: " +
+//                "only a capture binding pattern or an error binding pattern is allowed", 92, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "invalid list binding pattern: attempted " +
+//                "to infer a list type, but found 'error'", 92, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "a wildcard binding pattern can be used only " +
+//                "with a value that belong to type 'any'", 99, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "invalid binding pattern in 'on fail' clause: " +
+//                "only a capture binding pattern or an error binding pattern is allowed", 106, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "invalid record binding pattern " +
+//                "with type 'error'", 106, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "unknown error detail arg 'cause' passed to " +
+//                "closed error detail type 'SampleComplexErrorData'", 114, 66);
+//        BAssertUtil.validateError(negativeResult, i++, "invalid error variable; expecting an error " +
+//                "type but found '(SampleComplexError|SampleError)' in type definition", 117, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected '(Error2|error)', found " +
+//                "'Error1'", 132, 15);
+//        BAssertUtil.validateError(negativeResult, i++, "type 'int?' not allowed here; expected an 'error' or a " +
+//                "subtype of 'error'", 141, 14);
+//        BAssertUtil.validateError(negativeResult, i++, "type 'int?' not allowed here; expected an 'error' or a " +
+//                "subtype of 'error'", 150, 14);
+//        BAssertUtil.validateError(negativeResult, i++, "undefined symbol 'e'", 158, 14);
+//        BAssertUtil.validateError(negativeResult, i++, "undefined symbol 'e'", 166, 14);
+//        BAssertUtil.validateError(negativeResult, i++, "redeclared symbol 'm'", 176, 25);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/onfail/OnFailClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/onfail/OnFailClauseTest.java
@@ -52,6 +52,11 @@ public class OnFailClauseTest {
         BRunUtil.invoke(result, "testOnFailWithCheckpanicOfDifferentErrorInDoClause");
     }
 
+    @Test
+    public void testOnFailWithCaptureBPAgainstMultipleCheckExprs() {
+        BRunUtil.invoke(result, "testOnFailWithCaptureBPAgainstMultipleCheckExprs");
+    }
+
     @Test(description = "Test on-fail clause negative cases - v1")
     public void testOnFailClauseNegativeCaseV1() {
         CompileResult negativeResult = BCompileUtil.compile(

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/retrystmt/RetryStmtWithOnFailTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/retrystmt/RetryStmtWithOnFailTest.java
@@ -46,7 +46,7 @@ public class RetryStmtWithOnFailTest {
         BRunUtil.invoke(programFile, "testRetryStatement", params);
     }
 
-    @Test(dataProvider = "onFailClauseWithErrorBPTestDataProvider")
+    @Test(dataProvider = "onFailClauseWithErrorBPTestDataProvider", enabled = false)
     public void testOnFailWithErrorBP(String funcName) {
         BRunUtil.invoke(programFile, funcName);
     }
@@ -83,6 +83,8 @@ public class RetryStmtWithOnFailTest {
                 "expected 'ErrorTypeA', found 'ErrorTypeB'", 14, 14);
         BAssertUtil.validateError(negativeFile1, index++, "incompatible types: " +
                 "expected '(ErrorTypeA|ErrorTypeB)', found 'ErrorTypeA'", 36, 12);
+        BAssertUtil.validateError(negativeFile1, index++, "error binding patterns are not yet supported in " +
+                "'on fail' clauses", 66, 15);
         BAssertUtil.validateError(negativeFile1, index++, "invalid error variable; " +
                 "expecting an error type but found '(SampleComplexError|SampleError)' in type definition", 66, 15);
         Assert.assertEquals(negativeFile1.getDiagnostics().length, index);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/whilestatement/WhileStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/whilestatement/WhileStmtTest.java
@@ -257,6 +257,8 @@ public class WhileStmtTest {
                 "incompatible types: expected 'ErrorTypeA', found 'ErrorTypeB'", 17, 12);
         BAssertUtil.validateError(onfailNegativeCompileResult, index++,
                 "incompatible types: expected '(ErrorTypeA|ErrorTypeB)', found 'ErrorTypeA'", 41, 12);
+        BAssertUtil.validateError(onfailNegativeCompileResult, index++, "error binding patterns are not yet supported" +
+                " in 'on fail' clauses", 72, 15);
         BAssertUtil.validateError(onfailNegativeCompileResult, index++, "invalid error variable; " +
                 "expecting an error type but found '(SampleComplexError|SampleError)' in type definition", 72, 15);
         Assert.assertEquals(onfailNegativeCompileResult.getDiagnostics().length, index);
@@ -324,7 +326,7 @@ public class WhileStmtTest {
         Assert.assertEquals(compileResult.getDiagnostics().length, index);
     }
 
-    @Test(dataProvider = "onFailClauseWithErrorBPTestDataProvider")
+    @Test(dataProvider = "onFailClauseWithErrorBPTestDataProvider", enabled = false)
     public void testOnFailWithErrorBP(String funcName) {
         BRunUtil.invoke(onfailCompileResult, funcName);
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/unused_variable_analysis_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/unused_variable_analysis_test.bal
@@ -421,18 +421,18 @@ function f19() {
     record {@annotOne {value: n4} string x;} k2 = {x: ""}; // unused `k2`
 }
 
-type SampleError error<record {|int code; string reason;|}>;
+// type SampleError error<record {|int code; string reason;|}>;
 
-function testUnusedVariablesInErrorBindingPatternsOfOnFailClauses() {
-    int i = 2;
+// function testUnusedVariablesInErrorBindingPatternsOfOnFailClauses() {
+//     int i = 2;
 
-    while i <= 2 {
-        do {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//     while i <= 2 {
+//         do {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         } on fail var error(msg1, code = errCode1, reason = errReason1) {
 
-        }
-        i = i + 1;
-    } on fail SampleError error(msg2, cause, code = errCode2, reason = errReason2) {
-    }
-}
+//         }
+//         i = i + 1;
+//     } on fail SampleError error(msg2, cause, code = errCode2, reason = errReason2) {
+//     }
+// }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/lock/lock-on-fail.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/lock/lock-on-fail.bal
@@ -89,356 +89,356 @@ function getError()  returns int|error {
     return err;
 }
 
-type SampleErrorData record {|
-    int code;
-    string reason;
-|};
+// type SampleErrorData record {|
+//     int code;
+//     string reason;
+// |};
 
-type SampleError error<SampleErrorData>;
+// type SampleError error<SampleErrorData>;
 
-string testMessage = "";
-int testErrorCode = 0;
-string testErrorReason = "";
+// string testMessage = "";
+// int testErrorCode = 0;
+// string testErrorReason = "";
 
-function testSimpleOnFailWithErrorBP() {
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error("error!");
-    } on fail error error(msg) {
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-}
+// function testSimpleOnFailWithErrorBP() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error("error!");
+//     } on fail error error(msg) {
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+// }
 
-function testSimpleOnFailWithErrorBPWithVar() {
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error("error!");
-    } on fail var error(msg) {
-        testMessage = msg;
-    }
-     assertEquality(testMessage, "error!");
-}
+// function testSimpleOnFailWithErrorBPWithVar() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error("error!");
+//     } on fail var error(msg) {
+//         testMessage = msg;
+//     }
+//      assertEquality(testMessage, "error!");
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithError() {
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithError() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithVar() {
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail var error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithVar() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail var error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedType() {
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail SampleError error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedType() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail SampleError error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail1() {
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<SampleErrorData> error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail1() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<SampleErrorData> error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail2() {
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<record {int code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail2() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<record {int code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail3() {
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<record {int code;}> error(code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail3() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<record {int code;}> error(code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail4() {
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<record {int|string code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail4() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<record {int|string code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecord() {
-    lock {
-        lockWithinLockInt1 = 99;
-        error<record {int code;}> errVar = error("error", code = 34);
-        fail errVar;
-    } on fail error<record {int code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecord() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         error<record {int code;}> errVar = error("error", code = 34);
+//         fail errVar;
+//     } on fail error<record {int code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecordWithVar() {
-    lock {
-        lockWithinLockInt1 = 99;
-        error<record {int code;}> errVar = error("error", code = 34);
-        fail errVar;
-    } on fail var error(msg, code = errCode) {
-        testErrorCode = errCode;
-        testErrorReason = msg;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-    assertEquality(testErrorReason, "error");
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecordWithVar() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         error<record {int code;}> errVar = error("error", code = 34);
+//         fail errVar;
+//     } on fail var error(msg, code = errCode) {
+//         testErrorCode = errCode;
+//         testErrorReason = msg;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+//     assertEquality(testErrorReason, "error");
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecordWithUnionType() {
-    lock {
-        lockWithinLockInt1 = 99;
-        error<record {int code;}> errVar = error("error", code = 34);
-        fail errVar;
-    } on fail error<record {int|string code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecordWithUnionType() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         error<record {int code;}> errVar = error("error", code = 34);
+//         fail errVar;
+//     } on fail error<record {int|string code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-type SampleComplexErrorData record {|
-    error cause;
-    int code;
-    int[2] pos;
-    record {string moreInfo;} infoDetails;
-|};
+// type SampleComplexErrorData record {|
+//     error cause;
+//     int code;
+//     int[2] pos;
+//     record {string moreInfo;} infoDetails;
+// |};
 
-type SampleComplexError error<SampleComplexErrorData>;
+// type SampleComplexError error<SampleComplexErrorData>;
 
-int testErrorPosRow = 0;
-int testErrorPosCol = 0;
-string testErrorMoreInfo = "";
+// int testErrorPosRow = 0;
+// int testErrorPosCol = 0;
+// string testErrorMoreInfo = "";
 
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP1() {
-    string causeMsg;
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(_, cause = errCause, code = errCode, pos = errorPos, infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = errorPos[0];
-        testErrorPosCol = errorPos[1];
-        testErrorMoreInfo = errInfo.moreInfo;
-        causeMsg = errCause.message();
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(causeMsg, "Database Error");
-    assertEquality(causeMsg is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP1() {
+//     string causeMsg;
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(_, cause = errCause, code = errCode, pos = errorPos, infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = errorPos[0];
+//         testErrorPosCol = errorPos[1];
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         causeMsg = errCause.message();
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(causeMsg, "Database Error");
+//     assertEquality(causeMsg is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP2() {
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = errorPos, infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = errorPos[0];
-        testErrorPosCol = errorPos[1];
-        testErrorMoreInfo = errInfo.moreInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP2() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = errorPos, infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = errorPos[0];
+//         testErrorPosCol = errorPos[1];
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP3() {
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = [row, col], infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo.moreInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP3() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = [row, col], infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP4() {
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP4() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP5() {
-    lock {
-        lockWithinLockInt1 = 99;
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail var error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP5() {
+//     lock {
+//         lockWithinLockInt1 = 99;
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail var error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testMultiLevelOnFailWithErrorBP() {
-    int i = 2;
-    string str = "";
+// function testMultiLevelOnFailWithErrorBP() {
+//     int i = 2;
+//     string str = "";
 
-    lock {
-        lock {
-            str += " -> Iteration " + i.toString() + ", ";
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        } on fail var error(msg1, code = errCode1, reason = errReason1) {
-                str += " -> On Fail #" + i.toString();
-                testMessage = msg1;
-                testErrorCode = errCode1;
-                testErrorReason = errReason1;
-        }
-        i = i + 1;
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
-            str += " -> On Fail Final";
-    }
+//     lock {
+//         lock {
+//             str += " -> Iteration " + i.toString() + ", ";
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//                 str += " -> On Fail #" + i.toString();
+//                 testMessage = msg1;
+//                 testErrorCode = errCode1;
+//                 testErrorReason = errReason1;
+//         }
+//         i = i + 1;
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
+//             str += " -> On Fail Final";
+//     }
 
-    assertEquality(" -> Iteration 2,  -> On Fail #2 -> On Fail Final", str);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testMessage, "error!");
-}
+//     assertEquality(" -> Iteration 2,  -> On Fail #2 -> On Fail Final", str);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+// }
 
-function testMultiLevelOnFailWithoutErrorInOneLevel() {
-    int i = 2;
-    string str = "";
+// function testMultiLevelOnFailWithoutErrorInOneLevel() {
+//     int i = 2;
+//     string str = "";
 
-    lock {
-        lock {
-            str += " -> Iteration " + i.toString() + ", ";
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        } on fail var error(msg1, code = errCode1, reason = errReason1) {
-                str += " -> On Fail #" + i.toString();
-                testMessage = msg1;
-                testErrorCode = errCode1;
-                testErrorReason = errReason1;
-        }
-        i = i + 1;
-    } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
-            str += " -> On Fail Final";
-    }
+//     lock {
+//         lock {
+//             str += " -> Iteration " + i.toString() + ", ";
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//                 str += " -> On Fail #" + i.toString();
+//                 testMessage = msg1;
+//                 testErrorCode = errCode1;
+//                 testErrorReason = errReason1;
+//         }
+//         i = i + 1;
+//     } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
+//             str += " -> On Fail Final";
+//     }
 
-    assertEquality(" -> Iteration 2,  -> On Fail #2", str);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testMessage, "error!");
-}
+//     assertEquality(" -> Iteration 2,  -> On Fail #2", str);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+// }
 
 function assertEquality(anydata expected, anydata actual) {
     if expected == actual {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/matchstmt_on_fail.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/matchstmt_on_fail.bal
@@ -361,436 +361,436 @@ function getErrorDetailNestedMatch([int, string] dataEntry) returns string {
     return str;
 }
 
-type SampleErrorData record {|
-    int code;
-    string reason;
-|};
+// type SampleErrorData record {|
+//     int code;
+//     string reason;
+// |};
 
-type SampleError error<SampleErrorData>;
+// type SampleError error<SampleErrorData>;
 
-string testMessage = "";
-int testErrorCode = 0;
-string testErrorReason = "";
-string matchString = "fail";
-string matchRes = "";
+// string testMessage = "";
+// int testErrorCode = 0;
+// string testErrorReason = "";
+// string matchString = "fail";
+// string matchRes = "";
 
-function testSimpleOnFailWithErrorBP() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error("error!");
-        }
-    } on fail error error(msg) {
-        testMessage = msg;
-    }
-     assertEquals(testMessage, "error!");
-}
+// function testSimpleOnFailWithErrorBP() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error("error!");
+//         }
+//     } on fail error error(msg) {
+//         testMessage = msg;
+//     }
+//      assertEquals(testMessage, "error!");
+// }
 
-function testSimpleOnFailWithErrorBPWithVar() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error("error!");
-        }
-    } on fail var error(msg) {
-        testMessage = msg;
-    }
-     assertEquals(testMessage, "error!");
-}
+// function testSimpleOnFailWithErrorBPWithVar() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error("error!");
+//         }
+//     } on fail var error(msg) {
+//         testMessage = msg;
+//     }
+//      assertEquals(testMessage, "error!");
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithError() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail error error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquals(testMessage, "error!");
-    assertEquals(testErrorCode, 20);
-    assertEquals(testErrorReason, "deadlock condition");
-    assertEquals(testErrorCode is int, true);
-    assertEquals(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithError() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail error error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquals(testMessage, "error!");
+//     assertEquals(testErrorCode, 20);
+//     assertEquals(testErrorReason, "deadlock condition");
+//     assertEquals(testErrorCode is int, true);
+//     assertEquals(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithVar() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail var error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquals(testMessage, "error!");
-    assertEquals(testErrorCode, 20);
-    assertEquals(testErrorReason, "deadlock condition");
-    assertEquals(testErrorCode is int, true);
-    assertEquals(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithVar() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail var error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquals(testMessage, "error!");
+//     assertEquals(testErrorCode, 20);
+//     assertEquals(testErrorReason, "deadlock condition");
+//     assertEquals(testErrorCode is int, true);
+//     assertEquals(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedType() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail SampleError error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquals(testMessage, "error!");
-    assertEquals(testErrorCode, 20);
-    assertEquals(testErrorReason, "deadlock condition");
-    assertEquals(testErrorCode is int, true);
-    assertEquals(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedType() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail SampleError error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquals(testMessage, "error!");
+//     assertEquals(testErrorCode, 20);
+//     assertEquals(testErrorReason, "deadlock condition");
+//     assertEquals(testErrorCode is int, true);
+//     assertEquals(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail1() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail error<SampleErrorData> error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquals(testMessage, "error!");
-    assertEquals(testErrorCode, 20);
-    assertEquals(testErrorReason, "deadlock condition");
-    assertEquals(testErrorCode is int, true);
-    assertEquals(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail1() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail error<SampleErrorData> error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquals(testMessage, "error!");
+//     assertEquals(testErrorCode, 20);
+//     assertEquals(testErrorReason, "deadlock condition");
+//     assertEquals(testErrorCode is int, true);
+//     assertEquals(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail2() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail error<record {int code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquals(testErrorCode, 20);
-    assertEquals(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail2() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail error<record {int code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquals(testErrorCode, 20);
+//     assertEquals(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail3() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail error<record {int code;}> error(code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-    }
-    assertEquals(testErrorCode, 20);
-    assertEquals(testErrorReason, "deadlock condition");
-    assertEquals(testErrorCode is int, true);
-    assertEquals(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail3() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail error<record {int code;}> error(code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//     }
+//     assertEquals(testErrorCode, 20);
+//     assertEquals(testErrorReason, "deadlock condition");
+//     assertEquals(testErrorCode is int, true);
+//     assertEquals(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail4() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail error<record {int|string code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquals(testErrorCode, 20);
-    assertEquals(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail4() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail error<record {int|string code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquals(testErrorCode, 20);
+//     assertEquals(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecord() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            error<record {int code;}> errVar = error("error", code = 34);
-            fail errVar;
-        }
-    } on fail error<record {int code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquals(testErrorCode, 34);
-    assertEquals(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecord() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             error<record {int code;}> errVar = error("error", code = 34);
+//             fail errVar;
+//         }
+//     } on fail error<record {int code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquals(testErrorCode, 34);
+//     assertEquals(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecordWithVar() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            error<record {int code;}> errVar = error("error", code = 34);
-            fail errVar;
-        }
-    } on fail var error(msg, code = errCode) {
-        testErrorCode = errCode;
-        testErrorReason = msg;
-    }
-    assertEquals(testErrorCode, 34);
-    assertEquals(testErrorCode is int, true);
-    assertEquals(testErrorReason is string, true);
-    assertEquals(testErrorReason, "error");
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecordWithVar() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             error<record {int code;}> errVar = error("error", code = 34);
+//             fail errVar;
+//         }
+//     } on fail var error(msg, code = errCode) {
+//         testErrorCode = errCode;
+//         testErrorReason = msg;
+//     }
+//     assertEquals(testErrorCode, 34);
+//     assertEquals(testErrorCode is int, true);
+//     assertEquals(testErrorReason is string, true);
+//     assertEquals(testErrorReason, "error");
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecordWithUnionType() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            error<record {int code;}> errVar = error("error", code = 34);
-            fail errVar;
-        }
-    } on fail error<record {int|string code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquals(testErrorCode, 34);
-    assertEquals(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecordWithUnionType() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             error<record {int code;}> errVar = error("error", code = 34);
+//             fail errVar;
+//         }
+//     } on fail error<record {int|string code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquals(testErrorCode, 34);
+//     assertEquals(testErrorCode is int, true);
+// }
 
-type SampleComplexErrorData record {|
-    error cause;
-    int code;
-    int[2] pos;
-    record {string moreInfo;} infoDetails;
-|};
+// type SampleComplexErrorData record {|
+//     error cause;
+//     int code;
+//     int[2] pos;
+//     record {string moreInfo;} infoDetails;
+// |};
 
-type SampleComplexError error<SampleComplexErrorData>;
+// type SampleComplexError error<SampleComplexErrorData>;
 
-int testErrorPosRow = 0;
-int testErrorPosCol = 0;
-string testErrorMoreInfo = "";
+// int testErrorPosRow = 0;
+// int testErrorPosCol = 0;
+// string testErrorMoreInfo = "";
 
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP1() {
-    string causeMsg;
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-        }
-    } on fail SampleComplexError error(_, cause = errCause, code = errCode, pos = errorPos, infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = errorPos[0];
-        testErrorPosCol = errorPos[1];
-        testErrorMoreInfo = errInfo.moreInfo;
-        causeMsg = errCause.message();
-    }
-    assertEquals(testErrorPosRow, 30);
-    assertEquals(testErrorPosRow is int, true);
-    assertEquals(testErrorPosCol, 45);
-    assertEquals(testErrorPosCol is int, true);
-    assertEquals(testErrorMoreInfo, "deadlock condition");
-    assertEquals(testErrorMoreInfo is string,  true);
-    assertEquals(testErrorCode, 20);
-    assertEquals(testErrorCode is int, true);
-    assertEquals(causeMsg, "Database Error");
-    assertEquals(causeMsg is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP1() {
+//     string causeMsg;
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//         }
+//     } on fail SampleComplexError error(_, cause = errCause, code = errCode, pos = errorPos, infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = errorPos[0];
+//         testErrorPosCol = errorPos[1];
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         causeMsg = errCause.message();
+//     }
+//     assertEquals(testErrorPosRow, 30);
+//     assertEquals(testErrorPosRow is int, true);
+//     assertEquals(testErrorPosCol, 45);
+//     assertEquals(testErrorPosCol is int, true);
+//     assertEquals(testErrorMoreInfo, "deadlock condition");
+//     assertEquals(testErrorMoreInfo is string,  true);
+//     assertEquals(testErrorCode, 20);
+//     assertEquals(testErrorCode is int, true);
+//     assertEquals(causeMsg, "Database Error");
+//     assertEquals(causeMsg is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP2() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-        }
-    } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = errorPos, infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = errorPos[0];
-        testErrorPosCol = errorPos[1];
-        testErrorMoreInfo = errInfo.moreInfo;
-        testMessage = msg;
-    }
-    assertEquals(testErrorPosRow, 30);
-    assertEquals(testErrorPosRow is int, true);
-    assertEquals(testErrorPosCol, 45);
-    assertEquals(testErrorPosCol is int, true);
-    assertEquals(testErrorMoreInfo, "deadlock condition");
-    assertEquals(testErrorMoreInfo is string,  true);
-    assertEquals(testErrorCode, 20);
-    assertEquals(testErrorCode is int, true);
-    assertEquals(testMessage, "Database Error");
-    assertEquals(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP2() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//         }
+//     } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = errorPos, infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = errorPos[0];
+//         testErrorPosCol = errorPos[1];
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         testMessage = msg;
+//     }
+//     assertEquals(testErrorPosRow, 30);
+//     assertEquals(testErrorPosRow is int, true);
+//     assertEquals(testErrorPosCol, 45);
+//     assertEquals(testErrorPosCol is int, true);
+//     assertEquals(testErrorMoreInfo, "deadlock condition");
+//     assertEquals(testErrorMoreInfo is string,  true);
+//     assertEquals(testErrorCode, 20);
+//     assertEquals(testErrorCode is int, true);
+//     assertEquals(testMessage, "Database Error");
+//     assertEquals(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP3() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-        }
-    } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = [row, col], infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo.moreInfo;
-        testMessage = msg;
-    }
-    assertEquals(testErrorPosRow, 30);
-    assertEquals(testErrorPosRow is int, true);
-    assertEquals(testErrorPosCol, 45);
-    assertEquals(testErrorPosCol is int, true);
-    assertEquals(testErrorMoreInfo, "deadlock condition");
-    assertEquals(testErrorMoreInfo is string,  true);
-    assertEquals(testErrorCode, 20);
-    assertEquals(testErrorCode is int, true);
-    assertEquals(testMessage, "Database Error");
-    assertEquals(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP3() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//         }
+//     } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = [row, col], infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         testMessage = msg;
+//     }
+//     assertEquals(testErrorPosRow, 30);
+//     assertEquals(testErrorPosRow is int, true);
+//     assertEquals(testErrorPosCol, 45);
+//     assertEquals(testErrorPosCol is int, true);
+//     assertEquals(testErrorMoreInfo, "deadlock condition");
+//     assertEquals(testErrorMoreInfo is string,  true);
+//     assertEquals(testErrorCode, 20);
+//     assertEquals(testErrorCode is int, true);
+//     assertEquals(testMessage, "Database Error");
+//     assertEquals(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP4() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-        }
-    } on fail SampleComplexError error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo;
-        testMessage = msg;
-    }
-    assertEquals(testErrorPosRow, 30);
-    assertEquals(testErrorPosRow is int, true);
-    assertEquals(testErrorPosCol, 45);
-    assertEquals(testErrorPosCol is int, true);
-    assertEquals(testErrorMoreInfo, "deadlock condition");
-    assertEquals(testErrorMoreInfo is string,  true);
-    assertEquals(testErrorCode, 20);
-    assertEquals(testErrorCode is int, true);
-    assertEquals(testMessage, "Database Error");
-    assertEquals(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP4() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//         }
+//     } on fail SampleComplexError error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo;
+//         testMessage = msg;
+//     }
+//     assertEquals(testErrorPosRow, 30);
+//     assertEquals(testErrorPosRow is int, true);
+//     assertEquals(testErrorPosCol, 45);
+//     assertEquals(testErrorPosCol is int, true);
+//     assertEquals(testErrorMoreInfo, "deadlock condition");
+//     assertEquals(testErrorMoreInfo is string,  true);
+//     assertEquals(testErrorCode, 20);
+//     assertEquals(testErrorCode is int, true);
+//     assertEquals(testMessage, "Database Error");
+//     assertEquals(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP5() {
-    match matchString {
-        12 => {
-            matchRes = "12";
-        }
-        "fail" => {
-            fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-        }
-    } on fail var error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo;
-        testMessage = msg;
-    }
-    assertEquals(testErrorPosRow, 30);
-    assertEquals(testErrorPosRow is int, true);
-    assertEquals(testErrorPosCol, 45);
-    assertEquals(testErrorPosCol is int, true);
-    assertEquals(testErrorMoreInfo, "deadlock condition");
-    assertEquals(testErrorMoreInfo is string,  true);
-    assertEquals(testErrorCode, 20);
-    assertEquals(testErrorCode is int, true);
-    assertEquals(testMessage, "Database Error");
-    assertEquals(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP5() {
+//     match matchString {
+//         12 => {
+//             matchRes = "12";
+//         }
+//         "fail" => {
+//             fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//         }
+//     } on fail var error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo;
+//         testMessage = msg;
+//     }
+//     assertEquals(testErrorPosRow, 30);
+//     assertEquals(testErrorPosRow is int, true);
+//     assertEquals(testErrorPosCol, 45);
+//     assertEquals(testErrorPosCol is int, true);
+//     assertEquals(testErrorMoreInfo, "deadlock condition");
+//     assertEquals(testErrorMoreInfo is string,  true);
+//     assertEquals(testErrorCode, 20);
+//     assertEquals(testErrorCode is int, true);
+//     assertEquals(testMessage, "Database Error");
+//     assertEquals(testMessage is string, true);
+// }
 
-function testMultiLevelOnFailWithErrorBP() {
-    int i = 2;
-    string str = "";
+// function testMultiLevelOnFailWithErrorBP() {
+//     int i = 2;
+//     string str = "";
 
-    while i <= 2 {
-        match matchString {
-            12 => {
-                matchRes = "12";
-            }
-            "fail" => {
-                str += " -> Iteration " + i.toString() + ", ";
-                fail error SampleError("error!", code = 30, reason = "deadlock condition");
-            }
-        } on fail var error(msg1, code = errCode1, reason = errReason1) {
-                str += " -> On Fail #" + i.toString();
-                testMessage = msg1;
-                testErrorCode = errCode1;
-                testErrorReason = errReason1;
-        }
-        i = i + 1;
-        fail error SampleError("database error!", code = 20, reason = "database connection error");
-    } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
-            str += " -> On Fail Final";
-    }
+//     while i <= 2 {
+//         match matchString {
+//             12 => {
+//                 matchRes = "12";
+//             }
+//             "fail" => {
+//                 str += " -> Iteration " + i.toString() + ", ";
+//                 fail error SampleError("error!", code = 30, reason = "deadlock condition");
+//             }
+//         } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//                 str += " -> On Fail #" + i.toString();
+//                 testMessage = msg1;
+//                 testErrorCode = errCode1;
+//                 testErrorReason = errReason1;
+//         }
+//         i = i + 1;
+//         fail error SampleError("database error!", code = 20, reason = "database connection error");
+//     } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
+//             str += " -> On Fail Final";
+//     }
 
-    assertEquals(" -> Iteration 2,  -> On Fail #2 -> On Fail Final", str);
-    assertEquals(testErrorCode, 30);
-    assertEquals(testErrorReason, "deadlock condition");
-    assertEquals(testMessage, "error!");
-}
+//     assertEquals(" -> Iteration 2,  -> On Fail #2 -> On Fail Final", str);
+//     assertEquals(testErrorCode, 30);
+//     assertEquals(testErrorReason, "deadlock condition");
+//     assertEquals(testMessage, "error!");
+// }
 
-function testMultiLevelOnFailWithoutErrorInOneLevel() {
-    int i = 2;
-    string str = "";
+// function testMultiLevelOnFailWithoutErrorInOneLevel() {
+//     int i = 2;
+//     string str = "";
 
-    while i <= 2 {
-        match matchString {
-            12 => {
-                matchRes = "12";
-            }
-            "fail" => {
-                str += " -> Iteration " + i.toString() + ", ";
-                fail error SampleError("error!", code = 20, reason = "deadlock condition");
-            }
-        } on fail var error(msg1, code = errCode1, reason = errReason1) {
-                str += " -> On Fail #" + i.toString();
-                testMessage = msg1;
-                testErrorCode = errCode1;
-                testErrorReason = errReason1;
-        }
-        i = i + 1;
-    } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
-            str += " -> On Fail Final";
-    }
+//     while i <= 2 {
+//         match matchString {
+//             12 => {
+//                 matchRes = "12";
+//             }
+//             "fail" => {
+//                 str += " -> Iteration " + i.toString() + ", ";
+//                 fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//             }
+//         } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//                 str += " -> On Fail #" + i.toString();
+//                 testMessage = msg1;
+//                 testErrorCode = errCode1;
+//                 testErrorReason = errReason1;
+//         }
+//         i = i + 1;
+//     } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
+//             str += " -> On Fail Final";
+//     }
 
-    assertEquals(" -> Iteration 2,  -> On Fail #2", str);
-    assertEquals(testErrorCode, 20);
-    assertEquals(testErrorReason, "deadlock condition");
-    assertEquals(testMessage, "error!");
-}
+//     assertEquals(" -> Iteration 2,  -> On Fail #2", str);
+//     assertEquals(testErrorCode, 20);
+//     assertEquals(testErrorReason, "deadlock condition");
+//     assertEquals(testMessage, "error!");
+// }
 
 function assertEquals(anydata expected, anydata actual) {
     if expected == actual {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause-negative.bal
@@ -28,152 +28,152 @@ function getError() returns error {
     return err;
 }
 
-type SampleErrorData record {|
-    int code;
-    string reason;
-|};
+// type SampleErrorData record {|
+//     int code;
+//     string reason;
+// |};
 
-type SampleError error<SampleErrorData>;
+// type SampleError error<SampleErrorData>;
 
-type SampleComplexErrorData record {|
-    int code;
-    int[2] pos;
-    record {string moreInfo;} infoDetails;
-|};
+// type SampleComplexErrorData record {|
+//     int code;
+//     int[2] pos;
+//     record {string moreInfo;} infoDetails;
+// |};
 
-type SampleComplexError error<SampleComplexErrorData>;
+// type SampleComplexError error<SampleComplexErrorData>;
 
-function testOnFailWithErrorBPHavingMismatchedTypes1() {
-    do {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<record {string code;}> error(code = errCode) {
-    }
-}
+// function testOnFailWithErrorBPHavingMismatchedTypes1() {
+//     do {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<record {string code;}> error(code = errCode) {
+//     }
+// }
 
-function testOnFailWithErrorBPHavingMismatchedTypes2() {
-    do {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail SampleComplexError error(code = errCode) {
-    }
-}
+// function testOnFailWithErrorBPHavingMismatchedTypes2() {
+//     do {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail SampleComplexError error(code = errCode) {
+//     }
+// }
 
-function testOnFailWithErrorBPHavingMismatchedTypes3() {
-    do {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail int error(code = errCode) {
-    }
-}
+// function testOnFailWithErrorBPHavingMismatchedTypes3() {
+//     do {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail int error(code = errCode) {
+//     }
+// }
 
-function testOnFailWithErrorBPHavingMismatchedTypes4() {
-    do {
-        error<record {string code;}> errVar = error("error", code = "23");
-        fail errVar;
-    } on fail error<record {int code;}> error(code = errorCode) {
-    }
-}
+// function testOnFailWithErrorBPHavingMismatchedTypes4() {
+//     do {
+//         error<record {string code;}> errVar = error("error", code = "23");
+//         fail errVar;
+//     } on fail error<record {int code;}> error(code = errorCode) {
+//     }
+// }
 
-function testOnFailWithErrorBPHavingMismatchedTypes5() {
-    do {
-        fail error("error!");
-    } on fail anydata error(msg) {
-    }
-}
+// function testOnFailWithErrorBPHavingMismatchedTypes5() {
+//     do {
+//         fail error("error!");
+//     } on fail anydata error(msg) {
+//     }
+// }
 
-function testOnFailWithErrorBPHavingInvalidListBP1() {
-    do {
-        fail error("error!");
-    } on fail [error] [err] {
-    }
-}
+// function testOnFailWithErrorBPHavingInvalidListBP1() {
+//     do {
+//         fail error("error!");
+//     } on fail [error] [err] {
+//     }
+// }
 
-function testOnFailWithErrorBPHavingInvalidListBP2() {
-    do {
-        fail error("error!");
-    } on fail error [err] {
-    }
-}
+// function testOnFailWithErrorBPHavingInvalidListBP2() {
+//     do {
+//         fail error("error!");
+//     } on fail error [err] {
+//     }
+// }
 
-function testOnFailWithErrorBPHavingInvalidWildcardBP() {
-    do {
-        fail error("error!");
-    } on fail error _ {
-    }
-}
+// function testOnFailWithErrorBPHavingInvalidWildcardBP() {
+//     do {
+//         fail error("error!");
+//     } on fail error _ {
+//     }
+// }
 
-function testOnFailWithErrorBPHavingInvalidMappingBP() {
-    do {
-        fail error("error!");
-    } on fail error {failError: err} {
-    }
-}
+// function testOnFailWithErrorBPHavingInvalidMappingBP() {
+//     do {
+//         fail error("error!");
+//     } on fail error {failError: err} {
+//     }
+// }
 
-function testOnFailWithMultipleErrors() {
-    boolean isPositiveState = false;
-    do {
-        if isPositiveState {
-            fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-        }
-        fail error SampleError("Transaction Failure", code = 50, reason = "deadlock condition");
-    } on fail var error(msg) {
-    }
-}
+// function testOnFailWithMultipleErrors() {
+//     boolean isPositiveState = false;
+//     do {
+//         if isPositiveState {
+//             fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//         }
+//         fail error SampleError("Transaction Failure", code = 50, reason = "deadlock condition");
+//     } on fail var error(msg) {
+//     }
+// }
 
-type Error1 distinct error;
-type Error2 distinct error;
+// type Error1 distinct error;
+// type Error2 distinct error;
 
-function functionWithCheckpanicInDoClauseNegative() {
-    do {
-        _ = checkpanic fn();
+// function functionWithCheckpanicInDoClauseNegative() {
+//     do {
+//         _ = checkpanic fn();
 
-        Error2? x = ();
-        check x;
+//         Error2? x = ();
+//         check x;
 
-        fail error("Error");
-    } on fail Error1 e {
-    }
-}
+//         fail error("Error");
+//     } on fail Error1 e {
+//     }
+// }
 
-function fn() returns int|Error1 => 1;
+// function fn() returns int|Error1 => 1;
 
-function f1() {
-    int? e = 10;
-    do {
-        fail e;
-    } on fail var m {
+// function f1() {
+//     int? e = 10;
+//     do {
+//         fail e;
+//     } on fail var m {
 
-    }
-}
+//     }
+// }
 
-function f2() {
-    int? e = 10;
-    do {
-        fail e;
-    } on fail var error(m) {
+// function f2() {
+//     int? e = 10;
+//     do {
+//         fail e;
+//     } on fail var error(m) {
 
-    }
-}
+//     }
+// }
 
-function f3() {
-    do {
-        fail e;
-    } on fail var m {
+// function f3() {
+//     do {
+//         fail e;
+//     } on fail var m {
 
-    }
-}
+//     }
+// }
 
-function f4() {
-    do {
-        fail e;
-    } on fail error error(m) {
+// function f4() {
+//     do {
+//         fail e;
+//     } on fail error error(m) {
 
-    }
-}
+//     }
+// }
 
-function f5() {
-    string m = "str";
-    do {
-        fail error(m);
-    } on fail var error(m) {
+// function f5() {
+//     string m = "str";
+//     do {
+//         fail error(m);
+//     } on fail var error(m) {
 
-    }
-}
+//     }
+// }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
@@ -1008,6 +1008,54 @@ function functionWithCheckpanicInDoClause(1|2 val) returns [int, Error]? {
 }
 
 function fn(1|2 val) returns int|error => val == 1 ? 1 : error("error!");
+
+function testOnFailWithCaptureBPAgainstMultipleCheckExprs() {
+    int f1Result = f1("1");
+    assertEquality(1, f1Result);
+
+    f1Result = f1("2");
+    assertEquality(2, f1Result);
+
+    f1Result = f1("3");
+    assertEquality(3, f1Result);
+
+    f1Result = f1("4");
+    assertEquality(4, f1Result);
+}
+
+function f1(string str) returns int {
+    do {
+        check f2(str);
+        check f2(str);
+    } on fail error e {
+        string message = e.message();
+        match message {
+            "Error 1" => {
+                return 1;
+            }
+            "Error 2" => {
+                return 2;
+            }
+        }
+        return 3;
+    }
+    return 4;
+}
+
+function f2(string str) returns error? {
+    match str {
+        "1" => {
+            return error("Error 1");
+        }
+        "2" => {
+            return error("Error 2");
+        }
+        "3" => {
+            return error("Error 3");
+        }
+    }
+}
+
 //-------------------------------------------------------------------------------
 
 type AssertionError error;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
@@ -588,397 +588,399 @@ function testOnFailInAnonFunctionExpr() returns error? {
     assertEquality((<error>result2).detail().get("message"), "'string' value 'a2' cannot be converted to 'int'");
 }
 
-type SampleErrorData record {|
-    int code;
-    string reason;
-|};
+// TODO: add call logic on Java side (OnFailClauseTest) when enabling these.
+// TODO: Seems like these weren't added with the original changes.
+// type SampleErrorData record {|
+//     int code;
+//     string reason;
+// |};
 
-type SampleError error<SampleErrorData>;
+// type SampleError error<SampleErrorData>;
 
-string testMessage = "";
-int testErrorCode = 0;
-string testErrorReason = "";
+// string testMessage = "";
+// int testErrorCode = 0;
+// string testErrorReason = "";
 
-function testSimpleOnFailWithErrorBP() {
-    do {
-        fail error("error!");
-    } on fail error error(msg) {
-        testMessage = msg;
-    }
-     assertEquality(testMessage, "error!");
-}
+// function testSimpleOnFailWithErrorBP() {
+//     do {
+//         fail error("error!");
+//     } on fail error error(msg) {
+//         testMessage = msg;
+//     }
+//      assertEquality(testMessage, "error!");
+// }
 
-function testSimpleOnFailWithErrorBPWithVar() {
-    do {
-        fail error("error!");
-    } on fail var error(msg) {
-        testMessage = msg;
-    }
-     assertEquality(testMessage, "error!");
-}
+// function testSimpleOnFailWithErrorBPWithVar() {
+//     do {
+//         fail error("error!");
+//     } on fail var error(msg) {
+//         testMessage = msg;
+//     }
+//      assertEquality(testMessage, "error!");
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithError() {
-    do {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithError() {
+//     do {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithVar() {
-    do {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail var error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithVar() {
+//     do {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail var error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedType() {
-    do {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail SampleError error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedType() {
+//     do {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail SampleError error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail1() {
-    do {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<SampleErrorData> error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail1() {
+//     do {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<SampleErrorData> error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail2() {
-    do {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<record {int code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail2() {
+//     do {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<record {int code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail3() {
-    do {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<record {int code;}> error(code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail3() {
+//     do {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<record {int code;}> error(code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail4() {
-    do {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<record {int|string code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail4() {
+//     do {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<record {int|string code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecord() {
-    do {
-        error<record {int code;}> errVar = error("error", code = 34);
-        fail errVar;
-    } on fail error<record {int code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecord() {
+//     do {
+//         error<record {int code;}> errVar = error("error", code = 34);
+//         fail errVar;
+//     } on fail error<record {int code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecordWithVar() {
-    do {
-        error<record {int code;}> errVar = error("error", code = 34);
-        fail errVar;
-    } on fail var error(msg, code = errCode) {
-        testErrorCode = errCode;
-        testErrorReason = msg;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-    assertEquality(testErrorReason, "error");
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecordWithVar() {
+//     do {
+//         error<record {int code;}> errVar = error("error", code = 34);
+//         fail errVar;
+//     } on fail var error(msg, code = errCode) {
+//         testErrorCode = errCode;
+//         testErrorReason = msg;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+//     assertEquality(testErrorReason, "error");
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecordWithUnionType() {
-    do {
-        error<record {int code;}> errVar = error("error", code = 34);
-        fail errVar;
-    } on fail error<record {int|string code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecordWithUnionType() {
+//     do {
+//         error<record {int code;}> errVar = error("error", code = 34);
+//         fail errVar;
+//     } on fail error<record {int|string code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-type SampleComplexErrorData record {|
-    error cause;
-    int code;
-    int[2] pos;
-    record {string moreInfo;} infoDetails;
-|};
+// type SampleComplexErrorData record {|
+//     error cause;
+//     int code;
+//     int[2] pos;
+//     record {string moreInfo;} infoDetails;
+// |};
 
-type SampleComplexError error<SampleComplexErrorData>;
+// type SampleComplexError error<SampleComplexErrorData>;
 
-int testErrorPosRow = 0;
-int testErrorPosCol = 0;
-string testErrorMoreInfo = "";
+// int testErrorPosRow = 0;
+// int testErrorPosCol = 0;
+// string testErrorMoreInfo = "";
 
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP1() {
-    string causeMsg;
-    do {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(_, cause = errCause, code = errCode, pos = errorPos, infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = errorPos[0];
-        testErrorPosCol = errorPos[1];
-        testErrorMoreInfo = errInfo.moreInfo;
-        causeMsg = errCause.message();
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(causeMsg, "Database Error");
-    assertEquality(causeMsg is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP1() {
+//     string causeMsg;
+//     do {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(_, cause = errCause, code = errCode, pos = errorPos, infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = errorPos[0];
+//         testErrorPosCol = errorPos[1];
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         causeMsg = errCause.message();
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(causeMsg, "Database Error");
+//     assertEquality(causeMsg is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP2() {
-    do {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = errorPos, infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = errorPos[0];
-        testErrorPosCol = errorPos[1];
-        testErrorMoreInfo = errInfo.moreInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP2() {
+//     do {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = errorPos, infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = errorPos[0];
+//         testErrorPosCol = errorPos[1];
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP3() {
-    do {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = [row, col], infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo.moreInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP3() {
+//     do {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = [row, col], infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP4() {
-    do {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP4() {
+//     do {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP5() {
-    do {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail var error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP5() {
+//     do {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail var error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-int testErrorCodeNested = 0;
-string testMessageNested = "";
+// int testErrorCodeNested = 0;
+// string testMessageNested = "";
 
-function testNestedOnFailWithErrorBP() {
-    string testErrorReasonNested = "";
-    do {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail var error(msg1, code = errCode1, reason = errReason1) {
-        if errCode1 == 20 {
-            do {
-                fail error SampleError("nested error!", code = 30, reason = "database error");
-            } on fail var error(msg2, code = errCode2, reason = errReason2) {
-                testErrorCode = errCode1;
-                testErrorCodeNested = errCode2;
-                testErrorReason = errReason1;
-                testErrorReasonNested = errReason2;
-                testMessage = msg1;
-                testMessageNested = msg2;
-            }
-        }
-    }
+// function testNestedOnFailWithErrorBP() {
+//     string testErrorReasonNested = "";
+//     do {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//         if errCode1 == 20 {
+//             do {
+//                 fail error SampleError("nested error!", code = 30, reason = "database error");
+//             } on fail var error(msg2, code = errCode2, reason = errReason2) {
+//                 testErrorCode = errCode1;
+//                 testErrorCodeNested = errCode2;
+//                 testErrorReason = errReason1;
+//                 testErrorReasonNested = errReason2;
+//                 testMessage = msg1;
+//                 testMessageNested = msg2;
+//             }
+//         }
+//     }
 
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCodeNested, 30);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorReasonNested, "database error");
-    assertEquality(testMessage, "error!");
-    assertEquality(testMessageNested, "nested error!");
-}
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCodeNested, 30);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorReasonNested, "database error");
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testMessageNested, "nested error!");
+// }
 
-function testNestedOnFailWithErrorBPWithErrorArgsHavingBP() {
-    do {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail var error(msg1, code = errCode1, reason = errReason1) {
-        if errCode1 == 20 {
-            do {
-                fail error SampleComplexError("nested error!", cause = error("Database Error"), code = 30, pos = [35, 45], infoDetails = {moreInfo: "deadlock condition"});
-            } on fail SampleComplexError error(_, cause = error(msg2), code = errCode2, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-                testErrorCode = errCode1;
-                testErrorCodeNested = errCode2;
-                testMessage = msg1;
-                testMessageNested = msg2;
-                testErrorPosRow = row;
-                testErrorPosCol = col;
-                testErrorMoreInfo = errInfo;
-            }
-        }
-    }
+// function testNestedOnFailWithErrorBPWithErrorArgsHavingBP() {
+//     do {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//         if errCode1 == 20 {
+//             do {
+//                 fail error SampleComplexError("nested error!", cause = error("Database Error"), code = 30, pos = [35, 45], infoDetails = {moreInfo: "deadlock condition"});
+//             } on fail SampleComplexError error(_, cause = error(msg2), code = errCode2, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//                 testErrorCode = errCode1;
+//                 testErrorCodeNested = errCode2;
+//                 testMessage = msg1;
+//                 testMessageNested = msg2;
+//                 testErrorPosRow = row;
+//                 testErrorPosCol = col;
+//                 testErrorMoreInfo = errInfo;
+//             }
+//         }
+//     }
 
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCodeNested, 30);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testMessage, "error!");
-    assertEquality(testMessageNested, "Database Error");
-    assertEquality(testErrorPosRow, 35);
-    assertEquality(testErrorPosCol, 45);
-}
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCodeNested, 30);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testMessageNested, "Database Error");
+//     assertEquality(testErrorPosRow, 35);
+//     assertEquality(testErrorPosCol, 45);
+// }
 
-function testMultiLevelOnFailWithErrorBP() {
-    int i = 2;
-    string str = "";
+// function testMultiLevelOnFailWithErrorBP() {
+//     int i = 2;
+//     string str = "";
 
-    while i <= 2 {
-        do {
-            str += " -> Iteration " + i.toString() + ", ";
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        } on fail var error(msg1, code = errCode1, reason = errReason1) {
-                str += " -> On Fail #" + i.toString();
-                testMessage = msg1;
-                testErrorCode = errCode1;
-                testErrorReason = errReason1;
-        }
-        i = i + 1;
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
-            str += " -> On Fail Final";
-    }
+//     while i <= 2 {
+//         do {
+//             str += " -> Iteration " + i.toString() + ", ";
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//                 str += " -> On Fail #" + i.toString();
+//                 testMessage = msg1;
+//                 testErrorCode = errCode1;
+//                 testErrorReason = errReason1;
+//         }
+//         i = i + 1;
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
+//             str += " -> On Fail Final";
+//     }
 
-    assertEquality(" -> Iteration 2,  -> On Fail #2 -> On Fail Final", str);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testMessage, "error!");
-}
+//     assertEquality(" -> Iteration 2,  -> On Fail #2 -> On Fail Final", str);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+// }
 
-function testMultiLevelOnFailWithoutErrorInOneLevel() {
-    int i = 2;
-    string str = "";
+// function testMultiLevelOnFailWithoutErrorInOneLevel() {
+//     int i = 2;
+//     string str = "";
 
-    while i <= 2 {
-        do {
-            str += " -> Iteration " + i.toString() + ", ";
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        } on fail var error(msg1, code = errCode1, reason = errReason1) {
-                str += " -> On Fail #" + i.toString();
-                testMessage = msg1;
-                testErrorCode = errCode1;
-                testErrorReason = errReason1;
-        }
-        i = i + 1;
-    } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
-            str += " -> On Fail Final";
-    }
+//     while i <= 2 {
+//         do {
+//             str += " -> Iteration " + i.toString() + ", ";
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//                 str += " -> On Fail #" + i.toString();
+//                 testMessage = msg1;
+//                 testErrorCode = errCode1;
+//                 testErrorReason = errReason1;
+//         }
+//         i = i + 1;
+//     } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
+//             str += " -> On Fail Final";
+//     }
 
-    assertEquality(" -> Iteration 2,  -> On Fail #2", str);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testMessage, "error!");
-}
+//     assertEquality(" -> Iteration 2,  -> On Fail #2", str);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+// }
 
 type Error distinct error;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/retry_stmt_with_on_fail.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/retry_stmt_with_on_fail.bal
@@ -289,397 +289,397 @@ function testNestedRetryOnFailJump2() returns string {
     return str;
 }
 
-type SampleErrorData record {|
-    int code;
-    string reason;
-|};
+// type SampleErrorData record {|
+//     int code;
+//     string reason;
+// |};
 
-type SampleError error<SampleErrorData>;
+// type SampleError error<SampleErrorData>;
 
-string testMessage = "";
-int testErrorCode = 0;
-string testErrorReason = "";
+// string testMessage = "";
+// int testErrorCode = 0;
+// string testErrorReason = "";
 
-function testSimpleOnFailWithErrorBP() {
-    retry(3) {
-        fail error("error!");
-    } on fail error error(msg) {
-        testMessage = msg;
-    }
-     assertEquality(testMessage, "error!");
-}
+// function testSimpleOnFailWithErrorBP() {
+//     retry(3) {
+//         fail error("error!");
+//     } on fail error error(msg) {
+//         testMessage = msg;
+//     }
+//      assertEquality(testMessage, "error!");
+// }
 
-function testSimpleOnFailWithErrorBPWithVar() {
-    retry(3) {
-        fail error("error!");
-    } on fail var error(msg) {
-        testMessage = msg;
-    }
-     assertEquality(testMessage, "error!");
-}
+// function testSimpleOnFailWithErrorBPWithVar() {
+//     retry(3) {
+//         fail error("error!");
+//     } on fail var error(msg) {
+//         testMessage = msg;
+//     }
+//      assertEquality(testMessage, "error!");
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithError() {
-    retry(3) {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithError() {
+//     retry(3) {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithVar() {
-    retry(3) {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail var error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithVar() {
+//     retry(3) {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail var error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedType() {
-    retry(3) {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail SampleError error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedType() {
+//     retry(3) {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail SampleError error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail1() {
-    retry(3) {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<SampleErrorData> error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail1() {
+//     retry(3) {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<SampleErrorData> error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail2() {
-    retry(3) {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<record {int code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail2() {
+//     retry(3) {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<record {int code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail3() {
-    retry(3) {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<record {int code;}> error(code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail3() {
+//     retry(3) {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<record {int code;}> error(code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail4() {
-    retry(3) {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail error<record {int|string code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail4() {
+//     retry(3) {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail error<record {int|string code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecord() {
-    retry(3) {
-        error<record {int code;}> errVar = error("error", code = 34);
-        fail errVar;
-    } on fail error<record {int code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecord() {
+//     retry(3) {
+//         error<record {int code;}> errVar = error("error", code = 34);
+//         fail errVar;
+//     } on fail error<record {int code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecordWithVar() {
-    retry(3) {
-        error<record {int code;}> errVar = error("error", code = 34);
-        fail errVar;
-    } on fail var error(msg, code = errCode) {
-        testErrorCode = errCode;
-        testErrorReason = msg;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-    assertEquality(testErrorReason, "error");
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecordWithVar() {
+//     retry(3) {
+//         error<record {int code;}> errVar = error("error", code = 34);
+//         fail errVar;
+//     } on fail var error(msg, code = errCode) {
+//         testErrorCode = errCode;
+//         testErrorReason = msg;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+//     assertEquality(testErrorReason, "error");
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecordWithUnionType() {
-    retry(3) {
-        error<record {int code;}> errVar = error("error", code = 34);
-        fail errVar;
-    } on fail error<record {int|string code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecordWithUnionType() {
+//     retry(3) {
+//         error<record {int code;}> errVar = error("error", code = 34);
+//         fail errVar;
+//     } on fail error<record {int|string code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-type SampleComplexErrorData record {|
-    error cause;
-    int code;
-    int[2] pos;
-    record {string moreInfo;} infoDetails;
-|};
+// type SampleComplexErrorData record {|
+//     error cause;
+//     int code;
+//     int[2] pos;
+//     record {string moreInfo;} infoDetails;
+// |};
 
-type SampleComplexError error<SampleComplexErrorData>;
+// type SampleComplexError error<SampleComplexErrorData>;
 
-int testErrorPosRow = 0;
-int testErrorPosCol = 0;
-string testErrorMoreInfo = "";
+// int testErrorPosRow = 0;
+// int testErrorPosCol = 0;
+// string testErrorMoreInfo = "";
 
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP1() {
-    string causeMsg;
-    retry(3) {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(_, cause = errCause, code = errCode, pos = errorPos, infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = errorPos[0];
-        testErrorPosCol = errorPos[1];
-        testErrorMoreInfo = errInfo.moreInfo;
-        causeMsg = errCause.message();
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(causeMsg, "Database Error");
-    assertEquality(causeMsg is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP1() {
+//     string causeMsg;
+//     retry(3) {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(_, cause = errCause, code = errCode, pos = errorPos, infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = errorPos[0];
+//         testErrorPosCol = errorPos[1];
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         causeMsg = errCause.message();
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(causeMsg, "Database Error");
+//     assertEquality(causeMsg is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP2() {
-    retry(3) {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = errorPos, infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = errorPos[0];
-        testErrorPosCol = errorPos[1];
-        testErrorMoreInfo = errInfo.moreInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP2() {
+//     retry(3) {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = errorPos, infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = errorPos[0];
+//         testErrorPosCol = errorPos[1];
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP3() {
-    retry(3) {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = [row, col], infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo.moreInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP3() {
+//     retry(3) {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = [row, col], infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP4() {
-    retry(3) {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail SampleComplexError error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP4() {
+//     retry(3) {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail SampleComplexError error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP5() {
-    retry(3) {
-        fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-    } on fail var error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP5() {
+//     retry(3) {
+//         fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//     } on fail var error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-int testErrorCodeNested = 0;
-string testMessageNested = "";
+// int testErrorCodeNested = 0;
+// string testMessageNested = "";
 
-function testNestedOnFailWithErrorBP() {
-    string testErrorReasonNested = "";
-    retry(3) {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail var error(msg1, code = errCode1, reason = errReason1) {
-        if errCode1 == 20 {
-            retry(3) {
-                fail error SampleError("nested error!", code = 30, reason = "database error");
-            } on fail var error(msg2, code = errCode2, reason = errReason2) {
-                testErrorCode = errCode1;
-                testErrorCodeNested = errCode2;
-                testErrorReason = errReason1;
-                testErrorReasonNested = errReason2;
-                testMessage = msg1;
-                testMessageNested = msg2;
-            }
-        }
-    }
+// function testNestedOnFailWithErrorBP() {
+//     string testErrorReasonNested = "";
+//     retry(3) {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//         if errCode1 == 20 {
+//             retry(3) {
+//                 fail error SampleError("nested error!", code = 30, reason = "database error");
+//             } on fail var error(msg2, code = errCode2, reason = errReason2) {
+//                 testErrorCode = errCode1;
+//                 testErrorCodeNested = errCode2;
+//                 testErrorReason = errReason1;
+//                 testErrorReasonNested = errReason2;
+//                 testMessage = msg1;
+//                 testMessageNested = msg2;
+//             }
+//         }
+//     }
 
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCodeNested, 30);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorReasonNested, "database error");
-    assertEquality(testMessage, "error!");
-    assertEquality(testMessageNested, "nested error!");
-}
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCodeNested, 30);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorReasonNested, "database error");
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testMessageNested, "nested error!");
+// }
 
-function testNestedOnFailWithErrorBPWithErrorArgsHavingBP() {
-    retry(3) {
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail var error(msg1, code = errCode1, reason = errReason1) {
-        if errCode1 == 20 {
-            retry(3) {
-                fail error SampleComplexError("nested error!", cause = error("Database Error"), code = 30, pos = [35, 45], infoDetails = {moreInfo: "deadlock condition"});
-            } on fail SampleComplexError error(_, cause = error(msg2), code = errCode2, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-                testErrorCode = errCode1;
-                testErrorCodeNested = errCode2;
-                testMessage = msg1;
-                testMessageNested = msg2;
-                testErrorPosRow = row;
-                testErrorPosCol = col;
-                testErrorMoreInfo = errInfo;
-            }
-        }
-    }
+// function testNestedOnFailWithErrorBPWithErrorArgsHavingBP() {
+//     retry(3) {
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//         if errCode1 == 20 {
+//             retry(3) {
+//                 fail error SampleComplexError("nested error!", cause = error("Database Error"), code = 30, pos = [35, 45], infoDetails = {moreInfo: "deadlock condition"});
+//             } on fail SampleComplexError error(_, cause = error(msg2), code = errCode2, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//                 testErrorCode = errCode1;
+//                 testErrorCodeNested = errCode2;
+//                 testMessage = msg1;
+//                 testMessageNested = msg2;
+//                 testErrorPosRow = row;
+//                 testErrorPosCol = col;
+//                 testErrorMoreInfo = errInfo;
+//             }
+//         }
+//     }
 
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCodeNested, 30);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testMessage, "error!");
-    assertEquality(testMessageNested, "Database Error");
-    assertEquality(testErrorPosRow, 35);
-    assertEquality(testErrorPosCol, 45);
-}
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCodeNested, 30);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testMessageNested, "Database Error");
+//     assertEquality(testErrorPosRow, 35);
+//     assertEquality(testErrorPosCol, 45);
+// }
 
-function testMultiLevelOnFailWithErrorBP() {
-    int i = 2;
-    string str = "";
+// function testMultiLevelOnFailWithErrorBP() {
+//     int i = 2;
+//     string str = "";
 
-    while i <= 2 {
-        retry(3) {
-            str += " -> Iteration " + i.toString() + ", ";
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        } on fail var error(msg1, code = errCode1, reason = errReason1) {
-                str += " -> On Fail #" + i.toString();
-                testMessage = msg1;
-                testErrorCode = errCode1;
-                testErrorReason = errReason1;
-        }
-        i = i + 1;
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
-            str += " -> On Fail Final";
-    }
+//     while i <= 2 {
+//         retry(3) {
+//             str += " -> Iteration " + i.toString() + ", ";
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//                 str += " -> On Fail #" + i.toString();
+//                 testMessage = msg1;
+//                 testErrorCode = errCode1;
+//                 testErrorReason = errReason1;
+//         }
+//         i = i + 1;
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
+//             str += " -> On Fail Final";
+//     }
 
-    assertEquality(" -> Iteration 2,  -> On Fail #2 -> On Fail Final", str);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testMessage, "error!");
-}
+//     assertEquality(" -> Iteration 2,  -> On Fail #2 -> On Fail Final", str);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+// }
 
-function testMultiLevelOnFailWithoutErrorInOneLevel() {
-    int i = 2;
-    string str = "";
+// function testMultiLevelOnFailWithoutErrorInOneLevel() {
+//     int i = 2;
+//     string str = "";
 
-    while i <= 2 {
-        retry(3) {
-            str += " -> Iteration " + i.toString() + ", ";
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        } on fail var error(msg1, code = errCode1, reason = errReason1) {
-                str += " -> On Fail #" + i.toString();
-                testMessage = msg1;
-                testErrorCode = errCode1;
-                testErrorReason = errReason1;
-        }
-        i = i + 1;
-    } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
-            str += " -> On Fail Final";
-    }
+//     while i <= 2 {
+//         retry(3) {
+//             str += " -> Iteration " + i.toString() + ", ";
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//                 str += " -> On Fail #" + i.toString();
+//                 testMessage = msg1;
+//                 testErrorCode = errCode1;
+//                 testErrorReason = errReason1;
+//         }
+//         i = i + 1;
+//     } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
+//             str += " -> On Fail Final";
+//     }
 
-    assertEquality(" -> Iteration 2,  -> On Fail #2", str);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testMessage, "error!");
-}
+//     assertEquality(" -> Iteration 2,  -> On Fail #2", str);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+// }
 
 const ASSERTION_ERROR_REASON = "AssertionError";
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/whilestatement/while-stmt-on-fail.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/whilestatement/while-stmt-on-fail.bal
@@ -135,489 +135,489 @@ function testWhileStmtWithOnFailWithoutVariable() {
     assertEquality(" Value: 1 Value: 2 Value: 3-> error caught. -> reached end", str);
 }
 
-type SampleErrorData record {|
-    int code;
-    string reason;
-|};
+// type SampleErrorData record {|
+//     int code;
+//     string reason;
+// |};
 
-type SampleError error<SampleErrorData>;
+// type SampleError error<SampleErrorData>;
 
-string testMessage = "";
-int testErrorCode = 0;
-string testErrorReason = "";
-int whileIndex = 0;
+// string testMessage = "";
+// int testErrorCode = 0;
+// string testErrorReason = "";
+// int whileIndex = 0;
 
-function testSimpleOnFailWithErrorBP() {
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error("error!");
-        }
-    } on fail error error(msg) {
-        testMessage = msg;
-    }
-     assertEquality(testMessage, "error!");
-}
+// function testSimpleOnFailWithErrorBP() {
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error("error!");
+//         }
+//     } on fail error error(msg) {
+//         testMessage = msg;
+//     }
+//      assertEquality(testMessage, "error!");
+// }
 
-function testSimpleOnFailWithErrorBPWithVar() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error("error!");
-        }
-    } on fail var error(msg) {
-        testMessage = msg;
-    }
-     assertEquality(testMessage, "error!");
-}
+// function testSimpleOnFailWithErrorBPWithVar() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error("error!");
+//         }
+//     } on fail var error(msg) {
+//         testMessage = msg;
+//     }
+//      assertEquality(testMessage, "error!");
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithError() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail error error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithError() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail error error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithVar() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail var error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithVar() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail var error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedType() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail SampleError error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedType() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail SampleError error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail1() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail error<SampleErrorData> error(msg, code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-        testMessage = msg;
-    }
-    assertEquality(testMessage, "error!");
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail1() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail error<SampleErrorData> error(msg, code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//         testMessage = msg;
+//     }
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail2() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail error<record {int code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail2() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail error<record {int code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail3() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail error<record {int code;}> error(code = errCode, reason = errReason) {
-        testErrorCode = errCode;
-        testErrorReason = errReason;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail3() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail error<record {int code;}> error(code = errCode, reason = errReason) {
+//         testErrorCode = errCode;
+//         testErrorReason = errReason;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+// }
 
-function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail4() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail error<record {int|string code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingUserDefinedTypeWithErrDetail4() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail error<record {int|string code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecord() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            error<record {int code;}> errVar = error("error", code = 34);
-            fail errVar;
-        }
-    } on fail error<record {int code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecord() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             error<record {int code;}> errVar = error("error", code = 34);
+//             fail errVar;
+//         }
+//     } on fail error<record {int code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecordWithVar() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            error<record {int code;}> errVar = error("error", code = 34);
-            fail errVar;
-        }
-    } on fail var error(msg, code = errCode) {
-        testErrorCode = errCode;
-        testErrorReason = msg;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testErrorReason is string, true);
-    assertEquality(testErrorReason, "error");
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecordWithVar() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             error<record {int code;}> errVar = error("error", code = 34);
+//             fail errVar;
+//         }
+//     } on fail var error(msg, code = errCode) {
+//         testErrorCode = errCode;
+//         testErrorReason = msg;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testErrorReason is string, true);
+//     assertEquality(testErrorReason, "error");
+// }
 
-function testOnFailWithErrorBPHavingAnonDetailRecordWithUnionType() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            error<record {int code;}> errVar = error("error", code = 34);
-            fail errVar;
-        }
-    } on fail error<record {int|string code;}> error(code = errCode) {
-        testErrorCode = errCode;
-    }
-    assertEquality(testErrorCode, 34);
-    assertEquality(testErrorCode is int, true);
-}
+// function testOnFailWithErrorBPHavingAnonDetailRecordWithUnionType() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             error<record {int code;}> errVar = error("error", code = 34);
+//             fail errVar;
+//         }
+//     } on fail error<record {int|string code;}> error(code = errCode) {
+//         testErrorCode = errCode;
+//     }
+//     assertEquality(testErrorCode, 34);
+//     assertEquality(testErrorCode is int, true);
+// }
 
-type SampleComplexErrorData record {|
-    error cause;
-    int code;
-    int[2] pos;
-    record {string moreInfo;} infoDetails;
-|};
+// type SampleComplexErrorData record {|
+//     error cause;
+//     int code;
+//     int[2] pos;
+//     record {string moreInfo;} infoDetails;
+// |};
 
-type SampleComplexError error<SampleComplexErrorData>;
+// type SampleComplexError error<SampleComplexErrorData>;
 
-int testErrorPosRow = 0;
-int testErrorPosCol = 0;
-string testErrorMoreInfo = "";
+// int testErrorPosRow = 0;
+// int testErrorPosCol = 0;
+// string testErrorMoreInfo = "";
 
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP1() {
-    string causeMsg = "";
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-        }
-    } on fail SampleComplexError error(_, cause = errCause, code = errCode, pos = errorPos, infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = errorPos[0];
-        testErrorPosCol = errorPos[1];
-        testErrorMoreInfo = errInfo.moreInfo;
-        causeMsg = errCause.message();
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(causeMsg, "Database Error");
-    assertEquality(causeMsg is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP1() {
+//     string causeMsg = "";
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//         }
+//     } on fail SampleComplexError error(_, cause = errCause, code = errCode, pos = errorPos, infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = errorPos[0];
+//         testErrorPosCol = errorPos[1];
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         causeMsg = errCause.message();
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(causeMsg, "Database Error");
+//     assertEquality(causeMsg is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP2() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-        }
-    } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = errorPos, infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = errorPos[0];
-        testErrorPosCol = errorPos[1];
-        testErrorMoreInfo = errInfo.moreInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP2() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//         }
+//     } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = errorPos, infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = errorPos[0];
+//         testErrorPosCol = errorPos[1];
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP3() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-        }
-    } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = [row, col], infoDetails = errInfo) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo.moreInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP3() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//         }
+//     } on fail SampleComplexError error(message, cause = error(msg), code = errCode, pos = [row, col], infoDetails = errInfo) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo.moreInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP4() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-        }
-    } on fail SampleComplexError error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP4() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//         }
+//     } on fail SampleComplexError error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-function testOnFailWithErrorBPWithErrorArgsHavingBP5() {
-    whileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
-        }
-    } on fail var error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-        testErrorCode = errCode;
-        testErrorPosRow = row;
-        testErrorPosCol = col;
-        testErrorMoreInfo = errInfo;
-        testMessage = msg;
-    }
-    assertEquality(testErrorPosRow, 30);
-    assertEquality(testErrorPosRow is int, true);
-    assertEquality(testErrorPosCol, 45);
-    assertEquality(testErrorPosCol is int, true);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testErrorMoreInfo is string,  true);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCode is int, true);
-    assertEquality(testMessage, "Database Error");
-    assertEquality(testMessage is string, true);
-}
+// function testOnFailWithErrorBPWithErrorArgsHavingBP5() {
+//     whileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleComplexError("Transaction Failure", cause = error("Database Error"), code = 20, pos = [30, 45], infoDetails = {moreInfo: "deadlock condition"});
+//         }
+//     } on fail var error(_, cause = error(msg), code = errCode, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//         testErrorCode = errCode;
+//         testErrorPosRow = row;
+//         testErrorPosCol = col;
+//         testErrorMoreInfo = errInfo;
+//         testMessage = msg;
+//     }
+//     assertEquality(testErrorPosRow, 30);
+//     assertEquality(testErrorPosRow is int, true);
+//     assertEquality(testErrorPosCol, 45);
+//     assertEquality(testErrorPosCol is int, true);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testErrorMoreInfo is string,  true);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCode is int, true);
+//     assertEquality(testMessage, "Database Error");
+//     assertEquality(testMessage is string, true);
+// }
 
-int testErrorCodeNested = 0;
-string testMessageNested = "";
+// int testErrorCodeNested = 0;
+// string testMessageNested = "";
 
-function testNestedOnFailWithErrorBP() {
-    string testErrorReasonNested = "";
-    whileIndex = 0;
-    int innerWhileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail var error(msg1, code = errCode1, reason = errReason1) {
-        if errCode1 == 20 {
-            while innerWhileIndex >= 0 {
-                innerWhileIndex = innerWhileIndex + 1;
-                if innerWhileIndex == 1 {
-                    fail error SampleError("nested error!", code = 30, reason = "database error");
-                }
-            } on fail var error(msg2, code = errCode2, reason = errReason2) {
-                testErrorCode = errCode1;
-                testErrorCodeNested = errCode2;
-                testErrorReason = errReason1;
-                testErrorReasonNested = errReason2;
-                testMessage = msg1;
-                testMessageNested = msg2;
-            }
-        }
-    }
+// function testNestedOnFailWithErrorBP() {
+//     string testErrorReasonNested = "";
+//     whileIndex = 0;
+//     int innerWhileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//         if errCode1 == 20 {
+//             while innerWhileIndex >= 0 {
+//                 innerWhileIndex = innerWhileIndex + 1;
+//                 if innerWhileIndex == 1 {
+//                     fail error SampleError("nested error!", code = 30, reason = "database error");
+//                 }
+//             } on fail var error(msg2, code = errCode2, reason = errReason2) {
+//                 testErrorCode = errCode1;
+//                 testErrorCodeNested = errCode2;
+//                 testErrorReason = errReason1;
+//                 testErrorReasonNested = errReason2;
+//                 testMessage = msg1;
+//                 testMessageNested = msg2;
+//             }
+//         }
+//     }
 
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCodeNested, 30);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testErrorReasonNested, "database error");
-    assertEquality(testMessage, "error!");
-    assertEquality(testMessageNested, "nested error!");
-}
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCodeNested, 30);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testErrorReasonNested, "database error");
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testMessageNested, "nested error!");
+// }
 
-function testNestedOnFailWithErrorBPWithErrorArgsHavingBP() {
-    whileIndex = 0;
-    int innerWhileIndex = 0;
-    while whileIndex >= 0 {
-        whileIndex = whileIndex + 1;
-        if whileIndex == 1 {
-            fail error SampleError("error!", code = 20, reason = "deadlock condition");
-        }
-    } on fail var error(msg1, code = errCode1, reason = errReason1) {
-        if errCode1 == 20 {
-            while innerWhileIndex >= 0 {
-                innerWhileIndex = innerWhileIndex + 1;
-                if innerWhileIndex == 1 {
-                    fail error SampleComplexError("nested error!", cause = error("Database Error"), code = 30, pos = [35, 45], infoDetails = {moreInfo: "deadlock condition"});
-                }
-            } on fail SampleComplexError error(_, cause = error(msg2), code = errCode2, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
-                testErrorCode = errCode1;
-                testErrorCodeNested = errCode2;
-                testMessage = msg1;
-                testMessageNested = msg2;
-                testErrorPosRow = row;
-                testErrorPosCol = col;
-                testErrorMoreInfo = errInfo;
-            }
-        }
-    }
+// function testNestedOnFailWithErrorBPWithErrorArgsHavingBP() {
+//     whileIndex = 0;
+//     int innerWhileIndex = 0;
+//     while whileIndex >= 0 {
+//         whileIndex = whileIndex + 1;
+//         if whileIndex == 1 {
+//             fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//         }
+//     } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//         if errCode1 == 20 {
+//             while innerWhileIndex >= 0 {
+//                 innerWhileIndex = innerWhileIndex + 1;
+//                 if innerWhileIndex == 1 {
+//                     fail error SampleComplexError("nested error!", cause = error("Database Error"), code = 30, pos = [35, 45], infoDetails = {moreInfo: "deadlock condition"});
+//                 }
+//             } on fail SampleComplexError error(_, cause = error(msg2), code = errCode2, pos = [row, col], infoDetails = {moreInfo: errInfo}) {
+//                 testErrorCode = errCode1;
+//                 testErrorCodeNested = errCode2;
+//                 testMessage = msg1;
+//                 testMessageNested = msg2;
+//                 testErrorPosRow = row;
+//                 testErrorPosCol = col;
+//                 testErrorMoreInfo = errInfo;
+//             }
+//         }
+//     }
 
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorCodeNested, 30);
-    assertEquality(testErrorMoreInfo, "deadlock condition");
-    assertEquality(testMessage, "error!");
-    assertEquality(testMessageNested, "Database Error");
-    assertEquality(testErrorPosRow, 35);
-    assertEquality(testErrorPosCol, 45);
-}
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorCodeNested, 30);
+//     assertEquality(testErrorMoreInfo, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+//     assertEquality(testMessageNested, "Database Error");
+//     assertEquality(testErrorPosRow, 35);
+//     assertEquality(testErrorPosCol, 45);
+// }
 
-function testMultiLevelOnFailWithErrorBP() {
-    int i = 0;
-    string str = "";
-    whileIndex = 0;
+// function testMultiLevelOnFailWithErrorBP() {
+//     int i = 0;
+//     string str = "";
+//     whileIndex = 0;
 
-    while i == 0 {
-        while whileIndex == 0 {
-            whileIndex = whileIndex + 1;
-            if (whileIndex == 1) {
-                str += " -> Iteration " + i.toString() + ", ";
-                fail error SampleError("error!", code = 20, reason = "deadlock condition");
-            }
-        } on fail var error(msg1, code = errCode1, reason = errReason1) {
-                str += " -> On Fail #" + i.toString();
-                testMessage = msg1;
-                testErrorCode = errCode1;
-                testErrorReason = errReason1;
-        }
-        i = i + 1;
-        fail error SampleError("error!", code = 20, reason = "deadlock condition");
-    } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
-            str += " -> On Fail Final";
-    }
+//     while i == 0 {
+//         while whileIndex == 0 {
+//             whileIndex = whileIndex + 1;
+//             if (whileIndex == 1) {
+//                 str += " -> Iteration " + i.toString() + ", ";
+//                 fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//             }
+//         } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//                 str += " -> On Fail #" + i.toString();
+//                 testMessage = msg1;
+//                 testErrorCode = errCode1;
+//                 testErrorReason = errReason1;
+//         }
+//         i = i + 1;
+//         fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//     } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
+//             str += " -> On Fail Final";
+//     }
 
-    assertEquality(" -> Iteration 0,  -> On Fail #0 -> On Fail Final", str);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testMessage, "error!");
-}
+//     assertEquality(" -> Iteration 0,  -> On Fail #0 -> On Fail Final", str);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+// }
 
-function testMultiLevelOnFailWithoutErrorInOneLevel() {
-    int i = 0;
-    string str = "";
-    whileIndex = 0;
+// function testMultiLevelOnFailWithoutErrorInOneLevel() {
+//     int i = 0;
+//     string str = "";
+//     whileIndex = 0;
 
-    while i == 0 {
-        while whileIndex == 0 {
-            whileIndex = whileIndex + 1;
-            if (whileIndex == 1) {
-                str += " -> Iteration " + i.toString() + ", ";
-                fail error SampleError("error!", code = 20, reason = "deadlock condition");
-            }
-        } on fail var error(msg1, code = errCode1, reason = errReason1) {
-                str += " -> On Fail #" + i.toString();
-                testMessage = msg1;
-                testErrorCode = errCode1;
-                testErrorReason = errReason1;
-        }
-        i = i + 1;
-    } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
-            str += " -> On Fail Final";
-    }
+//     while i == 0 {
+//         while whileIndex == 0 {
+//             whileIndex = whileIndex + 1;
+//             if (whileIndex == 1) {
+//                 str += " -> Iteration " + i.toString() + ", ";
+//                 fail error SampleError("error!", code = 20, reason = "deadlock condition");
+//             }
+//         } on fail var error(msg1, code = errCode1, reason = errReason1) {
+//                 str += " -> On Fail #" + i.toString();
+//                 testMessage = msg1;
+//                 testErrorCode = errCode1;
+//                 testErrorReason = errReason1;
+//         }
+//         i = i + 1;
+//     } on fail SampleError error(msg2, code = errCode2, reason = errReason2) {
+//             str += " -> On Fail Final";
+//     }
 
-    assertEquality(" -> Iteration 0,  -> On Fail #0", str);
-    assertEquality(testErrorCode, 20);
-    assertEquality(testErrorReason, "deadlock condition");
-    assertEquality(testMessage, "error!");
-}
+//     assertEquality(" -> Iteration 0,  -> On Fail #0", str);
+//     assertEquality(testErrorCode, 20);
+//     assertEquality(testErrorReason, "deadlock condition");
+//     assertEquality(testMessage, "error!");
+// }
 
 function assertEquality(anydata expected, anydata actual) {
     if actual == expected {


### PR DESCRIPTION
## Purpose
Due to https://github.com/ballerina-platform/ballerina-lang/issues/42477. There are issues already (U8) with capture BPs too, but we will disable error BPs for now since it is a new feature anyway.

Closes https://github.com/ballerina-platform/ballerina-lang/issues/42497

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
