### PR TITLE
[2201.9.x] Fix `autoClose()` langlib invocation when current strand is root strand

### DIFF
--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/WorkerChannels.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/WorkerChannels.java
@@ -22,6 +22,8 @@ import io.ballerina.runtime.internal.scheduling.Scheduler;
 import io.ballerina.runtime.internal.scheduling.Strand;
 import io.ballerina.runtime.internal.scheduling.WorkerDataChannel;
 
+import java.util.Objects;
+
 /**
  * Native implementation of lang.internal:WorkerChannels.
  *
@@ -35,10 +37,11 @@ public class WorkerChannels {
      * @param channelIds channel IDs of the channels to be closed
      */
     public static void autoClose(BString[] channelIds) {
-        Strand parent = Scheduler.getStrand().parent;
+        Strand currentStrand = Scheduler.getStrand();
+        Strand channelHoldingStrand = Objects.requireNonNullElse(currentStrand.parent, currentStrand);
         for (BString channelId : channelIds) {
-            String channelName = channelId.getValue() + ":" + (parent.functionInvocation - 1);
-            WorkerDataChannel workerDataChannel = parent.wdChannels.getWorkerDataChannel(channelName);
+            String channelName = channelId.getValue() + ":" + (channelHoldingStrand.functionInvocation - 1);
+            WorkerDataChannel workerDataChannel = channelHoldingStrand.wdChannels.getWorkerDataChannel(channelName);
             workerDataChannel.autoClose();
         }
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/ForkInFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/ForkInFunctionTest.java
@@ -63,4 +63,12 @@ public class ForkInFunctionTest {
         long returnInt = (long) returns;
         Assert.assertEquals(returnInt, 10);
     }
+
+    @Test(description = "Test fork within if condition")
+    public void testForkWithinIfCondition() {
+        CompileResult result = BCompileUtil.compile("test-src/workers/fork-within-if-condition.bal");
+        Object returns = BRunUtil.invoke(result, "testForkWithinIfCondition");
+        Assert.assertTrue(returns instanceof Long);
+        Assert.assertEquals(((Long) returns).intValue(), 1);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/fork-within-if-condition.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/fork-within-if-condition.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function testForkWithinIfCondition() returns int {
+    boolean isForked = false;
+    if isForked {
+        fork {
+            worker A {
+                5 -> B;
+                string value = <- B;
+            }
+
+            worker B {
+                int value = <- A;
+                "a" -> A;
+            }
+        }
+        return 0;
+    }
+    return 1;
+}


### PR DESCRIPTION
## Purpose
$subject.

Fixes #42515

## Approach
n/a

## Samples
n/a

## Remarks
n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
