### PR TITLE
[2201.9.x] Fix incorrect convertible types resolved from type-value pair set for union of records

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -60,7 +60,6 @@ import io.ballerina.runtime.internal.values.RegExpValue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -372,12 +371,12 @@ public class TypeConverter {
 
         for (Type memType : memberTypes) {
             if (TypeChecker.checkIsLikeType(inputValue, memType, false)) {
-                return getConvertibleType(inputValue, memType, varName, new HashSet<>(unresolvedValues), errors, false);
+                return getConvertibleType(inputValue, memType, varName, unresolvedValues, errors, false);
             }
         }
         for (Type memType : memberTypes) {
-            Type convertibleTypeInUnion = getConvertibleType(inputValue, memType, varName,
-                    new HashSet<>(unresolvedValues), errors, allowNumericConversion);
+            Type convertibleTypeInUnion = getConvertibleType(inputValue, memType, varName, unresolvedValues, errors,
+                    allowNumericConversion);
             if (convertibleTypeInUnion != null) {
                 return convertibleTypeInUnion;
             }
@@ -394,8 +393,8 @@ public class TypeConverter {
         int currentErrorListSize = initialErrorListSize;
         for (Type memType : memberTypes) {
             initialErrorCount = errors.size();
-            Type convertibleTypeInUnion = getConvertibleType(inputValue, memType, varName,
-                    new HashSet<>(unresolvedValues), errors, allowNumericConversion);
+            Type convertibleTypeInUnion = getConvertibleType(inputValue, memType, varName, unresolvedValues, errors,
+                    allowNumericConversion);
             currentErrorListSize = errors.size();
             if (convertibleTypeInUnion != null) {
                 errors.subList(initialErrorListSize - 1, currentErrorListSize).clear();
@@ -519,8 +518,12 @@ public class TypeConverter {
             }
 
             if ((!returnVal) && (errors.size() >= MAX_CONVERSION_ERROR_COUNT + 1)) {
+                unresolvedValues.remove(typeValuePair);
                 return false;
             }
+        }
+        if (!returnVal) {
+            unresolvedValues.remove(typeValuePair);
         }
         return returnVal;
     }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -371,6 +371,7 @@ public class LangLibValueTest {
                 "testCloneWithTypeWithAmbiguousUnion", "testCloneWithTypeXmlToUnion",
                 "testCloneWithTypeWithTuples", "testCloneWithTypeToJson",
                 "testCloneWithTypeToUnion",
+                "testCloneWithTypeWithUnionOfRecordsWithTypeInclusion",
                 "testCloneWithTypeTable",
                 "testCloneWithTypeOnRegExp",
                 "testCloneWithTypeOnRegExpNegative",

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -4414,6 +4414,55 @@ function testTableToJsonConversion() {
                                 "\"c\":\"xyz\"}, {\"a\":5, \"b\":{\"x\":[45.6, \"asd\"]}, \"d\":10.0, \"e\":12.5}]");
 }
 
+type Basic record {|
+    int id?;
+|};
+
+type PersonRec record {|
+    string name;
+    int age?;
+    Basic ...;
+|};
+
+type StudentRec record {|
+    *PersonRec;
+    int studentId;
+    string code?;
+|};
+
+type PartTimeStudent record {|
+    *PersonRec;
+    string:Char code?;
+    StudentRec s;
+|};
+
+type StudentResearcher record {|
+    *PersonRec;
+    string code?;
+|};
+
+type StudentTutor record {|
+    *PersonRec;
+|};
+
+type S StudentTutor|StudentResearcher|PartTimeStudent;
+
+function testCloneWithTypeWithUnionOfRecordsWithTypeInclusion() returns error? {
+    json student = {
+        name: "Anne",
+        code: "A",
+        s: {
+            name: "Anne",
+            studentId: 1001
+        }
+    };
+    S s = check student.cloneWithType();
+    assertTrue(s is PartTimeStudent);
+    assertFalse(s is StudentResearcher);
+    assertFalse(s is StudentTutor);
+    assert(s.toString(), "{\"code\":\"A\",\"s\":{\"studentId\":1001,\"name\":\"Anne\"},\"name\":\"Anne\"}");
+}
+
 ///////////////////////// Tests for `ensureType()` ///////////////////////////
 
 json p = {


### PR DESCRIPTION
## Purpose
> $title

Fixes #42402 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
