### PR TITLE
Fix addition of xml with strings

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -5367,6 +5367,15 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 if (leftConstituent != null && rightConstituent != null) {
                     actualType = new BXMLType(BUnionType.create(null, leftConstituent, rightConstituent), null);
                     break;
+                } else if (leftConstituent != null || rightConstituent != null) {
+                    if (leftConstituent != null && types.isAssignable(rhsType, symTable.stringType)) {
+                        actualType = new BXMLType(BUnionType.create(null, leftConstituent, symTable.xmlTextType), null);
+                        break;
+                    } else if (rightConstituent != null && types.isAssignable(lhsType, symTable.stringType)) {
+                        actualType =
+                                new BXMLType(BUnionType.create(null, symTable.xmlTextType, rightConstituent), null);
+                        break;
+                    }
                 }
                 // Fall through
             default:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -5368,12 +5368,12 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     actualType = new BXMLType(BUnionType.create(null, leftConstituent, rightConstituent), null);
                     break;
                 } else if (leftConstituent != null || rightConstituent != null) {
+                    Location pos = binaryExpr.pos;
                     if (leftConstituent != null && types.isAssignable(rhsType, symTable.stringType)) {
-                        actualType = new BXMLType(BUnionType.create(null, leftConstituent, symTable.xmlTextType), null);
+                        actualType = getXmlBinaryOpResultType(lhsType, leftConstituent, data.env, pos);
                         break;
                     } else if (rightConstituent != null && types.isAssignable(lhsType, symTable.stringType)) {
-                        actualType =
-                                new BXMLType(BUnionType.create(null, symTable.xmlTextType, rightConstituent), null);
+                        actualType = getXmlBinaryOpResultType(rhsType, rightConstituent, data.env, pos);
                         break;
                     }
                 }
@@ -5427,6 +5427,20 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         }
 
         data.resultType = types.checkType(binaryExpr, actualType, data.expType);
+    }
+
+    private BType getXmlBinaryOpResultType(BType opType, BType constituentType, SymbolEnv env, Location pos) {
+        if (types.isAssignable(symTable.xmlTextType, constituentType)) {
+            return opType;
+        }
+
+        BTypeSymbol typeSymbol =
+                Symbols.createTypeSymbol(SymTag.UNION_TYPE, 0, Names.EMPTY, env.enclPkg.symbol.pkgID, null,
+                        env.scope.owner, pos, VIRTUAL);
+        BType type = new BXMLType(BUnionType.create(typeSymbol, constituentType, symTable.xmlTextType),
+                symTable.xmlType.tsymbol);
+        typeSymbol.type = type;
+        return type;
     }
 
     public boolean isOptionalFloatOrDecimal(BType expectedType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -5368,12 +5368,12 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     actualType = new BXMLType(BUnionType.create(null, leftConstituent, rightConstituent), null);
                     break;
                 } else if (leftConstituent != null || rightConstituent != null) {
-                    Location pos = binaryExpr.pos;
                     if (leftConstituent != null && types.isAssignable(rhsType, symTable.stringType)) {
-                        actualType = getXmlBinaryOpResultType(lhsType, leftConstituent, data.env, pos);
+                        actualType = getXmlStringBinaryOpResultType(lhsType, leftConstituent, data.env, binaryExpr.pos);
                         break;
                     } else if (rightConstituent != null && types.isAssignable(lhsType, symTable.stringType)) {
-                        actualType = getXmlBinaryOpResultType(rhsType, rightConstituent, data.env, pos);
+                        actualType =
+                                getXmlStringBinaryOpResultType(rhsType, rightConstituent, data.env, binaryExpr.pos);
                         break;
                     }
                 }
@@ -5429,7 +5429,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         data.resultType = types.checkType(binaryExpr, actualType, data.expType);
     }
 
-    private BType getXmlBinaryOpResultType(BType opType, BType constituentType, SymbolEnv env, Location pos) {
+    private BType getXmlStringBinaryOpResultType(BType opType, BType constituentType, SymbolEnv env, Location pos) {
         if (types.isAssignable(symTable.xmlTextType, constituentType)) {
             return opType;
         }
@@ -5437,8 +5437,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         BTypeSymbol typeSymbol =
                 Symbols.createTypeSymbol(SymTag.UNION_TYPE, 0, Names.EMPTY, env.enclPkg.symbol.pkgID, null,
                         env.scope.owner, pos, VIRTUAL);
-        BType type = new BXMLType(BUnionType.create(typeSymbol, constituentType, symTable.xmlTextType),
-                symTable.xmlType.tsymbol);
+        BType type = new BXMLType(BUnionType.create(typeSymbol, constituentType, symTable.xmlTextType), null);
         typeSymbol.type = type;
         return type;
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
@@ -177,6 +177,11 @@ public class AddOperationTest {
         };
     }
 
+    @Test
+    public void testXmlStringAddition() {
+        BRunUtil.invoke(result, "testXmlStringAddition");
+    }
+
     @Test(description = "Test binary statement with errors")
     public void testSubtractStmtNegativeCases() {
         int i = 0;
@@ -269,7 +274,24 @@ public class AddOperationTest {
         BAssertUtil.validateError(resultNegative, i++, "missing binary operator", 164, 12);
         BAssertUtil.validateError(resultNegative, i++, "missing binary operator", 165, 14);
         BAssertUtil.validateError(resultNegative, i++, "missing binary operator", 166, 12);
-
+        BAssertUtil.validateError(resultNegative, i++, "operator '+' not defined for 'xml' and 'int'", 178, 13);
+        BAssertUtil.validateError(resultNegative, i++, "operator '+' not defined for 'xml:Text' and 'int'", 181, 18);
+        BAssertUtil.validateError(resultNegative, i++, "operator '+' not defined for 'xml:Text' and '(string|int)'",
+                184, 18);
+        BAssertUtil.validateError(resultNegative, i++,
+                "incompatible types: expected 'xml<xml:Element>', found 'xml<(xml:Element|xml:Text|xml:Text)>'", 187,
+                26);
+        BAssertUtil.validateError(resultNegative, i++,
+                "incompatible types: expected 'xml<(xml:Element|xml:Comment|xml:ProcessingInstruction)>', found 'xml'",
+                190, 64);
+        BAssertUtil.validateError(resultNegative, i++,
+                "incompatible types: expected 'xml<xml:Element>', found 'xml<(xml:Element|xml:Text)>'", 193, 26);
+        BAssertUtil.validateError(resultNegative, i++,
+                "incompatible types: expected 'xml<(xml:Element|xml:Comment)>', found 'xml<" +
+                        "(xml:Element|xml:Comment|xml:Text)>'",
+                197, 38);
+        BAssertUtil.validateError(resultNegative, i++,
+                "incompatible types: expected 'xml<never>', found 'xml<(never|xml:Text)>'", 200, 20);
         Assert.assertEquals(resultNegative.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
@@ -279,7 +279,7 @@ public class AddOperationTest {
         BAssertUtil.validateError(resultNegative, i++, "operator '+' not defined for 'xml:Text' and '(string|int)'",
                 184, 18);
         BAssertUtil.validateError(resultNegative, i++,
-                "incompatible types: expected 'xml<xml:Element>', found 'xml<(xml:Element|xml:Text|xml:Text)>'", 187,
+                "incompatible types: expected 'xml<xml:Element>', found 'xml<(xml:Element|xml:Text)>'", 187,
                 26);
         BAssertUtil.validateError(resultNegative, i++,
                 "incompatible types: expected 'xml<(xml:Element|xml:Comment|xml:ProcessingInstruction)>', found 'xml'",
@@ -292,6 +292,9 @@ public class AddOperationTest {
                 197, 38);
         BAssertUtil.validateError(resultNegative, i++,
                 "incompatible types: expected 'xml<never>', found 'xml<(never|xml:Text)>'", 200, 20);
+        BAssertUtil.validateError(resultNegative, i++,
+                "incompatible types: expected 'xml<(xml:Element|xml:Comment)>', found 'xml<(xml:Element|xml:Text)>'",
+                204, 38);
         Assert.assertEquals(resultNegative.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation-negative.bal
@@ -171,3 +171,31 @@ function foo(string s) returns string {
 }
 
 function bar() {}
+
+function testXmlStringAdditionNegative() {
+    int i = 1;
+    xml x1 = xml `<a>a</a>`;
+    xml _ = x1 + i;
+
+    xml:Text x2 = xml `text`;
+    xml:Text _ = x2 + i;
+
+    string|int s1 = "string";
+    xml:Text _ = x2 + s1;
+
+    xml<xml:Element|xml:Text> x3 = xml `<a/>text`;
+    xml<xml:Element> _ = x3 + "a";
+
+    xml<xml:Element|xml:Comment|xml:ProcessingInstruction> x4 = xml `<a/><?data?><!--comment-->`;
+    xml<xml:Element|xml:Comment|xml:ProcessingInstruction> _ = x4 + "abc";
+
+    string s2 = "<a>abcd</a>";
+    xml<xml:Element> _ = xml `<a/>` + s2;
+
+    xml<xml:Element|xml:Comment> x5 = xml `<foo/>`;
+    "foo"|"bar" s3 = "foo";
+    xml<xml:Element|xml:Comment> _ = x5 + s3;
+
+    xml<never> x6 = xml ``;
+    xml<never> _ = x6 + s3;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation-negative.bal
@@ -198,4 +198,8 @@ function testXmlStringAdditionNegative() {
 
     xml<never> x6 = xml ``;
     xml<never> _ = x6 + s3;
+
+    xml<xml:Element|xml:Text> x7 = xml `<foo/>`;
+    ("foo"|"bar") s4 = "foo";
+    xml<xml:Element|xml:Comment> _ = x7 + s4;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -539,6 +539,229 @@ function baz() returns int? {
     return ();
 }
 
+type S string;
+
+type P2 "s6"|"s7";
+
+function testXmlStringAddition() {
+    string s1 = "s1";
+    string:Char s2 = "s";
+    "s3" s3 = "s3";
+    "s4"|"s5" s4 = "s4";
+    S s5 = "s5";
+    P2 s6 = "s6";
+
+    xml<xml:Element> x1 = xml `<a>a</a>`;
+    xml<xml:Element|xml:Text> r1 = x1 + s1;
+    assertEquality(x1 + s1, xml `<a>a</a>s1`);
+    r1 = x1 + s2;
+    assertEquality(r1, xml `<a>a</a>s`);
+    r1 = x1 + s3;
+    assertEquality(r1, xml `<a>a</a>s3`);
+    r1 = x1 + s4;
+    assertEquality(r1, xml `<a>a</a>s4`);
+    r1 = x1 + s5;
+    assertEquality(r1, xml `<a>a</a>s5`);
+    r1 = x1 + s6;
+    assertEquality(r1, xml `<a>a</a>s6`);
+
+    xml<xml:Comment> x2 = xml `<!--comment-->`;
+    xml<xml:Comment|xml:Text> r2 = x2 + s1;
+    assertEquality(r2, xml `<!--comment-->s1`);
+    r2 = x2 + s2;
+    assertEquality(r2, xml `<!--comment-->s`);
+    r2 = x2 + s3;
+    assertEquality(r2, xml `<!--comment-->s3`);
+    r2 = x2 + s4;
+    assertEquality(r2, xml `<!--comment-->s4`);
+    r2 = x2 + s5;
+    assertEquality(r2, xml `<!--comment-->s5`);
+    r2 = x2 + s6;
+    assertEquality(r2, xml `<!--comment-->s6`);
+
+    xml<xml:ProcessingInstruction> x3 = xml `<?data?>`;
+    xml<xml:ProcessingInstruction|xml:Text> r3 = x3 + s1;
+    assertEquality(r3, xml `<?data?>s1`);
+    r3 = x3 + s2;
+    assertEquality(r3, xml `<?data?>s`);
+    r3 = x3 + s3;
+    assertEquality(r3, xml `<?data?>s3`);
+    r3 = x3 + s4;
+    assertEquality(r3, xml `<?data?>s4`);
+    r3 = x3 + s5;
+    assertEquality(r3, xml `<?data?>s5`);
+    r3 = x3 + s6;
+    assertEquality(r3, xml `<?data?>s6`);
+
+    xml:Text x4 = xml `Xml text`;
+    xml:Text r4 = x4 + s1;
+    assertEquality(r4, xml `Xml texts1`);
+    r4 = x4 + s2;
+    assertEquality(r4, xml `Xml texts`);
+    r4 = x4 + s3;
+    assertEquality(r4, xml `Xml texts3`);
+    r4 = x4 + s4;
+    assertEquality(r4, xml `Xml texts4`);
+    r4 = x4 + s5;
+    assertEquality(r4, xml `Xml texts5`);
+    r4 = x4 + s6;
+    assertEquality(r4, xml `Xml texts6`);
+
+    xml<xml:Element|xml:Comment> x5 = xml `<a>a</a><b><!--comment--></b><c>c</c>`;
+    xml<xml:Element|xml:Comment|xml:Text> r5 = x5 + s1;
+    assertEquality(r5, xml `<a>a</a><b><!--comment--></b><c>c</c>s1`);
+    r5 = x5 + s2;
+    assertEquality(r5, xml `<a>a</a><b><!--comment--></b><c>c</c>s`);
+    r5 = x5 + s3;
+    assertEquality(r5, xml `<a>a</a><b><!--comment--></b><c>c</c>s3`);
+    r5 = x5 + s4;
+    assertEquality(r5, xml `<a>a</a><b><!--comment--></b><c>c</c>s4`);
+    r5 = x5 + s5;
+    assertEquality(r5, xml `<a>a</a><b><!--comment--></b><c>c</c>s5`);
+    r5 = x5 + s6;
+    assertEquality(r5, xml `<a>a</a><b><!--comment--></b><c>c</c>s6`);
+
+    xml<xml:Element|xml:ProcessingInstruction> x6 = xml `<a>a</a><b>b</b><?pi?>`;
+    xml<xml:Element|xml:ProcessingInstruction|xml:Text> r6 = x6 + s1;
+    assertEquality(r6, xml `<a>a</a><b>b</b><?pi?>s1`);
+    r6 = x6 + s2;
+    assertEquality(r6, xml `<a>a</a><b>b</b><?pi?>s`);
+    r6 = x6 + s3;
+    assertEquality(r6, xml `<a>a</a><b>b</b><?pi?>s3`);
+    r6 = x6 + s4;
+    assertEquality(r6, xml `<a>a</a><b>b</b><?pi?>s4`);
+    r6 = x6 + s5;
+    assertEquality(r6, xml `<a>a</a><b>b</b><?pi?>s5`);
+    r6 = x6 + s6;
+    assertEquality(r6, xml `<a>a</a><b>b</b><?pi?>s6`);
+
+    xml<xml:Element|xml:Text> x7 = xml `<a>a</a><b>b</b>Xml text`;
+    xml<xml:Element|xml:Text> r7 = x7 + s1;
+    assertEquality(r7, xml `<a>a</a><b>b</b>Xml texts1`);
+    r7 = x7 + s2;
+    assertEquality(r7, xml `<a>a</a><b>b</b>Xml texts`);
+    r7 = x7 + s3;
+    assertEquality(r7, xml `<a>a</a><b>b</b>Xml texts3`);
+    r7 = x7 + s4;
+    assertEquality(r7, xml `<a>a</a><b>b</b>Xml texts4`);
+    r7 = x7 + s5;
+    assertEquality(r7, xml `<a>a</a><b>b</b>Xml texts5`);
+    r7 = x7 + s6;
+    assertEquality(r7, xml `<a>a</a><b>b</b>Xml texts6`);
+
+    xml<xml:Comment|xml:ProcessingInstruction> x8 = xml `<!--comment--><?pi?>`;
+    xml<xml:Comment|xml:ProcessingInstruction|xml:Text> r8 = x8 + s1;
+    assertEquality(r8, xml `<!--comment--><?pi?>s1`);
+    r8 = x8 + s2;
+    assertEquality(r8, xml `<!--comment--><?pi?>s`);
+    r8 = x8 + s3;
+    assertEquality(r8, xml `<!--comment--><?pi?>s3`);
+    r8 = x8 + s4;
+    assertEquality(r8, xml `<!--comment--><?pi?>s4`);
+    r8 = x8 + s5;
+    assertEquality(r8, xml `<!--comment--><?pi?>s5`);
+    r8 = x8 + s6;
+    assertEquality(r8, xml `<!--comment--><?pi?>s6`);
+
+    xml<xml:Comment|xml:Text> x9 = xml `<!--comment 2-->Xml text 2`;
+    xml<xml:Comment|xml:Text> r9 = x9 + s1;
+    assertEquality(r9, xml `<!--comment 2-->Xml text 2s1`);
+    r9 = x9 + s2;
+    assertEquality(r9, xml `<!--comment 2-->Xml text 2s`);
+    r9 = x9 + s3;
+    assertEquality(r9, xml `<!--comment 2-->Xml text 2s3`);
+    r9 = x9 + s4;
+    assertEquality(r9, xml `<!--comment 2-->Xml text 2s4`);
+    r9 = x9 + s5;
+    assertEquality(r9, xml `<!--comment 2-->Xml text 2s5`);
+    r9 = x9 + s6;
+    assertEquality(r9, xml `<!--comment 2-->Xml text 2s6`);
+
+    xml<xml:ProcessingInstruction|xml:Text> x10 = xml `<?pi?>Xml text 3`;
+    xml<xml:ProcessingInstruction|xml:Text> r10 = x10 + s1;
+    assertEquality(r10, xml `<?pi?>Xml text 3s1`);
+    r10 = x10 + s2;
+    assertEquality(r10, xml `<?pi?>Xml text 3s`);
+    r10 = x10 + s3;
+    assertEquality(r10, xml `<?pi?>Xml text 3s3`);
+    r10 = x10 + s4;
+    assertEquality(r10, xml `<?pi?>Xml text 3s4`);
+    r10 = x10 + s5;
+    assertEquality(r10, xml `<?pi?>Xml text 3s5`);
+    r10 = x10 + s6;
+    assertEquality(r10, xml `<?pi?>Xml text 3s6`);
+
+    xml<xml:Element|xml:Comment|xml:ProcessingInstruction> x11 = xml `<a>a</a><!--comment--><?pi?>`;
+    xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text> r11 = x11 + s1;
+    assertEquality(r11, xml `<a>a</a><!--comment--><?pi?>s1`);
+    r11 = x11 + s2;
+    assertEquality(r11, xml `<a>a</a><!--comment--><?pi?>s`);
+    r11 = x11 + s3;
+    assertEquality(r11, xml `<a>a</a><!--comment--><?pi?>s3`);
+    r11 = x11 + s4;
+    assertEquality(r11, xml `<a>a</a><!--comment--><?pi?>s4`);
+    r11 = x11 + s5;
+    assertEquality(r11, xml `<a>a</a><!--comment--><?pi?>s5`);
+    r11 = x11 + s6;
+    assertEquality(r11, xml `<a>a</a><!--comment--><?pi?>s6`);
+
+    xml<xml:Element|xml:Comment|xml:Text> x12 = xml `<a>a</a><!--comment-->text`;
+    xml<xml:Element|xml:Comment|xml:Text> r12 = x12 + s1;
+    assertEquality(r12, xml `<a>a</a><!--comment-->texts1`);
+    r12 = x12 + s2;
+    assertEquality(r12, xml `<a>a</a><!--comment-->texts`);
+    r12 = x12 + s3;
+    assertEquality(r12, xml `<a>a</a><!--comment-->texts3`);
+    r12 = x12 + s4;
+    assertEquality(r12, xml `<a>a</a><!--comment-->texts4`);
+    r12 = x12 + s5;
+    assertEquality(r12, xml `<a>a</a><!--comment-->texts5`);
+    r12 = x12 + s6;
+    assertEquality(r12, xml `<a>a</a><!--comment-->texts6`);
+
+    xml<xml:Element|xml:ProcessingInstruction|xml:Text> x13 = xml `text<a>a</a><?data?>`;
+    xml<xml:Element|xml:ProcessingInstruction|xml:Text> r13 = x13 + s1;
+    assertEquality(r13, xml `text<a>a</a><?data?>s1`);
+    r13 = x13 + s2;
+    assertEquality(r13, xml `text<a>a</a><?data?>s`);
+    r13 = x13 + s3;
+    assertEquality(r13, xml `text<a>a</a><?data?>s3`);
+    r13 = x13 + s4;
+    assertEquality(r13, xml `text<a>a</a><?data?>s4`);
+    r13 = x13 + s5;
+    assertEquality(r13, xml `text<a>a</a><?data?>s5`);
+    r13 = x13 + s6;
+    assertEquality(r13, xml `text<a>a</a><?data?>s6`);
+
+    xml<xml:Comment|xml:ProcessingInstruction|xml:Text> x14 = xml `<!--comment--><?pi?>text`;
+    xml<xml:Comment|xml:ProcessingInstruction|xml:Text> r14 = x14 + s1;
+    assertEquality(r14, xml `<!--comment--><?pi?>texts1`);
+    r14 = x14 + s2;
+    assertEquality(r14, xml `<!--comment--><?pi?>texts`);
+    r14 = x14 + s3;
+    assertEquality(r14, xml `<!--comment--><?pi?>texts3`);
+    r14 = x14 + s4;
+    assertEquality(r14, xml `<!--comment--><?pi?>texts4`);
+    r14 = x14 + s5;
+    assertEquality(r14, xml `<!--comment--><?pi?>texts5`);
+    r14 = x14 + s6;
+    assertEquality(r14, xml `<!--comment--><?pi?>texts6`);
+
+    xml<never> x15 = xml ``;
+    xml:Text r15 = x15 + s1;
+    assertEquality(r15, xml `s1`);
+    r15 = x15 + s2;
+    assertEquality(r15, xml `s`);
+    r15 = x15 + s3;
+    assertEquality(r15, xml `s3`);
+    r15 = x15 + s4;
+    assertEquality(r15, xml `s4`);
+    r15 = x15 + s5;
+    assertEquality(r15, xml `s5`);
+    r15 = x15 + s6;
+    assertEquality(r15, xml `s6`);
+}
+
 function assertEquality(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;


### PR DESCRIPTION
## Purpose
Fixes #33066
Fixes #32976

## Approach
Allow addition of xml values and a variable which is assignable to string type.

## Samples

## Remarks

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
