### PR TITLE
[2201.9.0] Add the union of the types in the `Create variable with type` code action

### DIFF
--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableWithTypeTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableWithTypeTest.java
@@ -54,7 +54,15 @@ public class CreateVariableWithTypeTest extends AbstractCodeActionTest {
                 {"type_infer_for_resource_action_config.json"},
                 {"type_infer_for_resource_action_config2.json"},
                 {"type_infer_for_resource_action_with_check1.json"},
-                {"type_infer_for_resource_action_with_check2.json"}
+                {"type_infer_for_resource_action_with_check2.json"},
+                {"type_infer_for_action_with_union_config1.json"},
+                {"type_infer_for_action_with_union_config2.json"},
+                {"type_infer_for_action_with_union_config3.json"},
+                {"type_infer_for_action_with_union_config4.json"},
+                {"type_infer_for_action_with_union_config5.json"},
+                {"type_infer_for_action_with_union_config6.json"},
+                {"type_infer_for_action_with_union_config7.json"},
+                {"type_infer_for_action_with_union_config8.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config1.json
@@ -1,66 +1,66 @@
 {
   "position": {
-    "line": 11,
-    "character": 13
+    "line": 50,
+    "character": 18
   },
-  "source": "source1.bal",
+  "source": "source2.bal",
   "expected": [
     {
-      "title": "Create variable with 'module1:Response|anydata'",
+      "title": "Create variable with 'Rec1|Rec2'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 50,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 50,
               "character": 4
             }
           },
-          "newText": "module1:Response|anydata forward = "
+          "newText": "Rec1|Rec2 targetType = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'anydata'",
+      "title": "Create variable with 'Rec1'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 50,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 50,
               "character": 4
             }
           },
-          "newText": "anydata forward = "
+          "newText": "Rec1 targetType = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'module1:Response'",
+      "title": "Create variable with 'Rec2'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 50,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 50,
               "character": 4
             }
           },
-          "newText": "module1:Response forward = "
+          "newText": "Rec2 targetType = "
         }
       ],
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config2.json
@@ -1,66 +1,66 @@
 {
   "position": {
-    "line": 11,
-    "character": 13
+    "line": 51,
+    "character": 18
   },
-  "source": "source1.bal",
+  "source": "source2.bal",
   "expected": [
     {
-      "title": "Create variable with 'module1:Response|anydata'",
+      "title": "Create variable with 'Rec1|string|Error2'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 51,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 51,
               "character": 4
             }
           },
-          "newText": "module1:Response|anydata forward = "
+          "newText": "Rec1|string|Error2 unionResult = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'anydata'",
+      "title": "Create variable with 'string|Error2'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 51,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 51,
               "character": 4
             }
           },
-          "newText": "anydata forward = "
+          "newText": "string|Error2 unionResult = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'module1:Response'",
+      "title": "Create variable with 'Rec1|Error2'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 51,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 51,
               "character": 4
             }
           },
-          "newText": "module1:Response forward = "
+          "newText": "Rec1|Error2 unionResult = "
         }
       ],
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config3.json
@@ -1,66 +1,66 @@
 {
   "position": {
-    "line": 11,
-    "character": 13
+    "line": 52,
+    "character": 18
   },
-  "source": "source1.bal",
+  "source": "source2.bal",
   "expected": [
     {
-      "title": "Create variable with 'module1:Response|anydata'",
+      "title": "Create variable with 'Rec2|Rec3|error'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 52,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 52,
               "character": 4
             }
           },
-          "newText": "module1:Response|anydata forward = "
+          "newText": "Rec2|Rec3|error unionResult = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'anydata'",
+      "title": "Create variable with 'Rec2|error'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 52,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 52,
               "character": 4
             }
           },
-          "newText": "anydata forward = "
+          "newText": "Rec2|error unionResult = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'module1:Response'",
+      "title": "Create variable with 'Rec3|error'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 52,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 52,
               "character": 4
             }
           },
-          "newText": "module1:Response forward = "
+          "newText": "Rec3|error unionResult = "
         }
       ],
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config4.json
@@ -1,66 +1,66 @@
 {
   "position": {
-    "line": 11,
-    "character": 13
+    "line": 53,
+    "character": 18
   },
-  "source": "source1.bal",
+  "source": "source2.bal",
   "expected": [
     {
-      "title": "Create variable with 'module1:Response|anydata'",
+      "title": "Create variable with 'Rec2|Rec3|Error1|Error2'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 53,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 53,
               "character": 4
             }
           },
-          "newText": "module1:Response|anydata forward = "
+          "newText": "Rec2|Rec3|Error1|Error2 unionResult = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'anydata'",
+      "title": "Create variable with 'Rec2|Error1|Error2'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 53,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 53,
               "character": 4
             }
           },
-          "newText": "anydata forward = "
+          "newText": "Rec2|Error1|Error2 unionResult = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'module1:Response'",
+      "title": "Create variable with 'Rec3|Error1|Error2'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 53,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 53,
               "character": 4
             }
           },
-          "newText": "module1:Response forward = "
+          "newText": "Rec3|Error1|Error2 unionResult = "
         }
       ],
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config5.json
@@ -1,0 +1,89 @@
+{
+  "position": {
+    "line": 54,
+    "character": 18
+  },
+  "source": "source2.bal",
+  "expected": [
+    {
+      "title": "Create variable with 'Rec1|Rec2|Rec3|Error1'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 54,
+              "character": 4
+            },
+            "end": {
+              "line": 54,
+              "character": 4
+            }
+          },
+          "newText": "Rec1|Rec2|Rec3|Error1 unionResult = "
+        }
+      ],
+      "resolvable": false
+    },
+    {
+      "title": "Create variable with 'Rec1|Error1'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 54,
+              "character": 4
+            },
+            "end": {
+              "line": 54,
+              "character": 4
+            }
+          },
+          "newText": "Rec1|Error1 unionResult = "
+        }
+      ],
+      "resolvable": false
+    },
+    {
+      "title": "Create variable with 'Rec2|Error1'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 54,
+              "character": 4
+            },
+            "end": {
+              "line": 54,
+              "character": 4
+            }
+          },
+          "newText": "Rec2|Error1 unionResult = "
+        }
+      ],
+      "resolvable": false
+    },
+    {
+      "title": "Create variable with 'Rec3|Error1'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 54,
+              "character": 4
+            },
+            "end": {
+              "line": 54,
+              "character": 4
+            }
+          },
+          "newText": "Rec3|Error1 unionResult = "
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config6.json
@@ -1,66 +1,66 @@
 {
   "position": {
-    "line": 11,
-    "character": 13
+    "line": 55,
+    "character": 18
   },
-  "source": "source1.bal",
+  "source": "source2.bal",
   "expected": [
     {
-      "title": "Create variable with 'module1:Response|anydata'",
+      "title": "Create variable with 'Rec1|Rec2|Error1'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 55,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 55,
               "character": 4
             }
           },
-          "newText": "module1:Response|anydata forward = "
+          "newText": "Rec1|Rec2|Error1 targetType = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'anydata'",
+      "title": "Create variable with 'Rec1|Error1'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 55,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 55,
               "character": 4
             }
           },
-          "newText": "anydata forward = "
+          "newText": "Rec1|Error1 targetType = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'module1:Response'",
+      "title": "Create variable with 'Rec2|Error1'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 55,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 55,
               "character": 4
             }
           },
-          "newText": "module1:Response forward = "
+          "newText": "Rec2|Error1 targetType = "
         }
       ],
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config7.json
@@ -1,66 +1,66 @@
 {
   "position": {
-    "line": 11,
-    "character": 13
+    "line": 56,
+    "character": 18
   },
-  "source": "source1.bal",
+  "source": "source2.bal",
   "expected": [
     {
-      "title": "Create variable with 'module1:Response|anydata'",
+      "title": "Create variable with 'Rec1|Rec2|Error1'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 56,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 56,
               "character": 4
             }
           },
-          "newText": "module1:Response|anydata forward = "
+          "newText": "Rec1|Rec2|Error1 delete = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'anydata'",
+      "title": "Create variable with 'Rec1|Error1'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 56,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 56,
               "character": 4
             }
           },
-          "newText": "anydata forward = "
+          "newText": "Rec1|Error1 delete = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'module1:Response'",
+      "title": "Create variable with 'Rec2|Error1'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 56,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 56,
               "character": 4
             }
           },
-          "newText": "module1:Response forward = "
+          "newText": "Rec2|Error1 delete = "
         }
       ],
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_action_with_union_config8.json
@@ -1,66 +1,66 @@
 {
   "position": {
-    "line": 11,
-    "character": 13
+    "line": 57,
+    "character": 12
   },
-  "source": "source1.bal",
+  "source": "source2.bal",
   "expected": [
     {
-      "title": "Create variable with 'module1:Response|anydata'",
+      "title": "Create variable with 'Rec2|Rec3|error'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 57,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 57,
               "character": 4
             }
           },
-          "newText": "module1:Response|anydata forward = "
+          "newText": "Rec2|Rec3|error put = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'anydata'",
+      "title": "Create variable with 'Rec2|error'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 57,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 57,
               "character": 4
             }
           },
-          "newText": "anydata forward = "
+          "newText": "Rec2|error put = "
         }
       ],
       "resolvable": false
     },
     {
-      "title": "Create variable with 'module1:Response'",
+      "title": "Create variable with 'Rec3|error'",
       "kind": "quickfix",
       "edits": [
         {
           "range": {
             "start": {
-              "line": 11,
+              "line": 57,
               "character": 4
             },
             "end": {
-              "line": 11,
+              "line": 57,
               "character": 4
             }
           },
-          "newText": "module1:Response forward = "
+          "newText": "Rec3|error put = "
         }
       ],
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_remote_method_call_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_remote_method_call_config1.json
@@ -6,6 +6,26 @@
   "source": "source1.bal",
   "expected": [
     {
+      "title": "Create variable with 'module1:Response|anydata|module1:ClientError'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 4
+            },
+            "end": {
+              "line": 6,
+              "character": 4
+            }
+          },
+          "newText": "module1:Response|anydata|module1:ClientError get = "
+        }
+      ],
+      "resolvable": false
+    },
+    {
       "title": "Create variable with 'module1:Response|module1:ClientError'",
       "kind": "quickfix",
       "edits": [

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_resource_action_config.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_resource_action_config.json
@@ -6,6 +6,26 @@
   "source": "source1.bal",
   "expected": [
     {
+      "title": "Create variable with 'module1:Response|anydata|module1:ClientError'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 15,
+              "character": 4
+            },
+            "end": {
+              "line": 15,
+              "character": 4
+            }
+          },
+          "newText": "module1:Response|anydata|module1:ClientError unionResult = "
+        }
+      ],
+      "resolvable": false
+    },
+    {
       "title": "Create variable with 'module1:Response|module1:ClientError'",
       "kind": "quickfix",
       "edits": [

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_resource_action_with_check1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_resource_action_with_check1.json
@@ -6,6 +6,26 @@
   "source": "source1.bal",
   "expected": [
     {
+      "title": "Create variable with 'module1:Response|anydata'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 19,
+              "character": 4
+            },
+            "end": {
+              "line": 19,
+              "character": 4
+            }
+          },
+          "newText": "module1:Response|anydata targetType = "
+        }
+      ],
+      "resolvable": false
+    },
+    {
       "title": "Create variable with 'module1:Response'",
       "kind": "quickfix",
       "edits": [

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_resource_action_with_check2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/config/type_infer_for_resource_action_with_check2.json
@@ -6,6 +6,26 @@
   "source": "source1.bal",
   "expected": [
     {
+      "title": "Create variable with 'module1:Response|anydata'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 23,
+              "character": 4
+            },
+            "end": {
+              "line": 23,
+              "character": 4
+            }
+          },
+          "newText": "module1:Response|anydata targetType = "
+        }
+      ],
+      "resolvable": false
+    },
+    {
       "title": "Create variable with 'module1:Response'",
       "kind": "quickfix",
       "edits": [

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/source/source2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-var-with-type/source/source2.bal
@@ -1,0 +1,59 @@
+type Rec1 record {|
+    int id;
+|};
+
+type Rec2 record {|
+    string msg;
+|};
+
+type Rec3 record {|
+    boolean value;
+|};
+
+type Error1 distinct error;
+
+type Error2 error<Rec2>;
+
+type TargetType1 typedesc<Rec1|Rec2>;
+
+type TargetType2 typedesc<Rec2|Rec3>;
+
+type UnionType string|boolean;
+
+client class MyClient {
+    resource function get v1/values/[string id](TargetType1 targetType = <>)
+        returns targetType = external;
+
+    resource function get v2/values/[string id](typedesc<Rec1|string> targetType = <>)
+        returns targetType|Error2 = external;
+
+    resource function get v3/values/[string id](TargetType2 targetType = <>)
+        returns targetType|error = external;
+
+    resource function get v4/values/[string id](TargetType2 targetType = <>)
+        returns targetType|Error1|Error2 = external;
+
+    resource function get v5/values/[string id](typedesc<Rec1|Rec2|Rec3> targetType = <>)
+        returns targetType|Error1 = external;
+
+    resource function get v6/values/[string id](typedesc<Rec1|Rec2|Error1> targetType = <>)
+        returns targetType = external;
+
+    remote function delete(typedesc<Rec1|Rec2|Error1> targetType = <>)
+        returns targetType = external;
+
+    remote function put(Rec1 rec, TargetType2 targetType = <>)
+        returns targetType|error = external;
+}
+
+public function main() returns error? {
+    MyClient myCl = new;
+    myCl->/v1/values/path();
+    myCl->/v2/values/path();
+    myCl->/v3/values/path();
+    myCl->/v4/values/path();
+    myCl->/v5/values/path();
+    myCl->/v6/values/path();
+    myCl->delete();
+    myCl->put({id: 0});
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config-rename-positional-capability/createVariableWithInferredType1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config-rename-positional-capability/createVariableWithInferredType1.json
@@ -6,7 +6,7 @@
   "source": "createVariableWithInferredType.bal",
   "expected": [
     {
-      "title": "Create variable",
+      "title": "Create variable with 'anydata|mod2:ClientError2'",
       "kind": "quickfix",
       "edits": [
         {

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config-rename-positional-capability/createVariableWithInferredType3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config-rename-positional-capability/createVariableWithInferredType3.json
@@ -6,7 +6,7 @@
   "source": "createVariableWithInferredType.bal",
   "expected": [
     {
-      "title": "Create variable",
+      "title": "Create variable with 'anydata|module1:ClientError'",
       "kind": "quickfix",
       "edits": [
         {


### PR DESCRIPTION
## Purpose
In scenarios like the one described in the sample, there may arise situations where dependent types require a union of types rather than individual ones. To address this, the PR introduces an additional code action with a union type alongside the existing ones to cover this specific use case.

Fixes #42591

## Approach
Return the union of all the possible types along with the ones that are already provided in the respective code action.

## Samples

https://github.com/ballerina-platform/ballerina-lang/assets/59343084/a8f874a2-b670-49bb-994f-b3b93fd37348

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
