### PR TITLE
Update github actions to not use deprecated node 16

### DIFF
--- a/.github/workflows/automate_issue_labels.yml
+++ b/.github/workflows/automate_issue_labels.yml
@@ -8,7 +8,7 @@ jobs:
   Add-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check for Type label inclusion
         if: ${{ !(contains(join(github.event.issue.labels.*.name, ','), 'Type/')) }}

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17.0.7'
@@ -25,7 +25,7 @@ jobs:
         run: git submodule update --init
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ github.sha }}
@@ -65,12 +65,12 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin' 
           java-version: '17.0.7'
@@ -79,14 +79,14 @@ jobs:
         run: git submodule update --init
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ github.sha }}

--- a/.github/workflows/daily_spec_conformance_test_runner.yml
+++ b/.github/workflows/daily_spec_conformance_test_runner.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: spec-conformance-test-runner
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "17"
@@ -35,7 +35,7 @@ jobs:
           ./gradlew ballerina-spec-conformance-tests:test --configure-on-demand --no-daemon
 
       - name: Spec conformance report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: spec-conformance-test-report

--- a/.github/workflows/fossa_scan.yml
+++ b/.github/workflows/fossa_scan.yml
@@ -5,7 +5,7 @@ jobs:
   fossa-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: fossas/fossa-action@main
         with:
           api-key: ${{secrets.FOSSA_APIKEY}}

--- a/.github/workflows/fossa_scan_1.2.x.yml
+++ b/.github/workflows/fossa_scan_1.2.x.yml
@@ -5,7 +5,7 @@ jobs:
   fossa-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: fossas/fossa-action@main
         with:
           api-key: ${{secrets.FOSSA_APIKEY}}

--- a/.github/workflows/nightly_publish_timestamped_release.yml
+++ b/.github/workflows/nightly_publish_timestamped_release.yml
@@ -17,12 +17,12 @@ jobs:
     if: github.repository_owner == 'ballerina-platform'
     steps:
       -   name: Checkout Repository
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
           with:
             ref: ${{ matrix.branch }}
 
       -   name: Set up JDK 17
-          uses: actions/setup-java@v3
+          uses: actions/setup-java@v4
           with:
             distribution: 'temurin'
             java-version: '17.0.7'
@@ -61,6 +61,6 @@ jobs:
             }"
 
       -   name: Generate Codecov Report
-          uses: codecov/codecov-action@v3
+          uses: codecov/codecov-action@v4
           with:
             files: ./.jacoco/reports/jacoco/report.xml

--- a/.github/workflows/observe_package_push.yaml
+++ b/.github/workflows/observe_package_push.yaml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Checkout Tag
         run: git checkout ${{ github.event.inputs.repoTag }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17.0.7'

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17.0.7'

--- a/.github/workflows/publish_timestamped_release.yml
+++ b/.github/workflows/publish_timestamped_release.yml
@@ -14,10 +14,10 @@ jobs:
     if: github.repository_owner == 'ballerina-platform'
     steps:
       -   name: Checkout Repository
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
 
       -   name: Set up JDK 17
-          uses: actions/setup-java@v3
+          uses: actions/setup-java@v4
           with:
             distribution: 'temurin'
             java-version: '17.0.7'
@@ -49,6 +49,6 @@ jobs:
             ./gradlew createCodeCoverageReport
 
       -   name: Generate Codecov Report
-          uses: codecov/codecov-action@v3
+          uses: codecov/codecov-action@v4
           with:
             files: ./.jacoco/reports/jacoco/report.xml

--- a/.github/workflows/pull_request_full_build.yml
+++ b/.github/workflows/pull_request_full_build.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17.0.7'
@@ -39,7 +39,7 @@ jobs:
           ./gradlew clean build -x check publishToMavenLocal --stacktrace --scan
 
       - name: Archive Lang Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Lang Artifacts
           path: ~/.m2/
@@ -62,20 +62,20 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17.0.7'
 
       - name: Setup NodeJs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 10.22.1
       - name: Download Ballerina Lang Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Ballerina Lang Artifacts
           path: ~/.m2/
@@ -127,18 +127,18 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'ballerina-platform/ballerina-distribution'
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17.0.7'
 
       - name: Download Ballerina Lang Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Ballerina Lang Artifacts
           path: ~/.m2/

--- a/.github/workflows/pull_request_ubuntu_build.yml
+++ b/.github/workflows/pull_request_ubuntu_build.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17.0.7'
@@ -39,7 +39,7 @@ jobs:
         run: git submodule update --init
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ github.sha }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: Generate Codecov Report
         if: github.event_name == 'pull_request'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./.jacoco/reports/jacoco/report.xml
 
@@ -83,12 +83,12 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17.0.7'
@@ -97,14 +97,14 @@ jobs:
         run: git submodule update --init
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ github.sha }}

--- a/.github/workflows/pull_request_windows_build.yml
+++ b/.github/workflows/pull_request_windows_build.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17.0.7'
@@ -45,7 +45,7 @@ jobs:
         run: git submodule update --init
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/push_master.yml
+++ b/.github/workflows/push_master.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17.0.7'
@@ -29,7 +29,7 @@ jobs:
         run: git submodule update --init
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ github.sha }}
@@ -52,10 +52,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17.0.7'
@@ -71,7 +71,7 @@ jobs:
         run: git submodule update --init
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
@@ -91,12 +91,12 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin' 
           java-version: '17.0.7'
@@ -105,14 +105,14 @@ jobs:
         run: git submodule update --init
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ github.sha }}

--- a/.github/workflows/stale_check.yml
+++ b/.github/workflows/stale_check.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v9
         with:
           stale-pr-message: 'This PR has been open for more than 15 days with no activity. This will be closed in 3 days unless the `stale` label is removed or commented.'
           close-pr-message: 'Closed PR due to inactivity for more than 18 days.'

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17.0.7'
@@ -21,7 +21,7 @@ jobs:
       - name: Initialize sub-modules
         run: git submodule update --init
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ github.sha }}


### PR DESCRIPTION
## Purpose
Update github actions to not use deprecated node 16.

Fixes #42617

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
