### PR TITLE
[Bindgen Tool] Fix return statement generation for binding functions with error returns

### DIFF
--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenNodeFactory.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenNodeFactory.java
@@ -610,7 +610,7 @@ class BindgenNodeFactory {
         List<StatementNode> statementNodes = new LinkedList<>();
         FunctionCallExpressionNode innerFunctionCall = createFunctionCallExpressionNode(
                 jField.getExternalFunctionName(), getParameterArgumentList(jField));
-        statementNodes.add(createReturnToStringStatement(jField.getEnv(),
+        statementNodes.add(createStringReturnStatement(jField.getEnv(),
                 Collections.singletonList(innerFunctionCall.toSourceCode())));
 
         return statementNodes;
@@ -698,7 +698,7 @@ class BindgenNodeFactory {
                 jMethod.getExternalFunctionName(), getParameterArgumentList(jMethod));
         PositionalArgumentNode positionalArgNode = createPositionalArgumentNode(innerFunctionCall.toSourceCode());
 
-        return createReturnToStringStatement(jMethod.getEnv(),
+        return createStringReturnStatement(jMethod.getEnv(),
                 Collections.singletonList(positionalArgNode.toSourceCode()));
     }
 
@@ -830,8 +830,7 @@ class BindgenNodeFactory {
                 createBracedExpressionNode(createSimpleNameReferenceNode("externalObj is error")),
                 getCheckExceptionBlock(jMethod.getExceptionName(), jMethod.getExceptionConstName()),
                 createElseBlockNode(createBlockStatementNode(AbstractNodeFactory.createNodeList(
-                        createReturnStatementNode(createFunctionCallExpressionNode(
-                                "java:toString", Collections.singletonList("externalObj"))))))));
+                        createStringReturnStatement(jMethod.getEnv(), Collections.singletonList("externalObj")))))));
 
         return statementNodes;
     }
@@ -989,7 +988,7 @@ class BindgenNodeFactory {
         );
     }
 
-    private static ReturnStatementNode createReturnToStringStatement(BindgenEnv env, List<String> argNodes) {
+    private static ReturnStatementNode createStringReturnStatement(BindgenEnv env, List<String> argNodes) {
         FunctionCallExpressionNode funcCallExprNode = createFunctionCallExpressionNode("java:toString", argNodes);
 
         if (env.isOptionalTypes() || env.isOptionalReturnTypes()) {

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/FieldsTestResource.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/FieldsTestResource.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.bindgen;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.AbstractList;
@@ -125,6 +126,11 @@ public class FieldsTestResource implements InterfaceTestResource {
     @Override
     public int testMethod(int x) {
         return 0;
+    }
+
+    @Override
+    public String testMethodWithException(Object obj) throws IOException {
+        throw new IOException();
     }
 
     @Override

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/InterfaceTestResource.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/InterfaceTestResource.java
@@ -17,15 +17,20 @@
  */
 package org.ballerinalang.bindgen;
 
+import java.io.IOException;
+
 /**
  * Java resources for the unit testing of superclass bindings generated.
  *
  * @since 2.0.0
  */
 public interface InterfaceTestResource {
+
     public static long TEST_FIELD = 123456;
 
     public int testMethod(int x);
+
+    public String testMethodWithException(Object obj) throws IOException;
 
     public String[] returnStringArray();
 }

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/MethodsTestResource.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/MethodsTestResource.java
@@ -299,6 +299,11 @@ public class MethodsTestResource extends RestrictedTestResource implements Inter
     }
 
     @Override
+    public String testMethodWithException(Object obj) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
     public String[] returnStringArray() {
         return new String[0];
     }

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/fields.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/fields.bal
@@ -24,6 +24,7 @@ distinct class FieldsTestResource {
     function toString() returns string {
         return java:toString(self.jObj) ?: "";
     }
+
     # The function that maps to the `equals` method of `org.ballerinalang.bindgen.FieldsTestResource`.
     #
     # + arg0 - The `Object` value required to map with the Java method parameter.
@@ -75,6 +76,20 @@ distinct class FieldsTestResource {
     # + return - The `int` value returning from the Java mapping.
     function testMethod(int arg0) returns int {
         return org_ballerinalang_bindgen_FieldsTestResource_testMethod(self.jObj, arg0);
+    }
+
+    # The function that maps to the `testMethodWithException` method of `org.ballerinalang.bindgen.FieldsTestResource`.
+    #
+    # + arg0 - The `Object` value required to map with the Java method parameter.
+    # + return - The `string` or the `IOException` value returning from the Java mapping.
+    function testMethodWithException(Object arg0) returns string|IOException {
+        handle|error externalObj = org_ballerinalang_bindgen_FieldsTestResource_testMethodWithException(self.jObj, arg0.jObj);
+        if (externalObj is error) {
+            IOException e = error IOException(IOEXCEPTION, externalObj, message = externalObj.message());
+            return e;
+        } else {
+            return java:toString(externalObj) ?: "";
+        }
     }
 
     # The function that maps to the `wait` method of `org.ballerinalang.bindgen.FieldsTestResource`.
@@ -1086,6 +1101,12 @@ function org_ballerinalang_bindgen_FieldsTestResource_testMethod(handle receiver
     name: "testMethod",
     'class: "org.ballerinalang.bindgen.FieldsTestResource",
     paramTypes: ["int"]
+} external;
+
+function org_ballerinalang_bindgen_FieldsTestResource_testMethodWithException(handle receiver, handle arg0) returns handle|error = @java:Method {
+    name: "testMethodWithException",
+    'class: "org.ballerinalang.bindgen.FieldsTestResource",
+    paramTypes: ["java.lang.Object"]
 } external;
 
 function org_ballerinalang_bindgen_FieldsTestResource_wait(handle receiver) returns error? = @java:Method {

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/interfaceMapping.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/interfaceMapping.bal
@@ -1,3 +1,6 @@
+import test.java.io as javaio;
+import test.java.lang as javalang;
+
 import ballerina/jballerina.java;
 import ballerina/jballerina.java.arrays as jarrays;
 
@@ -23,6 +26,7 @@ public distinct class InterfaceTestResource {
     public function toString() returns string {
         return java:toString(self.jObj) ?: "";
     }
+
     # The function that maps to the `returnStringArray` method of `org.ballerinalang.bindgen.InterfaceTestResource`.
     #
     # + return - The `string[]` value returning from the Java mapping.
@@ -40,6 +44,20 @@ public distinct class InterfaceTestResource {
     # + return - The `int` value returning from the Java mapping.
     public function testMethod(int arg0) returns int {
         return org_ballerinalang_bindgen_InterfaceTestResource_testMethod(self.jObj, arg0);
+    }
+
+    # The function that maps to the `testMethodWithException` method of `org.ballerinalang.bindgen.InterfaceTestResource`.
+    #
+    # + arg0 - The `javalang:Object` value required to map with the Java method parameter.
+    # + return - The `string` or the `javaio:IOException` value returning from the Java mapping.
+    public function testMethodWithException(javalang:Object arg0) returns string|javaio:IOException {
+        handle|error externalObj = org_ballerinalang_bindgen_InterfaceTestResource_testMethodWithException(self.jObj, arg0.jObj);
+        if (externalObj is error) {
+            javaio:IOException e = error javaio:IOException(javaio:IOEXCEPTION, externalObj, message = externalObj.message());
+            return e;
+        } else {
+            return java:toString(externalObj) ?: "";
+        }
     }
 
 }
@@ -61,6 +79,12 @@ function org_ballerinalang_bindgen_InterfaceTestResource_testMethod(handle recei
     name: "testMethod",
     'class: "org.ballerinalang.bindgen.InterfaceTestResource",
     paramTypes: ["int"]
+} external;
+
+function org_ballerinalang_bindgen_InterfaceTestResource_testMethodWithException(handle receiver, handle arg0) returns handle|error = @java:Method {
+    name: "testMethodWithException",
+    'class: "org.ballerinalang.bindgen.InterfaceTestResource",
+    paramTypes: ["java.lang.Object"]
 } external;
 
 function org_ballerinalang_bindgen_InterfaceTestResource_getTEST_FIELD() returns int = @java:FieldGet {

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/methods.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/methods.bal
@@ -24,6 +24,7 @@ distinct class MethodsTestResource {
     function toString() returns string {
         return java:toString(self.jObj) ?: "";
     }
+
     # The function that maps to the `abstractObjectParam` method of `org.ballerinalang.bindgen.MethodsTestResource`.
     #
     # + arg0 - The `AbstractSet` value required to map with the Java method parameter.
@@ -540,6 +541,20 @@ distinct class MethodsTestResource {
     # + return - The `int` value returning from the Java mapping.
     function testMethod(int arg0) returns int {
         return org_ballerinalang_bindgen_MethodsTestResource_testMethod(self.jObj, arg0);
+    }
+
+    # The function that maps to the `testMethodWithException` method of `org.ballerinalang.bindgen.MethodsTestResource`.
+    #
+    # + arg0 - The `Object` value required to map with the Java method parameter.
+    # + return - The `string` or the `IOException` value returning from the Java mapping.
+    function testMethodWithException(Object arg0) returns string|IOException {
+        handle|error externalObj = org_ballerinalang_bindgen_MethodsTestResource_testMethodWithException(self.jObj, arg0.jObj);
+        if (externalObj is error) {
+            IOException e = error IOException(IOEXCEPTION, externalObj, message = externalObj.message());
+            return e;
+        } else {
+            return java:toString(externalObj) ?: "";
+        }
     }
 
     # The function that maps to the `wait` method of `org.ballerinalang.bindgen.MethodsTestResource`.
@@ -1130,6 +1145,12 @@ function org_ballerinalang_bindgen_MethodsTestResource_testMethod(handle receive
     name: "testMethod",
     'class: "org.ballerinalang.bindgen.MethodsTestResource",
     paramTypes: ["int"]
+} external;
+
+function org_ballerinalang_bindgen_MethodsTestResource_testMethodWithException(handle receiver, handle arg0) returns handle|error = @java:Method {
+    name: "testMethodWithException",
+    'class: "org.ballerinalang.bindgen.MethodsTestResource",
+    paramTypes: ["java.lang.Object"]
 } external;
 
 function org_ballerinalang_bindgen_MethodsTestResource_unsupportedReturnType(handle receiver) returns handle = @java:Method {

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalParamTypes/fields.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalParamTypes/fields.bal
@@ -24,6 +24,7 @@ distinct class FieldsTestResource {
     function toString() returns string {
         return java:toString(self.jObj) ?: "";
     }
+
     # The function that maps to the `equals` method of `org.ballerinalang.bindgen.FieldsTestResource`.
     #
     # + arg0 - The `Object?` value required to map with the Java method parameter.
@@ -75,6 +76,20 @@ distinct class FieldsTestResource {
     # + return - The `int` value returning from the Java mapping.
     function testMethod(int arg0) returns int {
         return org_ballerinalang_bindgen_FieldsTestResource_testMethod(self.jObj, arg0);
+    }
+
+    # The function that maps to the `testMethodWithException` method of `org.ballerinalang.bindgen.FieldsTestResource`.
+    #
+    # + arg0 - The `Object?` value required to map with the Java method parameter.
+    # + return - The `string` or the `IOException` value returning from the Java mapping.
+    function testMethodWithException(Object? arg0) returns string|IOException {
+        handle|error externalObj = org_ballerinalang_bindgen_FieldsTestResource_testMethodWithException(self.jObj, arg0 is () ? java:createNull() : arg0.jObj);
+        if (externalObj is error) {
+            IOException e = error IOException(IOEXCEPTION, externalObj, message = externalObj.message());
+            return e;
+        } else {
+            return java:toString(externalObj) ?: "";
+        }
     }
 
     # The function that maps to the `wait` method of `org.ballerinalang.bindgen.FieldsTestResource`.
@@ -1086,6 +1101,12 @@ function org_ballerinalang_bindgen_FieldsTestResource_testMethod(handle receiver
     name: "testMethod",
     'class: "org.ballerinalang.bindgen.FieldsTestResource",
     paramTypes: ["int"]
+} external;
+
+function org_ballerinalang_bindgen_FieldsTestResource_testMethodWithException(handle receiver, handle arg0) returns handle|error = @java:Method {
+    name: "testMethodWithException",
+    'class: "org.ballerinalang.bindgen.FieldsTestResource",
+    paramTypes: ["java.lang.Object"]
 } external;
 
 function org_ballerinalang_bindgen_FieldsTestResource_wait(handle receiver) returns error? = @java:Method {

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalParamTypes/interfaceMapping.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalParamTypes/interfaceMapping.bal
@@ -1,3 +1,6 @@
+import test.java.io as javaio;
+import test.java.lang as javalang;
+
 import ballerina/jballerina.java;
 import ballerina/jballerina.java.arrays as jarrays;
 
@@ -23,6 +26,7 @@ public distinct class InterfaceTestResource {
     public function toString() returns string {
         return java:toString(self.jObj) ?: "";
     }
+
     # The function that maps to the `returnStringArray` method of `org.ballerinalang.bindgen.InterfaceTestResource`.
     #
     # + return - The `string[]` value returning from the Java mapping.
@@ -40,6 +44,20 @@ public distinct class InterfaceTestResource {
     # + return - The `int` value returning from the Java mapping.
     public function testMethod(int arg0) returns int {
         return org_ballerinalang_bindgen_InterfaceTestResource_testMethod(self.jObj, arg0);
+    }
+
+    # The function that maps to the `testMethodWithException` method of `org.ballerinalang.bindgen.InterfaceTestResource`.
+    #
+    # + arg0 - The `javalang:Object?` value required to map with the Java method parameter.
+    # + return - The `string` or the `javaio:IOException` value returning from the Java mapping.
+    public function testMethodWithException(javalang:Object? arg0) returns string|javaio:IOException {
+        handle|error externalObj = org_ballerinalang_bindgen_InterfaceTestResource_testMethodWithException(self.jObj, arg0 is () ? java:createNull() : arg0.jObj);
+        if (externalObj is error) {
+            javaio:IOException e = error javaio:IOException(javaio:IOEXCEPTION, externalObj, message = externalObj.message());
+            return e;
+        } else {
+            return java:toString(externalObj) ?: "";
+        }
     }
 
 }
@@ -61,6 +79,12 @@ function org_ballerinalang_bindgen_InterfaceTestResource_testMethod(handle recei
     name: "testMethod",
     'class: "org.ballerinalang.bindgen.InterfaceTestResource",
     paramTypes: ["int"]
+} external;
+
+function org_ballerinalang_bindgen_InterfaceTestResource_testMethodWithException(handle receiver, handle arg0) returns handle|error = @java:Method {
+    name: "testMethodWithException",
+    'class: "org.ballerinalang.bindgen.InterfaceTestResource",
+    paramTypes: ["java.lang.Object"]
 } external;
 
 function org_ballerinalang_bindgen_InterfaceTestResource_getTEST_FIELD() returns int = @java:FieldGet {

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalParamTypes/methods.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalParamTypes/methods.bal
@@ -24,6 +24,7 @@ distinct class MethodsTestResource {
     function toString() returns string {
         return java:toString(self.jObj) ?: "";
     }
+
     # The function that maps to the `abstractObjectParam` method of `org.ballerinalang.bindgen.MethodsTestResource`.
     #
     # + arg0 - The `AbstractSet?` value required to map with the Java method parameter.
@@ -540,6 +541,20 @@ distinct class MethodsTestResource {
     # + return - The `int` value returning from the Java mapping.
     function testMethod(int arg0) returns int {
         return org_ballerinalang_bindgen_MethodsTestResource_testMethod(self.jObj, arg0);
+    }
+
+    # The function that maps to the `testMethodWithException` method of `org.ballerinalang.bindgen.MethodsTestResource`.
+    #
+    # + arg0 - The `Object?` value required to map with the Java method parameter.
+    # + return - The `string` or the `IOException` value returning from the Java mapping.
+    function testMethodWithException(Object? arg0) returns string|IOException {
+        handle|error externalObj = org_ballerinalang_bindgen_MethodsTestResource_testMethodWithException(self.jObj, arg0 is () ? java:createNull() : arg0.jObj);
+        if (externalObj is error) {
+            IOException e = error IOException(IOEXCEPTION, externalObj, message = externalObj.message());
+            return e;
+        } else {
+            return java:toString(externalObj) ?: "";
+        }
     }
 
     # The function that maps to the `wait` method of `org.ballerinalang.bindgen.MethodsTestResource`.
@@ -1130,6 +1145,12 @@ function org_ballerinalang_bindgen_MethodsTestResource_testMethod(handle receive
     name: "testMethod",
     'class: "org.ballerinalang.bindgen.MethodsTestResource",
     paramTypes: ["int"]
+} external;
+
+function org_ballerinalang_bindgen_MethodsTestResource_testMethodWithException(handle receiver, handle arg0) returns handle|error = @java:Method {
+    name: "testMethodWithException",
+    'class: "org.ballerinalang.bindgen.MethodsTestResource",
+    paramTypes: ["java.lang.Object"]
 } external;
 
 function org_ballerinalang_bindgen_MethodsTestResource_unsupportedReturnType(handle receiver) returns handle = @java:Method {

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalReturnTypes/fields.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalReturnTypes/fields.bal
@@ -24,6 +24,7 @@ distinct class FieldsTestResource {
     function toString() returns string? {
         return java:toString(self.jObj);
     }
+
     # The function that maps to the `equals` method of `org.ballerinalang.bindgen.FieldsTestResource`.
     #
     # + arg0 - The `Object` value required to map with the Java method parameter.
@@ -75,6 +76,20 @@ distinct class FieldsTestResource {
     # + return - The `int` value returning from the Java mapping.
     function testMethod(int arg0) returns int {
         return org_ballerinalang_bindgen_FieldsTestResource_testMethod(self.jObj, arg0);
+    }
+
+    # The function that maps to the `testMethodWithException` method of `org.ballerinalang.bindgen.FieldsTestResource`.
+    #
+    # + arg0 - The `Object` value required to map with the Java method parameter.
+    # + return - The `string?` or the `IOException` value returning from the Java mapping.
+    function testMethodWithException(Object arg0) returns string?|IOException {
+        handle|error externalObj = org_ballerinalang_bindgen_FieldsTestResource_testMethodWithException(self.jObj, arg0.jObj);
+        if (externalObj is error) {
+            IOException e = error IOException(IOEXCEPTION, externalObj, message = externalObj.message());
+            return e;
+        } else {
+            return java:toString(externalObj);
+        }
     }
 
     # The function that maps to the `wait` method of `org.ballerinalang.bindgen.FieldsTestResource`.
@@ -1098,6 +1113,12 @@ function org_ballerinalang_bindgen_FieldsTestResource_testMethod(handle receiver
     name: "testMethod",
     'class: "org.ballerinalang.bindgen.FieldsTestResource",
     paramTypes: ["int"]
+} external;
+
+function org_ballerinalang_bindgen_FieldsTestResource_testMethodWithException(handle receiver, handle arg0) returns handle|error = @java:Method {
+    name: "testMethodWithException",
+    'class: "org.ballerinalang.bindgen.FieldsTestResource",
+    paramTypes: ["java.lang.Object"]
 } external;
 
 function org_ballerinalang_bindgen_FieldsTestResource_wait(handle receiver) returns error? = @java:Method {

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalReturnTypes/interfaceMapping.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalReturnTypes/interfaceMapping.bal
@@ -1,3 +1,6 @@
+import test.java.io as javaio;
+import test.java.lang as javalang;
+
 import ballerina/jballerina.java;
 import ballerina/jballerina.java.arrays as jarrays;
 
@@ -23,6 +26,7 @@ public distinct class InterfaceTestResource {
     public function toString() returns string? {
         return java:toString(self.jObj);
     }
+
     # The function that maps to the `returnStringArray` method of `org.ballerinalang.bindgen.InterfaceTestResource`.
     #
     # + return - The `string?[]?` value returning from the Java mapping.
@@ -40,6 +44,20 @@ public distinct class InterfaceTestResource {
     # + return - The `int` value returning from the Java mapping.
     public function testMethod(int arg0) returns int {
         return org_ballerinalang_bindgen_InterfaceTestResource_testMethod(self.jObj, arg0);
+    }
+
+    # The function that maps to the `testMethodWithException` method of `org.ballerinalang.bindgen.InterfaceTestResource`.
+    #
+    # + arg0 - The `javalang:Object` value required to map with the Java method parameter.
+    # + return - The `string?` or the `javaio:IOException` value returning from the Java mapping.
+    public function testMethodWithException(javalang:Object arg0) returns string?|javaio:IOException {
+        handle|error externalObj = org_ballerinalang_bindgen_InterfaceTestResource_testMethodWithException(self.jObj, arg0.jObj);
+        if (externalObj is error) {
+            javaio:IOException e = error javaio:IOException(javaio:IOEXCEPTION, externalObj, message = externalObj.message());
+            return e;
+        } else {
+            return java:toString(externalObj);
+        }
     }
 
 }
@@ -61,6 +79,12 @@ function org_ballerinalang_bindgen_InterfaceTestResource_testMethod(handle recei
     name: "testMethod",
     'class: "org.ballerinalang.bindgen.InterfaceTestResource",
     paramTypes: ["int"]
+} external;
+
+function org_ballerinalang_bindgen_InterfaceTestResource_testMethodWithException(handle receiver, handle arg0) returns handle|error = @java:Method {
+    name: "testMethodWithException",
+    'class: "org.ballerinalang.bindgen.InterfaceTestResource",
+    paramTypes: ["java.lang.Object"]
 } external;
 
 function org_ballerinalang_bindgen_InterfaceTestResource_getTEST_FIELD() returns int = @java:FieldGet {

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalReturnTypes/methods.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalReturnTypes/methods.bal
@@ -24,6 +24,7 @@ distinct class MethodsTestResource {
     function toString() returns string? {
         return java:toString(self.jObj);
     }
+
     # The function that maps to the `abstractObjectParam` method of `org.ballerinalang.bindgen.MethodsTestResource`.
     #
     # + arg0 - The `AbstractSet` value required to map with the Java method parameter.
@@ -544,6 +545,20 @@ distinct class MethodsTestResource {
     # + return - The `int` value returning from the Java mapping.
     function testMethod(int arg0) returns int {
         return org_ballerinalang_bindgen_MethodsTestResource_testMethod(self.jObj, arg0);
+    }
+
+    # The function that maps to the `testMethodWithException` method of `org.ballerinalang.bindgen.MethodsTestResource`.
+    #
+    # + arg0 - The `Object` value required to map with the Java method parameter.
+    # + return - The `string?` or the `IOException` value returning from the Java mapping.
+    function testMethodWithException(Object arg0) returns string?|IOException {
+        handle|error externalObj = org_ballerinalang_bindgen_MethodsTestResource_testMethodWithException(self.jObj, arg0.jObj);
+        if (externalObj is error) {
+            IOException e = error IOException(IOEXCEPTION, externalObj, message = externalObj.message());
+            return e;
+        } else {
+            return java:toString(externalObj);
+        }
     }
 
     # The function that maps to the `wait` method of `org.ballerinalang.bindgen.MethodsTestResource`.
@@ -1136,6 +1151,12 @@ function org_ballerinalang_bindgen_MethodsTestResource_testMethod(handle receive
     name: "testMethod",
     'class: "org.ballerinalang.bindgen.MethodsTestResource",
     paramTypes: ["int"]
+} external;
+
+function org_ballerinalang_bindgen_MethodsTestResource_testMethodWithException(handle receiver, handle arg0) returns handle|error = @java:Method {
+    name: "testMethodWithException",
+    'class: "org.ballerinalang.bindgen.MethodsTestResource",
+    paramTypes: ["java.lang.Object"]
 } external;
 
 function org_ballerinalang_bindgen_MethodsTestResource_unsupportedReturnType(handle receiver) returns handle = @java:Method {

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalTypes/fields.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalTypes/fields.bal
@@ -24,6 +24,7 @@ distinct class FieldsTestResource {
     function toString() returns string? {
         return java:toString(self.jObj);
     }
+
     # The function that maps to the `equals` method of `org.ballerinalang.bindgen.FieldsTestResource`.
     #
     # + arg0 - The `Object?` value required to map with the Java method parameter.
@@ -75,6 +76,20 @@ distinct class FieldsTestResource {
     # + return - The `int` value returning from the Java mapping.
     function testMethod(int arg0) returns int {
         return org_ballerinalang_bindgen_FieldsTestResource_testMethod(self.jObj, arg0);
+    }
+
+    # The function that maps to the `testMethodWithException` method of `org.ballerinalang.bindgen.FieldsTestResource`.
+    #
+    # + arg0 - The `Object?` value required to map with the Java method parameter.
+    # + return - The `string?` or the `IOException` value returning from the Java mapping.
+    function testMethodWithException(Object? arg0) returns string?|IOException {
+        handle|error externalObj = org_ballerinalang_bindgen_FieldsTestResource_testMethodWithException(self.jObj, arg0 is () ? java:createNull() : arg0.jObj);
+        if (externalObj is error) {
+            IOException e = error IOException(IOEXCEPTION, externalObj, message = externalObj.message());
+            return e;
+        } else {
+            return java:toString(externalObj);
+        }
     }
 
     # The function that maps to the `wait` method of `org.ballerinalang.bindgen.FieldsTestResource`.
@@ -1098,6 +1113,12 @@ function org_ballerinalang_bindgen_FieldsTestResource_testMethod(handle receiver
     name: "testMethod",
     'class: "org.ballerinalang.bindgen.FieldsTestResource",
     paramTypes: ["int"]
+} external;
+
+function org_ballerinalang_bindgen_FieldsTestResource_testMethodWithException(handle receiver, handle arg0) returns handle|error = @java:Method {
+    name: "testMethodWithException",
+    'class: "org.ballerinalang.bindgen.FieldsTestResource",
+    paramTypes: ["java.lang.Object"]
 } external;
 
 function org_ballerinalang_bindgen_FieldsTestResource_wait(handle receiver) returns error? = @java:Method {

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalTypes/interfaceMapping.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalTypes/interfaceMapping.bal
@@ -1,3 +1,6 @@
+import test.java.io as javaio;
+import test.java.lang as javalang;
+
 import ballerina/jballerina.java;
 import ballerina/jballerina.java.arrays as jarrays;
 
@@ -23,6 +26,7 @@ public distinct class InterfaceTestResource {
     public function toString() returns string? {
         return java:toString(self.jObj);
     }
+
     # The function that maps to the `returnStringArray` method of `org.ballerinalang.bindgen.InterfaceTestResource`.
     #
     # + return - The `string?[]?` value returning from the Java mapping.
@@ -40,6 +44,20 @@ public distinct class InterfaceTestResource {
     # + return - The `int` value returning from the Java mapping.
     public function testMethod(int arg0) returns int {
         return org_ballerinalang_bindgen_InterfaceTestResource_testMethod(self.jObj, arg0);
+    }
+
+    # The function that maps to the `testMethodWithException` method of `org.ballerinalang.bindgen.InterfaceTestResource`.
+    #
+    # + arg0 - The `javalang:Object?` value required to map with the Java method parameter.
+    # + return - The `string?` or the `javaio:IOException` value returning from the Java mapping.
+    public function testMethodWithException(javalang:Object? arg0) returns string?|javaio:IOException {
+        handle|error externalObj = org_ballerinalang_bindgen_InterfaceTestResource_testMethodWithException(self.jObj, arg0 is () ? java:createNull() : arg0.jObj);
+        if (externalObj is error) {
+            javaio:IOException e = error javaio:IOException(javaio:IOEXCEPTION, externalObj, message = externalObj.message());
+            return e;
+        } else {
+            return java:toString(externalObj);
+        }
     }
 
 }
@@ -61,6 +79,12 @@ function org_ballerinalang_bindgen_InterfaceTestResource_testMethod(handle recei
     name: "testMethod",
     'class: "org.ballerinalang.bindgen.InterfaceTestResource",
     paramTypes: ["int"]
+} external;
+
+function org_ballerinalang_bindgen_InterfaceTestResource_testMethodWithException(handle receiver, handle arg0) returns handle|error = @java:Method {
+    name: "testMethodWithException",
+    'class: "org.ballerinalang.bindgen.InterfaceTestResource",
+    paramTypes: ["java.lang.Object"]
 } external;
 
 function org_ballerinalang_bindgen_InterfaceTestResource_getTEST_FIELD() returns int = @java:FieldGet {

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalTypes/methods.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/withOptionalTypes/methods.bal
@@ -24,6 +24,7 @@ distinct class MethodsTestResource {
     function toString() returns string? {
         return java:toString(self.jObj);
     }
+
     # The function that maps to the `abstractObjectParam` method of `org.ballerinalang.bindgen.MethodsTestResource`.
     #
     # + arg0 - The `AbstractSet?` value required to map with the Java method parameter.
@@ -544,6 +545,20 @@ distinct class MethodsTestResource {
     # + return - The `int` value returning from the Java mapping.
     function testMethod(int arg0) returns int {
         return org_ballerinalang_bindgen_MethodsTestResource_testMethod(self.jObj, arg0);
+    }
+
+    # The function that maps to the `testMethodWithException` method of `org.ballerinalang.bindgen.MethodsTestResource`.
+    #
+    # + arg0 - The `Object?` value required to map with the Java method parameter.
+    # + return - The `string?` or the `IOException` value returning from the Java mapping.
+    function testMethodWithException(Object? arg0) returns string?|IOException {
+        handle|error externalObj = org_ballerinalang_bindgen_MethodsTestResource_testMethodWithException(self.jObj, arg0 is () ? java:createNull() : arg0.jObj);
+        if (externalObj is error) {
+            IOException e = error IOException(IOEXCEPTION, externalObj, message = externalObj.message());
+            return e;
+        } else {
+            return java:toString(externalObj);
+        }
     }
 
     # The function that maps to the `wait` method of `org.ballerinalang.bindgen.MethodsTestResource`.
@@ -1136,6 +1151,12 @@ function org_ballerinalang_bindgen_MethodsTestResource_testMethod(handle receive
     name: "testMethod",
     'class: "org.ballerinalang.bindgen.MethodsTestResource",
     paramTypes: ["int"]
+} external;
+
+function org_ballerinalang_bindgen_MethodsTestResource_testMethodWithException(handle receiver, handle arg0) returns handle|error = @java:Method {
+    name: "testMethodWithException",
+    'class: "org.ballerinalang.bindgen.MethodsTestResource",
+    paramTypes: ["java.lang.Object"]
 } external;
 
 function org_ballerinalang_bindgen_MethodsTestResource_unsupportedReturnType(handle receiver) returns handle = @java:Method {


### PR DESCRIPTION
## Purpose
This PR 
- fixes Ballerina binding function generation logic for non-void java object methods which throws exceptions.
- updates the bindgen unit test suite to cover the aforementioned scenario.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/42624

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
