### PR TITLE
Check org, name for null before package resolution when resolving dependencies in Ballerina.toml

### DIFF
--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
@@ -1263,6 +1263,22 @@ public class BuildCommandTest extends BaseCommandTest {
         }
     }
 
+    @Test(description = "Build a project with invalid fields in TOML array 'dependency'")
+    public void testBuildProjectWithInvalidDependencyArrayInBallerinaToml() throws IOException {
+        Path projectPath = this.testResources.resolve("invalid-dependency-array-project");
+        System.setProperty(USER_DIR_PROPERTY, projectPath.toString());
+        BuildCommand buildCommand = new BuildCommand(projectPath, printStream, printStream, false);
+        new CommandLine(buildCommand).parseArgs();
+        try {
+            buildCommand.execute();
+        } catch (BLauncherException e) {
+            Assert.assertEquals("error: compilation contains errors", e.getDetailedMessages().get(0));
+            String buildLog = readOutput(true);
+            Assert.assertEquals(buildLog.replaceAll("\r", ""),
+                    getOutput("build-bal-project-with-invalid-dependency-array.txt"));
+        }
+    }
+
     private String getNewVersionForOldDistWarning() {
         SemanticVersion currentDistributionVersion = SemanticVersion.from(RepoUtils.getBallerinaShortVersion());
         String currentVersionForDiagnostic = String.valueOf(currentDistributionVersion.minor());

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bal-project-with-invalid-dependency-array.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bal-project-with-invalid-dependency-array.txt
@@ -1,0 +1,12 @@
+Compiling source
+	foo/winery:0.1.0
+ERROR [Ballerina.toml:(7:7,7:19)] invalid 'org' under [[dependency]]: 'org' can only contain alphanumerics and underscores
+ERROR [Ballerina.toml:(8:8,8:15)] invalid 'name' under [[dependency]]: 'name' can only contain alphanumerics, underscores and periods
+ERROR [Ballerina.toml:(9:11,9:19)] invalid 'version' under [[dependency]]: 'version' should be compatible with semver
+ERROR [Ballerina.toml:(12:1,16:21)] 'name' under [[dependency]] is missing
+ERROR [Ballerina.toml:(12:1,16:21)] 'org' under [[dependency]] is missing
+ERROR [Ballerina.toml:(12:1,16:21)] 'version' under [[dependency]] is missing
+ERROR [Ballerina.toml:(13:1,13:19)] key 'org1' not supported in schema 'dependency'
+ERROR [Ballerina.toml:(14:1,14:15)] key 'name2' not supported in schema 'dependency'
+ERROR [Ballerina.toml:(15:1,15:19)] key 'version3' not supported in schema 'dependency'
+ERROR [main.bal:(2:13,2:20)] incompatible types: expected 'int', found 'string'

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-project-with-invalid-dependency-array.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-project-with-invalid-dependency-array.txt
@@ -1,0 +1,12 @@
+Compiling source
+	foo/winery:0.1.0
+ERROR [Ballerina.toml:(7:7,7:19)] invalid 'org' under [[dependency]]: 'org' can only contain alphanumerics and underscores
+ERROR [Ballerina.toml:(8:8,8:15)] invalid 'name' under [[dependency]]: 'name' can only contain alphanumerics, underscores and periods
+ERROR [Ballerina.toml:(9:11,9:19)] invalid 'version' under [[dependency]]: 'version' should be compatible with semver
+ERROR [Ballerina.toml:(12:1,16:21)] 'name' under [[dependency]] is missing
+ERROR [Ballerina.toml:(12:1,16:21)] 'org' under [[dependency]] is missing
+ERROR [Ballerina.toml:(12:1,16:21)] 'version' under [[dependency]] is missing
+ERROR [Ballerina.toml:(13:1,13:19)] key 'org1' not supported in schema 'dependency'
+ERROR [Ballerina.toml:(14:1,14:15)] key 'name2' not supported in schema 'dependency'
+ERROR [Ballerina.toml:(15:1,15:19)] key 'version3' not supported in schema 'dependency'
+ERROR [main.bal:(2:13,2:20)] incompatible types: expected 'int', found 'string'

--- a/cli/ballerina-cli/src/test/resources/test-resources/invalid-dependency-array-project/Ballerina.toml
+++ b/cli/ballerina-cli/src/test/resources/test-resources/invalid-dependency-array-project/Ballerina.toml
@@ -1,0 +1,16 @@
+[package]
+org = "foo"
+name = "winery"
+version = "0.1.0"
+
+[[dependency]]
+org = "ballerina#"
+name = "dat$a"
+version = "0.1.0r"
+repository = "local"
+
+[[dependency]]
+org1 = "ballerina"
+name2 = "data"
+version3 = "0.1.0"
+repository = "maven"

--- a/cli/ballerina-cli/src/test/resources/test-resources/invalid-dependency-array-project/main.bal
+++ b/cli/ballerina-cli/src/test/resources/test-resources/invalid-dependency-array-project/main.bal
@@ -1,0 +1,3 @@
+public function main() {
+    int x = "hello";
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/FileSystemRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/FileSystemRepository.java
@@ -52,7 +52,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -138,6 +137,9 @@ public class FileSystemRepository extends AbstractPackageRepository {
     public boolean isPackageExists(PackageOrg org,
                                    PackageName name,
                                    PackageVersion version) {
+        if (org.value() == null || name.value() == null) {
+            return false;
+        }
         Path balaPath = getPackagePath(org.value(), name.value(), version.value().toString());
         return Files.exists(balaPath);
     }
@@ -209,7 +211,7 @@ public class FileSystemRepository extends AbstractPackageRepository {
             Path balaPackagePath = bala.resolve(org.value()).resolve(name.value());
             if (Files.exists(balaPackagePath)) {
                 try (Stream<Path> collect = Files.list(balaPackagePath)) {
-                    versions.addAll(collect.collect(Collectors.toList()));
+                    versions.addAll(collect.toList());
                 }
             }
         } catch (IOException e) {


### PR DESCRIPTION
## Purpose
When there is an invalid entry like,
```
[[dependency]]
org = "ballerina"
name1 = "data.jsondata"
version = "0.1.0"
repository = "local"
```
the toml validator adds error diagnostics. However, since we are proceeding to the `CompileTask` without failing, we get a bad sad error when accessing the `name` field. 

This fix will check if `org`, `name` are not null before accessing the dependencies. The version is already validated when casting to `SemanticVersion` class.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/42472

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
