### PR TITLE
[master] Add digest to connection reset related Central API tests

### DIFF
--- a/cli/central-client/src/test/java/org/ballerinalang/central/client/TestCentralApiClient.java
+++ b/cli/central-client/src/test/java/org/ballerinalang/central/client/TestCentralApiClient.java
@@ -1060,7 +1060,8 @@ public class TestCentralApiClient extends CentralAPIClient {
         String retryOutput = "* Retrying to pull the tool: foosf:1.3.5 due to: error" +
                 ": Connection reset. Retry attempt: ";
         String responseBody = "{\"id\":14069, \"organization\":\"foo\", \"name\":\"sf\", \"version\":\"1.3.5\", " +
-                "\"platform\":\"java17\", \"balaURL\":\"" + this.balaUrl + "\"}";
+                "\"platform\":\"java17\", \"balaURL\":\"" + this.balaUrl + "\", " +
+                "\"digest\":\"sha-256=47e043c80d516234b1e6bd93140f126c9d9e79b5c7c0600cc6316d12504c2cf4\"}";
         Path balaPath = UTILS_TEST_RESOURCES.resolve(TEST_BALA_NAME);
         File balaFile = new File(String.valueOf(balaPath));
         String balaFileName = "attachment; filename=sf-2020r2-any-1.3.5.bala";
@@ -1126,7 +1127,8 @@ public class TestCentralApiClient extends CentralAPIClient {
         String retryOutput = "* Retrying to pull the tool: foosf:1.3.5 due to: error" +
                 ": Connection reset. Retry attempt: ";
         String responseBody = "{\"id\":14069, \"organization\":\"foo\", \"name\":\"sf\", \"version\":\"1.3.5\", " +
-                "\"platform\":\"java17\", \"balaURL\":\"" + this.balaUrl + "\"}";
+                "\"platform\":\"java17\", \"balaURL\":\"" + this.balaUrl + "\", " +
+                "\"digest\":\"sha-256=47e043c80d516234b1e6bd93140f126c9d9e79b5c7c0600cc6316d12504c2cf4\"}";
         Path balaPath = UTILS_TEST_RESOURCES.resolve(TEST_BALA_NAME);
         File balaFile = new File(String.valueOf(balaPath));
         String balaFileName = "attachment; filename=sf-2020r2-any-1.3.5.bala";


### PR DESCRIPTION
## Purpose
Daily build for master has been failing due to retry tests not having the digest field. https://scans.gradle.com/s/ftiih7lsc5jlw

Fixes #<Issue Number>

## Approach
Added digest field to retry test response bodies.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
