### PR TITLE
Generate unknown type diagnostic for checked explicit constructors

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLog.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLog.java
@@ -285,6 +285,10 @@ public class BLangDiagnosticLog implements DiagnosticLog {
         return diagArgs;
     }
 
+    public boolean isMute() {
+        return isMute;
+    }
+
     private void storeDiagnosticInModule(PackageID pkgId, Diagnostic diagnostic) {
         BLangPackage pkgNode = this.packageCache.get(pkgId);
         pkgNode.addDiagnostic(diagnostic);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -624,7 +624,7 @@ public class TypeResolver {
         Location pos = td.pos;
         LocationData locationData = new LocationData(td.typeName.value, pos.lineRange().startLine().line(),
                 pos.lineRange().startLine().offset());
-        return unknownTypeRefs.add(locationData);
+        return dlog.isMute() || unknownTypeRefs.add(locationData);
     }
 
     public BType validateModuleLevelDef(String name, Name pkgAlias, Name typeName, BLangUserDefinedType td) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
@@ -81,7 +81,7 @@ public class ObjectInitializerTest {
     @Test(description = "Test negative object initializers scenarios")
     public void testObjectInitializerNegatives() {
         CompileResult result = BCompileUtil.compile("test-src/object/object_initializer_negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 8);
+        Assert.assertEquals(result.getErrorCount(), 12);
         int i = 0;
         validateError(result, i++, "redeclared symbol 'Foo.init'", 23, 14);
         validateError(result, i++,
@@ -96,8 +96,13 @@ public class ObjectInitializerTest {
         validateError(result, i++,
                 "invalid object constructor return type '(FooErr|BarErr)', expected a subtype of 'error?' " +
                         "containing '()'", 89, 29);
-        validateError(result, i, "object 'init' method call is allowed only within the type descriptor",
+        validateError(result, i++, "object 'init' method call is allowed only within the type descriptor",
                 106, 5);
+        validateError(result, i++, "unknown type 'User'", 110, 13);
+        validateError(result, i++, "unknown type 'User'", 111, 13);
+        validateError(result, i++, "unknown type 'User'", 115, 19);
+        validateError(result, i, "unknown type 'User'", 116, 19);
+
     }
 
     @Test(description = "Test error returning object initializer invocation")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object_initializer_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object_initializer_negative.bal
@@ -105,3 +105,13 @@ function callInitFunction() {
     Too t = new;
     t.init(); // invalid
 }
+
+function initUndefinedClass() {
+    _ = new User();
+    _ = new User("val");
+}
+
+function initUndefinedClassWithCheck() {
+    _ = check new User();
+    _ = check new User(1, flag=false);
+}


### PR DESCRIPTION
## Purpose
$title. 

Fixes #42705 

## Approach

The `unknownTypeRefs` are updated even during silent type checking, which in result excludes relevant unknown type diagnostics. With the changes, the respective set is only updated if the diagnostic log is not muted.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
