### PR TITLE
Fix compiler crash on lang lib xml iterable operations on union types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
@@ -757,7 +757,7 @@ public class MethodGen {
             } else if (bType.tag == TypeTags.NEVER) {
                 mv.visitFieldInsn(GETFIELD, frameName, localVar.jvmVarName, GET_OBJECT);
                 mv.visitVarInsn(ASTORE, index);
-            } else if (types.isAssignable(bType, symbolTable.xmlType)) {
+            } else if (TypeTags.isXMLTypeTag(bType.tag)) {
                 mv.visitFieldInsn(GETFIELD, frameName, localVar.jvmVarName,
                         GET_XML);
                 mv.visitVarInsn(ASTORE, index);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -6664,9 +6664,11 @@ public class Desugar extends BLangNodeVisitor {
             targetVarRef = new BLangArrayAccessExpr(indexAccessExpr.pos, indexAccessExpr.expr,
                                                     indexAccessExpr.indexExpr);
         } else if (types.isAssignable(varRefType, symTable.xmlType)) {
-            targetVarRef = new BLangXMLAccessExpr(indexAccessExpr.pos,
-                    createTypeCastExpr(indexAccessExpr.expr, symTable.xmlType),
-                    indexAccessExpr.indexExpr);
+            BLangExpression indexAccessExprExpr = indexAccessExpr.expr;
+            if (Types.getImpliedType(indexAccessExprExpr.getBType()).tag == TypeTags.UNION) {
+                indexAccessExprExpr = createTypeCastExpr(indexAccessExprExpr, symTable.xmlType);
+            }
+            targetVarRef = new BLangXMLAccessExpr(indexAccessExpr.pos, indexAccessExprExpr, indexAccessExpr.indexExpr);
         } else if (types.isAssignable(varRefType, symTable.stringType)) {
             indexAccessExpr.expr = types.addConversionExprIfRequired(indexAccessExpr.expr, symTable.stringType);
             targetVarRef = new BLangStringAccessExpr(indexAccessExpr.pos, indexAccessExpr.expr,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -6664,7 +6664,8 @@ public class Desugar extends BLangNodeVisitor {
             targetVarRef = new BLangArrayAccessExpr(indexAccessExpr.pos, indexAccessExpr.expr,
                                                     indexAccessExpr.indexExpr);
         } else if (types.isAssignable(varRefType, symTable.xmlType)) {
-            targetVarRef = new BLangXMLAccessExpr(indexAccessExpr.pos, indexAccessExpr.expr,
+            targetVarRef = new BLangXMLAccessExpr(indexAccessExpr.pos,
+                    createTypeCastExpr(indexAccessExpr.expr, symTable.xmlType),
                     indexAccessExpr.indexExpr);
         } else if (types.isAssignable(varRefType, symTable.stringType)) {
             indexAccessExpr.expr = types.addConversionExprIfRequired(indexAccessExpr.expr, symTable.stringType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -6665,6 +6665,7 @@ public class Desugar extends BLangNodeVisitor {
                                                     indexAccessExpr.indexExpr);
         } else if (types.isAssignable(varRefType, symTable.xmlType)) {
             BLangExpression indexAccessExprExpr = indexAccessExpr.expr;
+            // TODO: Remove the casting after fixing the xml union type representation in runtime.
             if (Types.getImpliedType(indexAccessExprExpr.getBType()).tag == TypeTags.UNION) {
                 indexAccessExprExpr = createTypeCastExpr(indexAccessExprExpr, symTable.xmlType);
             }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
@@ -348,6 +348,11 @@ public class LangLibXMLTest {
     }
 
     @Test
+    public void testIterableOperationsOnUnionType() {
+        BRunUtil.invoke(compileResult, "testIterableOperationsOnUnionType");
+    }
+
+    @Test
     public void testNegativeCases() {
         negativeResult = BCompileUtil.compile("test-src/xmllib_test_negative.bal");
         int i = 0;

--- a/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
@@ -1126,4 +1126,13 @@ function testIterableOperationsOnUnionType() {
                 index += 1;
             });
     assertEquals(index, 1);
+
+    xml<xml:Element|xml:ProcessingInstruction>|xml<xml:Comment|xml:Text> x11 = xml `<a><b/><c/></a>`;
+    index = 0;
+    assertEquals(xml:map(xml:elements(<xml>x11), v => xml:getChildren(v)), xml `<b/><c/>`);
+    assertEquals(xml:filter(<xml>x11, v => xml:getAttributes(<xml:Element>v).length() > 0), xml ``);
+    xml:forEach(<xml>x11, function(xml v) {
+                index += 1;
+            });
+    assertEquals(index, 1);
 }


### PR DESCRIPTION
## Purpose
Fixes #42771

## Approach
The xml lang lib functions does not support union types. The union types are represented in the runtime as Objects. The runtime change done [here](https://github.com/ballerina-platform/ballerina-lang/pull/42150/files) caused using the XMLValue class for union types in the runtime instead of the Object class. This change is wrong. And in order to support the union types in the indexed based access in the desugar phase the variable are cast into the xml type.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
