### PR TITLE
Fix `xml:filter` return type on non `xml:Element` singleton values

### DIFF
--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Filter.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Filter.java
@@ -57,7 +57,7 @@ public class Filter {
             func.asyncCall(args,
                       result -> {
                           if ((Boolean) result) {
-                              return ValueCreator.createXmlSequence(x);
+                              return x;
                           }
                           return ValueCreator.createXmlSequence();
                       }, METADATA);

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
@@ -363,6 +363,11 @@ public class LangLibXMLTest {
     }
 
     @Test
+    public void testXmlFilterValueAndErrorWithNonElementSingletonValues() {
+        BRunUtil.invoke(compileResult, "testXmlFilterValueAndErrorWithNonElementSingletonValues");
+    }
+
+    @Test
     public void testNegativeCases() {
         negativeResult = BCompileUtil.compile("test-src/xmllib_test_negative.bal");
         int i = 0;

--- a/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
@@ -1034,7 +1034,7 @@ function testIterableOperationsOnUnionType() {
     x = <xml>x2;
     string s = "";
     assertEquals(xml:map(x, v => v), xml `<?data?>`);
-    assertEquals(xml:filter(x, v => xml:getTarget(<xml:ProcessingInstruction>v) == "data").get(0), xml `<?data?>`);
+    assertEquals(xml:filter(x, v => xml:getTarget(<xml:ProcessingInstruction>v) == "data"), xml `<?data?>`);
     xml:forEach(x, function(xml v) {
                 s += xml:getTarget(<xml:ProcessingInstruction>v);
             });
@@ -1044,7 +1044,7 @@ function testIterableOperationsOnUnionType() {
     x = <xml>x3;
     index = 0;
     assertEquals(xml:map(x, v => xml:concat(v, "new")).get(0), xml `this is a text in xmlnew`);
-    assertEquals(xml:filter(x, v => xml:length(<xml>v) > 0).get(0), xml `this is a text in xml`);
+    assertEquals(xml:filter(x, v => xml:length(<xml>v) > 0), xml `this is a text in xml`);
     xml:forEach(x, function(xml v) {
                 index += 1;
             });
@@ -1054,7 +1054,7 @@ function testIterableOperationsOnUnionType() {
     x = <xml>x4;
     index = 0;
     assertEquals(xml:map(x, v => xml:concat(v, xml `<a/>`)), xml `<!--comment--><a/>`);
-    assertEquals(xml:filter(x, v => xml:data(<xml>v).length() == 0).get(0), xml `<!--comment-->`);
+    assertEquals(xml:filter(x, v => xml:data(<xml>v).length() == 0), xml `<!--comment-->`);
     xml:forEach(x, function(xml v) {
                 index += 1;
             });
@@ -1079,7 +1079,7 @@ function testIterableOperationsOnUnionType() {
     x = <xml>x6;
     index = 0;
     assertEquals(xml:map(x, v => xml:children(<xml>v)), xml ``);
-    assertEquals(xml:filter(x, v => xml:getContent(<xml:Comment>v).length() > 0).get(0), xml `<!--comment-->`);
+    assertEquals(xml:filter(x, v => xml:getContent(<xml:Comment>v).length() > 0), xml `<!--comment-->`);
     xml:forEach(x, function(xml v) {
                 index += xml:length(v);
             });
@@ -1089,7 +1089,7 @@ function testIterableOperationsOnUnionType() {
     x = <xml>x7;
     index = 0;
     assertEquals(xml:map(x, v => xml:text(<xml>v)), xml `An xml text`);
-    assertEquals(xml:filter(x, v => xml:length(xml:text(<xml>v)) > 0).get(0), xml `An xml text`);
+    assertEquals(xml:filter(x, v => xml:length(xml:text(<xml>v)) > 0), xml `An xml text`);
     xml:forEach(x, function(xml v) {
                 index += xml:length(xml:text(v));
             });
@@ -1099,7 +1099,7 @@ function testIterableOperationsOnUnionType() {
     x = <xml>x8;
     index = 0;
     assertEquals(xml:map(x, v => xml:createText(xml:getContent(<xml:ProcessingInstruction>v))), xml `descending`);
-    assertEquals(xml:filter(x, v => xml:getTarget(<xml:ProcessingInstruction>v).length() > 0).get(0), xml `<?data2 descending?>`);
+    assertEquals(xml:filter(x, v => xml:getTarget(<xml:ProcessingInstruction>v).length() > 0), xml `<?data2 descending?>`);
     xml:forEach(x, function(xml v) {
                 index += 1;
             });
@@ -1121,7 +1121,7 @@ function testIterableOperationsOnUnionType() {
     x = <xml>x10;
     index = 0;
     assertEquals(xml:map(x, v => xml:createText(xml:data(<xml>v))), xml `A second xml text`);
-    assertEquals(xml:filter(x, v => xml:length(xml:text(<xml>v)) > 0).get(0), xml `A second xml text`);
+    assertEquals(xml:filter(x, v => xml:length(xml:text(<xml>v)) > 0), xml `A second xml text`);
     xml:forEach(x, function(xml v) {
                 index += 1;
             });

--- a/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
@@ -1226,6 +1226,30 @@ function assertXmlSequenceItems(xml actual, xml[] expected) {
     }
 }
 
+function testXmlFilterValueAndErrorWithNonElementSingletonValues() {
+    xml<xml:ProcessingInstruction> x1 = xml `<?data?>`;
+    assertEquals(xml:filter(x1, v => true), xml `<?data?>`);
+    assertEquals(xml:filter(xml:filter(x1, v => true), v => v is xml:ProcessingInstruction), xml `<?data?>`);
+    assertError(trap xml:filter(xml:filter(x1, v => true), y => xml:getChildren(<xml:Element>y).length() == 0),
+            "{ballerina}TypeCastError",
+            "incompatible types: 'lang.xml:ProcessingInstruction' cannot be cast to 'lang.xml:Element'");
+
+    xml<xml:Comment> x2 = xml `<!--comment-->`;
+    assertEquals(xml:filter(xml:filter(x2, v => true), v => v is xml:Comment), xml `<!--comment-->`);
+    assertEquals(xml:filter(x2, v => true), xml `<!--comment-->`);
+
+    assertError(trap xml:filter(xml:filter(x2, v => true), y => xml:getChildren(<xml:Element>y).length() == 0),
+            "{ballerina}TypeCastError",
+            "incompatible types: 'lang.xml:Comment' cannot be cast to 'lang.xml:Element'");
+
+    xml<xml:Text> x3 = xml `this is a text`;
+    assertEquals(xml:filter(x3, v => true), xml `this is a text`);
+    assertEquals(xml:filter(xml:filter(x3, v => true), v => v is xml:Text), xml `this is a text`);
+    assertError(trap xml:filter(xml:filter(x3, v => true), y => xml:getChildren(<xml:Element>y).length() == 0),
+            "{ballerina}TypeCastError",
+            "incompatible types: 'lang.xml:Text' cannot be cast to 'lang.xml:Element'");
+}
+
 type Error error<record {string message;}>;
 
 function assertError(any|error value, string errorMessage, string expDetailMessage) {


### PR DESCRIPTION
## Purpose
Fixes #42817

## Approach

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
