### PR TITLE
[Master] Revise the definition API of the TypeReferenceTypeSymbol to exclude searching for virtual symbols in the scope

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -27,6 +27,7 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.tools.diagnostics.Location;
+import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BParameterizedType;
@@ -103,7 +104,7 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
         if (referredType.tag == TypeTags.PARAMETERIZED_TYPE || bType.tag == TypeTags.PARAMETERIZED_TYPE) {
             this.definition = symbolFactory.getBCompiledSymbol(((BParameterizedType) this.tSymbol.type).paramSymbol,
                                                                this.name());
-        } else if (referredType.tag == TypeTags.INTERSECTION) {
+        } else if (referredType.tag == TypeTags.INTERSECTION || referredType.tsymbol.origin == SymbolOrigin.VIRTUAL) {
             this.definition = symbolFactory.getBCompiledSymbol(bType.tsymbol,
                     referredType.tsymbol.getName().getValue());
         } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
@@ -583,7 +583,7 @@ public class ImmutableTypeCloner {
         BRecordTypeSymbol recordSymbol =
                 Symbols.createRecordSymbol(recordTypeSymbol.flags | Flags.READONLY,
                         getImmutableTypeName(names,  getSymbolFQN(recordTypeSymbol)),
-                        pkgID, null, env.scope.owner, pos, recordTypeSymbol.origin);
+                        pkgID, null, env.scope.owner, pos, VIRTUAL);
 
         BInvokableType bInvokableType = new BInvokableType(new ArrayList<>(), symTable.nilType, null);
         BInvokableSymbol initFuncSymbol = Symbols.createFunctionSymbol(

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typedescriptors/TypeReferenceTSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typedescriptors/TypeReferenceTSymbolTest.java
@@ -33,6 +33,7 @@ import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
@@ -175,6 +176,33 @@ public class TypeReferenceTSymbolTest {
         return new Object[][]{
                 {46, 4, "Foo"},
                 {48, 4, "Baz"},
+        };
+    }
+
+    @Test(dataProvider = "TypeRefPosForTypeNarrowing")
+    public void testTypeRefLookupForTypeNarrowing(int line, int start, int end) {
+        Optional<TypeSymbol> typeSymbol = model.typeOf(LineRange.from(srcFile.name(), LinePosition.from(line, start),
+                LinePosition.from(line, end)));
+
+        assertTrue(typeSymbol.isPresent());
+        assertEquals(typeSymbol.get().typeKind(), TypeDescKind.TYPE_REFERENCE);
+
+        TypeReferenceTypeSymbol typeRefTSymbol = (TypeReferenceTypeSymbol) typeSymbol.get();
+        Symbol definition = typeRefTSymbol.definition();
+        assertEquals(definition.kind(), TYPE_DEFINITION);
+
+        Optional<String> definitionName = definition.getName();
+        assertTrue(definitionName.isPresent());
+        assertEquals(definitionName.get(), "(Person & readonly)");
+    }
+
+    @DataProvider(name = "TypeRefPosForTypeNarrowing")
+    public Object[][] getTypeRefPosForTypeNarrowing() {
+        return new Object[][]{
+                {56, 8, 14},
+                {62, 12, 18},
+                {68, 8, 14},
+                {76, 8, 11},
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedescriptors/typeref_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedescriptors/typeref_test.bal
@@ -49,9 +49,39 @@ function test() {
     Baz z;
 }
 
+function test2() {
+    readonly & Person|int person = {name: "A", age: 0};
+    if person is int {
+        return;
+    }
+    _ = person.entries();
+}
+
+function test3() {
+    readonly & Person|int person = {name: "A", age: 0};
+    if person is readonly & Person {
+        _ = person.entries();
+    }
+}
+
+function test4() returns error? {
+    var person = check fn();
+    _ = person.entries();
+}
+
+function test5() {
+    Person & readonly|xml & readonly|error val = error("");
+    if val is xml & readonly|error {
+        return;
+    }
+    _ = val.entries();
+}
+
 // utils
 type Foo Person;
 
 type Bar Foo;
 
 type Baz decimal;
+
+function fn() returns readonly & Person|error => error("");


### PR DESCRIPTION
## Purpose
$title as virtual symbols are not stored in the scope.

Fixes #42454 

## Approach
The current approach ensures that the `definition` API of the type references does not search for virtual symbols in the current scope.

## Remarks
Although this PR fixed the semantic API issue, the tsymbol set for narrowed type symbols remains invalid, which is being tracked separately.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
