### PR TITLE
Reorder the desugaring of type definitions before the desugaring of global variables and configurables in the desugar phase

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -937,7 +937,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangStatementExpression stmtExpr = createStatementExpression(ifElse, resultVarRef);
         stmtExpr.setBType(configurableVar.getBType());
 
-        // This statement expression is desugared when visiting the init function
+        // This statement expression is desugared when it is visited in the init function
         return stmtExpr;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -937,6 +937,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangStatementExpression stmtExpr = createStatementExpression(ifElse, resultVarRef);
         stmtExpr.setBType(configurableVar.getBType());
 
+        // This statement expression is desugared when visiting the init function
         return stmtExpr;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -794,6 +794,8 @@ public class Desugar extends BLangNodeVisitor {
 
         pkgNode.constants = removeDuplicateConstants(pkgNode);
 
+        rewrite(pkgNode.typeDefinitions, env);
+
         pkgNode.globalVars = desugarGlobalVariables(pkgNode, initFnBody);
 
         pkgNode.services.forEach(service -> serviceDesugar.engageCustomServiceDesugar(service, env));
@@ -806,7 +808,6 @@ public class Desugar extends BLangNodeVisitor {
         //Sort type definitions with precedence
         pkgNode.typeDefinitions.sort(Comparator.comparing(t -> t.precedence));
 
-        pkgNode.typeDefinitions = rewrite(pkgNode.typeDefinitions, env);
         pkgNode.xmlnsList = rewrite(pkgNode.xmlnsList, env);
         pkgNode.constants = rewrite(pkgNode.constants, env);
         pkgNode.globalVars = rewrite(pkgNode.globalVars, env);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -794,8 +794,6 @@ public class Desugar extends BLangNodeVisitor {
 
         pkgNode.constants = removeDuplicateConstants(pkgNode);
 
-        rewrite(pkgNode.typeDefinitions, env);
-
         pkgNode.globalVars = desugarGlobalVariables(pkgNode, initFnBody);
 
         pkgNode.services.forEach(service -> serviceDesugar.engageCustomServiceDesugar(service, env));
@@ -808,6 +806,7 @@ public class Desugar extends BLangNodeVisitor {
         //Sort type definitions with precedence
         pkgNode.typeDefinitions.sort(Comparator.comparing(t -> t.precedence));
 
+        pkgNode.typeDefinitions = rewrite(pkgNode.typeDefinitions, env);
         pkgNode.xmlnsList = rewrite(pkgNode.xmlnsList, env);
         pkgNode.constants = rewrite(pkgNode.constants, env);
         pkgNode.globalVars = rewrite(pkgNode.globalVars, env);
@@ -938,7 +937,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangStatementExpression stmtExpr = createStatementExpression(ifElse, resultVarRef);
         stmtExpr.setBType(configurableVar.getBType());
 
-        return rewrite(stmtExpr, initFunctionEnv);
+        return stmtExpr;
     }
 
     private List<BLangExpression> getConfigurableLangLibInvocationParam(BLangSimpleVariable configurableVar) {

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configurableProject/Config.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configurableProject/Config.toml
@@ -124,3 +124,6 @@ salary = 25000.0
 [[main.empInfoTab]]
 id = 303
 name = "belle"
+
+[main.customConfig]
+username = "chiranS"

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configurableProject/main/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configurableProject/main/main.bal
@@ -83,6 +83,13 @@ type EmployeeInfo record {|
     float salary?;
 |};
 
+public type CustomConfiguration record {
+    string username;
+    string logLevel = "OFF";
+};
+
+configurable CustomConfiguration customConfig = ?;
+
 type UserTable table<AuthInfo> key(username);
 
 type EmployeeTable table<Employee> key(id) & readonly;
@@ -193,6 +200,9 @@ function testRecordValues() {
     test:assertEquals(34, empInfo.id);
     test:assertEquals("test", empInfo.name);
     test:assertEquals(75000.0, empInfo["salary"]);
+
+    test:assertEquals("chiranS", customConfig.username);
+    test:assertEquals("OFF", customConfig.logLevel);
 }
 
 function testTableValues() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_var_decl.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_var_decl.bal
@@ -25,9 +25,22 @@ configurable UserInfo admin = {
     password: "password"
 };
 
+public type CustomConfiguration record {
+    string username;
+    string logLevel = "OFF";
+};
+
+configurable CustomConfiguration customConfig1 = {username: "chiranS"};
+
+configurable CustomConfiguration customConfig2 = {username: "chiranS", logLevel: "DEBUG"};
+
 function testConfigValue() {
     assertEquality("default", admin.username);
     assertEquality("password", admin.password);
+    assertEquality("chiranS", customConfig1.username);
+    assertEquality("OFF", customConfig1.logLevel);
+    assertEquality("chiranS", customConfig2.username);
+    assertEquality("DEBUG", customConfig2.logLevel);
 }
 
 function assertEquality(any|error expected, any|error actual) {


### PR DESCRIPTION
## Purpose
> $title. In the current implementation, we desugar the value of global variables after adding the init function, but for configurables, we desugar before adding them to the init function. Due to this, we need to desugar type definitions before desugaring global variables and configurables.

Fixes #42829 

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
