### PR TITLE
Replace charset name argument with StandardCharsets.UTF_8

### DIFF
--- a/docs/bir-spec/src/main/java/org/ballerinalang/birspec/BIRSpecGenerator.java
+++ b/docs/bir-spec/src/main/java/org/ballerinalang/birspec/BIRSpecGenerator.java
@@ -66,6 +66,6 @@ public class BIRSpecGenerator {
         while ((length = inputStream.read(buffer)) != -1) {
             result.write(buffer, 0, length);
         }
-        return result.toString(StandardCharsets.UTF_8.name());
+        return result.toString(StandardCharsets.UTF_8);
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientLogger.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientLogger.java
@@ -29,7 +29,6 @@ import org.eclipse.lsp4j.services.LanguageClient;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientLogger.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientLogger.java
@@ -98,12 +98,8 @@ public class LSClientLogger {
         String details = getErrorDetails(identifier, error, pos);
         if (config.isDebugLogEnabled()) {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            try {
-                PrintStream ps = new PrintStream(baos, true, StandardCharsets.UTF_8.name());
-                error.printStackTrace(ps);
-            } catch (UnsupportedEncodingException e1) {
-                //ignore
-            }
+            PrintStream ps = new PrintStream(baos, true, StandardCharsets.UTF_8);
+            error.printStackTrace(ps);
             this.languageClient.logMessage(
                     new MessageParams(MessageType.Error, message + " " + details + "\n" + baos));
         }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/io/StringUtils.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/io/StringUtils.java
@@ -146,14 +146,9 @@ public class StringUtils {
         String encodedKey = key;
         String encodedValue;
         for (String character : specialCharacters) {
-            try {
-                if (encodedKey.contains(character)) {
-                    encodedValue = URLEncoder.encode(character, StandardCharsets.UTF_8.toString());
-                    encodedKey = encodedKey.replace(character, encodedValue);
-                }
-            } catch (UnsupportedEncodingException e) {
-                return ErrorHelper.getRuntimeException(
-                        ErrorCodes.INCOMPATIBLE_ARGUMENTS, "Error while encoding: " + e.getMessage());
+            if (encodedKey.contains(character)) {
+                encodedValue = URLEncoder.encode(character, StandardCharsets.UTF_8);
+                encodedKey = encodedKey.replace(character, encodedValue);
             }
         }
         return encodedKey;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/utils/ResponseReader.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/utils/ResponseReader.java
@@ -46,7 +46,8 @@ public class ResponseReader {
         final char[] buffer = new char[bufferSize];
         final StringBuilder out = new StringBuilder();
         try {
-            reader = new InputStreamReader(new HttpMessageDataStreamer(response).getInputStream(), StandardCharsets.UTF_8);
+            reader = new InputStreamReader(
+                    new HttpMessageDataStreamer(response).getInputStream(), StandardCharsets.UTF_8);
             while (true) {
                 int size = reader.read(buffer, 0, buffer.length);
                 if (size < 0) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/utils/ResponseReader.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/utils/ResponseReader.java
@@ -26,13 +26,13 @@ import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Utility class for managing responses.
  */
 public class ResponseReader {
     private static final Logger LOG = LoggerFactory.getLogger(ResponseReader.class);
-    public static final String UTF_8 = "UTF-8";
 
     /**
      * Get the response value from input stream.
@@ -46,7 +46,7 @@ public class ResponseReader {
         final char[] buffer = new char[bufferSize];
         final StringBuilder out = new StringBuilder();
         try {
-            reader = new InputStreamReader(new HttpMessageDataStreamer(response).getInputStream(), UTF_8);
+            reader = new InputStreamReader(new HttpMessageDataStreamer(response).getInputStream(), StandardCharsets.UTF_8);
             while (true) {
                 int size = reader.read(buffer, 0, buffer.length);
                 if (size < 0) {


### PR DESCRIPTION
## Purpose
Use the constant `StandardCharset.UTF_8` instead of resolving the Charset based on the name.
Should solve some sonar cloud issues.

## Approach
> Use IntelliJ automatic refactoring.

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
