### PR TITLE
Fix deprecated usage of `main` and replace it with `mainClass` in gradle files

### DIFF
--- a/ballerina-shell/modules/shell-cli/build.gradle
+++ b/ballerina-shell/modules/shell-cli/build.gradle
@@ -52,7 +52,7 @@ test {
 
 def mainCliClass = 'io.ballerina.shell.cli.ReplShellApplication'
 task run(type: JavaExec) {
-    main = mainCliClass
+    mainClass = mainCliClass
     standardInput = System.in
     classpath = sourceSets.main.runtimeClasspath
 }

--- a/compiler/ballerina-treegen/build.gradle
+++ b/compiler/ballerina-treegen/build.gradle
@@ -21,7 +21,7 @@ apply from: "$rootDir/gradle/javaProject.gradle"
 description = 'Ballerina - Syntax Tree Generator'
 
 task treegen(type: JavaExec) {
-    main = "io.ballerinalang.compiler.internal.treegen.TreeGen"
+    mainClass = "io.ballerinalang.compiler.internal.treegen.TreeGen"
     classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/distribution/zip/jballerina-tools/build.gradle
+++ b/distribution/zip/jballerina-tools/build.gradle
@@ -413,7 +413,7 @@ task generateDocs(type: JavaExec) {
     outputs.cacheIf { true }
     systemProperty("ballerina.home", "$buildDir")
     classpath = files(pathingJar.archivePath)
-    main = 'org.ballerinalang.plugin.gradle.doc.DocerinaGen'
+    mainClass = 'org.ballerinalang.plugin.gradle.doc.DocerinaGen'
     args("$buildDir/api-docs")
 }
 

--- a/docs/bir-spec/build.gradle
+++ b/docs/bir-spec/build.gradle
@@ -59,7 +59,7 @@ checkstyleMain.exclude '**/kaitai/**'
 task genBirSpec(type: JavaExec) {
     dependsOn classes
     classpath += sourceSets.main.runtimeClasspath
-    main = 'org.ballerinalang.birspec.BIRSpecGenerator'
+    mainClass = 'org.ballerinalang.birspec.BIRSpecGenerator'
 
     inputs.dir('src/main/resources')
     outputs.files('../compiler/bir-spec.md')

--- a/gradle/balNativeLibProject.gradle
+++ b/gradle/balNativeLibProject.gradle
@@ -50,7 +50,7 @@ class CreateBalaTask extends JavaExec {
     def newParser = 'true'
 
     CreateBalaTask() {
-        setMain('org.ballerinalang.stdlib.utils.GenerateBala')
+        setMainClass('org.ballerinalang.stdlib.utils.GenerateBala')
         setEnableAssertions(true)
     }
 

--- a/gradle/ballerinaNativeStdLibBuild.gradle
+++ b/gradle/ballerinaNativeStdLibBuild.gradle
@@ -83,7 +83,7 @@ class BallerinaLangLibBuildTask extends JavaExec {
     @Internal def skipBootstrap = 'false'
 
     BallerinaLangLibBuildTask() {
-        setMain('org.ballerinalang.stdlib.utils.BuildLangLib')
+        setMainClass('org.ballerinalang.stdlib.utils.BuildLangLib')
     }
 
     @Override

--- a/gradle/ballerinaStdLibBuildInternal.gradle
+++ b/gradle/ballerinaStdLibBuildInternal.gradle
@@ -85,7 +85,7 @@ class BallerinaLangLibBuildTask extends JavaExec {
     @Internal def skipBootstrap = 'false'
 
     BallerinaLangLibBuildTask() {
-        setMain('org.ballerinalang.stdlib.utils.BuildLangLib')
+        setMainClass('org.ballerinalang.stdlib.utils.BuildLangLib')
     }
 
     @Override


### PR DESCRIPTION
## Purpose
https://docs.gradle.org/current/userguide/upgrading_version_7.html#javaexec_api_cleanup

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
