### PR TITLE
[Refactoring] Fix usage of rawtypes

### DIFF
--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ModuleMemberTrial.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ModuleMemberTrial.java
@@ -62,12 +62,12 @@ public class ModuleMemberTrial extends TreeParserTrial {
         ModulePartNode node = tree.rootNode();
         NodeList<ModuleMemberDeclarationNode> members = node.members();
         Iterator<ImportDeclarationNode> importIterator = node.imports().iterator();
-        Iterator memberIterator = members.iterator();
+        Iterator<ModuleMemberDeclarationNode> memberIterator = members.iterator();
         while (importIterator.hasNext()) {
             nodes.add(importIterator.next());
         }
         while (memberIterator.hasNext()) {
-            ModuleMemberDeclarationNode dclnNode = (ModuleMemberDeclarationNode) memberIterator.next();
+            ModuleMemberDeclarationNode dclnNode = memberIterator.next();
             validateModuleDeclaration(dclnNode);
             nodes.add(dclnNode);
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/PredefinedTypes.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/PredefinedTypes.java
@@ -245,7 +245,7 @@ public final class PredefinedTypes {
         ArrayList<Type> members = new ArrayList<>();
         members.add(TYPE_XML);
         members.add(TYPE_READONLY);
-        var valueModule = new Module(BALLERINA_BUILTIN_PKG_PREFIX, VALUE_LANG_LIB, null);
+        Module valueModule = new Module(BALLERINA_BUILTIN_PKG_PREFIX, VALUE_LANG_LIB, null);
         BUnionType cloneable = new BUnionType(TypeConstants.CLONEABLE_TNAME, valueModule, members, false);
         cloneable.isCyclic = true;
         MapType internalCloneableMap = new BMapType(TypeConstants.MAP_TNAME, cloneable, valueModule);
@@ -266,7 +266,7 @@ public final class PredefinedTypes {
         members.add(TYPE_BOOLEAN);
         members.add(TYPE_STRING);
         members.add(TYPE_DECIMAL);
-        var valueModule = new Module(BALLERINA_BUILTIN_PKG_PREFIX, VALUE_LANG_LIB, null);
+        Module valueModule = new Module(BALLERINA_BUILTIN_PKG_PREFIX, VALUE_LANG_LIB, null);
         BUnionType jsonDecimal = new BUnionType(TypeConstants.JSON_DECIMAL_TNAME, valueModule, members, false);
         jsonDecimal.isCyclic = true;
         MapType internalJsonDecimalMap = new BMapType(TypeConstants.MAP_TNAME, jsonDecimal, valueModule);
@@ -282,7 +282,7 @@ public final class PredefinedTypes {
         members.add(TYPE_BOOLEAN);
         members.add(TYPE_STRING);
         members.add(TYPE_FLOAT);
-        var valueModule = new Module(BALLERINA_BUILTIN_PKG_PREFIX, VALUE_LANG_LIB, null);
+        Module valueModule = new Module(BALLERINA_BUILTIN_PKG_PREFIX, VALUE_LANG_LIB, null);
         BUnionType jsonFloat = new BUnionType(TypeConstants.JSON_FLOAT_TNAME, valueModule, members, false);
         jsonFloat.isCyclic = true;
         MapType internalJsonFloatMap = new BMapType(TypeConstants.MAP_TNAME, jsonFloat, valueModule);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/Runtime.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/Runtime.java
@@ -178,7 +178,7 @@ public abstract class Runtime {
 
     public abstract void deregisterListener(BObject listener);
 
-    public abstract void registerStopHandler(BFunctionPointer<?, ?> stopHandler);
+    public abstract void registerStopHandler(BFunctionPointer<Object[], Object> stopHandler);
 
     /**
      * Invoke a Ballerina function pointer asynchronously.

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ErrorCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ErrorCreator.java
@@ -82,7 +82,7 @@ public final class ErrorCreator {
         } else {
             initialValues = new MappingInitialValueEntry[0];
         }
-        MapValueImpl<BString, Object> detailMap = new MapValueImpl(PredefinedTypes.TYPE_ERROR_DETAIL, initialValues);
+        MapValueImpl<BString, Object> detailMap = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL, initialValues);
         return createError(message, detailMap);
     }
 
@@ -130,7 +130,7 @@ public final class ErrorCreator {
         } else {
             initialValues = new MappingInitialValueEntry[0];
         }
-        MapValueImpl<BString, Object> detailMap = new MapValueImpl(PredefinedTypes.TYPE_ERROR_DETAIL, initialValues);
+        MapValueImpl<BString, Object> detailMap = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL, initialValues);
         return createError(type, message, null, detailMap);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ValueCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ValueCreator.java
@@ -320,8 +320,8 @@ public final class ValueCreator {
      * @param type     {@code FunctionType} of the function pointer
      * @return         function pointer
      */
-    public static BFunctionPointer createFPValue(Function function, FunctionType type) {
-        return new FPValue(function, type, null, false);
+    public static BFunctionPointer<?, ?> createFPValue(Function<Object[], ?> function, FunctionType type) {
+        return new FPValue<>(function, type, null, false);
     }
 
     /**
@@ -332,8 +332,9 @@ public final class ValueCreator {
      * @param strandName name for newly creating strand which is used to run the function pointer
      * @return           function pointer
      */
-    public static BFunctionPointer createFPValue(Function function, FunctionType type, String strandName) {
-        return new FPValue(function, type, strandName, false);
+    public static BFunctionPointer<?, ?> createFPValue(Function<Object[], ?> function,
+                                                       FunctionType type, String strandName) {
+        return new FPValue<>(function, type, strandName, false);
     }
 
     // TODO: remove this with https://github.com/ballerina-platform/ballerina-lang/issues/40175
@@ -786,7 +787,7 @@ public final class ValueCreator {
      * @param mappingValue mapping value
      * @return             spread field entry
      */
-    public static BMapInitialValueEntry createSpreadFieldEntry(BMap mappingValue) {
+    public static BMapInitialValueEntry createSpreadFieldEntry(BMap<?, ?> mappingValue) {
         return new MappingInitialValueEntry.SpreadFieldEntry(mappingValue);
     }
 
@@ -957,8 +958,8 @@ public final class ValueCreator {
      * @param tableType table type
      * @return          table value for given type
      */
-    public static BTable createTableValue(TableType tableType) {
-        return new TableValueImpl(tableType);
+    public static BTable<?, ?> createTableValue(TableType tableType) {
+        return new TableValueImpl<>(tableType);
     }
 
     /**
@@ -969,8 +970,8 @@ public final class ValueCreator {
      * @param fieldNames table field names
      * @return           table value for given type
      */
-    public static BTable createTableValue(TableType tableType, BArray data, BArray fieldNames) {
-        return new TableValueImpl(tableType, (ArrayValue) data, (ArrayValue) fieldNames);
+    public static BTable<?, ?> createTableValue(TableType tableType, BArray data, BArray fieldNames) {
+        return new TableValueImpl<>(tableType, (ArrayValue) data, (ArrayValue) fieldNames);
     }
 
     private ValueCreator() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/JsonUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/JsonUtils.java
@@ -155,7 +155,7 @@ public final class JsonUtils {
      * @param bTable {@link BTable} to be converted to JSON
      * @return JSON representation of the provided bTable
      */
-    public static Object parse(BTable bTable) {
+    public static Object parse(BTable<?, ?> bTable) {
         return JsonInternalUtils.toJSON(bTable);
     }
 
@@ -341,10 +341,10 @@ public final class JsonUtils {
                 newValue = convertArrayToJson((BArray) value, unresolvedValues);
                 break;
             case TypeTags.TABLE_TAG:
-                BTable bTable = (BTable) value;
+                BTable<?, ?> bTable = (BTable<?, ?>) value;
                 Type constrainedType = TypeUtils.getImpliedType(((TableType) sourceType).getConstrainedType());
                 if (constrainedType.getTag() == TypeTags.MAP_TAG) {
-                    newValue = convertMapConstrainedTableToJson((BTable) value, unresolvedValues);
+                    newValue = convertMapConstrainedTableToJson((BTable<?, ?>) value, unresolvedValues);
                 } else {
                     try {
                         newValue = JsonInternalUtils.toJSON(bTable);
@@ -364,12 +364,12 @@ public final class JsonUtils {
         return newValue;
     }
 
-    private static Object convertMapConstrainedTableToJson(BTable value, List<TypeValuePair> unresolvedValues) {
+    private static Object convertMapConstrainedTableToJson(BTable<?, ?> value, List<TypeValuePair> unresolvedValues) {
         BArray membersArray = ValueCreator.createArrayValue(PredefinedTypes.TYPE_JSON_ARRAY);
-        BIterator itr = value.getIterator();
+        BIterator<?> itr = value.getIterator();
         while (itr.hasNext()) {
             BArray tupleValue = (BArray) itr.next();
-            BMap mapValue = ((BMap) tupleValue.get(0));
+            BMap<?, ?> mapValue = ((BMap<?, ?>) tupleValue.get(0));
             Object member = convertMapToJson(mapValue, unresolvedValues);
             membersArray.append(member);
         }
@@ -379,7 +379,7 @@ public final class JsonUtils {
     private static Object convertMapToJson(BMap<?, ?> map, List<TypeValuePair> unresolvedValues) {
         BMap<BString, Object> newMap =
                 ValueCreator.createMapValue(TypeCreator.createMapType(PredefinedTypes.TYPE_JSON));
-        for (Map.Entry entry : map.entrySet()) {
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
             Object newValue = convertToJsonType(entry.getValue(), unresolvedValues);
             newMap.put(StringUtils.fromString(entry.getKey().toString()), newValue);
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/StringUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/StringUtils.java
@@ -241,7 +241,7 @@ public final class StringUtils {
             case TypeTags.NULL_TAG -> "null";
             case TypeTags.STRING_TAG -> stringToJson((BString) jsonValue);
             case TypeTags.MAP_TAG -> {
-                MapValueImpl mapValue = (MapValueImpl) jsonValue;
+                MapValueImpl<?, ?> mapValue = (MapValueImpl<?, ?>) jsonValue;
                 yield mapValue.getJSONString();
             }
             case TypeTags.ARRAY_TAG -> {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/XmlUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/XmlUtils.java
@@ -95,8 +95,8 @@ public final class XmlUtils {
      * @param table {@link BTable} to convert
      * @return converted {@link BXml}
      */
-    public static BXml parse(BTable table) {
-        return XmlFactory.tableToXML((TableValueImpl) table);
+    public static BXml parse(BTable<?, ?> table) {
+        return XmlFactory.tableToXML((TableValueImpl<?, ?>) table);
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BMap.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BMap.java
@@ -190,7 +190,7 @@ public interface BMap<K, V> extends BRefValue, BCollection {
 
     long getDefaultableIntValue(BString key);
 
-    Object merge(BMap v2, boolean checkMergeability);
+    Object merge(BMap<?, ?> v2, boolean checkMergeability);
 
     void populateInitialValue(K key, V value);
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
@@ -66,6 +66,7 @@ public interface BObject extends BRefValue {
 
     boolean getBooleanValue(BString fieldName);
 
+    @SuppressWarnings("rawtypes")
     BMap getMapValue(BString fieldName);
 
     BObject getObjectValue(BString fieldName);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BString.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BString.java
@@ -38,6 +38,6 @@ public interface BString {
 
     BString substring(int beginIndex, int endIndex);
 
-    BIterator<Object> getIterator();
+    BIterator<String> getIterator();
 
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/AnnotationUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/AnnotationUtils.java
@@ -50,7 +50,7 @@ public final class AnnotationUtils {
      * @param globalAnnotMap The global annotation map
      * @param bType          The type for which annotations need to be set
      */
-    public static void processAnnotations(MapValue globalAnnotMap, Type bType) {
+    public static void processAnnotations(MapValue<BString, Object> globalAnnotMap, Type bType) {
         if (!(bType instanceof BAnnotatableType type)) {
             return;
         }
@@ -94,13 +94,14 @@ public final class AnnotationUtils {
         }
     }
 
-    public static void processObjectCtorAnnotations(BObjectType bType, MapValue globalAnnotMap, Strand strand) {
+    public static void processObjectCtorAnnotations(BObjectType bType,
+                                                    MapValue<BString, Object> globalAnnotMap, Strand strand) {
         BString annotationKey = StringUtils.fromString(bType.getAnnotationKey());
 
         if (globalAnnotMap.containsKey(annotationKey)) {
             Object annot = globalAnnotMap.get(annotationKey);
             // If annotations are already set via desugard service-decl, skip.
-            Object annotValue = ((FPValue) annot).call(new Object[]{strand});
+            Object annotValue = ((FPValue<Object[], ?>) annot).call(new Object[]{strand});
             bType.setAnnotations((MapValue<BString, Object>) annotValue);
         }
         for (MethodType attachedFunction : bType.getMethods()) {
@@ -113,13 +114,14 @@ public final class AnnotationUtils {
         }
     }
 
-    private static void processObjectMethodLambdaAnnotation(MapValue globalAnnotMap, Strand strand,
+    private static void processObjectMethodLambdaAnnotation(MapValue<BString, Object> globalAnnotMap, Strand strand,
                                                             MethodType attachedFunction) {
         BString annotationKey = StringUtils.fromString(attachedFunction.getAnnotationKey());
 
         if (globalAnnotMap.containsKey(annotationKey)) {
             ((BMethodType) attachedFunction)
-                    .setAnnotations((MapValue<BString, Object>) ((FPValue) globalAnnotMap.get(annotationKey))
+                    .setAnnotations(
+                            (MapValue<BString, Object>) ((FPValue<Object[], ?>) globalAnnotMap.get(annotationKey))
                             .call(new Object[]{strand}));
         }
     }
@@ -131,7 +133,8 @@ public final class AnnotationUtils {
      * @param globalAnnotMap The global annotation map
      * @param name           The function name that acts as the annotation key
      */
-    public static void processFPValueAnnotations(FPValue fpValue, MapValue globalAnnotMap, String name) {
+    public static void processFPValueAnnotations(FPValue<?, ?> fpValue,
+                                                 MapValue<BString, Object> globalAnnotMap, String name) {
         BAnnotatableType type = (BAnnotatableType) fpValue.getType();
         BString nameKey = StringUtils.fromString(name);
         if (globalAnnotMap.containsKey(nameKey)) {
@@ -145,7 +148,7 @@ public final class AnnotationUtils {
      * @param fpValue function pointer to be invoked
      * @return true if should run concurrently
      */
-    public static boolean isConcurrent(FPValue fpValue) {
+    public static boolean isConcurrent(FPValue<?, ?> fpValue) {
         return fpValue.isConcurrent;
     }
 
@@ -156,7 +159,7 @@ public final class AnnotationUtils {
      * @param defaultName default strand name
      * @return annotated strand name
      */
-    public static String getStrandName(FPValue fpValue, String defaultName) {
+    public static String getStrandName(FPValue<?, ?> fpValue, String defaultName) {
         if (fpValue.strandName != null) {
             return fpValue.strandName;
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/AnnotationUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/AnnotationUtils.java
@@ -108,7 +108,7 @@ public final class AnnotationUtils {
             processObjectMethodLambdaAnnotation(globalAnnotMap, strand, attachedFunction);
         }
         if (bType instanceof BServiceType serviceType) {
-            for (var resourceFunction : serviceType.getResourceMethods()) {
+            for (ResourceMethodType resourceFunction : serviceType.getResourceMethods()) {
                 processObjectMethodLambdaAnnotation(globalAnnotMap, strand, resourceFunction);
             }
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BalRuntime.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BalRuntime.java
@@ -175,7 +175,7 @@ public class BalRuntime extends Runtime {
             AsyncUtils.getArgsWithDefaultValues(scheduler, objectVal, methodName, new Callback() {
                 @Override
                 public void notifySuccess(Object result) {
-                    Function<?, ?> func = getFunction((Object[]) result, objectVal, methodName);
+                    Function<Object[], Object> func = getFunction((Object[]) result, objectVal, methodName);
                     scheduler.scheduleToObjectGroup(new Object[1], func, future);
                 }
 
@@ -224,7 +224,7 @@ public class BalRuntime extends Runtime {
             AsyncUtils.getArgsWithDefaultValues(scheduler, objectVal, methodName, new Callback() {
                 @Override
                 public void notifySuccess(Object result) {
-                    Function<?, ?> func = getFunction((Object[]) result, objectVal, methodName);
+                    var func = getFunction((Object[]) result, objectVal, methodName);
                     scheduler.schedule(new Object[1], func, future);
                 }
 
@@ -281,7 +281,7 @@ public class BalRuntime extends Runtime {
             AsyncUtils.getArgsWithDefaultValues(scheduler, objectVal, methodName, new Callback() {
                 @Override
                 public void notifySuccess(Object result) {
-                    Function<?, ?> func = getFunction((Object[]) result, objectVal, methodName);
+                    var func = getFunction((Object[]) result, objectVal, methodName);
                     if (isIsolated) {
                         scheduler.schedule(new Object[1], func, future);
                     } else {
@@ -349,16 +349,17 @@ public class BalRuntime extends Runtime {
     }
 
     @Override
-    public void registerStopHandler(BFunctionPointer<?, ?> stopHandler) {
+    public void registerStopHandler(BFunctionPointer<Object[], Object> stopHandler) {
         scheduler.getRuntimeRegistry().registerStopHandler(stopHandler);
     }
 
-    private Function<?, ?> getFunction(Object[] argsWithDefaultValues, ObjectValue objectVal, String methodName) {
-        Function<?, ?> func;
+    private Function<Object[], Object> getFunction(Object[] argsWithDefaultValues,
+                                                   ObjectValue objectVal, String methodName) {
+        Function<Object[], Object> func;
         if (argsWithDefaultValues.length == 1) {
-            func = o -> objectVal.call((Strand) (((Object[]) o)[0]), methodName, argsWithDefaultValues[0]);
+            func = o -> objectVal.call((Strand) ((o)[0]), methodName, argsWithDefaultValues[0]);
         } else {
-            func = o -> objectVal.call((Strand) (((Object[]) o)[0]), methodName, argsWithDefaultValues);
+            func = o -> objectVal.call((Strand) ((o)[0]), methodName, argsWithDefaultValues);
         }
         return func;
     }
@@ -414,7 +415,7 @@ public class BalRuntime extends Runtime {
                               Object... args) {
         ValueCreator valueCreator = ValueCreator.getValueCreator(ValueCreator.getLookupKey(module.getOrg(),
                 module.getName(), module.getMajorVersion(), module.isTestPkg()));
-        Function<?, ?> func = o -> valueCreator.call((Strand) (((Object[]) o)[0]), functionName, args);
+        Function<Object[], ?> func = o -> valueCreator.call((Strand) (o[0]), functionName, args);
         FutureValue future = scheduler.createFuture(null, callback, null, returnType, strandName, null);
         Object[] argsWithStrand = new Object[args.length + 1];
         argsWithStrand[0] = future.strand;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BalRuntime.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BalRuntime.java
@@ -224,7 +224,7 @@ public class BalRuntime extends Runtime {
             AsyncUtils.getArgsWithDefaultValues(scheduler, objectVal, methodName, new Callback() {
                 @Override
                 public void notifySuccess(Object result) {
-                    var func = getFunction((Object[]) result, objectVal, methodName);
+                    Function<Object[], Object> func = getFunction((Object[]) result, objectVal, methodName);
                     scheduler.schedule(new Object[1], func, future);
                 }
 
@@ -281,7 +281,7 @@ public class BalRuntime extends Runtime {
             AsyncUtils.getArgsWithDefaultValues(scheduler, objectVal, methodName, new Callback() {
                 @Override
                 public void notifySuccess(Object result) {
-                    var func = getFunction((Object[]) result, objectVal, methodName);
+                    Function<Object[], Object> func = getFunction((Object[]) result, objectVal, methodName);
                     if (isIsolated) {
                         scheduler.schedule(new Object[1], func, future);
                     } else {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BalStringUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BalStringUtils.java
@@ -147,7 +147,7 @@ public final class BalStringUtils {
      */
     public static Object parseMapExpressionStringValue(String exprValue, BLink parent) {
         List<String> list = getElements(exprValue);
-        MapValueImpl eleMap = new MapValueImpl(new BMapType(TYPE_ANYDATA));
+        MapValueImpl<BString, Object> eleMap = new MapValueImpl<>(new BMapType(TYPE_ANYDATA));
         if (list.isEmpty()) {
             return eleMap;
         }
@@ -176,12 +176,12 @@ public final class BalStringUtils {
         }
         if (typeSet.size() > 1) {
             BUnionType type = new BUnionType(new ArrayList<>(typeSet));
-            MapValueImpl result = new MapValueImpl(new BMapType(type));
+            MapValueImpl<BString, Object> result = new MapValueImpl<>(new BMapType(type));
             result.putAll(eleMap);
             return result;
         } else {
             Type type = typeSet.iterator().next();
-            MapValueImpl result = new MapValueImpl(new BMapType(type));
+            MapValueImpl<BString, Object> result = new MapValueImpl<>(new BMapType(type));
             result.putAll(eleMap);
             return result;
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ErrorUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ErrorUtils.java
@@ -78,7 +78,7 @@ public final class ErrorUtils {
         } else {
             initialValues = new MappingInitialValueEntry[0];
         }
-        BMap<BString, Object> detailMap = new MapValueImpl(PredefinedTypes.TYPE_ERROR_DETAIL, initialValues);
+        BMap<BString, Object> detailMap = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL, initialValues);
 
         return (ErrorValue) createError(StringUtils.fromString(e.getClass().getName()), detailMap);
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonInternalUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonInternalUtils.java
@@ -463,7 +463,7 @@ public final class JsonInternalUtils {
                                                 StringUtils.fromString("JSON Merge failed for key '" + key + "'"));
             initialValues[1] = new MappingInitialValueEntry.KeyValueEntry(TypeConstants.DETAIL_CAUSE,
                                                                           elementMergeNullableError);
-            MapValueImpl<BString, Object> detailMap = new MapValueImpl(PredefinedTypes.TYPE_ERROR_DETAIL,
+            MapValueImpl<BString, Object> detailMap = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL,
                                                                         initialValues);
             return ErrorCreator.createError(ErrorReasons.MERGE_JSON_ERROR, detailMap);
         }
@@ -541,7 +541,7 @@ public final class JsonInternalUtils {
      * @param table {@link BTable} to be converted
      * @return JSON representation of the provided table
      */
-    public static Object toJSON(BTable table) {
+    public static Object toJSON(BTable<?, ?> table) {
         TableJsonDataSource jsonDataSource = new TableJsonDataSource(table);
         return jsonDataSource.build();
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MapUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MapUtils.java
@@ -69,8 +69,9 @@ public final class MapUtils {
                                                                                expType, valuesType));
     }
 
-    public static boolean handleInherentTypeViolatingRecordUpdate(MapValue mapValue, BString fieldName, Object value,
-                                                                  BRecordType recType, boolean initialValue) {
+    public static boolean handleInherentTypeViolatingRecordUpdate(
+            MapValue<?, ?> mapValue, BString fieldName, Object value,
+            BRecordType recType, boolean initialValue) {
         Field recField = recType.getFields().get(fieldName.getValue());
         Type recFieldType;
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableJsonDataSource.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableJsonDataSource.java
@@ -47,14 +47,14 @@ import java.util.Map;
  */
 public class TableJsonDataSource implements JsonDataSource {
 
-    private BTable tableValue;
+    private BTable<?, ?> tableValue;
     private JSONObjectGenerator objGen;
 
-    public TableJsonDataSource(BTable tableValue) {
+    public TableJsonDataSource(BTable<?, ?> tableValue) {
         this(tableValue, new DefaultJSONObjectGenerator());
     }
 
-    private TableJsonDataSource(BTable tableValue, JSONObjectGenerator objGen) {
+    private TableJsonDataSource(BTable<?, ?> tableValue, JSONObjectGenerator objGen) {
         this.tableValue = tableValue;
         this.objGen = objGen;
     }
@@ -81,11 +81,11 @@ public class TableJsonDataSource implements JsonDataSource {
     @Override
     public Object build() {
         ArrayValue values = new ArrayValueImpl(new BArrayType(PredefinedTypes.TYPE_JSON));
-        BIterator itr = this.tableValue.getIterator();
+        BIterator<?> itr = this.tableValue.getIterator();
         while (itr.hasNext()) {
             TupleValueImpl tupleValue = (TupleValueImpl) itr.next();
             //Retrieve table value from key-value tuple
-            BMap record = ((BMap) tupleValue.get(1));
+            BMap<?, ?> record = ((BMap<?, ?>) tupleValue.get(1));
             try {
                 values.append(this.objGen.transform(record));
             } catch (IOException e) {
@@ -104,7 +104,7 @@ public class TableJsonDataSource implements JsonDataSource {
         @Override
         public Object transform(BMap<?, ?> record) {
             MapValue<BString, Object> objNode = new MapValueImpl<>(new BMapType(PredefinedTypes.TYPE_JSON));
-            for (Map.Entry entry : record.entrySet()) {
+            for (Map.Entry<?, ?> entry : record.entrySet()) {
                 Type type = TypeChecker.getType(entry.getValue());
                 BString keyName = StringUtils.fromString(entry.getKey().toString());
                 constructJsonData(record, objNode, keyName, type);
@@ -152,7 +152,7 @@ public class TableJsonDataSource implements JsonDataSource {
             case TypeTags.MAP_TAG:
             case TypeTags.RECORD_TYPE_TAG:
                 MapValue<BString, Object> jsonData = new MapValueImpl<>(new BMapType(PredefinedTypes.TYPE_JSON));
-                for (Map.Entry entry : record.getMapValue(key).entrySet()) {
+                for (Map.Entry<?, ?> entry : record.getMapValue(key).entrySet()) {
                     Type internalType = TypeChecker.getType(entry.getValue());
                     BString internalKeyName = StringUtils.fromString(entry.getKey().toString());
                     constructJsonData(record.getMapValue(key), jsonData, internalKeyName, internalType);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableOmDataSource.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableOmDataSource.java
@@ -51,11 +51,11 @@ public class TableOmDataSource extends AbstractPushOMDataSource {
     private static final String DEFAULT_ROOT_WRAPPER = "results";
     private static final String DEFAULT_ROW_WRAPPER = "result";
 
-    private TableValueImpl table;
+    private TableValueImpl<?, ?> table;
     private String rootWrapper;
     private String rowWrapper;
 
-    public TableOmDataSource(TableValueImpl table, String rootWrapper, String rowWrapper) {
+    public TableOmDataSource(TableValueImpl<?, ?> table, String rootWrapper, String rowWrapper) {
         this.table = table;
         this.rootWrapper = rootWrapper != null ? rootWrapper : DEFAULT_ROOT_WRAPPER;
         this.rowWrapper = rowWrapper != null ? rowWrapper : DEFAULT_ROW_WRAPPER;
@@ -64,13 +64,13 @@ public class TableOmDataSource extends AbstractPushOMDataSource {
     @Override
     public void serialize(XMLStreamWriter xmlStreamWriter) throws XMLStreamException {
         xmlStreamWriter.writeStartElement("", this.rootWrapper, "");
-        IteratorValue itr = this.table.getIterator();
+        IteratorValue<?> itr = this.table.getIterator();
 
         while (itr.hasNext()) {
             table.getIterator().next();
             xmlStreamWriter.writeStartElement("", this.rowWrapper, "");
             TupleValueImpl tupleValue = (TupleValueImpl) itr.next();
-            MapValueImpl record = ((MapValueImpl) tupleValue.get(0));
+            MapValueImpl<?, ?> record = ((MapValueImpl<?, ?>) tupleValue.get(0));
 
             BStructureType structType = (BStructureType) record.getType();
             BField[] structFields = null;
@@ -90,7 +90,8 @@ public class TableOmDataSource extends AbstractPushOMDataSource {
         xmlStreamWriter.flush();
     }
 
-    private void writeElement(MapValueImpl record, XMLStreamWriter xmlStreamWriter, String name, int type, int index,
+    private void writeElement(MapValueImpl<?, ?> record,
+                              XMLStreamWriter xmlStreamWriter, String name, int type, int index,
                               BField[] structFields) throws XMLStreamException {
         boolean isArray = false;
         xmlStreamWriter.writeStartElement("", name, "");
@@ -125,7 +126,7 @@ public class TableOmDataSource extends AbstractPushOMDataSource {
                     BArray structData = record.getArrayValue(key);
                     processArray(xmlStreamWriter, structData);
                 } else {
-                    BMap structData = record.getMapValue(key);
+                    BMap<?, ?> structData = record.getMapValue(key);
                     processStruct(xmlStreamWriter, structData, structFields, index);
                 }
                 break;
@@ -154,7 +155,7 @@ public class TableOmDataSource extends AbstractPushOMDataSource {
         }
     }
 
-    private void processStruct(XMLStreamWriter xmlStreamWriter, BMap structData,
+    private void processStruct(XMLStreamWriter xmlStreamWriter, BMap<?, ?> structData,
                                BField[] structFields, int index) throws XMLStreamException {
         boolean structError = true;
         Type internalType = TypeUtils.getImpliedType(structFields[index].getFieldType());
@@ -167,7 +168,7 @@ public class TableOmDataSource extends AbstractPushOMDataSource {
                     BString internalKeyName = StringUtils.fromString(internalStructFields[i].getFieldName());
                     Object val = structData.get(internalKeyName);
                     xmlStreamWriter.writeStartElement("", internalStructFields[i].getFieldName(), "");
-                    if (val instanceof MapValueImpl mapValue) {
+                    if (val instanceof MapValueImpl<?, ?> mapValue) {
                         processStruct(xmlStreamWriter, mapValue, internalStructFields, i);
                     } else {
                         xmlStreamWriter.writeCharacters(val.toString());

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableUtils.java
@@ -30,8 +30,6 @@ import io.ballerina.runtime.internal.values.MapValue;
 import io.ballerina.runtime.internal.values.RegExpValue;
 import io.ballerina.runtime.internal.values.TableValue;
 
-import java.util.Map;
-
 import static io.ballerina.runtime.internal.CycleUtils.Node;
 import static io.ballerina.runtime.internal.errors.ErrorReasons.TABLE_KEY_CYCLIC_VALUE_REFERENCE_ERROR;
 
@@ -71,16 +69,16 @@ public final class TableUtils {
 
             Type refType = TypeUtils.getImpliedType(refValue.getType());
             if (refType.getTag() == TypeTags.MAP_TAG || refType.getTag() == TypeTags.RECORD_TYPE_TAG) {
-                MapValue mapValue = (MapValue) refValue;
-                for (Object entry : mapValue.entrySet()) {
-                    result = 31 * result + hash(((Map.Entry) entry).getKey(), node) +
-                            (((Map.Entry) entry).getValue() == null ? 0 : hash(((Map.Entry) entry).getValue(),
+                MapValue<?, ?> mapValue = (MapValue<?, ?>) refValue;
+                for (var entry : mapValue.entrySet()) {
+                    result = 31 * result + hash(entry.getKey(), node) +
+                            (entry.getValue() == null ? 0 : hash(entry.getValue(),
                                     node));
                 }
                 return result;
             } else if (refType.getTag() == TypeTags.ARRAY_TAG || refType.getTag() == TypeTags.TUPLE_TAG) {
                 ArrayValue arrayValue = (ArrayValue) refValue;
-                IteratorValue arrayIterator = arrayValue.getIterator();
+                IteratorValue<?> arrayIterator = arrayValue.getIterator();
                 while (arrayIterator.hasNext()) {
                     result = 31 * result + hash(arrayIterator.next(), node);
                 }
@@ -91,8 +89,8 @@ public final class TableUtils {
                     refType.getTag() == TypeTags.XMLNS_TAG) {
                 return (long) refValue.toString().hashCode();
             } else if (refType.getTag() == TypeTags.TABLE_TAG) {
-                TableValue tableValue = (TableValue) refValue;
-                IteratorValue tableIterator = tableValue.getIterator();
+                TableValue<?, ?> tableValue = (TableValue<?, ?>) refValue;
+                IteratorValue<?> tableIterator = tableValue.getIterator();
                 while (tableIterator.hasNext()) {
                     result = 31 * result + hash(tableIterator.next(), node);
                 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableUtils.java
@@ -30,6 +30,8 @@ import io.ballerina.runtime.internal.values.MapValue;
 import io.ballerina.runtime.internal.values.RegExpValue;
 import io.ballerina.runtime.internal.values.TableValue;
 
+import java.util.Map;
+
 import static io.ballerina.runtime.internal.CycleUtils.Node;
 import static io.ballerina.runtime.internal.errors.ErrorReasons.TABLE_KEY_CYCLIC_VALUE_REFERENCE_ERROR;
 
@@ -70,7 +72,7 @@ public final class TableUtils {
             Type refType = TypeUtils.getImpliedType(refValue.getType());
             if (refType.getTag() == TypeTags.MAP_TAG || refType.getTag() == TypeTags.RECORD_TYPE_TAG) {
                 MapValue<?, ?> mapValue = (MapValue<?, ?>) refValue;
-                for (var entry : mapValue.entrySet()) {
+                for (Map.Entry<?, ?> entry : mapValue.entrySet()) {
                     result = 31 * result + hash(entry.getKey(), node) +
                             (entry.getValue() == null ? 0 : hash(entry.getValue(),
                                     node));

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -1174,7 +1174,7 @@ public final class TypeChecker {
         Type constraintType = sourceType.getConstrainedType();
 
         for (Field field : targetType.getFields().values()) {
-            var flags = field.getFlags();
+            long flags = field.getFlags();
             if (!SymbolFlags.isFlagOn(flags, SymbolFlags.OPTIONAL)) {
                 return false;
             }
@@ -1894,7 +1894,7 @@ public final class TypeChecker {
         }
 
         if (sourceType.getTag() == TypeTags.OBJECT_TYPE_TAG) {
-            var flags = ((BObjectType) sourceType).flags;
+            long flags = ((BObjectType) sourceType).flags;
             return (flags & SymbolFlags.SERVICE) == SymbolFlags.SERVICE;
         }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -417,7 +417,7 @@ public final class TypeConverter {
     private static boolean isConvertibleToRecordType(Object sourceValue, BRecordType targetType, String varName,
                                                      Set<TypeValuePair> unresolvedValues,
                                                      List<String> errors, boolean allowNumericConversion) {
-        if (!(sourceValue instanceof MapValueImpl sourceMapValueImpl)) {
+        if (!(sourceValue instanceof MapValueImpl<?, ?> sourceMapValueImpl)) {
             return false;
         }
 
@@ -435,7 +435,7 @@ public final class TypeConverter {
             targetFieldTypes.put(field.getKey(), field.getValue().getFieldType());
         }
 
-        for (Map.Entry targetTypeEntry : targetFieldTypes.entrySet()) {
+        for (Map.Entry<String, Type> targetTypeEntry : targetFieldTypes.entrySet()) {
             String fieldName = targetTypeEntry.getKey().toString();
             String fieldNameLong = getLongFieldName(varName, fieldName);
 
@@ -453,8 +453,7 @@ public final class TypeConverter {
             }
         }
 
-        for (Object object : sourceMapValueImpl.entrySet()) {
-            Map.Entry valueEntry = (Map.Entry) object;
+        for (Map.Entry<?, ?> valueEntry : sourceMapValueImpl.entrySet()) {
             String fieldName = valueEntry.getKey().toString();
             String fieldNameLong = getLongFieldName(varName, fieldName);
             int initialErrorCount = errors.size();
@@ -585,8 +584,7 @@ public final class TypeConverter {
         }
 
         boolean returnVal = true;
-        for (Object object : ((MapValueImpl) sourceValue).entrySet()) {
-            Map.Entry valueEntry = (Map.Entry) object;
+        for (Map.Entry<?, ?> valueEntry : ((MapValueImpl<?, ?>) sourceValue).entrySet()) {
             String fieldNameLong = getLongFieldName(varName, valueEntry.getKey().toString());
             int initialErrorCount = errors.size();
             if (getConvertibleType(valueEntry.getValue(), targetType.getConstrainedType(), fieldNameLong,

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueConverter.java
@@ -263,7 +263,7 @@ public final class ValueConverter {
                 BArray data = ValueCreator
                         .createArrayValue(tableValues, TypeCreator.createArrayType(tableType.getConstrainedType()));
                 BArray fieldNames = StringUtils.fromStringArray(tableType.getFieldNames());
-                return new TableValueImpl(targetRefType, (ArrayValue) data, (ArrayValue) fieldNames);
+                return new TableValueImpl<>(targetRefType, (ArrayValue) data, (ArrayValue) fieldNames);
             default:
                 break;
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/XmlFactory.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/XmlFactory.java
@@ -216,7 +216,7 @@ public final class XmlFactory {
      * @param table {@link io.ballerina.runtime.internal.values.TableValue} to convert
      * @return converted {@link XmlValue}
      */
-    public static BXml tableToXML(TableValueImpl table) {
+    public static BXml tableToXML(TableValueImpl<?, ?> table) {
         try {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             XMLStreamWriter streamWriter = XMLOutputFactory.newInstance().createXMLStreamWriter(outputStream);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/errors/ErrorHelper.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/errors/ErrorHelper.java
@@ -53,7 +53,8 @@ public final class ErrorHelper {
         MappingInitialValueEntry[] initialValues = new MappingInitialValueEntry[1];
         initialValues[0] = new MappingInitialValueEntry.KeyValueEntry(ERROR_MESSAGE_FIELD, StringUtils
                 .fromString(MessageFormat.format(messageBundle.getString(errorCodes.messageKey()), params)));
-        var errorDetail = new MapValueImpl<BString, Object>(PredefinedTypes.TYPE_ERROR_DETAIL, initialValues);
+        MapValueImpl<BString, Object> errorDetail =
+                new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL, initialValues);
         return ErrorCreator.createError(reason, errorDetail);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/errors/ErrorHelper.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/errors/ErrorHelper.java
@@ -53,7 +53,7 @@ public final class ErrorHelper {
         MappingInitialValueEntry[] initialValues = new MappingInitialValueEntry[1];
         initialValues[0] = new MappingInitialValueEntry.KeyValueEntry(ERROR_MESSAGE_FIELD, StringUtils
                 .fromString(MessageFormat.format(messageBundle.getString(errorCodes.messageKey()), params)));
-        MapValueImpl<BString, Object> errorDetail = new MapValueImpl(PredefinedTypes.TYPE_ERROR_DETAIL, initialValues);
+        var errorDetail = new MapValueImpl<BString, Object>(PredefinedTypes.TYPE_ERROR_DETAIL, initialValues);
         return ErrorCreator.createError(reason, errorDetail);
     }
 
@@ -67,7 +67,7 @@ public final class ErrorHelper {
         initialValues[0] = new MappingInitialValueEntry.KeyValueEntry(ERROR_MESSAGE_FIELD,
                 StringUtils.fromString(MessageFormat.format(messageBundle.getString(
                         errorCodes.messageKey()), params)));
-        return new MapValueImpl(PredefinedTypes.TYPE_ERROR_DETAIL, initialValues);
+        return new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL, initialValues);
     }
 
     public static BString getErrorMessage(String messageFormat, Object... params) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/AsyncUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/AsyncUtils.java
@@ -81,7 +81,7 @@ public final class AsyncUtils {
      * @param scheduler            The scheduler for invoking functions
      * @return Future Value
      */
-    public static FutureValue invokeFunctionPointerAsync(BFunctionPointer<?, ?> func, String strandName,
+    public static FutureValue invokeFunctionPointerAsync(BFunctionPointer<Object[], ?> func, String strandName,
                                                          StrandMetadata metadata, Object[] args,
                                                          Function<Object, Object> resultHandleFunction,
                                                          Scheduler scheduler) {
@@ -130,7 +130,7 @@ public final class AsyncUtils {
      * @param returnValueSupplier  Suppler used to set the final return value for the parent function invocation.
      * @param scheduler            The scheduler for invoking functions
      */
-    public static void invokeFunctionPointerAsyncIteratively(BFunctionPointer<?, ?> func, String strandName,
+    public static void invokeFunctionPointerAsyncIteratively(BFunctionPointer<Object[], ?> func, String strandName,
                                                              StrandMetadata metadata, int noOfIterations,
                                                              Supplier<Object[]> argsSupplier,
                                                              Consumer<Object> futureResultConsumer,
@@ -216,7 +216,7 @@ public final class AsyncUtils {
                                                  List<Object> argsWithDefaultValues,
                                                  Parameter parameter) {
         String funcName = parameter.defaultFunctionName;
-        Function<?, ?> defaultFunc = o -> valueCreator.call((Strand) (((Object[]) o)[0]), funcName,
+        Function<Object[], ?> defaultFunc = o -> valueCreator.call((Strand) (((Object[]) o)[0]), funcName,
                 argsWithDefaultValues.toArray());
         Callback defaultFunctionCallback = new Callback() {
             @Override
@@ -254,7 +254,7 @@ public final class AsyncUtils {
         return methodTypesMap.get(methodName);
     }
 
-    private static void scheduleNextFunction(BFunctionPointer<?, ?> func, BFunctionType funcType, Strand parent,
+    private static void scheduleNextFunction(BFunctionPointer<Object[], ?> func, BFunctionType funcType, Strand parent,
                                              String strandName, StrandMetadata metadata, int noOfIterations,
                                              AtomicInteger callCount, Supplier<Object[]> argsSupplier,
                                              Consumer<Object> futureResultConsumer,
@@ -289,7 +289,7 @@ public final class AsyncUtils {
         }, argsSupplier.get());
     }
 
-    private static void invokeFunctionPointerAsync(BFunctionPointer<?, ?> func, Strand parent,
+    private static void invokeFunctionPointerAsync(BFunctionPointer<Object[], ?> func, Strand parent,
                                                    FutureValue future, Object[] args,
                                                    AsyncFunctionCallback callback, Scheduler scheduler) {
         future.callback = callback;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/Scheduler.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/Scheduler.java
@@ -136,12 +136,14 @@ public class Scheduler {
      * @param metadata   meta data of new strand
      * @return {@link FutureValue} reference to the given function pointer invocation.
      */
-    public FutureValue scheduleFunction(Object[] params, BFunctionPointer<?, ?> fp, Strand parent, Type returnType,
+    public FutureValue scheduleFunction(Object[] params,
+                                        BFunctionPointer<Object[], Object> fp, Strand parent, Type returnType,
                                         String strandName, StrandMetadata metadata) {
         return schedule(params, fp.getFunction(), parent, null, null, returnType, strandName, metadata);
     }
 
-    public FutureValue scheduleFunction(Object[] params, BFunctionPointer<?, ?> fp, Strand parent, Type returnType,
+    public FutureValue scheduleFunction(Object[] params,
+                                        BFunctionPointer<Object[], Object> fp, Strand parent, Type returnType,
                                         String strandName, StrandMetadata metadata , Callback callback) {
         return schedule(params, fp.getFunction(), parent, callback, null, returnType, strandName, metadata);
     }
@@ -157,13 +159,14 @@ public class Scheduler {
      * @param metadata   meta data of new strand
      * @return {@link FutureValue} reference to the given function invocation.
      */
-    public FutureValue scheduleLocal(Object[] params, BFunctionPointer<?, ?> fp, Strand parent, Type returnType,
+    public FutureValue scheduleLocal(Object[] params, BFunctionPointer<Object[], ?> fp, Strand parent, Type returnType,
                                      String strandName, StrandMetadata metadata) {
         FutureValue future = createFuture(parent, null, null, returnType, strandName, metadata);
         return scheduleLocal(params, fp, parent, future);
     }
 
-    public FutureValue scheduleLocal(Object[] params, BFunctionPointer<?, ?> fp, Strand parent, FutureValue future) {
+    public FutureValue scheduleLocal(Object[] params, BFunctionPointer<Object[], ?> fp,
+                                     Strand parent, FutureValue future) {
         params[0] = future.strand;
         SchedulerItem item = new SchedulerItem(fp.getFunction(), params, future);
         future.strand.schedulerItem = item;
@@ -173,14 +176,15 @@ public class Scheduler {
         return future;
     }
 
-    public FutureValue scheduleToObjectGroup(Object[] params, Function function, Strand parent,
+    public FutureValue scheduleToObjectGroup(Object[] params, Function<Object[], ?> function, Strand parent,
                                              Callback callback, Map<String, Object> properties, Type returnType,
                                              String strandName, StrandMetadata metadata) {
         FutureValue future = createFuture(parent, callback, properties, returnType, strandName, metadata);
         return scheduleToObjectGroup(params, function, future);
     }
 
-    public FutureValue scheduleToObjectGroup(Object[] params, Function function, FutureValue future) {
+    public FutureValue scheduleToObjectGroup(Object[] params, Function<Object[], ?> function,
+                                             FutureValue future) {
         params[0] = future.strand;
         SchedulerItem item = new SchedulerItem(function, params, future);
         future.strand.schedulerItem = item;
@@ -204,7 +208,7 @@ public class Scheduler {
      * @param metadata   meta data of new strand
      * @return Reference to the scheduled task
      */
-    public FutureValue schedule(Object[] params, Function function, Strand parent, Callback callback,
+    public FutureValue schedule(Object[] params, Function<Object[], ?> function, Strand parent, Callback callback,
                                 Map<String, Object> properties, Type returnType, String strandName,
                                 StrandMetadata metadata) {
         FutureValue future = createFuture(parent, callback, properties, returnType, strandName, metadata);
@@ -222,13 +226,13 @@ public class Scheduler {
      * @param metadata   meta data of new strand
      * @return Reference to the scheduled task
      */
-    public FutureValue schedule(Object[] params, Function function, Strand parent, Callback callback,
+    public FutureValue schedule(Object[] params, Function<Object[], ?> function, Strand parent, Callback callback,
                                 String strandName, StrandMetadata metadata) {
         FutureValue future = createFuture(parent, callback, null, PredefinedTypes.TYPE_NULL, strandName, metadata);
         return schedule(params, function, future);
     }
 
-    public FutureValue schedule(Object[] params, Function function, FutureValue future) {
+    public FutureValue schedule(Object[] params, Function<Object[], ?> function, FutureValue future) {
         params[0] = future.strand;
         SchedulerItem item = new SchedulerItem(function, params, future);
         future.strand.schedulerItem = item;
@@ -252,7 +256,7 @@ public class Scheduler {
      * @return Reference to the scheduled task
      */
     @Deprecated
-    public FutureValue schedule(Object[] params, Consumer consumer, Strand parent, Callback callback,
+    public FutureValue schedule(Object[] params, Consumer<Object[]> consumer, Strand parent, Callback callback,
                                 String strandName, StrandMetadata metadata) {
         FutureValue future = createFuture(parent, callback, null, PredefinedTypes.TYPE_NULL, strandName, metadata);
         params[0] = future.strand;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/SchedulerItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/SchedulerItem.java
@@ -29,19 +29,19 @@ import java.util.function.Function;
  * @since 0.995.0
  */
 class SchedulerItem {
-    private Function function;
+    private Function<Object[], ?> function;
     private Object[] params;
     final FutureValue future;
     boolean parked;
 
-    public SchedulerItem(Function function, Object[] params, FutureValue future) {
+    public SchedulerItem(Function<Object[], ?> function, Object[] params, FutureValue future) {
         this.future = future;
         this.function = function;
         this.params = params;
     }
 
     @Deprecated
-    public SchedulerItem(Consumer consumer, Object[] params, FutureValue future) {
+    public SchedulerItem(Consumer<Object[]> consumer, Object[] params, FutureValue future) {
         this.future = future;
         this.function = val -> {
             consumer.accept(val);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/LargeStructureUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/LargeStructureUtils.java
@@ -59,7 +59,7 @@ public final class LargeStructureUtils {
 
     public static void setSpreadFieldEntry(HandleValue arrayList, Object spreadFieldEntry, long index) {
         BMapInitialValueEntry[] arr = (BMapInitialValueEntry[]) arrayList.getValue();
-        arr[(int) index] = new MappingInitialValueEntry.SpreadFieldEntry((BMap) spreadFieldEntry);
+        arr[(int) index] = new MappingInitialValueEntry.SpreadFieldEntry((BMap<?, ?>) spreadFieldEntry);
     }
 
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/StringUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/StringUtils.java
@@ -77,7 +77,7 @@ public final class StringUtils {
             return STR_CYCLE;
         }
         if (type.getTag() == TypeTags.MAP_TAG || type.getTag() == TypeTags.RECORD_TYPE_TAG) {
-            MapValueImpl mapValue = (MapValueImpl) value;
+            MapValueImpl<?, ?> mapValue = (MapValueImpl<?, ?>) value;
             return mapValue.stringValue(parent);
         }
         if (type.getTag() == TypeTags.ARRAY_TAG || type.getTag() == TypeTags.TUPLE_TAG) {
@@ -136,7 +136,7 @@ public final class StringUtils {
             return STR_CYCLE + "[" + node.getIndex() + "]";
         }
         if (type.getTag() == TypeTags.MAP_TAG || type.getTag() == TypeTags.RECORD_TYPE_TAG) {
-            MapValueImpl mapValue = (MapValueImpl) value;
+            MapValueImpl<?, ?> mapValue = (MapValueImpl<?, ?>) value;
             return mapValue.expressionStringValue(parent);
         }
         if (type.getTag() == TypeTags.ARRAY_TAG || type.getTag() == TypeTags.TUPLE_TAG) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/AbstractArrayValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/AbstractArrayValue.java
@@ -164,7 +164,7 @@ public abstract class AbstractArrayValue implements ArrayValue {
      * {@inheritDoc}
      */
     @Override
-    public IteratorValue getIterator() {
+    public IteratorValue<Object> getIterator() {
         return new ArrayIterator(this);
     }
 
@@ -279,7 +279,7 @@ public abstract class AbstractArrayValue implements ArrayValue {
      *
      * @since 0.995.0
      */
-    static class ArrayIterator implements IteratorValue {
+    static class ArrayIterator implements IteratorValue<Object> {
         ArrayValue array;
         long cursor = 0;
         long length;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/AbstractObjectValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/AbstractObjectValue.java
@@ -132,9 +132,10 @@ public abstract class AbstractObjectValue implements ObjectValue {
         return (boolean) get(fieldName);
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public BMap getMapValue(BString fieldName) {
-        return (MapValueImpl) get(fieldName);
+        return (MapValueImpl<?, ?>) get(fieldName);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -1088,7 +1088,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
      * {@inheritDoc}
      */
     @Override
-    public IteratorValue getIterator() {
+    public IteratorValue<Object> getIterator() {
         return new ArrayIterator(this);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/CharIterator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/CharIterator.java
@@ -23,7 +23,7 @@ package io.ballerina.runtime.internal.values;
  *
  * @since 2.0
  */
-public class CharIterator implements IteratorValue {
+public class CharIterator implements IteratorValue<String> {
 
     StringValue value;
     long cursor = 0;
@@ -37,7 +37,7 @@ public class CharIterator implements IteratorValue {
     }
 
     @Override
-    public Object next() {
+    public String next() {
         long currentIndex = this.cursor++;
         if (value.isNonBmp) {
             return getNonBmpCharWithSurrogates(currentIndex);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/CollectionValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/CollectionValue.java
@@ -32,5 +32,5 @@ import io.ballerina.runtime.api.values.BCollection;
 public interface CollectionValue extends BCollection {
 
     @Override
-    IteratorValue getIterator();
+    IteratorValue<?> getIterator();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
@@ -143,8 +143,8 @@ public class ErrorValue extends BError implements RefValue {
 
     private String getDetailsToString(BLink parent) {
         StringJoiner sj = new StringJoiner(",");
-        for (Object key : ((MapValue) details).getKeys()) {
-            Object value = ((MapValue) details).get(key);
+        for (Object key : ((MapValue<?, ?>) details).getKeys()) {
+            Object value = ((MapValue<?, ?>) details).get(key);
             if (value == null) {
                 sj.add(key + "=null");
             } else {
@@ -175,8 +175,8 @@ public class ErrorValue extends BError implements RefValue {
 
     private String getDetailsToBalString(BLink parent) {
         StringJoiner sj = new StringJoiner(",");
-        for (Object key : ((MapValue) details).getKeys()) {
-            Object value = ((MapValue) details).get(key);
+        for (Object key : ((MapValue<?, ?>) details).getKeys()) {
+            Object value = ((MapValue<?, ?>) details).get(key);
             sj.add(key + "=" + getExpressionStringVal(value, parent));
         }
         return "," + sj;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/FPValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/FPValue.java
@@ -73,7 +73,7 @@ public class FPValue<T, R> implements BFunctionPointer<T, R>, RefValue {
     @Override
     public BFuture asyncCall(Object[] args, Function<Object, Object> resultHandleFunction,
                              StrandMetadata metaData) {
-        return AsyncUtils.invokeFunctionPointerAsync(this, this.strandName, metaData,
+        return AsyncUtils.invokeFunctionPointerAsync((BFunctionPointer<Object[], ?>) this, this.strandName, metaData,
                                                      args, resultHandleFunction, Scheduler.getStrand().scheduler);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/IteratorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/IteratorValue.java
@@ -34,8 +34,9 @@ import java.util.Map;
  * </p>
  *  
  * @since 0.995.0
+ * @param <T> Type of the value returned by the iterator
  */
-public interface IteratorValue extends RefValue, BIterator {
+public interface IteratorValue<T> extends RefValue, BIterator<T> {
 
     BTypedesc TYPEDESC = new TypedescValueImpl(PredefinedTypes.TYPE_ITERATOR);
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -221,7 +221,7 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
         // The type should be a record or map for filling read.
         if (this.referredType.getTag() == TypeTags.RECORD_TYPE_TAG) {
             BRecordType recordType = (BRecordType) this.referredType;
-            Map fields = recordType.getFields();
+            Map<?, ?> fields = recordType.getFields();
             if (fields.containsKey(key.toString())) {
                 expectedType = ((BField) fields.get(key.toString())).getFieldType();
             } else {
@@ -248,7 +248,7 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
     }
 
     @Override
-    public Object merge(BMap v2, boolean checkMergeability) {
+    public Object merge(BMap<?, ?> v2, boolean checkMergeability) {
         if (checkMergeability) {
             BError errorIfUnmergeable = JsonInternalUtils.getErrorIfUnmergeable(this, v2, new ArrayList<>());
             if (errorIfUnmergeable != null) {
@@ -605,7 +605,7 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
     }
 
     @Override
-    public IteratorValue getIterator() {
+    public IteratorValue<Object> getIterator() {
         return new MapIterator<>(new LinkedHashSet<>(this.entrySet()).iterator());
     }
 
@@ -617,7 +617,7 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
      *
      * @since 0.995.0
      */
-    static class MapIterator<K, V> implements IteratorValue {
+    static class MapIterator<K, V> implements IteratorValue<Object> {
 
         Iterator<Map.Entry<K, V>> iterator;
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MappingInitialValueEntry.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MappingInitialValueEntry.java
@@ -56,9 +56,9 @@ public abstract class MappingInitialValueEntry implements BMapInitialValueEntry 
      */
     public static class SpreadFieldEntry extends MappingInitialValueEntry {
 
-        public BMap values;
+        public BMap<?, ?> values;
 
-        public SpreadFieldEntry(BMap mappingValue) {
+        public SpreadFieldEntry(BMap<?, ?> mappingValue) {
             this.values = mappingValue;
         }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StreamingJsonValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StreamingJsonValue.java
@@ -200,7 +200,7 @@ public class StreamingJsonValue extends ArrayValueImpl implements BStreamingJson
     }
 
     @Override
-    public IteratorValue getIterator() {
+    public IteratorValue<Object> getIterator() {
         return new ArrayIterator(this);
     }
 
@@ -209,7 +209,7 @@ public class StreamingJsonValue extends ArrayValueImpl implements BStreamingJson
      *
      * @since 0.995.0
      */
-    static class StreamingJsonIterator implements IteratorValue {
+    static class StreamingJsonIterator implements IteratorValue<Object> {
         StreamingJsonValue array;
         long cursor = 0;
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StringValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StringValue.java
@@ -55,7 +55,7 @@ public abstract class StringValue implements BString, SimpleValue {
     }
 
     @Override
-    public IteratorValue getIterator() {
+    public IteratorValue<String> getIterator() {
         return new CharIterator(this);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -149,7 +149,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
     }
 
     private void addData(ArrayValue data) {
-        BIterator itr = data.getIterator();
+        BIterator<?> itr = data.getIterator();
         while (itr.hasNext()) {
             Object next = itr.next();
             valueHolder.addData((V) next);
@@ -157,7 +157,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
     }
 
     @Override
-    public IteratorValue getIterator() {
+    public IteratorValue<?> getIterator() {
         return new TableIterator();
     }
 
@@ -178,7 +178,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             clone.fieldNames = fieldNames;
         }
 
-        IteratorValue itr = getIterator();
+        IteratorValue<?> itr = getIterator();
         while (itr.hasNext()) {
             TupleValueImpl tupleValue = (TupleValueImpl) itr.next();
             Object value = tupleValue.get(1);
@@ -510,7 +510,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         return true;
     }
 
-    private class TableIterator implements IteratorValue {
+    private class TableIterator implements IteratorValue<Object> {
         private long cursor;
 
         TableIterator() {
@@ -562,12 +562,12 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         }
 
         public V putData(V data) {
-            checkInherentTypeViolation((MapValue) data, tableType);
+            checkInherentTypeViolation((MapValue<?, ?>) data, tableType);
 
             ArrayList<V> newData = new ArrayList<>();
             newData.add(data);
 
-            Map.Entry<K, V> entry = new AbstractMap.SimpleEntry(data, data);
+            Map.Entry<K, V> entry = new AbstractMap.SimpleEntry<>((K) data, data);
             List<Map.Entry<K, V>> entryList = new ArrayList<>();
             entryList.add(entry);
             UUID uuid = UUID.randomUUID();
@@ -608,7 +608,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
 
         @Override
         public void addData(V data) {
-            MapValue dataMap = (MapValue) data;
+            MapValue<?, ?> dataMap = (MapValue<?, ?>) data;
             checkInherentTypeViolation(dataMap, tableType);
             K key = this.keyWrapper.wrapKey(dataMap);
 
@@ -621,7 +621,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
                 maxIntKey = ((Long) TypeChecker.anyToInt(key)).intValue();
             }
 
-            Map.Entry<K, V> entry = new AbstractMap.SimpleEntry(key, data);
+            Map.Entry<K, V> entry = new AbstractMap.SimpleEntry<>(key, data);
             Long hash = TableUtils.hash(key, null);
 
             if (entries.containsKey(hash)) {
@@ -652,8 +652,8 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
 
         @Override
         public V putData(K key, V data) {
-            Map.Entry<K, V> entry = new AbstractMap.SimpleEntry(key, data);
-            Object actualKey = this.keyWrapper.wrapKey((MapValue) data);
+            Map.Entry<K, V> entry = new AbstractMap.SimpleEntry<>(key, data);
+            Object actualKey = this.keyWrapper.wrapKey((MapValue<?, ?>) data);
             Long actualHash = TableUtils.hash(actualKey, null);
             Long hash = TableUtils.hash(key, null);
 
@@ -681,7 +681,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
 
         @Override
         public V putData(V data) {
-            MapValue dataMap = (MapValue) data;
+            MapValue<?, ?> dataMap = (MapValue<?, ?>) data;
             checkInherentTypeViolation(dataMap, tableType);
             K key = this.keyWrapper.wrapKey(dataMap);
             Map.Entry<K, V> entry = new AbstractMap.SimpleEntry<>(key, data);
@@ -774,7 +774,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
                 }
             }
 
-            public K wrapKey(MapValue data) {
+            public K wrapKey(MapValue<?, ?> data) {
                 return (K) data.get(StringUtils.fromString(fieldNames[0]));
             }
         }
@@ -797,7 +797,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             }
 
             @Override
-            public K wrapKey(MapValue data) {
+            public K wrapKey(MapValue<?, ?> data) {
                 TupleValueImpl arr = (TupleValueImpl) ValueCreator
                         .createTupleValue((BTupleType) keyType);
                 for (int i = 0; i < fieldNames.length; i++) {
@@ -830,7 +830,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
     }
 
     // This method checks for inherent table type violation
-    private void checkInherentTypeViolation(MapValue dataMap, TableType type) {
+    private void checkInherentTypeViolation(MapValue<?, ?> dataMap, TableType type) {
         if (!TypeChecker.checkIsType(dataMap.getType(), type.getConstrainedType())) {
             BString reason = getModulePrefixedReason(TABLE_LANG_LIB, INHERENT_TYPE_VIOLATION_ERROR_IDENTIFIER);
             BString detail = StringUtils.fromString("value type '" + dataMap.getType() + "' inconsistent with the " +

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -255,7 +255,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         for (List<Map.Entry<K, V>> entry: entries.values()) {
             entrySet.addAll(entry);
         }
-        return new LinkedHashSet(entries.values());
+        return entrySet;
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
@@ -630,7 +630,7 @@ public class TupleValueImpl extends AbstractArrayValue {
      * {@inheritDoc}
      */
     @Override
-    public IteratorValue getIterator() {
+    public IteratorValue<Object> getIterator() {
         return new ArrayIterator(this);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
@@ -25,6 +25,7 @@ import io.ballerina.runtime.api.values.BInitialValueEntry;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BListInitialValueEntry;
 import io.ballerina.runtime.api.values.BMapInitialValueEntry;
+import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.scheduling.Strand;
 import io.ballerina.runtime.internal.types.BAnnotatableType;
@@ -53,8 +54,8 @@ public class TypedescValueImpl implements TypedescValue {
 
     final Type type;
     final Type describingType; // Type of the value describe by this typedesc.
-    public MapValue[] closures;
-    public MapValue annotations;
+    public MapValue<?, ?>[] closures;
+    public MapValue<?, ?> annotations;
     private BTypedesc typedesc;
 
     public TypedescValueImpl(Type describingType) {
@@ -62,13 +63,13 @@ public class TypedescValueImpl implements TypedescValue {
         this.describingType = describingType;
     }
 
-    public TypedescValueImpl(Type describingType, MapValue[] closures) {
+    public TypedescValueImpl(Type describingType, MapValue<?, ?>[] closures) {
         this.type = new BTypedescType(describingType);
         this.describingType = describingType;
         this.closures = closures;
     }
 
-    public TypedescValueImpl(Type describingType, MapValue[] closures, MapValue annotations) {
+    public TypedescValueImpl(Type describingType, MapValue<?, ?>[] closures, MapValue<BString, Object> annotations) {
         this(describingType, closures);
         this.annotations = annotations;
         ((BAnnotatableType) describingType).setAnnotations(annotations);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlComment.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlComment.java
@@ -47,9 +47,9 @@ public class XmlComment extends XmlNonElementItem {
     }
 
     @Override
-    public IteratorValue getIterator() {
+    public IteratorValue<XmlComment> getIterator() {
         XmlComment that = this;
-        return new IteratorValue() {
+        return new IteratorValue<>() {
             boolean read = false;
             @Override
             public boolean hasNext() {
@@ -57,7 +57,7 @@ public class XmlComment extends XmlNonElementItem {
             }
 
             @Override
-            public Object next() {
+            public XmlComment next() {
                 if (!read) {
                     this.read = true;
                     return that;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
@@ -385,7 +385,7 @@ public final class XmlItem extends XmlValue implements BXmlItem {
                 StringUtils.fromString("Cycle detected"));
     }
 
-    private void mergeAdjoiningTextNodesIntoList(List leftList, List<BXml> appendingList) {
+    private void mergeAdjoiningTextNodesIntoList(List<BXml> leftList, List<BXml> appendingList) {
         XmlText lastChild = (XmlText) leftList.get(leftList.size() - 1);
         String firstChildContent = appendingList.get(0).getTextValue();
         String mergedTextContent = lastChild.getTextValue() + firstChildContent;
@@ -662,9 +662,9 @@ public final class XmlItem extends XmlValue implements BXmlItem {
     }
 
     @Override
-    public IteratorValue getIterator() {
+    public IteratorValue<XmlItem> getIterator() {
         XmlItem that = this;
-        return new IteratorValue() {
+        return new IteratorValue<>() {
             boolean read = false;
 
             @Override
@@ -673,7 +673,7 @@ public final class XmlItem extends XmlValue implements BXmlItem {
             }
 
             @Override
-            public Object next() {
+            public XmlItem next() {
                 if (read) {
                     throw new NoSuchElementException();
                 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlNonElementItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlNonElementItem.java
@@ -176,15 +176,15 @@ public abstract class XmlNonElementItem extends XmlValue implements BXmlNonEleme
     public abstract OMNode value();
 
     @Override
-    public IteratorValue getIterator() {
-        return new IteratorValue() {
+    public IteratorValue<?> getIterator() {
+        return new IteratorValue<>() {
             @Override
             public boolean hasNext() {
                 return false;
             }
 
             @Override
-            public Object next() {
+            public Void next() {
                 throw new NoSuchElementException();
             }
         };

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlPi.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlPi.java
@@ -51,9 +51,9 @@ public class XmlPi extends XmlNonElementItem {
     }
 
     @Override
-    public IteratorValue getIterator() {
+    public IteratorValue<XmlPi> getIterator() {
         XmlPi that = this;
-        return new IteratorValue() {
+        return new IteratorValue<>() {
             boolean read = false;
             @Override
             public boolean hasNext() {
@@ -61,7 +61,7 @@ public class XmlPi extends XmlNonElementItem {
             }
 
             @Override
-            public Object next() {
+            public XmlPi next() {
                 if (!read) {
                     this.read = true;
                     return that;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
@@ -214,7 +214,7 @@ public final class XmlSequence extends XmlValue implements BXmlSequence {
      */
     @Override
     public XmlValue elements() {
-        List elementsSeq = new ArrayList<XmlValue>();
+        List<BXml> elementsSeq = new ArrayList<>();
         for (BXml child : children) {
             if (child.getNodeType() == XmlNodeType.ELEMENT) {
                 elementsSeq.add(child);
@@ -612,8 +612,8 @@ public final class XmlSequence extends XmlValue implements BXmlSequence {
     }
 
     @Override
-    public IteratorValue getIterator() {
-        return new IteratorValue() {
+    public IteratorValue<BXml> getIterator() {
+        return new IteratorValue<>() {
             Iterator<BXml> iterator = children.iterator();
 
             @Override
@@ -622,7 +622,7 @@ public final class XmlSequence extends XmlValue implements BXmlSequence {
             }
 
             @Override
-            public Object next() {
+            public BXml next() {
                 return iterator.next();
             }
         };

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlText.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlText.java
@@ -92,9 +92,9 @@ public class XmlText extends XmlNonElementItem {
     }
 
     @Override
-    public IteratorValue getIterator() {
+    public IteratorValue<XmlText> getIterator() {
         XmlText that = this;
-        return new IteratorValue() {
+        return new IteratorValue<>() {
             boolean read = false;
             @Override
             public boolean hasNext() {
@@ -102,7 +102,7 @@ public class XmlText extends XmlNonElementItem {
             }
 
             @Override
-            public Object next() {
+            public XmlText next() {
                 if (!read) {
                     this.read = true;
                     return that;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/PolledGauge.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/PolledGauge.java
@@ -67,25 +67,25 @@ public interface PolledGauge extends Metric {
         }
 
         @Override
-        public Builder tags(String... keyValues) {
+        public Builder<T> tags(String... keyValues) {
             Tags.tags(this.tags, keyValues);
             return this;
         }
 
         @Override
-        public Builder tags(Iterable<Tag> tags) {
+        public Builder<T> tags(Iterable<Tag> tags) {
             Tags.tags(this.tags, tags);
             return this;
         }
 
         @Override
-        public Builder tag(String key, String value) {
+        public Builder<T> tag(String key, String value) {
             Tags.tags(this.tags, key, value);
             return this;
         }
 
         @Override
-        public Builder tags(Map<String, String> tags) {
+        public Builder<T> tags(Map<String, String> tags) {
             Tags.tags(this.tags, tags);
             return this;
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
@@ -95,8 +95,8 @@ public class TransactionResourceManager {
     private Map<String, Transaction> trxRegistry;
     private Map<String, Xid> xidRegistry;
 
-    private Map<String, List<BFunctionPointer>> committedFuncRegistry;
-    private Map<String, List<BFunctionPointer>> abortedFuncRegistry;
+    private Map<String, List<BFunctionPointer<?, ?>>> committedFuncRegistry;
+    private Map<String, List<BFunctionPointer<?, ?>>> abortedFuncRegistry;
 
     private ConcurrentSkipListSet<String> failedResourceParticipantSet = new ConcurrentSkipListSet<>();
     private ConcurrentSkipListSet<String> failedLocalParticipantSet = new ConcurrentSkipListSet<>();
@@ -259,7 +259,7 @@ public class TransactionResourceManager {
      * @param transactionBlockId the block id of the transaction
      * @param fpValue   the function pointer for the committed function
      */
-    public void registerCommittedFunction(String transactionBlockId, BFunctionPointer fpValue) {
+    public void registerCommittedFunction(String transactionBlockId, BFunctionPointer<?, ?> fpValue) {
         if (fpValue != null) {
             committedFuncRegistry.computeIfAbsent(transactionBlockId, list -> new ArrayList<>()).add(fpValue);
         }
@@ -271,7 +271,7 @@ public class TransactionResourceManager {
      * @param transactionBlockId the block id of the transaction
      * @param fpValue   the function pointer for the aborted function
      */
-    public void registerAbortedFunction(String transactionBlockId, BFunctionPointer fpValue) {
+    public void registerAbortedFunction(String transactionBlockId, BFunctionPointer<?, ?> fpValue) {
         if (fpValue != null) {
             abortedFuncRegistry.computeIfAbsent(transactionBlockId, list -> new ArrayList<>()).add(fpValue);
         }
@@ -532,7 +532,7 @@ public class TransactionResourceManager {
      * @return Array of rollback handlers
      */
     public BArray getRegisteredRollbackHandlerList() {
-        List<BFunctionPointer> abortFunctions =
+        List<BFunctionPointer<?, ?>> abortFunctions =
                 abortedFuncRegistry.get(Scheduler.getStrand().currentTrxContext.getGlobalTransactionId());
         if (abortFunctions != null && !abortFunctions.isEmpty()) {
             Collections.reverse(abortFunctions);
@@ -548,7 +548,7 @@ public class TransactionResourceManager {
      * @return Array of commit handlers
      */
     public BArray getRegisteredCommitHandlerList() {
-        List<BFunctionPointer> commitFunctions =
+        List<BFunctionPointer<?, ?>> commitFunctions =
                 committedFuncRegistry.get(Scheduler.getStrand().currentTrxContext.getGlobalTransactionId());
         if (commitFunctions != null && !commitFunctions.isEmpty()) {
             Collections.reverse(commitFunctions);

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TestUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TestUtils.java
@@ -109,11 +109,11 @@ public final class TestUtils {
 
         Map<String, ModuleCoverage> moduleCoverageMap = initializeCoverageMap(project);
         // Following lists will hold the coverage information needed for the coverage XML file generation.
-        List<ISourceFileCoverage> packageSourceCoverageList = new ArrayList();
-        List<IClassCoverage> packageNativeClassCoverageList = new ArrayList();
-        List<IClassCoverage> packageBalClassCoverageList = new ArrayList();
-        List<ExecutionData> packageExecData = new ArrayList();
-        List<SessionInfo> packageSessionInfo = new ArrayList();
+        List<ISourceFileCoverage> packageSourceCoverageList = new ArrayList<>();
+        List<IClassCoverage> packageNativeClassCoverageList = new ArrayList<>();
+        List<IClassCoverage> packageBalClassCoverageList = new ArrayList<>();
+        List<ExecutionData> packageExecData = new ArrayList<>();
+        List<SessionInfo> packageSessionInfo = new ArrayList<>();
         for (ModuleId moduleId : project.currentPackage().moduleIds()) {
             Module module = project.currentPackage().module(moduleId);
             CoverageReport coverageReport = new CoverageReport(module, moduleCoverageMap,
@@ -123,9 +123,9 @@ public final class TestUtils {
                     coverageModules.get(module.moduleName().toString()), exclusionClassList);
         }
         // Traverse coverage map and add module wise coverage to test report
-        for (Map.Entry mapElement : moduleCoverageMap.entrySet()) {
-            String moduleName = (String) mapElement.getKey();
-            ModuleCoverage moduleCoverage = (ModuleCoverage) mapElement.getValue();
+        for (var mapElement : moduleCoverageMap.entrySet()) {
+            String moduleName = mapElement.getKey();
+            ModuleCoverage moduleCoverage = mapElement.getValue();
             testReport.addCoverage(moduleName, moduleCoverage);
         }
         if (CodeCoverageUtils.isRequestedReportFormat(coverageReportFormat,

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TestUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TestUtils.java
@@ -123,7 +123,7 @@ public final class TestUtils {
                     coverageModules.get(module.moduleName().toString()), exclusionClassList);
         }
         // Traverse coverage map and add module wise coverage to test report
-        for (var mapElement : moduleCoverageMap.entrySet()) {
+        for (Map.Entry<String, ModuleCoverage> mapElement : moduleCoverageMap.entrySet()) {
             String moduleName = mapElement.getKey();
             ModuleCoverage moduleCoverage = mapElement.getValue();
             testReport.addCoverage(moduleName, moduleCoverage);

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BaseCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BaseCommandTest.java
@@ -37,6 +37,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.stream.Stream;
 
 import static io.ballerina.projects.util.ProjectConstants.CENTRAL_REPOSITORY_CACHE_NAME;
 
@@ -126,7 +127,7 @@ public abstract class BaseCommandTest {
         Path balaDestPath = centralRepoPath.resolve(org).resolve(name).resolve(version).resolve(platform);
         Files.createDirectories(balaDestPath);
 
-        try (var files = Files.walk(balaProjectDirectory)) {
+        try (Stream<Path> files = Files.walk(balaProjectDirectory)) {
             files.forEach(a -> {
                 Path b = Paths.get(String.valueOf(balaDestPath),
                         a.toString().substring(balaProjectDirectory.toString().length()));

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilerPluginContextIml.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilerPluginContextIml.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.projects;
 
+import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.projects.plugins.CodeAnalyzer;
 import io.ballerina.projects.plugins.CodeGenerator;
 import io.ballerina.projects.plugins.CodeModifier;
@@ -43,8 +44,8 @@ class CompilerPluginContextIml implements CompilerPluginContext {
     private final List<CodeModifierManager.CodeModifierInfo> codeModifiers = new ArrayList<>();
     private final List<CompilerLifecycleManager.LifecycleListenerInfo> lifecycleListeners = new ArrayList<>();
     private final List<CodeAction> codeActions = new ArrayList<>();
-    private Map<String, Object> compilerPluginUserData = new HashMap();
-    private final List<CompletionProvider> completionProviders = new ArrayList<>();
+    private Map<String, Object> compilerPluginUserData = new HashMap<>();
+    private final List<CompletionProvider<? extends Node>> completionProviders = new ArrayList<>();
 
     CompilerPluginContextIml(CompilerPluginInfo compilerPluginInfo) {
         this.compilerPluginInfo = compilerPluginInfo;
@@ -82,7 +83,7 @@ class CompilerPluginContextIml implements CompilerPluginContext {
     }
 
     @Override
-    public void addCompletionProvider(CompletionProvider completionProvider) {
+    public void addCompletionProvider(CompletionProvider<? extends Node> completionProvider) {
         completionProviders.add(completionProvider);
     }
 
@@ -106,7 +107,7 @@ class CompilerPluginContextIml implements CompilerPluginContext {
         return codeActions;
     }
 
-    public List<CompletionProvider> completionProviders() {
+    public List<CompletionProvider<? extends Node>> completionProviders() {
         return completionProviders;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompletionManager.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompletionManager.java
@@ -54,11 +54,13 @@ public class CompletionManager {
     private CompletionManager(List<CompilerPluginContextIml> compilerPluginContexts) {
         completionProviders = new HashMap<>();
         compilerPluginContexts.forEach(compilerPluginContextIml -> {
-            for (CompletionProvider<Node> completionProvider : compilerPluginContextIml.completionProviders()) {
+            for (CompletionProvider<? extends Node> completionProvider :
+                    compilerPluginContextIml.completionProviders()) {
                 for (Class<?> attachmentPoint : completionProvider.getSupportedNodes()) {
                     List<CompletionProviderDescriptor> completionProviderList =
                             completionProviders.computeIfAbsent(attachmentPoint, k -> new ArrayList<>());
-                    completionProviderList.add(new CompletionProviderDescriptor(completionProvider,
+                    completionProviderList.add(new CompletionProviderDescriptor(
+                            (CompletionProvider<Node>) completionProvider,
                             compilerPluginContextIml.compilerPluginInfo()));
                 }
             }
@@ -122,8 +124,9 @@ public class CompletionManager {
                 })
                 .forEach(descriptor -> {
                     try {
-                        result.addCompletionItems(descriptor.completionProvider()
-                                .getCompletions(context, serviceDeclarationNode));
+                        result.addCompletionItems(
+                                descriptor.completionProvider().getCompletions(context, serviceDeclarationNode)
+                        );
                     } catch (Throwable t) {
                         String name;
                         if (descriptor.compilerPluginInfo.kind() == CompilerPluginKind.PACKAGE_PROVIDED) {
@@ -197,14 +200,14 @@ public class CompletionManager {
     }
 
     /**
-     * Descriptor for a completion provider.
+     * Descriptor for a completion provider
      */
     static class CompletionProviderDescriptor {
 
         private final CompletionProvider<Node> completionProvider;
         private final CompilerPluginInfo compilerPluginInfo;
 
-        public CompletionProviderDescriptor(CompletionProvider completionProvider,
+        public CompletionProviderDescriptor(CompletionProvider<Node> completionProvider,
                                             CompilerPluginInfo compilerPluginInfo) {
             this.completionProvider = completionProvider;
             this.compilerPluginInfo = compilerPluginInfo;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompletionManager.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompletionManager.java
@@ -124,9 +124,8 @@ public class CompletionManager {
                 })
                 .forEach(descriptor -> {
                     try {
-                        result.addCompletionItems(
-                                descriptor.completionProvider().getCompletions(context, serviceDeclarationNode)
-                        );
+                        result.addCompletionItems(descriptor.completionProvider()
+                                .getCompletions(context, serviceDeclarationNode));
                     } catch (Throwable t) {
                         String name;
                         if (descriptor.compilerPluginInfo.kind() == CompilerPluginKind.PACKAGE_PROVIDED) {
@@ -200,7 +199,7 @@ public class CompletionManager {
     }
 
     /**
-     * Descriptor for a completion provider
+     * Descriptor for a completion provider.
      */
     static class CompletionProviderDescriptor {
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Module.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Module.java
@@ -146,7 +146,7 @@ public class Module {
         return this.moduleMd;
     }
 
-    private static class DocumentIterable implements Iterable {
+    private static class DocumentIterable implements Iterable<Document> {
         private final Collection<Document> documentList;
 
         public DocumentIterable(Collection<Document> documentList) {
@@ -159,7 +159,7 @@ public class Module {
         }
 
         @Override
-        public Spliterator spliterator() {
+        public Spliterator<Document> spliterator() {
             return this.documentList.spliterator();
         }
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
@@ -414,7 +414,7 @@ public class Package {
         return this.packageContext.getResolution(newCompOptions, true);
     }
 
-    private static class ModuleIterable implements Iterable {
+    private static class ModuleIterable implements Iterable<Module> {
 
         private final Collection<Module> moduleList;
 
@@ -428,7 +428,7 @@ public class Package {
         }
 
         @Override
-        public Spliterator spliterator() {
+        public Spliterator<Module> spliterator() {
             return this.moduleList.spliterator();
         }
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/BalToolsManifestBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/BalToolsManifestBuilder.java
@@ -53,7 +53,7 @@ public class BalToolsManifestBuilder {
     private final Map<String, OldTool> oldTools;
 
     private BalToolsManifestBuilder(TomlDocument balToolsToml) {
-        oldTools = new HashMap();
+        oldTools = new HashMap<>();
         this.balToolsToml = Optional.ofNullable(balToolsToml);
         this.balToolsManifest = parseAsBalToolsManifest();
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/CompilerPluginContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/CompilerPluginContext.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.projects.plugins;
 
+import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.projects.plugins.codeaction.CodeAction;
 import io.ballerina.projects.plugins.completion.CompletionProvider;
 
@@ -69,7 +70,7 @@ public interface CompilerPluginContext {
      *
      * @param completionProvider the {@link CompletionProvider} instance
      */
-    void addCompletionProvider(CompletionProvider completionProvider);
+    void addCompletionProvider(CompletionProvider<? extends Node> completionProvider);
 
     /**
      * Returns user data for the compiler plugin.

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/spi/SystemPackageRepositoryProvider.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/spi/SystemPackageRepositoryProvider.java
@@ -22,6 +22,7 @@ import org.wso2.ballerinalang.compiler.packaging.repo.Repo;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 
 /**
  * This represents the Java SPI interface for a Ballerina system package repository provider.
@@ -43,6 +44,6 @@ public interface SystemPackageRepositoryProvider {
      *
      * @return the loaded {@link PackageRepository} object
      */
-    Repo loadRepository();
+    Repo<Path> loadRepository();
 
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -397,7 +397,7 @@ public class BIRPackageSymbolEnter {
         String funcName = getStringCPEntryValue(dataInStream);
         String funcOrigName = getStringCPEntryValue(dataInStream);
         String workerName = getStringCPEntryValue(dataInStream);
-        var flags = dataInStream.readLong();
+        long flags = dataInStream.readLong();
         byte origin = dataInStream.readByte();
 
         BInvokableType funcType = (BInvokableType) readBType(dataInStream);
@@ -533,7 +533,7 @@ public class BIRPackageSymbolEnter {
         String typeDefName = getStringCPEntryValue(dataInStream);
         String typeDefOrigName = getStringCPEntryValue(dataInStream);
 
-        var flags = dataInStream.readLong();
+        long flags = dataInStream.readLong();
         byte origin = dataInStream.readByte();
 
         byte[] docBytes = readDocBytes(dataInStream);
@@ -693,7 +693,7 @@ public class BIRPackageSymbolEnter {
         String name = getStringCPEntryValue(dataInStream);
         String originalName = getStringCPEntryValue(dataInStream);
 
-        var flags = dataInStream.readLong();
+        long flags = dataInStream.readLong();
         byte origin = dataInStream.readByte();
         Location pos = readPosition(dataInStream);
 
@@ -751,7 +751,7 @@ public class BIRPackageSymbolEnter {
 
     private void defineConstant(DataInputStream dataInStream) throws IOException {
         String constantName = getStringCPEntryValue(dataInStream);
-        var flags = dataInStream.readLong();
+        long flags = dataInStream.readLong();
         byte origin = dataInStream.readByte();
         Location pos = readPosition(dataInStream);
 
@@ -869,7 +869,7 @@ public class BIRPackageSymbolEnter {
         Location pos = readPosition(dataInStream);
         dataInStream.readByte(); // Read and ignore the kind as it is anyway global variable
         String varName = getStringCPEntryValue(dataInStream);
-        var flags = dataInStream.readLong();
+        long flags = dataInStream.readLong();
         byte origin = dataInStream.readByte();
 
         byte[] docBytes = readDocBytes(dataInStream);
@@ -916,7 +916,7 @@ public class BIRPackageSymbolEnter {
         BInvokableType invokableType = (BInvokableType) invokableSymbol.type;
         for (int i = 0; i < requiredParamCount; i++) {
             String paramName = getStringCPEntryValue(dataInStream);
-            var flags = dataInStream.readLong();
+            long flags = dataInStream.readLong();
             BVarSymbol varSymbol = new BVarSymbol(flags, Names.fromString(paramName), this.env.pkgSymbol.pkgID,
                                                   invokableType.paramTypes.get(i), invokableSymbol,
                                                   symTable.builtinPos, COMPILED_SOURCE);
@@ -1154,7 +1154,7 @@ public class BIRPackageSymbolEnter {
             int params = inputStream.readInt();
             for (int i = 0; i < params; i++) {
                 String paramName = getStringCPEntryValue(inputStream);
-                var paramFlags = inputStream.readLong();
+                long paramFlags = inputStream.readLong();
                 byte[] docBytes = readDocBytes(inputStream);
                 BType fieldType = readTypeFromCp();
 
@@ -1170,7 +1170,7 @@ public class BIRPackageSymbolEnter {
             boolean hasRestParam = inputStream.readBoolean();
             if (hasRestParam) {
                 String fieldName = getStringCPEntryValue(inputStream);
-                var fieldFlags = inputStream.readLong();
+                long fieldFlags = inputStream.readLong();
                 byte[] docBytes = readDocBytes(inputStream);
                 BType fieldType = readTypeFromCp();
 
@@ -1193,7 +1193,7 @@ public class BIRPackageSymbolEnter {
 
         private BInvokableSymbol getSymbolOfClosure() throws IOException {
             String name = getStringCPEntryValue(inputStream);
-            var flags = inputStream.readLong();
+            long flags = inputStream.readLong();
             BType type = readTypeFromCp();
             int pkgCpIndex = inputStream.readInt();
             PackageID pkgId = getPackageId(pkgCpIndex);
@@ -1206,7 +1206,7 @@ public class BIRPackageSymbolEnter {
             int parameters = inputStream.readInt();
             for (int i = 0; i < parameters; i++) {
                 String fieldName = getStringCPEntryValue(inputStream);
-                var fieldFlags = inputStream.readLong();
+                long fieldFlags = inputStream.readLong();
                 byte[] docBytes = readDocBytes(inputStream);
                 BType fieldType = readTypeFromCp();
                 BVarSymbol varSymbol = new BVarSymbol(fieldFlags, Names.fromString(fieldName), pkgId, fieldType, null,
@@ -1220,7 +1220,7 @@ public class BIRPackageSymbolEnter {
         public BType readType(int cpI) throws IOException {
             byte tag = inputStream.readByte();
             Name name = Names.fromString(getStringCPEntryValue(inputStream));
-            var flags = inputStream.readLong();
+            long flags = inputStream.readLong();
 
             // Read the type flags to identify if type reference types are nullable.
             int typeFlags = inputStream.readInt();
@@ -1284,7 +1284,7 @@ public class BIRPackageSymbolEnter {
                     int recordFields = inputStream.readInt();
                     for (int i = 0; i < recordFields; i++) {
                         String fieldName = getStringCPEntryValue(inputStream);
-                        var fieldFlags = inputStream.readLong();
+                        long fieldFlags = inputStream.readLong();
 
                         byte[] docBytes = readDocBytes(inputStream);
 
@@ -1474,7 +1474,7 @@ public class BIRPackageSymbolEnter {
                     }
                     unionType.setOriginalMemberTypes(originalMemberTypes);
 
-                    var poppedUnionType = compositeStack.pop();
+                    Object poppedUnionType = compositeStack.pop();
                     assert poppedUnionType == unionType;
 
                     boolean isEnum = inputStream.readBoolean();
@@ -1600,7 +1600,7 @@ public class BIRPackageSymbolEnter {
                     return bFutureType;
                 case TypeTags.FINITE:
                     String finiteTypeName = getStringCPEntryValue(inputStream);
-                    var finiteTypeFlags = inputStream.readLong();
+                    long finiteTypeFlags = inputStream.readLong();
                     BTypeSymbol symbol = Symbols.createTypeSymbol(SymTag.FINITE_TYPE, finiteTypeFlags,
                                                                   Names.fromString(finiteTypeName), env.pkgSymbol.pkgID,
                                                                   null, env.pkgSymbol, symTable.builtinPos,
@@ -1643,8 +1643,8 @@ public class BIRPackageSymbolEnter {
                     int fieldCount = inputStream.readInt();
                     for (int i = 0; i < fieldCount; i++) {
                         String fieldName = getStringCPEntryValue(inputStream);
-                        var fieldFlags = inputStream.readLong();
-                        var defaultable = inputStream.readBoolean();
+                        long fieldFlags = inputStream.readLong();
+                        boolean defaultable = inputStream.readBoolean();
                         byte[] docBytes = readDocBytes(inputStream);
 
                         BType fieldType = readTypeFromCp();
@@ -1803,7 +1803,7 @@ public class BIRPackageSymbolEnter {
                                                                  BObjectTypeSymbol objectSymbol) throws IOException {
             String attachedFuncName = getStringCPEntryValue(inputStream);
             String attachedFuncOrigName = getStringCPEntryValue(inputStream);
-            var attachedFuncFlags = inputStream.readLong();
+            long attachedFuncFlags = inputStream.readLong();
             BInvokableType attachedFuncType = (BInvokableType) readTypeFromCp();
             Name funcName = Names.fromString(Symbols.getAttachedFuncSymbolName(
                     objectSymbol.name.value, attachedFuncName));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/properties/BCollectionProperty.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/properties/BCollectionProperty.java
@@ -28,7 +28,7 @@ import java.util.Collection;
  *
  * @since Swan Lake
  */
-public class BCollectionProperty implements DiagnosticProperty {
+public class BCollectionProperty implements DiagnosticProperty<Collection<DiagnosticProperty<?>>> {
     private final DiagnosticPropertyKind kind;
     private final Collection<DiagnosticProperty<?>> values;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/Patten.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/Patten.java
@@ -77,7 +77,7 @@ public class Patten {
     }
 
     @SuppressWarnings("unchecked")
-    public Stream<CompilerInput> convertToSources(Converter converter, PackageID id) {
+    public <T> Stream<CompilerInput> convertToSources(Converter<T> converter, PackageID id) {
         return convert(converter, id).flatMap(t -> converter.finalize(t, id));
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FilterSearch.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FilterSearch.java
@@ -11,8 +11,9 @@ import java.util.List;
 
 /**
  * Filters directories.
+ * @param <T> type of the file visitor
  */
-class FilterSearch extends SimpleFileVisitor {
+class FilterSearch<T> extends SimpleFileVisitor<T> {
 
     private final List<Path> excludeDir;
     private List<Path> pathList = new ArrayList<>();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
@@ -122,7 +122,7 @@ public class PathConverter implements Converter<Path> {
                 List<Path> excludePaths = new ArrayList<>();
                 excludePaths.add(Paths.get(ProjectDirConstants.TEST_DIR_NAME));
                 excludePaths.add(Paths.get(ProjectDirConstants.RESOURCE_DIR_NAME));
-                FilterSearch filterSearch = new FilterSearch(excludePaths);
+                var filterSearch = new FilterSearch<>(excludePaths);
                 Files.walkFileTree(path, filterSearch);
                 return filterSearch.getPathList().stream().sorted();
             } catch (IOException ignore) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
@@ -122,7 +122,7 @@ public class PathConverter implements Converter<Path> {
                 List<Path> excludePaths = new ArrayList<>();
                 excludePaths.add(Paths.get(ProjectDirConstants.TEST_DIR_NAME));
                 excludePaths.add(Paths.get(ProjectDirConstants.RESOURCE_DIR_NAME));
-                var filterSearch = new FilterSearch<>(excludePaths);
+                FilterSearch<Object> filterSearch = new FilterSearch<>(excludePaths);
                 Files.walkFileTree(path, filterSearch);
                 return filterSearch.getPathList().stream().sorted();
             } catch (IOException ignore) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -4669,7 +4669,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         if (type.tag == TypeTags.INVOKABLE && type.tsymbol != null) {
             BInvokableTypeSymbol tsymbol = (BInvokableTypeSymbol) type.tsymbol;
             BInvokableSymbol invokableSymbol = (BInvokableSymbol) varSymbol;
-            invokableSymbol.params = tsymbol.params == null ? null : new ArrayList(tsymbol.params);
+            invokableSymbol.params = tsymbol.params == null ? null : new ArrayList<>(tsymbol.params);
             invokableSymbol.restParam = tsymbol.restParam;
             invokableSymbol.retType = tsymbol.returnType;
             invokableSymbol.flags = tsymbol.flags;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -5702,7 +5702,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         return silentTypeCheckExpr(numericLiteral, referredType, data);
     }
 
-    public LinkedHashSet getIntSubtypesInUnionType(BUnionType expectedType) {
+    public LinkedHashSet<BType> getIntSubtypesInUnionType(BUnionType expectedType) {
         LinkedHashSet<BType> intTypesInUnion = new LinkedHashSet<>(expectedType.getMemberTypes().size());
         for (BType type : expectedType.getMemberTypes()) {
             BType referredType = Types.getImpliedType(type);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -3651,7 +3651,7 @@ public class Types {
         }
 
         // check if all the value types are assignable between two unions
-        var sourceIterator = sourceTypes.iterator();
+        Iterator<BType> sourceIterator = sourceTypes.iterator();
         while (sourceIterator.hasNext()) {
             BType sMember = sourceIterator.next();
             if (sMember.tag == TypeTags.NEVER) {
@@ -3696,7 +3696,7 @@ public class Types {
             }
 
             boolean sourceTypeIsNotAssignableToAnyTargetType = true;
-            var targetIterator = targetTypes.iterator();
+            Iterator<BType> targetIterator = targetTypes.iterator();
             while (targetIterator.hasNext()) {
                 BType t = targetIterator.next();
                 if (isAssignable(sMember, t, unresolvedTypes)) {
@@ -3716,7 +3716,7 @@ public class Types {
         while (sourceIterator.hasNext()) {
             BType sourceMember = sourceIterator.next();
             boolean sourceTypeIsNotAssignableToAnyTargetType = true;
-            var targetIterator = targetTypes.iterator();
+            Iterator<BType> targetIterator = targetTypes.iterator();
 
             boolean selfReferencedSource = (sourceMember != source) &&
                     isSelfReferencedStructuredType(source, sourceMember);
@@ -3799,7 +3799,7 @@ public class Types {
                                                     LinkedHashSet<BType> readOnlyMemTypes) {
         boolean sameMember = originalMemberType == immutableMemberType;
         if (originalMemberType.tag == TypeTags.ARRAY) {
-            var arrayType = (BArrayType) originalMemberType;
+            BArrayType arrayType = (BArrayType) originalMemberType;
             if (origUnionType == arrayType.eType) {
                 if (sameMember) {
                     BArrayType newArrayType = new BArrayType(newImmutableUnion, arrayType.tsymbol, arrayType.size,
@@ -3811,7 +3811,7 @@ public class Types {
                 }
             }
         } else if (originalMemberType.tag == TypeTags.MAP) {
-            var mapType = (BMapType) originalMemberType;
+            BMapType mapType = (BMapType) originalMemberType;
             if (origUnionType == mapType.constraint) {
                 if (sameMember) {
                     BMapType newMapType = new BMapType(mapType.tag, newImmutableUnion, mapType.tsymbol, mapType.flags);
@@ -3822,7 +3822,7 @@ public class Types {
                 }
             }
         } else if (originalMemberType.tag == TypeTags.TABLE) {
-            var tableType = (BTableType) originalMemberType;
+            BTableType tableType = (BTableType) originalMemberType;
             if (origUnionType == tableType.constraint) {
                 if (sameMember) {
                     BTableType newTableType = new BTableType(tableType.tag, newImmutableUnion, tableType.tsymbol,
@@ -3835,10 +3835,10 @@ public class Types {
                 return;
             }
 
-            var immutableConstraint = ((BTableType) immutableMemberType).constraint;
+            BType immutableConstraint = ((BTableType) immutableMemberType).constraint;
             if (tableType.constraint.tag == TypeTags.MAP) {
                 sameMember = tableType.constraint == immutableConstraint;
-                var mapType = (BMapType) tableType.constraint;
+                BMapType mapType = (BMapType) tableType.constraint;
                 if (origUnionType == mapType.constraint) {
                     if (sameMember) {
                         BMapType newMapType = new BMapType(mapType.tag, newImmutableUnion, mapType.tsymbol,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -6171,12 +6171,12 @@ public class Types {
         if (type.getValueSpace().size() == 1) { // For singleton types, that value is the implicit initial value
             return true;
         }
-        Iterator iterator = type.getValueSpace().iterator();
-        BLangExpression firstElement = (BLangExpression) iterator.next();
+        Iterator<BLangExpression> iterator = type.getValueSpace().iterator();
+        BLangExpression firstElement = iterator.next();
         boolean defaultFillValuePresent = isImplicitDefaultValue(firstElement);
 
         while (iterator.hasNext()) {
-            BLangExpression value = (BLangExpression) iterator.next();
+            BLangExpression value = iterator.next();
             if (!isSameBasicType(value.getBType(), firstElement.getBType())) {
                 return false;
             }
@@ -7180,9 +7180,9 @@ public class Types {
 
     public boolean isCloneableType(BUnionType type) {
         LinkedHashSet<BType> cloneableMemberTypes = symTable.cloneableType.getMemberTypes();
-        Iterator memItr = type.getMemberTypes().iterator();
+        Iterator<BType> memItr = type.getMemberTypes().iterator();
         for (BType memberType : cloneableMemberTypes) {
-            if (!memItr.hasNext() || memberType.tag != ((BType) memItr.next()).tag) {
+            if (!memItr.hasNext() || memberType.tag != memItr.next().tag) {
                 return false;
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
@@ -305,9 +305,9 @@ public final class RepoUtils {
      */
     public static Manifest getManifestFromBala(Path balaPath) {
         try (JarFile jar = new JarFile(balaPath.toString())) {
-            Enumeration enumEntries = jar.entries();
+            Enumeration<JarEntry> enumEntries = jar.entries();
             while (enumEntries.hasMoreElements()) {
-                JarEntry file = (JarEntry) enumEntries.nextElement();
+                JarEntry file = enumEntries.nextElement();
                 if (file.getName().contains(ProjectDirConstants.MANIFEST_FILE_NAME)) {
                     if (file.isDirectory()) { // if its a directory, ignore
                         continue;

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/BallerinaTomlTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/BallerinaTomlTests.java
@@ -546,7 +546,7 @@ public class BallerinaTomlTests {
         Assert.assertEquals(frequency.longValue(), 225);
 
         // other entry table array
-        List<Map<String, Object>> userContacts = (ArrayList) packageManifest.getValue("userContact");
+        var userContacts = (ArrayList<Map<String, Object>>) packageManifest.getValue("userContact");
         Assert.assertEquals(userContacts.size(), 2);
         Map<String, Object> firstContact = userContacts.get(0);
         Assert.assertEquals(firstContact.get("name"), "hevayo");

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/BallerinaTomlTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/BallerinaTomlTests.java
@@ -546,7 +546,8 @@ public class BallerinaTomlTests {
         Assert.assertEquals(frequency.longValue(), 225);
 
         // other entry table array
-        var userContacts = (ArrayList<Map<String, Object>>) packageManifest.getValue("userContact");
+        ArrayList<Map<String, Object>> userContacts =
+                (ArrayList<Map<String, Object>>) packageManifest.getValue("userContact");
         Assert.assertEquals(userContacts.size(), 2);
         Map<String, Object> firstContact = userContacts.get(0);
         Assert.assertEquals(firstContact.get("name"), "hevayo");

--- a/compiler/ballerina-lang/src/test/java/org/ballerinalang/toml/SingletonStackTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/ballerinalang/toml/SingletonStackTest.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 public class SingletonStackTest {
     @Test(description = "The value in the stack should be retrieved/popped out if a value is present")
     public void testPopWithValue() {
-        SingletonStack singletonStackTest = new SingletonStack();
+        SingletonStack<String> singletonStackTest = new SingletonStack<>();
         singletonStackTest.push("hello");
         Assert.assertEquals(singletonStackTest.pop(), "hello");
     }
@@ -35,27 +35,27 @@ public class SingletonStackTest {
     @Test(description = "The value should not be pushed to the stack if the stack already contains a value it should " +
             "give an exception", expectedExceptions = IllegalStateException.class)
     public void testPopWithoutValue() {
-        SingletonStack singletonStackTest = new SingletonStack();
+        SingletonStack<String> singletonStackTest = new SingletonStack<>();
         singletonStackTest.pop();
         Assert.assertEquals(singletonStackTest.present(), true);
     }
 
     @Test(description = "Return true if the value exists")
     public void testWithValuePresent() {
-        SingletonStack singletonStackTest = new SingletonStack();
+        SingletonStack<String> singletonStackTest = new SingletonStack<>();
         singletonStackTest.push("hello");
         Assert.assertEquals(singletonStackTest.present(), true);
     }
 
     @Test(description = "Return false if a value does not exists")
     public void testWithValueAbsent() {
-        SingletonStack singletonStackTest = new SingletonStack();
+        SingletonStack<String> singletonStackTest = new SingletonStack<>();
         Assert.assertEquals(singletonStackTest.present(), false);
     }
 
     @Test(description = "The value should be pushed to the stack if the stack is not null")
     public void testPushToStackWithValue() {
-        SingletonStack singletonStackTest = new SingletonStack();
+        SingletonStack<String> singletonStackTest = new SingletonStack<>();
         singletonStackTest.push("hello");
         Assert.assertEquals(singletonStackTest.present(), true);
         Assert.assertEquals(singletonStackTest.pop(), "hello");
@@ -64,7 +64,7 @@ public class SingletonStackTest {
     @Test(description = "The value should not be pushed to the stack if the stack already contains a value it should " +
             "give an exception", expectedExceptions = IllegalStateException.class)
     public void testPushMultipleValuesToStack() {
-        SingletonStack singletonStackTest = new SingletonStack();
+        SingletonStack<String> singletonStackTest = new SingletonStack<>();
         singletonStackTest.push("hello");
         singletonStackTest.push("world");
         Assert.assertEquals(singletonStackTest.present(), true);

--- a/compiler/ballerina-lang/src/test/java/org/ballerinalang/util/DiagnosticCodeTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/ballerinalang/util/DiagnosticCodeTest.java
@@ -80,7 +80,7 @@ public class DiagnosticCodeTest {
         }
     }
 
-    private String arrayToString(List listOfStrings) {
+    private String arrayToString(List<String> listOfStrings) {
         return String.join(", ", listOfStrings);
     }
 }

--- a/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/BLangNodeTransformerTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/BLangNodeTransformerTest.java
@@ -171,10 +171,10 @@ public class BLangNodeTransformerTest {
                                       int[] level) throws IllegalAccessException {
         if (objVal instanceof Map) {
             builder.append("{");
-            Iterator<Map.Entry> entries = ((Map) objVal).entrySet().iterator();
+            Iterator<? extends Map.Entry<?, ?>> entries = ((Map<?, ?>) objVal).entrySet().iterator();
             StringJoiner joiner = new StringJoiner(",");
             while (entries.hasNext()) {
-                Map.Entry entry = entries.next();
+                Map.Entry<?, ?> entry = entries.next();
                 StringBuilder sBuilder = new StringBuilder("\"" + entry.getKey() + "\": ");
                 joiner.add(generateFieldValueJson(entry.getValue().getClass(), entry.getValue(), skipList, visitedList,
                                                   sBuilder, referenceNode, level));
@@ -186,7 +186,7 @@ public class BLangNodeTransformerTest {
             // Lists, Sets
             builder.append("[");
             StringJoiner joiner = new StringJoiner(",");
-            for (Object item : (Collection) objVal) {
+            for (Object item : (Collection<?>) objVal) {
                 joiner.add(generateFieldValueJson(item.getClass(), item, skipList, visitedList, new StringBuilder(""),
                                                   referenceNode, level));
             }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
@@ -8311,7 +8311,7 @@ public class BallerinaParser extends AbstractParser {
         }
         
         // If the member type desc is an array type desc flatten the dimensions
-        List<STNode> arrayDimensions = new ArrayList();
+        List<STNode> arrayDimensions = new ArrayList<>();
         if (memberTypeDesc.kind == SyntaxKind.ARRAY_TYPE_DESC) {
             STArrayTypeDescriptorNode innerArrayType = (STArrayTypeDescriptorNode) memberTypeDesc;
             STNode innerArrayDimensions = innerArrayType.dimensions;

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/TreeModifier.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/TreeModifier.java
@@ -3725,7 +3725,7 @@ public abstract class TreeModifier extends NodeTransformer<Node> {
     }
 
     protected <T extends Node> SeparatedNodeList<T> modifySeparatedNodeList(SeparatedNodeList<T> nodeList) {
-        Function<NonTerminalNode, SeparatedNodeList> nodeListCreator = SeparatedNodeList::new;
+        Function<NonTerminalNode, SeparatedNodeList<T>> nodeListCreator = SeparatedNodeList::new;
         if (nodeList.isEmpty()) {
             return nodeList;
         }

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/diagnostics/DiagnosticCodeTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/diagnostics/DiagnosticCodeTest.java
@@ -73,7 +73,7 @@ public class DiagnosticCodeTest {
         }
     }
 
-    private String arrayToString(List listOfStrings) {
+    private String arrayToString(List<String> listOfStrings) {
         return String.join(", ", listOfStrings);
     }
 }

--- a/langlib/jballerina.java/src/main/java/org/ballerinalang/langlib/java/Cast.java
+++ b/langlib/jballerina.java/src/main/java/org/ballerinalang/langlib/java/Cast.java
@@ -60,10 +60,10 @@ public final class Cast {
                     + jObjField + "` field in `" + valueObjName + "`"));
         }
         try {
-            BMap objAnnotation;
+            BMap<?, ?> objAnnotation;
             BString objClass;
             try {
-                objAnnotation = (BMap) objType.getAnnotation(StringUtils.fromString(annotationType));
+                objAnnotation = (BMap<?, ?>) objType.getAnnotation(StringUtils.fromString(annotationType));
                 objClass = objAnnotation.getStringValue(StringUtils.fromString(classAttribute));
             } catch (Exception e) {
                 return createError(StringUtils.fromString(moduleName + " Error while retrieving details of the `" +
@@ -86,7 +86,7 @@ public final class Cast {
                         "parameter: " + e));
             }
             try {
-                BMap castObjAnnotation = (BMap) castObjType.getAnnotation(StringUtils.fromString(annotationType));
+                var castObjAnnotation = (BMap<?, ?>) castObjType.getAnnotation(StringUtils.fromString(annotationType));
                 castObjClass = castObjAnnotation.getStringValue(StringUtils.fromString(classAttribute));
             } catch (Exception e) {
                 return createError(StringUtils.fromString(moduleName + " Error while retrieving details of the `" +

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetFilterFunc.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetFilterFunc.java
@@ -36,8 +36,8 @@ public final class GetFilterFunc {
     private GetFilterFunc() {
     }
 
-    public static BFunctionPointer getFilterFunc(Object obj) {
-        BFunctionPointer bFunctionPointer = (BFunctionPointer) obj;
+    public static BFunctionPointer<?, ?> getFilterFunc(Object obj) {
+        BFunctionPointer<?, ?> bFunctionPointer = (BFunctionPointer<?, ?>) obj;
         FunctionType functionType = (FunctionType) TypeUtils.getImpliedType(bFunctionPointer.getType());
         functionType.getParameters()[0].type = TypeCreator.createUnionType(List.of(PredefinedTypes.TYPE_ANY,
                 PredefinedTypes.TYPE_ERROR), 0);

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetMapFunc.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetMapFunc.java
@@ -36,8 +36,8 @@ public final class GetMapFunc {
     private GetMapFunc() {
     }
 
-    public static BFunctionPointer getMapFunc(Object obj) {
-        BFunctionPointer functionPointer = (BFunctionPointer) obj;
+    public static BFunctionPointer<?, ?> getMapFunc(Object obj) {
+        BFunctionPointer<?, ?> functionPointer = (BFunctionPointer<?, ?>) obj;
         FunctionType functionType = (FunctionType) TypeUtils.getImpliedType(functionPointer.getType());
         functionType.getParameters()[0].type = TypeCreator.createUnionType(List.of(PredefinedTypes.TYPE_ANY,
                 PredefinedTypes.TYPE_ERROR), 0);

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetReturnType.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetReturnType.java
@@ -35,7 +35,7 @@ public final class GetReturnType {
     }
 
     public static BTypedesc getReturnType(Object obj) {
-        BFunctionPointer bFunctionPointer = (BFunctionPointer) obj;
+        BFunctionPointer<?, ?> bFunctionPointer = (BFunctionPointer<?, ?>) obj;
         FunctionType functionType = (FunctionType) TypeUtils.getImpliedType(bFunctionPointer.getType());
         return ValueCreator.createTypedescValue(functionType.getReturnType());
     }

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/InvokeAsExternal.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/InvokeAsExternal.java
@@ -41,7 +41,7 @@ public final class InvokeAsExternal {
 
     public static Object invokeAsExternal(Object func, Object[] args) {
 
-        BFunctionPointer function = (BFunctionPointer) func;
+        BFunctionPointer<?, ?> function = (BFunctionPointer<?, ?>) func;
         List<Object> argList = new ArrayList<>();
         for (Object arg : args) {
             argList.add(arg);

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/SetNarrowType.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/SetNarrowType.java
@@ -40,12 +40,12 @@ public final class SetNarrowType {
     private SetNarrowType() {
     }
 
-    public static BMap setNarrowType(BTypedesc td, BMap value) {
+    public static BMap<?, ?> setNarrowType(BTypedesc td, BMap<?, ?> value) {
         RecordType recordType = (RecordType) TypeUtils.getImpliedType(value.getType());
         RecordType newRecordType =
                 TypeCreator.createRecordType("narrowType", recordType.getPackage(), recordType.getTypeFlags(),
                                              recordType.isSealed(), recordType.getTypeFlags());
-        newRecordType.setFields(new HashMap() {{
+        newRecordType.setFields(new HashMap<>() {{
             put("value", TypeCreator.createField(td.getDescribingType(), "value",
                                                  SymbolFlags.PUBLIC + SymbolFlags.REQUIRED));
         }});

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Filter.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Filter.java
@@ -47,7 +47,7 @@ public final class Filter {
     private static final StrandMetadata METADATA = new StrandMetadata(BALLERINA_BUILTIN_PKG_PREFIX, ARRAY_LANG_LIB,
                                                                       ARRAY_VERSION, "filter");
 
-    public static BArray filter(BArray arr, BFunctionPointer<Object, Boolean> func) {
+    public static BArray filter(BArray arr, BFunctionPointer<Object[], Boolean> func) {
         BArray newArr;
         Type arrType = TypeUtils.getImpliedType(arr.getType());
         newArr = switch (arrType.getTag()) {

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/ForEach.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/ForEach.java
@@ -51,7 +51,7 @@ public final class ForEach {
     private ForEach() {
     }
 
-    public static void forEach(BArray arr, BFunctionPointer<Object, Object> func) {
+    public static void forEach(BArray arr, BFunctionPointer<Object[], Object> func) {
         int size = arr.size();
         Type arrType = arr.getType();
         GetFunction getFn = getElementAccessFunction(arrType, "forEach()");

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/GetIterator.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/GetIterator.java
@@ -37,7 +37,7 @@ public final class GetIterator {
     private GetIterator() {
     }
 
-    public static BIterator iterator(BArray arr) {
+    public static BIterator<?> iterator(BArray arr) {
         return arr.getIterator();
     }
 }

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Map.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Map.java
@@ -58,7 +58,7 @@ public final class Map {
     private Map() {
     }
 
-    public static BArray map(BArray arr, BFunctionPointer<Object, Object> func) {
+    public static BArray map(BArray arr, BFunctionPointer<Object[], Object> func) {
         Type elemType = ((FunctionType) TypeUtils.getImpliedType(func.getType())).getReturnType();
         Type retArrType = TypeCreator.createArrayType(elemType);
         BArray retArr = ValueCreator.createArrayValue((ArrayType) retArrType);

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Next.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Next.java
@@ -37,7 +37,7 @@ public final class Next {
 
     //TODO: refactor hard coded values
     public static Object next(BObject m) {
-        BIterator arrIterator = (BIterator) m.getNativeData("&iterator&");
+        BIterator<?> arrIterator = (BIterator<?>) m.getNativeData("&iterator&");
         BArray arr = (BArray) m.get(StringUtils.fromString("m"));
         if (arrIterator == null) {
             arrIterator = arr.getIterator();

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Reduce.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Reduce.java
@@ -47,7 +47,7 @@ public final class Reduce {
     private Reduce() {
     }
 
-    public static Object reduce(BArray arr, BFunctionPointer<Object, Boolean> func, Object initial) {
+    public static Object reduce(BArray arr, BFunctionPointer<Object[], Boolean> func, Object initial) {
         Type arrType = arr.getType();
         int size = arr.size();
         GetFunction getFn = getElementAccessFunction(arrType, "reduce()");

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Sort.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Sort.java
@@ -26,6 +26,7 @@ import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BFunctionPointer;
 import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.internal.ValueComparisonUtils;
 import io.ballerina.runtime.internal.scheduling.Scheduler;
 
@@ -112,7 +113,7 @@ public final class Sort {
 
             } catch (BError error) {
                 throw ErrorCreator.createError(getModulePrefixedReason(ARRAY_LANG_LIB, INVALID_TYPE_TO_SORT),
-                        (BMap) error.getDetails());
+                        (BMap<BString, Object>) error.getDetails());
             }
         }
     }

--- a/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/Detail.java
+++ b/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/Detail.java
@@ -35,7 +35,7 @@ public final class Detail {
     private Detail() {
     }
 
-    public static BMap detail(BError value) {
-        return (BMap) value.getDetails();
+    public static BMap<?, ?> detail(BError value) {
+        return (BMap<?, ?>) value.getDetails();
     }
 }

--- a/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/StackTrace.java
+++ b/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/StackTrace.java
@@ -182,7 +182,7 @@ public final class StackTrace {
         }
 
         @Override
-        public BMap getMapValue(BString fieldName) {
+        public BMap<BString, ? extends Object> getMapValue(BString fieldName) {
             return null;
         }
 

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Filter.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Filter.java
@@ -53,7 +53,7 @@ public final class Filter {
     private Filter() {
     }
 
-    public static BMap filter(BMap<?, ?> m, BFunctionPointer<Object, Boolean> func) {
+    public static BMap<?, ?> filter(BMap<?, ?> m, BFunctionPointer<Object[], Boolean> func) {
         Type mapType = TypeUtils.getImpliedType(m.getType());
         Type constraint = switch (mapType.getTag()) {
             case TypeTags.MAP_TAG -> {

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ForEach.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ForEach.java
@@ -43,7 +43,7 @@ public final class ForEach {
     private ForEach() {
     }
 
-    public static void forEach(BMap<?, ?> m, BFunctionPointer<Object, Object> func) {
+    public static void forEach(BMap<?, ?> m, BFunctionPointer<Object[], Object> func) {
         int size = m.size();
         AtomicInteger index = new AtomicInteger(-1);
         Object[] keys = m.getKeys();

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/GetIterator.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/GetIterator.java
@@ -37,7 +37,7 @@ public final class GetIterator {
     private GetIterator() {
     }
 
-    public static BIterator iterator(BMap<?, ?> map) {
+    public static BIterator<?> iterator(BMap<?, ?> map) {
         return map.getIterator();
     }
 }

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Map.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Map.java
@@ -55,7 +55,7 @@ public final class Map {
     private Map() {
     }
 
-    public static BMap map(BMap<?, ?> m, BFunctionPointer<Object, Object> func) {
+    public static BMap<BString, Object> map(BMap<?, ?> m, BFunctionPointer<Object[], Object> func) {
         MapType newMapType = TypeCreator.createMapType(
                 ((FunctionType) TypeUtils.getImpliedType(func.getType())).getReturnType());
         BMap<BString, Object> newMap = ValueCreator.createMapValue(newMapType);

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Next.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Next.java
@@ -45,8 +45,8 @@ public final class Next {
 
     //TODO: refactor hard coded values
     public static Object next(BObject m) {
-        BIterator mapIterator = (BIterator) m.getNativeData("&iterator&");
-        BMap bMap = (BMap) m.get(StringUtils.fromString("m"));
+        BIterator<?> mapIterator = (BIterator<?>) m.getNativeData("&iterator&");
+        BMap<?, ?> bMap = (BMap<?, ?>) m.get(StringUtils.fromString("m"));
         if (mapIterator == null) {
             mapIterator = bMap.getIterator();
             m.addNativeData("&iterator&", mapIterator);

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Reduce.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Reduce.java
@@ -41,7 +41,7 @@ public final class Reduce {
     private static final StrandMetadata METADATA = new StrandMetadata(BALLERINA_BUILTIN_PKG_PREFIX, MAP_LANG_LIB,
                                                                       MAP_VERSION, "reduce");
 
-    public static Object reduce(BMap<?, ?> m, BFunctionPointer<Object, Object> func, Object initial) {
+    public static Object reduce(BMap<?, ?> m, BFunctionPointer<Object[], Object> func, Object initial) {
         int size = m.values().size();
         AtomicReference<Object> accum = new AtomicReference<>(initial);
         AtomicInteger index = new AtomicInteger(-1);

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ToArray.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ToArray.java
@@ -59,7 +59,7 @@ public final class ToArray {
             default -> throw createOpNotSupportedError(mapType, "toArray()");
         };
 
-        Collection values = m.values();
+        Collection<?> values = m.values();
         int size = values.size();
         int i = 0;
         switch (TypeUtils.getImpliedType(arrElemType).getTag()) {

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/util/MapLibUtils.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/util/MapLibUtils.java
@@ -76,7 +76,7 @@ public final class MapLibUtils {
         return typeSet.size() == 1 ? typeSet.iterator().next() : TypeCreator.createUnionType(new ArrayList<>(typeSet));
     }
 
-    public static void validateRecord(BMap m) {
+    public static void validateRecord(BMap<?, ?> m) {
         Type type = TypeUtils.getImpliedType(m.getType());
         if (type.getTag() != TypeTags.RECORD_TYPE_TAG) {
             return;
@@ -102,7 +102,7 @@ public final class MapLibUtils {
                         ErrorCodes.FIELD_REMOVAL_NOT_ALLOWED, field, type.getQualifiedName()));
     }
 
-    public static void validateRequiredFieldForRecord(BMap m, String k) {
+    public static void validateRequiredFieldForRecord(BMap<?, ?> m, String k) {
         Type type = TypeUtils.getImpliedType(m.getType());
         if (type.getTag() == TypeTags.RECORD_TYPE_TAG && isRequiredField((RecordType) type, k)) {
             throw createOpNotSupportedErrorForRecord(type, k);

--- a/langlib/lang.query/src/main/java/org/ballerinalang/langlib/query/CreateImmutableType.java
+++ b/langlib/lang.query/src/main/java/org/ballerinalang/langlib/query/CreateImmutableType.java
@@ -26,19 +26,19 @@ public final class CreateImmutableType {
         value.freezeDirect();
     }
 
-    public static BTable createImmutableTable(BTable tbl, BArray arr) {
+    public static BTable<?, ?> createImmutableTable(BTable<?, ?> tbl, BArray arr) {
         Type type =  tbl.getType();
         TableType tableType = (TableType) TypeUtils.getImpliedType(type);
-        BTable immutableTable = new TableValueImpl(type,
+        BTable<?, ?> immutableTable = new TableValueImpl<>(type,
                 new ArrayValueImpl(arr.getValues(), (ArrayType) TypeUtils.getImpliedType(arr.getType())),
                 new ArrayValueImpl(tableType.getFieldNames(), true));
         immutableTable.freezeDirect();
         return immutableTable;
     }
 
-    public static BTable createTableWithKeySpecifier(BTable immutableTable, BTypedesc tableType) {
+    public static BTable<?, ?> createTableWithKeySpecifier(BTable<?, ?> immutableTable, BTypedesc tableType) {
         TableType type = (TableType) TypeUtils.getImpliedType(tableType.getDescribingType());
-        BTable tbl = new TableValueImpl(type,
+        BTable<?, ?> tbl = new TableValueImpl<>(type,
                 new ArrayValueImpl(((TableType) TypeUtils.getImpliedType(immutableTable.getType())).getFieldNames(),
                         false));
         return tbl;

--- a/langlib/lang.runtime/src/main/java/org/ballerinalang/langlib/runtime/Registry.java
+++ b/langlib/lang.runtime/src/main/java/org/ballerinalang/langlib/runtime/Registry.java
@@ -38,7 +38,7 @@ public final class Registry {
         env.getRuntime().deregisterListener(listener);
     }
 
-    public static void onGracefulStop(Environment env, BFunctionPointer<?, ?> stopHandler) {
+    public static void onGracefulStop(Environment env, BFunctionPointer<Object[], Object> stopHandler) {
         env.getRuntime().registerStopHandler(stopHandler);
     }
 

--- a/langlib/lang.string/src/main/java/org/ballerinalang/langlib/string/Next.java
+++ b/langlib/lang.string/src/main/java/org/ballerinalang/langlib/string/Next.java
@@ -37,7 +37,7 @@ public final class Next {
 
     //TODO: refactor hard coded values
     public static Object next(BObject stringObject) {
-        BIterator charIterator = (BIterator) stringObject.getNativeData("&iterator&");
+        BIterator<String> charIterator = (BIterator<String>) stringObject.getNativeData("&iterator&");
         if (charIterator == null) {
             BString bString = ((BString) stringObject.get(StringUtils.fromString("m")));
             charIterator = bString.getIterator();

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Add.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Add.java
@@ -37,11 +37,11 @@ public final class Add {
     private Add() {
     }
 
-    public static void add(BTable tbl, BMap val) {
+    public static void add(BTable<?, Object> tbl, BMap<?, ?> val) {
         tbl.add(val);
     }
 
-    public static void add_bstring(Strand strand, BTable tbl, BMap val) {
+    public static void add_bstring(Strand strand, BTable<?, Object> tbl, BMap<?, ?> val) {
         add(tbl, val);
     }
 }

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Filter.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Filter.java
@@ -53,9 +53,9 @@ public final class Filter {
     private Filter() {
     }
 
-    public static BTable filter(BTable tbl, BFunctionPointer<Object, Boolean> func) {
+    public static BTable<Object, Object> filter(BTable<?, ?> tbl, BFunctionPointer<Object[], Boolean> func) {
         TableType tableType = (TableType) TypeUtils.getImpliedType(tbl.getType());
-        BTable newTable =
+        BTable<Object, Object> newTable = (BTable<Object, Object>)
                 ValueCreator.createTableValue(TypeCreator.createTableType(tableType.getConstrainedType(),
                         tableType.getFieldNames(), false));
         int size = tbl.size();

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Foreach.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Foreach.java
@@ -48,7 +48,7 @@ public final class Foreach {
     private Foreach() {
     }
 
-    public static void forEach(BTable tbl, BFunctionPointer<Object, Object> func) {
+    public static void forEach(BTable<?, ?> tbl, BFunctionPointer<Object[], Object> func) {
         int size = tbl.size();
         AtomicInteger index = new AtomicInteger(-1);
         Object[] values = tbl.values().toArray();

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Get.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Get.java
@@ -37,7 +37,7 @@ public final class Get {
     private Get() {
     }
 
-    public static BMap get(BTable tbl, Object key) {
-        return (BMap) tbl.getOrThrow(key);
+    public static BMap<?, ?> get(BTable<?, ?> tbl, Object key) {
+        return (BMap<?, ?>) tbl.getOrThrow(key);
     }
 }

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/GetIterator.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/GetIterator.java
@@ -37,7 +37,7 @@ public final class GetIterator {
     private GetIterator() {
     }
 
-    public static BIterator iterator(BTable tbl) {
+    public static BIterator<?> iterator(BTable<?, ?> tbl) {
         return tbl.getIterator();
     }
 }

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/GetKeys.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/GetKeys.java
@@ -44,7 +44,7 @@ public final class GetKeys {
     private GetKeys() {
     }
 
-    public static BArray keys(BTable tbl) {
+    public static BArray keys(BTable<?, ?> tbl) {
         Type tableKeyType = tbl.getKeyType();
         Object[] keys = tbl.getKeys();
         switch (tableKeyType.getTag()) {

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/HasKey.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/HasKey.java
@@ -38,7 +38,7 @@ public final class HasKey {
     }
 
     @Deprecated
-    public static boolean hasKey(BTable tbl, Object key) {
+    public static boolean hasKey(BTable<?, ?> tbl, Object key) {
         return tbl.containsKey(key);
     }
 }

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Length.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Length.java
@@ -37,10 +37,10 @@ public final class Length {
     private Length() {
     }
 
-    public static long length(BTable tbl) {
+    public static long length(BTable<?, ?> tbl) {
         return tbl.size();
     }
-    public static long length_bstring(Strand strand, BTable tbl) {
+    public static long length_bstring(Strand strand, BTable<?, ?> tbl) {
         return length(tbl);
     }
 }

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Map.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Map.java
@@ -50,13 +50,13 @@ public final class Map {
     private Map() {
     }
 
-    public static BTable map(BTable tbl, BFunctionPointer<Object, Object> func) {
+    public static BTable<?, ?> map(BTable<?, ?> tbl, BFunctionPointer<Object[], Object> func) {
         Type newConstraintType = ((FunctionType) TypeUtils.getImpliedType(func.getType())).getReturnType();
         TableType tblType = (TableType) TypeUtils.getImpliedType(tbl.getType());
         TableType newTableType =
                 TypeCreator.createTableType(newConstraintType, PredefinedTypes.TYPE_NEVER, tblType.isReadOnly());
 
-        BTable newTable = ValueCreator.createTableValue(newTableType);
+        BTable<Object, Object> newTable = (BTable<Object, Object>) ValueCreator.createTableValue(newTableType);
         int size = tbl.size();
         Object[] tableValues = tbl.values().toArray();
         AtomicInteger index = new AtomicInteger(-1);

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Next.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Next.java
@@ -52,8 +52,8 @@ public final class Next {
 
     //TODO: refactor hard coded values
     public static Object next(BObject t) {
-        BIterator tableIterator = (BIterator) t.getNativeData("&iterator&");
-        BTable table = (BTable) t.get(StringUtils.fromString("t"));
+        BIterator<?> tableIterator = (BIterator<?>) t.getNativeData("&iterator&");
+        BTable<?, ?> table = (BTable<?, ?>) t.get(StringUtils.fromString("t"));
         BArray keys = (BArray) t.get(StringUtils.fromString("keys"));
         long initialSize = (long) t.get(StringUtils.fromString("size"));
         if (tableIterator == null) {
@@ -76,7 +76,7 @@ public final class Next {
         return null;
     }
 
-    private static void handleMutation(BTable table, BArray keys,
+    private static void handleMutation(BTable<?, ?> table, BArray keys,
                                        List<Object> returnedKeys, long initialSize) {
         if (initialSize < table.size() ||
                 // Key-less situation, mutation can occur only by calling add() or removeAll()

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/NextKey.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/NextKey.java
@@ -31,7 +31,7 @@ public final class NextKey {
     private NextKey() {
     }
 
-    public static long nextKey(BTable tbl) {
+    public static long nextKey(BTable<?, ?> tbl) {
         return tbl.getNextKey();
     }
 }

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Put.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Put.java
@@ -37,11 +37,11 @@ public final class Put {
     private Put() {
     }
 
-    public static void put(BTable tbl, BMap val) {
+    public static void put(BTable<Object, Object> tbl, BMap<?, ?> val) {
         tbl.put(val);
     }
 
-    public static void put_bstring(Strand strand, BTable tbl, BMap val) {
+    public static void put_bstring(Strand strand, BTable<Object, Object> tbl, BMap<?, ?> val) {
         put(tbl, val);
     }
 }

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Reduce.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Reduce.java
@@ -51,7 +51,7 @@ public final class Reduce {
     private Reduce() {
     }
 
-    public static Object reduce(BTable tbl, BFunctionPointer<Object, Object> func, Object initial) {
+    public static Object reduce(BTable<?, ?> tbl, BFunctionPointer<Object[], Object> func, Object initial) {
         int size = tbl.values().size();
         AtomicReference<Object> accum = new AtomicReference<>(initial);
         AtomicInteger index = new AtomicInteger(-1);

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Remove.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Remove.java
@@ -37,7 +37,7 @@ public final class Remove {
     private Remove() {
     }
 
-    public static BMap remove(BTable tbl, Object key) {
-        return (BMap) tbl.removeOrThrow(key);
+    public static BMap<?, ?> remove(BTable<?, ?> tbl, Object key) {
+        return (BMap<?, ?>) tbl.removeOrThrow(key);
     }
 }

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/RemoveAll.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/RemoveAll.java
@@ -36,7 +36,7 @@ public final class RemoveAll {
     private RemoveAll() {
     }
 
-    public static void removeAll(BTable tbl) {
+    public static void removeAll(BTable<?, ?> tbl) {
         try {
             tbl.clear();
         } catch (BError e) {

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/RemoveIfHasKey.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/RemoveIfHasKey.java
@@ -36,7 +36,7 @@ public final class RemoveIfHasKey {
     private RemoveIfHasKey() {
     }
 
-    public static Object removeIfHasKey(BTable tbl, Object key) {
+    public static Object removeIfHasKey(BTable<?, ?> tbl, Object key) {
         return tbl.remove(key);
     }
 }

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/ToArray.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/ToArray.java
@@ -45,10 +45,10 @@ public final class ToArray {
     private ToArray() {
     }
 
-    public static BArray toArray(BTable tbl) {
+    public static BArray toArray(BTable<?, ?> tbl) {
         Type constrainedType = ((TableType) TypeUtils.getImpliedType(tbl.getType())).getConstrainedType();
 
-        Collection values = tbl.values();
+        Collection<?> values = tbl.values();
         //Basic constrain types not applicable for table type
         return ValueCreator.createArrayValue(values.toArray(), TypeCreator.createArrayType(constrainedType));
     }

--- a/langlib/lang.transaction/src/main/java/org/ballerinalang/langlib/transaction/OnCommit.java
+++ b/langlib/lang.transaction/src/main/java/org/ballerinalang/langlib/transaction/OnCommit.java
@@ -33,7 +33,7 @@ public final class OnCommit {
     private OnCommit() {
     }
 
-    public static void onCommit(BFunctionPointer bFunctionPointer) {
+    public static void onCommit(BFunctionPointer<?, ?> bFunctionPointer) {
         TransactionLocalContext transactionLocalContext = Scheduler.getStrand().currentTrxContext;
         TransactionResourceManager transactionResourceManager = TransactionResourceManager.getInstance();
         transactionResourceManager.registerCommittedFunction(transactionLocalContext.getGlobalTransactionId(),

--- a/langlib/lang.transaction/src/main/java/org/ballerinalang/langlib/transaction/OnRollback.java
+++ b/langlib/lang.transaction/src/main/java/org/ballerinalang/langlib/transaction/OnRollback.java
@@ -33,7 +33,7 @@ public final class OnRollback {
     private OnRollback() {
     }
 
-    public static void onRollback(BFunctionPointer bFunctionPointer) {
+    public static void onRollback(BFunctionPointer<?, ?> bFunctionPointer) {
         TransactionLocalContext transactionLocalContext = Scheduler.getStrand().currentTrxContext;
         TransactionResourceManager transactionResourceManager = TransactionResourceManager.getInstance();
         transactionResourceManager.registerAbortedFunction(transactionLocalContext.getGlobalTransactionId(),

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Elements.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Elements.java
@@ -60,7 +60,7 @@ public final class Elements {
 
     private static BXml generateCodePointSequence(BXml value) {
         List<BXml> list = new ArrayList<>();
-        BIterator bIterator = value.getIterator();
+        BIterator<?> bIterator = value.getIterator();
         while (bIterator.hasNext()) {
             list.add((BXml) bIterator.next());
         }

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Filter.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Filter.java
@@ -54,7 +54,7 @@ public final class Filter {
     private Filter() {
     }
 
-    public static BXml filter(BXml x, BFunctionPointer<Object, Boolean> func) {
+    public static BXml filter(BXml x, BFunctionPointer<Object[], Boolean> func) {
         if (x.isSingleton()) {
             Object[] args = new Object[]{x, true};
             func.asyncCall(args,

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/ForEach.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/ForEach.java
@@ -43,7 +43,7 @@ public final class ForEach {
     private ForEach() {
     }
 
-    public static void forEach(BXml x, BFunctionPointer<Object, Object> func) {
+    public static void forEach(BXml x, BFunctionPointer<Object[], Object> func) {
         if (x.isSingleton()) {
             func.asyncCall(new Object[]{x, true}, METADATA);
             return;

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Map.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Map.java
@@ -54,7 +54,7 @@ public final class Map {
     private Map() {
     }
 
-    public static BXml map(BXml x, BFunctionPointer<Object, Object> func) {
+    public static BXml map(BXml x, BFunctionPointer<Object[], Object> func) {
         if (x.isSingleton()) {
             func.asyncCall(new Object[]{x, true}, METADATA);
             return null;

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Next.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Next.java
@@ -45,7 +45,7 @@ public final class Next {
 
     //TODO: refactor hard coded values
     public static Object next(BObject m) {
-        BIterator xmlIterator = (BIterator) m.getNativeData("&iterator&");
+        BIterator<?> xmlIterator = (BIterator<?>) m.getNativeData("&iterator&");
         BXml bXml = (BXml) m.get(StringUtils.fromString("m"));
 
         if (xmlIterator == null) {

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibMapTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibMapTest.java
@@ -85,7 +85,7 @@ public class LangLibMapTest {
         Object returns = BRunUtil.invoke(compileResult, "testEntries");
         assertEquals(getType(returns).getTag(), TypeTags.MAP_TAG);
 
-        BMap map = (BMap) returns;
+        BMap<?, ?> map = (BMap<?, ?>) returns;
         assertEquals(((BMapType) map.getType()).getConstrainedType().getTag(), TypeTags.TUPLE_TAG);
         assertEquals(map.size(), 3);
         assertEquals(map.get(StringUtils.fromString("lk")).toString(), "[\"lk\",\"Sri Lanka\"]");
@@ -100,7 +100,7 @@ public class LangLibMapTest {
         assertEquals(result.get(0).toString(), "United Kingdom");
         assertEquals(getType(result.get(1)).getTag(), TypeTags.MAP_TAG);
 
-        BMap map = (BMap) result.get(1);
+        BMap<?, ?> map = (BMap<?, ?>) result.get(1);
         assertEquals(map.size(), 2);
         assertEquals(map.get(StringUtils.fromString("lk")).toString(), "Sri Lanka");
         assertEquals(map.get(StringUtils.fromString("us")).toString(), "USA");
@@ -118,7 +118,7 @@ public class LangLibMapTest {
         Object returns = BRunUtil.invoke(compileResult, "testRemoveAll");
         assertEquals(getType(returns).getTag(), TypeTags.MAP_TAG);
         assertEquals(returns.toString(), "{}");
-        assertEquals(((BMap) returns).size(), 0);
+        assertEquals(((BMap<?, ?>) returns).size(), 0);
     }
 
     @Test(dataProvider = "mapKeyProvider")
@@ -147,7 +147,7 @@ public class LangLibMapTest {
         Object returns = BRunUtil.invoke(compileResult, "testMap");
         assertEquals(getType(returns).getTag(), TypeTags.MAP_TAG);
 
-        BMap map = (BMap) returns;
+        BMap<?, ?> map = (BMap<?, ?>) returns;
         assertEquals(((BMapType) map.getType()).getConstrainedType().getTag(), TypeTags.FLOAT_TAG);
         assertEquals(map.size(), 3);
         assertEquals(map.get(StringUtils.fromString("1")), 5.5d);
@@ -166,7 +166,7 @@ public class LangLibMapTest {
         Object returns = BRunUtil.invoke(compileResult, "testFilter");
         assertEquals(getType(returns).getTag(), TypeTags.MAP_TAG);
 
-        BMap map = (BMap) returns;
+        BMap<?, ?> map = (BMap<?, ?>) returns;
         assertEquals(((BMapType) map.getType()).getConstrainedType().getTag(), TypeTags.DECIMAL_TAG);
         assertEquals(map.size(), 2);
         assertEquals(map.get(StringUtils.fromString("1")), ValueCreator.createDecimalValue("12.34"));
@@ -186,8 +186,8 @@ public class LangLibMapTest {
         assertTrue(arr.get(0) instanceof Long);
         assertTrue(arr.get(1) instanceof BMap);
         assertEquals(arr.get(0), 118L);
-        assertEquals(((BMap) arr.get(1)).get(StringUtils.fromString("b")), 36L);
-        assertEquals(((BMap) arr.get(1)).get(StringUtils.fromString("c")), 78L);
+        assertEquals(((BMap<?, ?>) arr.get(1)).get(StringUtils.fromString("b")), 36L);
+        assertEquals(((BMap<?, ?>) arr.get(1)).get(StringUtils.fromString("c")), 78L);
     }
 
     @DataProvider(name = "mapKeyProvider")

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRecordTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRecordTest.java
@@ -87,7 +87,7 @@ public class LangLibRecordTest {
         Object returns = BRunUtil.invoke(compileResult, "testEntries");
         assertEquals(getType(returns).getTag(), TypeTags.MAP_TAG);
 
-        BMap map = (BMap) returns;
+        BMap<?, ?> map = (BMap<?, ?>) returns;
         assertEquals(((BMapType) map.getType()).getConstrainedType().getTag(), TypeTags.TUPLE_TAG);
         assertEquals(map.size(), 2);
         assertEquals(map.get(StringUtils.fromString("name")).toString(), "[\"name\",\"John Doe\"]");
@@ -142,7 +142,7 @@ public class LangLibRecordTest {
         Object returns = BRunUtil.invoke(compileResult, "testMap");
         assertEquals(getType(returns).getTag(), TypeTags.MAP_TAG);
 
-        BMap map = (BMap) returns;
+        BMap<?, ?> map = (BMap<?, ?>) returns;
         assertEquals(((BMapType) map.getType()).getConstrainedType().getTag(), TypeTags.INT_TAG);
         assertEquals(map.size(), 2);
         assertEquals(map.get(StringUtils.fromString("name")), 8L);
@@ -160,7 +160,7 @@ public class LangLibRecordTest {
         Object returns = BRunUtil.invoke(compileResult, "testFilter");
         assertEquals(getType(returns).getTag(), TypeTags.MAP_TAG);
 
-        BMap map = (BMap) returns;
+        BMap<?, ?> map = (BMap<?, ?>) returns;
         assertEquals(((BMapType) map.getType()).getConstrainedType().getTag(), TypeTags.INT_TAG);
         assertEquals(map.size(), 2);
         assertEquals(map.get(StringUtils.fromString("physics")), 75L);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -17,6 +17,7 @@ package org.ballerinalang.langserver;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 import io.ballerina.projects.util.ProjectConstants;
 import org.ballerinalang.langserver.command.LSCommandExecutorProvidersHolder;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
@@ -115,15 +116,18 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
         final InitializeResult res = new InitializeResult(new ServerCapabilities());
         res.getCapabilities().setTextDocumentSync(TextDocumentSyncKind.Full);
 
-        Map experimentalClientCapabilities = null;
+        Map<String, Object> experimentalClientCapabilities = null;
         if (params.getCapabilities().getExperimental() != null) {
             experimentalClientCapabilities = new Gson().fromJson(params.getCapabilities().getExperimental().toString(),
-                    HashMap.class);
+                    new TypeToken<>() {
+            });
         }
 
-        Map initializationOptions = null;
+        Map<String, Object> initializationOptions = null;
         if (params.getInitializationOptions() != null) {
-            initializationOptions = new Gson().fromJson(params.getInitializationOptions().toString(), HashMap.class);
+            initializationOptions = new Gson().fromJson(params.getInitializationOptions().toString(),
+                    new TypeToken<>() {
+            });
         }
 
         TextDocumentClientCapabilities textDocClientCapabilities = params.getCapabilities().getTextDocument();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/CentralPackageDescriptorLoader.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/CentralPackageDescriptorLoader.java
@@ -146,7 +146,7 @@ public class CentralPackageDescriptorLoader {
         }
 
         public Map<String, String> getQueryMap() {
-            Map<String, String> params = new HashMap();
+            Map<String, String> params = new HashMap<>();
             params.put("readme", "false");
 
             if (getOrganization() != null) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/ExtendedClientCapabilityBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/ExtendedClientCapabilityBuilder.java
@@ -47,6 +47,7 @@ public final class ExtendedClientCapabilityBuilder {
         if (capabilitySetters == null) {
             capabilitySetters = new ArrayList<>();
 
+            @SuppressWarnings("rawtypes")
             ServiceLoader<BallerinaClientCapabilitySetter> loader
                     = ServiceLoader.load(BallerinaClientCapabilitySetter.class);
             for (BallerinaClientCapabilitySetter<?> capabilitySetter : loader) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/ExtendedServerCapabilityBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/ExtendedServerCapabilityBuilder.java
@@ -44,6 +44,7 @@ public final class ExtendedServerCapabilityBuilder {
         if (capabilitySetters == null) {
             capabilitySetters = new ArrayList<>();
 
+            @SuppressWarnings("rawtypes")
             ServiceLoader<BallerinaServerCapabilitySetter> loader
                     = ServiceLoader.load(BallerinaServerCapabilitySetter.class);
             for (BallerinaServerCapabilitySetter<?> capabilitySetter : loader) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
@@ -44,8 +44,8 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
 
     LSClientCapabilitiesImpl(TextDocumentClientCapabilities textDocCapabilities,
                              WorkspaceClientCapabilities workspaceCapabilities,
-                             Map experimentalClientCapabilities,
-                             Map initializationOptionsMap) {
+                             Map<String, Object> experimentalClientCapabilities,
+                             Map<String, Object> initializationOptionsMap) {
         this.textDocCapabilities = (textDocCapabilities != null) ?
                 textDocCapabilities : new TextDocumentClientCapabilities();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/ProviderFactory.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/ProviderFactory.java
@@ -34,6 +34,7 @@ public class ProviderFactory {
     private static final ProviderFactory INSTANCE = new ProviderFactory();
 
     private ProviderFactory() {
+        @SuppressWarnings("rawtypes")
         ServiceLoader<BallerinaCompletionProvider> providerServices =
                 ServiceLoader.load(BallerinaCompletionProvider.class);
         for (BallerinaCompletionProvider<Node> provider : providerServices) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FunctionSignatureNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FunctionSignatureNodeContext.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver.completions.providers.context;
 import io.ballerina.compiler.syntax.tree.FunctionSignatureNode;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.ReturnTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.annotation.JavaSPIService;
@@ -33,6 +34,7 @@ import org.ballerinalang.langserver.completions.util.SortingUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Completion provider for {@link FunctionSignatureNode} context.
@@ -52,7 +54,7 @@ public class FunctionSignatureNodeContext extends AbstractCompletionProvider<Fun
         List<LSCompletionItem> completionItems = new ArrayList<>();
 
         if (withinReturnTypeDescContext(context, node)) {
-            var returnTypeDesc = node.returnTypeDesc();
+            Optional<ReturnTypeDescriptorNode> returnTypeDesc = node.returnTypeDesc();
             if (returnTypeDesc.isEmpty() || returnTypeDesc.get().returnsKeyword().isMissing()) {
                 /*
                 Covers the following cases.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorListRequest.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorListRequest.java
@@ -175,7 +175,7 @@ public class BallerinaConnectorListRequest {
     }
 
     public Map<String, String> getQueryMap() {
-        Map<String, String> params = new HashMap();
+        Map<String, String> params = new HashMap<>();
 
         if (getQuery() != null) {
             params.put("q", getQuery());

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AbstractCommandExecutionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AbstractCommandExecutionTest.java
@@ -112,16 +112,16 @@ public abstract class AbstractCommandExecutionTest {
         TestUtil.shutdownLanguageServer(this.serviceEndpoint);
     }
 
-    private List argsToJson(List<Object> args) {
-        List<JsonObject> jsonArgs = new ArrayList<>();
+    private List<Object> argsToJson(List<Object> args) {
+        List<Object> jsonArgs = new ArrayList<>();
         for (Object arg : args) {
-            jsonArgs.add((JsonObject) gson.toJsonTree(arg));
+            jsonArgs.add(gson.toJsonTree(arg));
         }
         return jsonArgs;
     }
 
     private JsonObject getCommandResponse(List<Object> args, String command) {
-        List argsList = argsToJson(args);
+        List<Object> argsList = argsToJson(args);
         ExecuteCommandParams params = new ExecuteCommandParams(command, argsList);
         String response = TestUtil.getExecuteCommandResponse(params, this.serviceEndpoint).replace("\\r\\n", "\\n");
         JsonObject responseJson = JsonParser.parseString(response).getAsJsonObject();

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/PullModuleExecutorTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/PullModuleExecutorTest.java
@@ -123,7 +123,7 @@ public class PullModuleExecutorTest {
     }
 
     private JsonObject getCommandResponse(List<Object> args, String command) {
-        List argsList = argsToJson(args);
+        List<Object> argsList = argsToJson(args);
         ExecuteCommandParams params = new ExecuteCommandParams(command, argsList);
         String response = TestUtil.getExecuteCommandResponse(params, this.serviceEndpoint)
                 .replace("\\r\\n", "\\n");
@@ -132,10 +132,10 @@ public class PullModuleExecutorTest {
         return responseJson;
     }
 
-    private List argsToJson(List<Object> args) {
-        List<JsonObject> jsonArgs = new ArrayList<>();
+    private List<Object> argsToJson(List<Object> args) {
+        List<Object> jsonArgs = new ArrayList<>();
         for (Object arg : args) {
-            jsonArgs.add((JsonObject) gson.toJsonTree(arg));
+            jsonArgs.add(gson.toJsonTree(arg));
         }
         return jsonArgs;
     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/LSExtensionTestUtil.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/LSExtensionTestUtil.java
@@ -93,7 +93,7 @@ public final class LSExtensionTestUtil {
                                                                               Endpoint serviceEndpoint) {
         BallerinaSyntaxTreeModifyRequest astModifyRequest = new BallerinaSyntaxTreeModifyRequest(
                 TestUtil.getTextDocumentIdentifier(filePath), astModifications);
-        CompletableFuture result = serviceEndpoint.request(SYNTAX_TREE_MODIFY, astModifyRequest);
+        CompletableFuture<?> result = serviceEndpoint.request(SYNTAX_TREE_MODIFY, astModifyRequest);
         return GSON.fromJson(getResult(result), BallerinaSyntaxTreeResponse.class);
     }
 
@@ -107,7 +107,7 @@ public final class LSExtensionTestUtil {
     public static BallerinaSyntaxTreeResponse getBallerinaSyntaxTree(String filePath, Endpoint serviceEndpoint) {
         BallerinaSyntaxTreeRequest astRequest = new BallerinaSyntaxTreeRequest(
                 TestUtil.getTextDocumentIdentifier(filePath));
-        CompletableFuture result = serviceEndpoint.request(AST, astRequest);
+        CompletableFuture<?> result = serviceEndpoint.request(AST, astRequest);
         return GSON.fromJson(getResult(result), BallerinaSyntaxTreeResponse.class);
     }
 
@@ -125,7 +125,7 @@ public final class LSExtensionTestUtil {
         BallerinaSyntaxTreeByRangeRequest request = new BallerinaSyntaxTreeByRangeRequest();
         request.setDocumentIdentifier(TestUtil.getTextDocumentIdentifier(filePath));
         request.setLineRange(range);
-        CompletableFuture result = serviceEndpoint.request(SYNTAX_TREE_BY_RANGE, request);
+        CompletableFuture<?> result = serviceEndpoint.request(SYNTAX_TREE_BY_RANGE, request);
         return GSON.fromJson(getResult(result), BallerinaSyntaxTreeResponse.class);
     }
 
@@ -142,7 +142,7 @@ public final class LSExtensionTestUtil {
                                                                            Endpoint serviceEndpoint) {
         BallerinaSyntaxTreeByRangeRequest request = new BallerinaSyntaxTreeByRangeRequest(
                 TestUtil.getTextDocumentIdentifier(filePath), range);
-        CompletableFuture result = serviceEndpoint.request(SYNTAX_TREE_LOCATE, request);
+        CompletableFuture<?> result = serviceEndpoint.request(SYNTAX_TREE_LOCATE, request);
         return GSON.fromJson(getResult(result), BallerinaSyntaxTreeResponse.class);
     }
 
@@ -176,23 +176,23 @@ public final class LSExtensionTestUtil {
         BallerinaSyntaxTreeByNameRequest request = new BallerinaSyntaxTreeByNameRequest();
         request.setDocumentIdentifier(TestUtil.getTextDocumentIdentifier(filePath));
         request.setLineRange(range);
-        CompletableFuture result = serviceEndpoint.request(SYNTAX_TREE_BY_NAME, request);
+        CompletableFuture<?> result = serviceEndpoint.request(SYNTAX_TREE_BY_NAME, request);
         return GSON.fromJson(getResult(result), BallerinaSyntaxTreeResponse.class);
     }
 
-    private static JsonObject getResult(CompletableFuture result) {
+    private static JsonObject getResult(CompletableFuture<?> result) {
         return JsonParser.parseString(TestUtil.getResponseString(result)).getAsJsonObject().getAsJsonObject("result");
     }
 
     public static BallerinaConnectorListResponse getConnectors(BallerinaConnectorListRequest request,
                                                                Endpoint serviceEndpoint) {
-        CompletableFuture result = serviceEndpoint.request(GET_CONNECTORS, request);
+        CompletableFuture<?> result = serviceEndpoint.request(GET_CONNECTORS, request);
         return GSON.fromJson(getResult(result), BallerinaConnectorListResponse.class);
     }
 
     public static JsonObject getConnectorById(String id, Endpoint serviceEndpoint) {
         BallerinaConnectorRequest connectorRequest = new BallerinaConnectorRequest(id);
-        CompletableFuture result = serviceEndpoint.request(GET_CONNECTOR, connectorRequest);
+        CompletableFuture<?> result = serviceEndpoint.request(GET_CONNECTOR, connectorRequest);
         return getResult(result);
     }
 
@@ -207,7 +207,7 @@ public final class LSExtensionTestUtil {
                                                String name, Endpoint serviceEndpoint) {
         BallerinaConnectorRequest connectorRequest = new BallerinaConnectorRequest(org, packageName, module,
                 version, name);
-        CompletableFuture result = serviceEndpoint.request(GET_CONNECTOR, connectorRequest);
+        CompletableFuture<?> result = serviceEndpoint.request(GET_CONNECTOR, connectorRequest);
         return getResult(result);
     }
 
@@ -232,7 +232,7 @@ public final class LSExtensionTestUtil {
         SymbolInfoRequest symbolInfoRequest = new SymbolInfoRequest();
         symbolInfoRequest.setPosition(position);
         symbolInfoRequest.setTextDocumentIdentifier(TestUtil.getTextDocumentIdentifier(filePath));
-        CompletableFuture result = serviceEndpoint.request(GET_SYMBOL, symbolInfoRequest);
+        CompletableFuture<?> result = serviceEndpoint.request(GET_SYMBOL, symbolInfoRequest);
         return GSON.fromJson(getResult(result), SymbolInfoResponse.class);
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
@@ -71,7 +71,7 @@ public class FormattingTest {
         String result = TestUtil.getFormattingResponse(documentFormattingParams, this.serviceEndpoint);
         Gson gson = new Gson();
         ResponseMessage responseMessage = gson.fromJson(result, ResponseMessage.class);
-        String actual = (String) ((LinkedTreeMap) ((List) responseMessage.getResult()).get(0)).get("newText");
+        String actual = (String) ((LinkedTreeMap<?, ?>) ((List<?>) responseMessage.getResult()).get(0)).get("newText");
         actual = actual.replaceAll("\\r\\n", "\n");
         TestUtil.closeDocument(this.serviceEndpoint, inputFilePath);
         Assert.assertEquals(actual, expected);
@@ -101,7 +101,7 @@ public class FormattingTest {
         String result = TestUtil.getFormattingResponse(documentFormattingParams, this.serviceEndpoint);
         Gson gson = new Gson();
         ResponseMessage responseMessage = gson.fromJson(result, ResponseMessage.class);
-        String actual = (String) ((LinkedTreeMap) ((List) responseMessage.getResult()).get(0)).get("newText");
+        String actual = (String) ((LinkedTreeMap<?, ?>) ((List<?>) responseMessage.getResult()).get(0)).get("newText");
         actual = actual.replaceAll("\\r\\n", "\n");
         TestUtil.closeDocument(this.serviceEndpoint, inputFilePath);
         Assert.assertEquals(actual, expected);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rangeformat/RangeFormattingTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rangeformat/RangeFormattingTest.java
@@ -77,7 +77,7 @@ public class RangeFormattingTest {
         String result = TestUtil.getRangeFormatResponse(params, this.serviceEndpoint);
         Gson gson = new Gson();
         ResponseMessage responseMessage = gson.fromJson(result, ResponseMessage.class);
-        String actual = (String) ((LinkedTreeMap) ((List) responseMessage.getResult()).get(0)).get("newText");
+        String actual = (String) ((LinkedTreeMap<?, ?>) ((List<?>) responseMessage.getResult()).get(0)).get("newText");
         actual = actual.replaceAll("\\r\\n", "\n");
         TestUtil.closeDocument(this.serviceEndpoint, inputFilePath);
         Assert.assertEquals(actual, expected);

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindingsGenerator.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindingsGenerator.java
@@ -285,7 +285,7 @@ public class BindingsGenerator {
         for (String c : classList) {
             try {
                 if (classLoader != null) {
-                    Class classInstance = classLoader.loadClass(c);
+                    Class<?> classInstance = classLoader.loadClass(c);
                     if (classInstance != null && isPublicClass(classInstance)) {
                         JClass jClass = new JClass(classInstance, env);
                         Path filePath;

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/BFunction.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/BFunction.java
@@ -34,7 +34,7 @@ public abstract class BFunction {
     private String externalFunctionName;
     private String externalReturnType;
     private String functionName;
-    private Class declaringClass;
+    private Class<?> declaringClass;
     private List<JParameter> parameters = new LinkedList<>();
     private List<JError> throwables = new LinkedList<>();
     private boolean isStatic = true;
@@ -70,11 +70,11 @@ public abstract class BFunction {
         return functionName;
     }
 
-    public Class getDeclaringClass() {
+    public Class<?> getDeclaringClass() {
         return declaringClass;
     }
 
-    void setDeclaringClass(Class declaringClass) {
+    void setDeclaringClass(Class<?> declaringClass) {
         this.declaringClass = declaringClass;
     }
 

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JClass.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JClass.java
@@ -50,7 +50,7 @@ import static org.ballerinalang.bindgen.utils.BindgenUtils.isPublicMethod;
 public class JClass {
 
     private final BindgenEnv env;
-    private final Class currentClass;
+    private final Class<?> currentClass;
     private final String prefix;
     private final String packageName;
     private final boolean modulesFlag;
@@ -65,7 +65,7 @@ public class JClass {
     private final List<JConstructor> constructorList = new ArrayList<>();
     private final Map<String, Integer> overloadedMethods = new HashMap<>();
 
-    public JClass(Class c, BindgenEnv env) {
+    public JClass(Class<?> c, BindgenEnv env) {
         this.env = env;
         currentClass = c;
         prefix = c.getName().replace(".", "_").replace("$", "_");
@@ -74,7 +74,7 @@ public class JClass {
         shortClassName = getExceptionName(c, shortClassName);
         modulesFlag = env.getModulesFlag();
 
-        Class sClass = c.getSuperclass();
+        Class<?> sClass = c.getSuperclass();
         // Iterate until a public super class is found.
         while (sClass != null && !isPublicClass(sClass)) {
             sClass = sClass.getSuperclass();
@@ -102,7 +102,7 @@ public class JClass {
         }
     }
 
-    private String getExceptionName(Class exception, String name) {
+    private String getExceptionName(Class<?> exception, String name) {
         try {
             // Append the exception class prefix in front of bindings generated for Java exceptions.
             if (this.getClass().getClassLoader().loadClass(Exception.class.getCanonicalName())
@@ -117,7 +117,7 @@ public class JClass {
         return name;
     }
 
-    private List<Method> getMethodsAsList(Class classObject) {
+    private List<Method> getMethodsAsList(Class<?> classObject) {
         Method[] declaredMethods = classObject.getMethods();
         List<Method> classMethods = new LinkedList<>();
         for (Method m : declaredMethods) {
@@ -128,10 +128,10 @@ public class JClass {
         return classMethods;
     }
 
-    private void populateConstructors(Constructor[] constructors) {
+    private void populateConstructors(Constructor<?>[] constructors) {
         int i = 1;
         List<JConstructor> tempList = new ArrayList<>();
-        for (Constructor constructor : constructors) {
+        for (Constructor<?> constructor : constructors) {
             if (isPublicConstructor(constructor)) {
                 tempList.add(new JConstructor(constructor, env, this, null));
             }
@@ -151,7 +151,7 @@ public class JClass {
         }
     }
 
-    private void populateMethods(Class c) {
+    private void populateMethods(Class<?> c) {
         List<JMethod> tempList = sortInheritedMethods(getMethodsAsList(c), new ArrayList<>(), c);
         for (JMethod method : tempList) {
             setMethodCount(method.getJavaMethodName());
@@ -169,7 +169,7 @@ public class JClass {
     }
 
     private List<JMethod> sortInheritedMethods(List<Method> methods, List<JMethod> sortedMethods,
-                                               Class declaringClass) {
+                                               Class<?> declaringClass) {
         if (declaringClass == null) {
             return sortedMethods;
         }
@@ -189,7 +189,7 @@ public class JClass {
         return sortInheritedMethods(methods, sortedMethods, declaringClass.getSuperclass());
     }
 
-    private List<Method> getSuperClassMethods(Class superClass, List<Method> methods) {
+    private List<Method> getSuperClassMethods(Class<?> superClass, List<Method> methods) {
         if (superClass == null) {
             return methods;
         }
@@ -257,7 +257,7 @@ public class JClass {
         return overloadedMethods.get(methodName);
     }
 
-    public Class getCurrentClass() {
+    public Class<?> getCurrentClass() {
         return currentClass;
     }
 

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JConstructor.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JConstructor.java
@@ -38,11 +38,11 @@ import static org.ballerinalang.bindgen.utils.BindgenUtils.getAlias;
  */
 public class JConstructor extends BFunction  {
 
-    private Class parentClass;
+    private Class<?> parentClass;
     private String exceptionName;
     private String shortClassName;
     private String exceptionConstName;
-    private Constructor constructor;
+    private Constructor<?> constructor;
 
     private boolean returnError = false;
     private boolean hasException = false; // identifies if the Ballerina returns should have an error declared
@@ -53,7 +53,7 @@ public class JConstructor extends BFunction  {
     private StringBuilder paramTypes = new StringBuilder();
     private Set<String> importedPackages = new HashSet<>();
 
-    JConstructor(Constructor c, BindgenEnv env, JClass jClass, String constructorName) {
+    JConstructor(Constructor<?> c, BindgenEnv env, JClass jClass, String constructorName) {
         super(BFunctionKind.CONSTRUCTOR, env);
         this.constructor = c;
         parentClass = c.getDeclaringClass();
@@ -101,7 +101,7 @@ public class JConstructor extends BFunction  {
         setExternalFunctionName(parentClass.getName().replace(".", "_").replace("$", "_") + "_" + constructorName);
     }
 
-    private String getExceptionName(Class exception, String name) {
+    private String getExceptionName(Class<?> exception, String name) {
         try {
             // Append the exception class prefix in front of bindings generated for Java exceptions.
             if (this.getClass().getClassLoader().loadClass(Exception.class.getCanonicalName())
@@ -114,7 +114,7 @@ public class JConstructor extends BFunction  {
         return name;
     }
 
-    private String getPackageAlias(String shortClassName, Class objectType) {
+    private String getPackageAlias(String shortClassName, Class<?> objectType) {
         if (objectType.getPackage() != parentClass.getPackage()) {
             return objectType.getPackageName().replace(".", "") + ":" + shortClassName;
         }
@@ -169,7 +169,7 @@ public class JConstructor extends BFunction  {
         return shortClassName;
     }
 
-    public Constructor getConstructor() {
+    public Constructor<?> getConstructor() {
         return constructor;
     }
 }

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JError.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JError.java
@@ -50,7 +50,7 @@ public class JError {
         return packageName;
     }
 
-    public Class getCurrentClass() {
+    public Class<?> getCurrentClass() {
         return currentClass;
     }
 }

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JField.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JField.java
@@ -55,7 +55,7 @@ public class JField extends BFunction {
 
     JField(Field field, BFunction.BFunctionKind fieldKind, BindgenEnv env, JClass jClass) {
         super(fieldKind, env);
-        Class type = field.getType();
+        Class<?> type = field.getType();
         fieldType = getBallerinaParamType(type, env);
         isStatic = isStaticField(field);
         super.setStatic(isStatic);

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JMethod.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JMethod.java
@@ -62,7 +62,7 @@ public class JMethod extends BFunction {
     private boolean isOptionalReturnTypes;
     private String parentPrefix;
 
-    private Class parentClass;
+    private Class<?> parentClass;
     private Method method;
     private String methodName;
     private String unescapedMethodName;
@@ -77,7 +77,7 @@ public class JMethod extends BFunction {
     private final StringBuilder paramTypes = new StringBuilder();
     private final Set<String> importedPackages = new HashSet<>();
 
-    JMethod(Method m, BindgenEnv env, String parentPrefix, Class jClass, int overloaded) {
+    JMethod(Method m, BindgenEnv env, String parentPrefix, Class<?> jClass, int overloaded) {
         super(BFunctionKind.METHOD, env);
         this.env = env;
         this.parentPrefix = parentPrefix;
@@ -96,7 +96,7 @@ public class JMethod extends BFunction {
         this.isOptionalReturnTypes = env.isOptionalTypes() || env.isOptionalReturnTypes();
 
         // Set the attributes required to identify different return types.
-        Class returnTypeClass = m.getReturnType();
+        Class<?> returnTypeClass = m.getReturnType();
         if (!returnTypeClass.equals(Void.TYPE)) {
             setReturnTypeAttributes(returnTypeClass);
         }
@@ -152,7 +152,7 @@ public class JMethod extends BFunction {
         }
     }
 
-    private void setReturnTypeAttributes(Class returnTypeClass) {
+    private void setReturnTypeAttributes(Class<?> returnTypeClass) {
         hasReturn = true;
         BindgenUtils.addImportedPackage(returnTypeClass, importedPackages);
 
@@ -197,14 +197,14 @@ public class JMethod extends BFunction {
         setReturnType(returnType);
     }
 
-    private String getPackageAlias(String shortClassName, Class objectType) {
+    private String getPackageAlias(String shortClassName, Class<?> objectType) {
         if (objectType.getPackage() != parentClass.getPackage()) {
             return objectType.getPackageName().replace(".", "") + ":" + shortClassName;
         }
         return shortClassName;
     }
 
-    private String getExceptionName(Class exception, String name) {
+    private String getExceptionName(Class<?> exception, String name) {
         try {
             // Append the exception class prefix in front of bindings generated for Java exceptions.
             if (this.getClass().getClassLoader().loadClass(Exception.class.getCanonicalName())

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JParameter.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JParameter.java
@@ -47,8 +47,8 @@ public class JParameter {
     private String componentType;
     private String fieldName;
 
-    private Class parentClass;
-    private Class parameterClass;
+    private Class<?> parentClass;
+    private Class<?> parameterClass;
 
     private Boolean isObj = false;
     private Boolean isString = false;
@@ -58,7 +58,7 @@ public class JParameter {
     private Boolean isStringArray = false;
     private Boolean isPrimitiveArray = false;
 
-    JParameter(Class parameterClass, Class parentClass, BindgenEnv env) {
+    JParameter(Class<?> parameterClass, Class<?> parentClass, BindgenEnv env) {
         this.env = env;
         this.parameterClass = parameterClass;
         this.parentClass = parentClass;
@@ -118,7 +118,7 @@ public class JParameter {
         fieldName = "arg";
     }
 
-    JParameter(Parameter parameter, Class parentClass, BindgenEnv env) {
+    JParameter(Parameter parameter, Class<?> parentClass, BindgenEnv env) {
         this(parameter.getType(), parentClass, env);
         List<String> reservedWords = Arrays.asList(BALLERINA_RESERVED_WORDS);
         fieldName = parameter.getName();
@@ -127,8 +127,8 @@ public class JParameter {
         }
     }
 
-    private void setArrayAttributes(Class parameterClass) {
-        Class component = parameterClass.getComponentType();
+    private void setArrayAttributes(Class<?> parameterClass) {
+        Class<?> component = parameterClass.getComponentType();
         componentType = component.getTypeName();
         if (!parameterClass.getComponentType().isPrimitive()) {
             isObjArray = true;
@@ -146,7 +146,7 @@ public class JParameter {
         }
     }
 
-    private String getPackageAlias(String shortTypeName, Class parameterClass) {
+    private String getPackageAlias(String shortTypeName, Class<?> parameterClass) {
         if (parameterClass.getPackage() != parentClass.getPackage()) {
             return parameterClass.getPackageName().replace(".", "") + ":" + shortTypeName;
         }
@@ -201,7 +201,7 @@ public class JParameter {
         return isObjArray || isStringArray || isPrimitiveArray;
     }
 
-    public Class getParameterClass() {
+    public Class<?> getParameterClass() {
         return parameterClass;
     }
 }

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenEnv.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenEnv.java
@@ -104,8 +104,8 @@ public class BindgenEnv {
         return projectRoot;
     }
 
-    public void setSuperClasses(Class superClass) {
-        Class parent = superClass;
+    public void setSuperClasses(Class<?> superClass) {
+        Class<?> parent = superClass;
         while (parent != null && isPublicClass(parent)) {
             this.superClasses.add(parent.getName());
             parent = parent.getSuperclass();

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenUtils.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenUtils.java
@@ -126,7 +126,7 @@ public final class BindgenUtils {
         }
     }
 
-    public static Set<String> addImportedPackage(Class type, Set<String> importedPackages) {
+    public static Set<String> addImportedPackage(Class<?> type, Set<String> importedPackages) {
         if (type.isArray()) {
             type = type.getComponentType();
         }
@@ -136,7 +136,7 @@ public final class BindgenUtils {
         return importedPackages;
     }
 
-    public static boolean isPublicConstructor(Constructor constructor) {
+    public static boolean isPublicConstructor(Constructor<?> constructor) {
         int modifiers = constructor.getModifiers();
         return Modifier.isPublic(modifiers);
     }
@@ -151,7 +151,7 @@ public final class BindgenUtils {
         return Modifier.isPublic(modifiers);
     }
 
-    public static boolean isPublicClass(Class javaClass) {
+    public static boolean isPublicClass(Class<?> javaClass) {
         int modifiers = javaClass.getModifiers();
         return Modifier.isPublic(modifiers);
     }
@@ -350,7 +350,7 @@ public final class BindgenUtils {
         BindgenUtils.outStream = outStream;
     }
 
-    public static String getAlias(Class className, Map<String, String> aliases) {
+    public static String getAlias(Class<?> className, Map<String, String> aliases) {
         if (!aliases.containsKey(className.getName())) {
             int i = 2;
             boolean notAdded = true;

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/FieldsTestResource.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/FieldsTestResource.java
@@ -62,8 +62,8 @@ public class FieldsTestResource implements InterfaceTestResource {
     public StringBuilder[] getInstanceObjectArray = new StringBuilder[2];
     public Integer[] getInstanceObjectMultiArray1 = new Integer[5];
     public Object[] getInstanceObjectMultiArray2 = new Object[2];
-    public List getInstanceInterface = new ArrayList<>();
-    public AbstractList getInstanceAbstractClass = new ArrayList<>();
+    public List<?> getInstanceInterface = new ArrayList<>();
+    public AbstractList<?> getInstanceAbstractClass = new ArrayList<>();
     public Path getInstanceObject = Paths.get("/test.txt");
     public Set<File> getInstanceGenericObject = new HashSet<>();
     public System.Logger.Level getInstanceEnumeration = System.Logger.Level.ALL;
@@ -111,8 +111,8 @@ public class FieldsTestResource implements InterfaceTestResource {
     public StringBuilder[] getStaticObjectArray = new StringBuilder[2];
     public Integer[] getStaticObjectMultiArray1 = new Integer[2];
     public Object[] getStaticObjectMultiArray2 = new Object[2];
-    public static List getStaticInterface = new ArrayList<>();
-    public static AbstractList getStaticAbstractClass = new ArrayList<>();
+    public static List<?> getStaticInterface = new ArrayList<>();
+    public static AbstractList<?> getStaticAbstractClass = new ArrayList<>();
     public static Path getStaticObject = Paths.get("/test.txt");
     public static Set<File> getStaticGenericObject = new HashSet<>();
     public static System.Logger.Level getStaticEnumeration = System.Logger.Level.ALL;

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/MethodsTestResource.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/MethodsTestResource.java
@@ -54,15 +54,15 @@ public class MethodsTestResource extends AbstractTestResource implements Interfa
         return new IOException();
     }
 
-    public Map returnInterface() {
-        return new HashMap();
+    public Map<?, ?> returnInterface() {
+        return new HashMap<>();
     }
 
     public Set<String> returnGenericObject() {
         return new HashSet<>();
     }
 
-    public AbstractSet returnAbstractObject() {
+    public AbstractSet<?> returnAbstractObject() {
         return new HashSet<>();
     }
 
@@ -73,7 +73,7 @@ public class MethodsTestResource extends AbstractTestResource implements Interfa
     public void errorParam(IOException x, String[] y) {
     }
 
-    public void interfaceParam(Map x, Object[] y, Object[] z) {
+    public void interfaceParam(Map<?, ?> x, Object[] y, Object[] z) {
     }
 
     public void unsupportedParam(Object[][] y) {
@@ -87,7 +87,7 @@ public class MethodsTestResource extends AbstractTestResource implements Interfa
         return x;
     }
 
-    public void abstractObjectParam(AbstractSet x, Object y, String z) {
+    public void abstractObjectParam(AbstractSet<?> x, Object y, String z) {
     }
 
     public System.Logger.Level enumParam(System.Logger.Level x) {
@@ -255,15 +255,15 @@ public class MethodsTestResource extends AbstractTestResource implements Interfa
         return new IOException();
     }
 
-    public static Map returnStaticInterface() {
-        return new HashMap();
+    public static Map<?, ?> returnStaticInterface() {
+        return new HashMap<>();
     }
 
     public static Set<String> returnStaticGenericObject() {
         return new HashSet<>();
     }
 
-    public static AbstractSet returnStaticAbstractObject() {
+    public static AbstractSet<?> returnStaticAbstractObject() {
         return new HashSet<>();
     }
 
@@ -271,14 +271,14 @@ public class MethodsTestResource extends AbstractTestResource implements Interfa
         return System.Logger.Level.INFO;
     }
 
-    public static void interfaceStaticParam(Map x, boolean[] y) {
+    public static void interfaceStaticParam(Map<?, ?> x, boolean[] y) {
     }
 
     public static Set<String> genericObjectStaticParam(Set<String> x) {
         return x;
     }
 
-    public static void abstractObjectStaticParam(AbstractSet x, int y, Object z) {
+    public static void abstractObjectStaticParam(AbstractSet<?> x, int y, Object z) {
     }
 
     public static System.Logger.Level enumStaticParam(System.Logger.Level x, Object[] y) {

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/ModuleMappingTest.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/ModuleMappingTest.java
@@ -27,6 +27,5 @@ import java.util.Comparator;
 public final class ModuleMappingTest {
 
     // Verifies that the module imports are correctly added in a final field.
-    public static final Comparator BUILD_AWARE_ORDER = null;
-
+    public static final Comparator<?> BUILD_AWARE_ORDER = null;
 }

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -480,14 +480,14 @@ class AIDataMapperCodeActionUtil {
     private void generateOptionalMap(Map<String, Object> rightSchemaMap, String foundTypeRight) {
         for (Map.Entry<String, Object> field : rightSchemaMap.entrySet()) {
             StringBuilder optionalKey = new StringBuilder(foundTypeRight.toLowerCase());
-            if (!(((Map) field.getValue()).containsKey(OPTIONAL))) {
+            if (!(((Map<?, ?>) field.getValue()).containsKey(OPTIONAL))) {
                 optionalKey.append(".").append(field.getKey());
-                generateOptionalMap((Map<String, Object>) ((Map) field.getValue()).get(PROPERTIES),
+                generateOptionalMap((Map<String, Object>) ((Map<?, ?>) field.getValue()).get(PROPERTIES),
                         optionalKey.toString());
-            } else if ((boolean) ((Map) field.getValue()).get(OPTIONAL) |
+            } else if ((boolean) ((Map<?, ?>) field.getValue()).get(OPTIONAL) |
                     (checkForOptionalRecordField(optionalKey.toString()) > 0)) {
                 optionalKey.append(".").append(field.getKey());
-                this.isOptionalMap.put(optionalKey.toString(), ((Map) field.getValue()).get(SIGNATURE).
+                this.isOptionalMap.put(optionalKey.toString(), ((Map<?, ?>) field.getValue()).get(SIGNATURE).
                         toString());
             }
         }
@@ -509,14 +509,14 @@ class AIDataMapperCodeActionUtil {
             if (!fieldName.isEmpty()) {
                 fieldKey.append(fieldName).append(".");
             }
-            if (!(((Map) field.getValue()).containsKey(READONLY))) {
+            if (!(((Map<?, ?>) field.getValue()).containsKey(READONLY))) {
                 fieldKey.append(field.getKey());
-                getLeftFields((Map<String, Object>) ((Map) field.getValue()).get(PROPERTIES),
+                getLeftFields((Map<String, Object>) ((Map<?, ?>) field.getValue()).get(PROPERTIES),
                         fieldKey.toString());
             } else {
                 fieldKey.append(field.getKey());
-                this.leftFieldMap.put(fieldKey.toString(), ((Map) field.getValue()).get(TYPE).toString());
-                if ((((Map) field.getValue()).get(READONLY)).toString().contains("true")) {
+                this.leftFieldMap.put(fieldKey.toString(), ((Map<?, ?>) field.getValue()).get(TYPE).toString());
+                if ((((Map<?, ?>) field.getValue()).get(READONLY)).toString().contains("true")) {
                     this.leftReadOnlyFields.add(field.getKey());
                 }
             }
@@ -530,9 +530,9 @@ class AIDataMapperCodeActionUtil {
      * @param schemaFields {@link List<RecordFieldSymbol>}
      */
     private void getSpreadFieldDetails(String key, Collection<RecordFieldSymbol> schemaFields) {
-        Iterator iterator = schemaFields.iterator();
+        Iterator<RecordFieldSymbol> iterator = schemaFields.iterator();
         while (iterator.hasNext()) {
-            RecordFieldSymbol attribute = (RecordFieldSymbol) iterator.next();
+            RecordFieldSymbol attribute = iterator.next();
             TypeSymbol attributeType = CommonUtil.getRawType(attribute.typeDescriptor());
 
             if (!key.isEmpty()) {
@@ -573,12 +573,12 @@ class AIDataMapperCodeActionUtil {
     private void getResponseKeys(Map<String, Object> leftSchemaMap, String keyName) {
         for (Map.Entry<String, Object> field : leftSchemaMap.entrySet()) {
             StringBuilder fieldKey = new StringBuilder();
-            Map treeMap = null;
+            Map<?, ?> treeMap = null;
             if (!keyName.isEmpty()) {
                 fieldKey.append(keyName).append(".");
             }
             try {
-                treeMap = (Map) field.getValue();
+                treeMap = (Map<?, ?>) field.getValue();
             } catch (Exception e) {
                 //ignore
             }

--- a/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/TestUtil.java
+++ b/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/TestUtil.java
@@ -91,7 +91,7 @@ public final class TestUtil {
                                                CodeActionContext context) {
         TextDocumentIdentifier identifier = getTextDocumentIdentifier(filePath);
         CodeActionParams codeActionParams = new CodeActionParams(identifier, range, context);
-        CompletableFuture result = serviceEndpoint.request(CODE_ACTION, codeActionParams);
+        CompletableFuture<?> result = serviceEndpoint.request(CODE_ACTION, codeActionParams);
         return getResponseString(result);
     }
 
@@ -182,7 +182,7 @@ public final class TestUtil {
         return identifier;
     }
 
-    public static String getResponseString(CompletableFuture completableFuture) {
+    public static String getResponseString(CompletableFuture<?> completableFuture) {
         ResponseMessage jsonrpcResponse = new ResponseMessage();
         try {
             jsonrpcResponse.setId("324");

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/jdi/VirtualMachineProxyImpl.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/jdi/VirtualMachineProxyImpl.java
@@ -714,7 +714,7 @@ public class VirtualMachineProxyImpl implements JdiTimer, VirtualMachineProxy {
             return null;
         }
 
-        private static Method getDeclaredMethod(Class<?> aClass, String name, Class... parameters) {
+        private static Method getDeclaredMethod(Class<?> aClass, String name, Class<?>... parameters) {
             try {
                 Method declaredMethod = aClass.getDeclaredMethod(name, parameters);
                 declaredMethod.setAccessible(true);

--- a/misc/debug-adapter/modules/debug-adapter-runtime/src/main/java/org/ballerinalang/debugadapter/runtime/DebuggerRuntime.java
+++ b/misc/debug-adapter/modules/debug-adapter-runtime/src/main/java/org/ballerinalang/debugadapter/runtime/DebuggerRuntime.java
@@ -113,7 +113,7 @@ public final class DebuggerRuntime {
             final Object[] finalResult = new Object[1];
             final Object[] paramValues = args[0] instanceof Strand ? Arrays.copyOfRange(args, 1, args.length) : args;
 
-            Function<?, ?> func = o -> bObject.call((Strand) (((Object[]) o)[0]), methodName, paramValues);
+            Function<Object[], ?> func = o -> bObject.call((Strand) ((o)[0]), methodName, paramValues);
             Object resultFuture = scheduler.schedule(new Object[1], func, null, new Callback() {
                 @Override
                 public void notifySuccess(Object result) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -793,7 +793,7 @@ public final class Generator {
                           isDeprecated(optionalMetadataNode), isClosed, fields);
     }
 
-    public static List<DefaultableVariable> getDefaultableVariableList(NodeList nodeList,
+    public static List<DefaultableVariable> getDefaultableVariableList(NodeList<?> nodeList,
                                                                        Optional<MetadataNode> optionalMetadataNode,
                                                                        SemanticModel semanticModel, Module module) {
         List<DefaultableVariable> variables = new ArrayList<>();

--- a/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/JsonToRecordConverter.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/JsonToRecordConverter.java
@@ -56,6 +56,7 @@ import org.ballerinalang.formatter.core.options.FormattingOptions;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -155,7 +156,8 @@ public final class JsonToRecordConverter {
         } else {
             // Sets generated type definition code block
             NodeList<ModuleMemberDeclarationNode> moduleMembers = AbstractNodeFactory.createNodeList(
-                    new ArrayList(typeDefinitionNodes.values()));
+                    new ArrayList<>(
+                            (Collection<ModuleMemberDeclarationNode>) (Collection<?>) typeDefinitionNodes.values()));
             Token eofToken = AbstractNodeFactory.createIdentifierToken("");
             ModulePartNode modulePartNode = NodeFactory.createModulePartNode(imports, moduleMembers, eofToken);
             response.setCodeBlock(Formatter.format(modulePartNode.syntaxTree(), formattingOptions).toSourceCode());

--- a/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/JsonToRecordConverter.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/JsonToRecordConverter.java
@@ -175,6 +175,7 @@ public final class JsonToRecordConverter {
      * @return {@link Map}  Map of Record Nodes
      * @throws JsonToRecordConverterException In case of bad record fields
      */
+    @SuppressWarnings("rawtypes")
     private static Map<String, NonTerminalNode> generateRecords(OpenAPI openApi, boolean isRecordTypeDescriptor,
                                                               boolean isClosedRecord)
             throws JsonToRecordConverterException {
@@ -283,6 +284,7 @@ public final class JsonToRecordConverter {
      * @param typeDefinitionNodes Map of type definition nodes to be updated in case of object type fields
      * @throws JsonToRecordConverterException In case of bad schema entries
      */
+    @SuppressWarnings("rawtypes")
     private static void addRecordFields(List<String> required, List<Node> recordFieldList,
                                         Map.Entry<String, Schema> field,
                                         Map<String, NonTerminalNode> typeDefinitionNodes,
@@ -314,6 +316,7 @@ public final class JsonToRecordConverter {
      * @return {@link TypeDescriptorNode} Type descriptor for record field
      * @throws JsonToRecordConverterException In case of invalid schema
      */
+    @SuppressWarnings("rawtypes")
     private static TypeDescriptorNode extractOpenApiSchema(Schema<?> schema, String name,
                                                            Map<String, NonTerminalNode> typeDefinitionNodes,
                                                            boolean isRecordTypeDescriptor)

--- a/misc/ls-extensions/modules/trigger-service/src/main/java/io/ballerina/trigger/entity/BallerinaTriggerListRequest.java
+++ b/misc/ls-extensions/modules/trigger-service/src/main/java/io/ballerina/trigger/entity/BallerinaTriggerListRequest.java
@@ -174,7 +174,7 @@ public class BallerinaTriggerListRequest {
     }
 
     public Map<String, String> getQueryMap() {
-        Map<String, String> params = new HashMap();
+        Map<String, String> params = new HashMap<>();
 
         if (getQuery() != null) {
             params.put("q", getQuery());

--- a/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TestExecutionGenerationTask.java
+++ b/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TestExecutionGenerationTask.java
@@ -184,7 +184,7 @@ public class TestExecutionGenerationTask implements GeneratorTask<SourceGenerato
                 rootNode.accept(testFunctionVisitor);
                 for (FunctionDefinitionNode func : testFunctionVisitor.getTestStaticFunctions()) {
                     FunctionBodyNode functionBodyNode = func.functionBody();
-                    NodeList statements = ((FunctionBodyBlockNode) functionBodyNode).statements();
+                    NodeList<StatementNode> statements = ((FunctionBodyBlockNode) functionBodyNode).statements();
                     for (int i = 0; i < statements.size(); i++) {
                         StatementNode statementNode = (StatementNode) statements.get(i);
 

--- a/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TesterinaCompilerPluginUtils.java
+++ b/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TesterinaCompilerPluginUtils.java
@@ -339,7 +339,7 @@ public final class TesterinaCompilerPluginUtils {
                 NodeFactory.createSimpleNameReferenceNode(NodeFactory.createIdentifierToken(argName)));
     }
 
-    public static void writeCacheMapAsJson(Map map, Path path, String fileName) {
+    public static void writeCacheMapAsJson(Map<?, ?> map, Path path, String fileName) {
         if (!Files.exists(path)) {
             try {
                 Files.createDirectories(path);

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/TesterinaSystemPackageRepositoryProvider.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/TesterinaSystemPackageRepositoryProvider.java
@@ -22,6 +22,8 @@ import org.ballerinalang.spi.SystemPackageRepositoryProvider;
 import org.wso2.ballerinalang.compiler.packaging.repo.JarRepo;
 import org.wso2.ballerinalang.compiler.packaging.repo.Repo;
 
+import java.nio.file.Path;
+
 /**
  * This represents the standard Ballerina built-in system package repository provider.
  *
@@ -31,7 +33,7 @@ import org.wso2.ballerinalang.compiler.packaging.repo.Repo;
 public class TesterinaSystemPackageRepositoryProvider implements SystemPackageRepositoryProvider {
 
     @Override
-    public Repo loadRepository() {
+    public Repo<Path> loadRepository() {
         return new JarRepo(SystemPackageRepositoryProvider.getClassUri(this));
     }
 

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/CommonUtils.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/CommonUtils.java
@@ -48,7 +48,7 @@ public final class CommonUtils {
      * @param func The function pointer
      * @return Whether the parameters are concurrency safe
      */
-    public static Object isFunctionParamConcurrencySafe(BFunctionPointer func) {
+    public static Object isFunctionParamConcurrencySafe(BFunctionPointer<?, ?> func) {
         FunctionType functionType = (FunctionType) func.getType();
         Parameter[] functionParameters = functionType.getParameters();
         for (Parameter functionParameter : functionParameters) {

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
@@ -115,6 +115,7 @@ public class GenericMockObjectValue implements ObjectValue {
         return false;
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public BMap getMapValue(BString fieldName) {
         return null;

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
@@ -232,7 +232,7 @@ public final class ObjectMock {
      * @param pathParams path parameters map provided by the user
      * @return an optional error if a validation fails
      */
-    public static BError validatePathParams(BObject caseObj, BMap pathParams) {
+    public static BError validatePathParams(BObject caseObj, BMap<?, ?> pathParams) {
         String functionName = caseObj.getStringValue(StringUtils.fromString(MockConstants.FUNCTION_NAME)).toString();
         String[] pathSegments = functionName.split(MockConstants.PATH_SEPARATOR);
         for (int i = 0; i < pathSegments.length; i++) {
@@ -323,7 +323,7 @@ public final class ObjectMock {
 
                 // validate if each argument is compatible with the type given in the function signature
                 int i = 0;
-                for (BIterator it = argsList.getIterator(); it.hasNext(); i++) {
+                for (BIterator<?> it = argsList.getIterator(); it.hasNext(); i++) {
                     Type paramType = TypeUtils.getImpliedType(attachedFunction.getType().getParameters()[i].type);
                     if (paramType instanceof UnionType unionType) {
                         Object arg = it.next();
@@ -398,7 +398,7 @@ public final class ObjectMock {
 
                 // validate if each argument is compatible with the type given in the function signature
                 int counter = 0;
-                for (BIterator bIterator = argsList.getIterator(); bIterator.hasNext(); counter++) {
+                for (BIterator<?> bIterator = argsList.getIterator(); bIterator.hasNext(); counter++) {
                     String detail = "incorrect type of path provided for '" + pathParamPlaceHolder[counter] +
                                 "' to mock the function '" + functionName;
                     Type paramType = TypeUtils.getImpliedType(attachedFunction.getType().getParameters()[counter].type);
@@ -478,7 +478,7 @@ public final class ObjectMock {
 
                 // validate if each argument is compatible with the type given in the function signature
                 int counter = 0;
-                for (BIterator bIterator = argsList.getIterator(); bIterator.hasNext(); counter++) {
+                for (BIterator<?> bIterator = argsList.getIterator(); bIterator.hasNext(); counter++) {
                     String detail = "incorrect type of argument provided at position '" + (counter + 1) + "' " +
                             "to mock the function '" + functionName;
                     Type paramType = TypeUtils.getImpliedType(attachedFunction.getType()

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyEntryNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyEntryNode.java
@@ -27,14 +27,14 @@ import io.ballerina.toml.syntax.tree.ValueNode;
  */
 public class TomlKeyEntryNode extends TomlNode {
 
-    private final TomlBasicValueNode name;
+    private final TomlBasicValueNode<?> name;
 
-    public TomlKeyEntryNode(ValueNode valueNode, TomlBasicValueNode name) {
+    public TomlKeyEntryNode(ValueNode valueNode, TomlBasicValueNode<?> name) {
         super(valueNode, name.kind(), name.location());
         this.name = name;
     }
 
-    public TomlBasicValueNode name() {
+    public TomlBasicValueNode<?> name() {
         return name;
     }
 

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTransformer.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTransformer.java
@@ -426,7 +426,7 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
         SeparatedNodeList<ValueNode> identifierList = identifier.value();
         List<TomlKeyEntryNode> nodeList = new ArrayList<>();
         for (Node node : identifierList) {
-            TomlBasicValueNode transformedNode = (TomlBasicValueNode) node.apply(this);
+            TomlBasicValueNode<?> transformedNode = (TomlBasicValueNode<?>) node.apply(this);
             nodeList.add(new TomlKeyEntryNode((ValueNode) node, transformedNode));
         }
         return new TomlKeyNode(identifier, nodeList, getTomlNodeListLocation(nodeList));

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/syntax/tree/TreeModifier.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/syntax/tree/TreeModifier.java
@@ -223,7 +223,7 @@ public abstract class TreeModifier extends NodeTransformer<Node> {
     }
 
     protected <T extends Node> SeparatedNodeList<T> modifySeparatedNodeList(SeparatedNodeList<T> nodeList) {
-        Function<NonTerminalNode, SeparatedNodeList> nodeListCreator = SeparatedNodeList::new;
+        Function<NonTerminalNode, SeparatedNodeList<T>> nodeListCreator = SeparatedNodeList::new;
         if (nodeList.isEmpty()) {
             return nodeList;
         }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/validator/BoilerplateGenerator.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/validator/BoilerplateGenerator.java
@@ -163,7 +163,7 @@ public class BoilerplateGenerator extends SchemaVisitor {
         for (AbstractSchema value : children.values()) {
             //If Anything other than array or table
             if (!(value.type() == Type.OBJECT || value.type() == Type.ARRAY)) {
-                if (((PrimitiveValueSchema) value).defaultValue().isPresent()) {
+                if (((PrimitiveValueSchema<?>) value).defaultValue().isPresent()) {
                     return true;
                 }
             }

--- a/misc/toml-parser/src/test/java/toml/parser/test/diagnostics/DiagnosticCodeTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/diagnostics/DiagnosticCodeTest.java
@@ -66,7 +66,7 @@ public class DiagnosticCodeTest {
         }
     }
 
-    private String arrayToString(List listOfStrings) {
+    private String arrayToString(List<String> listOfStrings) {
         return String.join(", ", listOfStrings);
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ConstAnnotationAttachmentSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ConstAnnotationAttachmentSymbolTest.java
@@ -87,7 +87,7 @@ public class ConstAnnotationAttachmentSymbolTest {
 
         // Test const value
         assertTrue(constVal.value() instanceof HashMap);
-        HashMap valueMap = (HashMap) constVal.value();
+        HashMap<?, ?> valueMap = (HashMap<?, ?>) constVal.value();
 
         assertTrue(valueMap.get("id") instanceof BallerinaConstantValue);
         BallerinaConstantValue idValue =
@@ -99,7 +99,7 @@ public class ConstAnnotationAttachmentSymbolTest {
         BallerinaConstantValue permValue = (BallerinaConstantValue) valueMap.get("perm");
         assertEquals(permValue.valueType().typeKind(), TypeDescKind.RECORD);
         assertTrue(permValue.value() instanceof HashMap);
-        HashMap permMap = (HashMap) permValue.value();
+        HashMap<?, ?> permMap = (HashMap<?, ?>) permValue.value();
         assertEquals(((BallerinaConstantValue) permMap.get("a")).value(), 1L);
         assertEquals(((BallerinaConstantValue) permMap.get("a")).valueType().typeKind(), TypeDescKind.INT);
         assertEquals(((BallerinaConstantValue) permMap.get("b")).value(), 2L);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ConstDeclSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ConstDeclSymbolTest.java
@@ -167,7 +167,7 @@ public class ConstDeclSymbolTest {
 
         // Test const value
         assertTrue(constVal.value() instanceof HashMap);
-        HashMap valueMap = (HashMap) constVal.value();
+        HashMap<?, ?> valueMap = (HashMap<?, ?>) constVal.value();
 
         assertTrue(valueMap.get("id") instanceof BallerinaConstantValue);
         BallerinaConstantValue idValue =
@@ -180,7 +180,7 @@ public class ConstDeclSymbolTest {
                 (BallerinaConstantValue) valueMap.get("perm");
         assertEquals(permValue.valueType().typeKind(), TypeDescKind.RECORD);
         assertTrue(permValue.value() instanceof HashMap);
-        HashMap permMap = (HashMap) permValue.value();
+        HashMap<?, ?> permMap = (HashMap<?, ?>) permValue.value();
         assertEquals(((BallerinaConstantValue) permMap.get("a")).value(), 1L);
         assertEquals(((BallerinaConstantValue) permMap.get("a")).valueType().typeKind(), TypeDescKind.INT);
         assertEquals(((BallerinaConstantValue) permMap.get("b")).value(), 2L);

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
@@ -385,7 +385,7 @@ public final class BRunUtil {
 //        }
     }
 
-    private static void directRun(Class<?> initClazz, String functionName, Class[] paramTypes, Object[] args) {
+    private static void directRun(Class<?> initClazz, String functionName, Class<?>[] paramTypes, Object[] args) {
         String funcName = JvmCodeGenUtil.cleanupFunctionName(functionName);
         String errorMsg = "Failed to invoke the function '%s' due to %s";
         Object response;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/TypeReference.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/TypeReference.java
@@ -143,7 +143,7 @@ public final class TypeReference {
         return true;
     }
 
-    public static Boolean validateTableType(BTypedesc typedesc, TableValue tableValue) {
+    public static Boolean validateTableType(BTypedesc typedesc, TableValue<?, ?> tableValue) {
         BTableType tableType = (BTableType) TypeUtils.getImpliedType(typedesc.getDescribingType());
         if (tableType.getConstrainedType().getTag() != TypeTags.TYPE_REFERENCED_TYPE_TAG ||
                 tableValue.getKeyType().getTag() != TypeTags.TYPE_REFERENCED_TYPE_TAG ||
@@ -241,7 +241,7 @@ public final class TypeReference {
         return true;
     }
 
-    public static Boolean validateBMap(BMap value1, BMap value2) {
+    public static Boolean validateBMap(BMap<?, ?> value1, BMap<?, ?> value2) {
         if (value1.getType().getTag() != TypeTags.TYPE_REFERENCED_TYPE_TAG ||
                 value2.getType().getTag() != TypeTags.TYPE_REFERENCED_TYPE_TAG) {
             throw ErrorCreator.createError(StringUtils.fromString("BMap getType API provided a non type " +
@@ -258,7 +258,7 @@ public final class TypeReference {
         return true;
     }
 
-    public static Boolean validateBFunctionPointer(BFunctionPointer value) {
+    public static Boolean validateBFunctionPointer(BFunctionPointer<?, ?> value) {
         if (value.getType().getTag() != TypeTags.TYPE_REFERENCED_TYPE_TAG) {
             throw  ErrorCreator.createError(StringUtils.fromString("Function Pointer getType API provided a non " +
                     "type reference type."));
@@ -286,7 +286,7 @@ public final class TypeReference {
         return true;
     }
 
-    public static boolean validateTableKeys(BTable table) {
+    public static boolean validateTableKeys(BTable<?, ?> table) {
         if (table.getType().getTag() != TypeTags.TYPE_REFERENCED_TYPE_TAG || table.size() != 1 ||
                 table.getKeyType().getTag() != TypeTags.TUPLE_TAG) {
             throw ErrorCreator.createError(StringUtils.fromString("Table keys does not provide type-reference " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -185,7 +185,7 @@ public final class Values {
         return StringUtils.fromString("");
     }
 
-    public static BString getParamTypesString(BFunctionPointer func) {
+    public static BString getParamTypesString(BFunctionPointer<?, ?> func) {
         BFunctionType funcType = (BFunctionType) func.getType();
         StringBuilder sb = new StringBuilder();
         for (Type type : funcType.getParameterTypes()) {
@@ -332,7 +332,7 @@ public final class Values {
         BMap<BString, Object> annotations = ((AnnotatableType) describingType).getAnnotations();
         if (annotations.containsKey(intAnnotation)) {
             Object annotValue = annotations.get(intAnnotation);
-            Long minValue = (Long) ((BMap) annotValue).get(StringUtils.fromString("minValue"));
+            Long minValue = (Long) ((BMap<?, ?>) annotValue).get(StringUtils.fromString("minValue"));
             if (((Long) value) >= minValue) {
                 return value;
             }
@@ -342,11 +342,12 @@ public final class Values {
 
     public static Object validateRecord(Object value, BTypedesc typedesc) {
         Type describingType = typedesc.getDescribingType();
-        Long age = ((BMap) value).getIntValue(StringUtils.fromString("age"));
+        Long age = ((BMap<?, ?>) value).getIntValue(StringUtils.fromString("age"));
         for (Field field : ((BRecordType) describingType).getFields().values()) {
             BMap<BString, Object> annotations = ((AnnotatableType) field.getFieldType()).getAnnotations();
             if (annotations.containsKey(intAnnotation)) {
-                Long minValue = (Long) ((BMap) annotations.get(intAnnotation)).get(StringUtils.fromString("minValue"));
+                Long minValue = (Long) ((BMap<?, ?>) annotations.get(intAnnotation))
+                        .get(StringUtils.fromString("minValue"));
                 if (age < minValue) {
                     return constraintError;
                 }
@@ -360,7 +361,7 @@ public final class Values {
         BMap<BString, Object> annotations = ((AnnotatableType) describingType).getAnnotations();
         if (annotations.containsKey(intAnnotation)) {
             Object annotValue = annotations.get(intAnnotation);
-            Long minValue = (Long) ((BMap) annotValue).get(StringUtils.fromString("minValue"));
+            Long minValue = (Long) ((BMap<?, ?>) annotValue).get(StringUtils.fromString("minValue"));
             for (Object element : ((BArray) value).getValues()) {
                 if (((Long) element) >= minValue) {
                     return value;
@@ -376,7 +377,7 @@ public final class Values {
         BString annotKey = StringUtils.fromString("testorg/types.typeref:1:Array");
         if (annotations.containsKey(annotKey)) {
             Object annotValue = annotations.get(annotKey);
-            Long maxLength = (Long) ((BMap) annotValue).get(StringUtils.fromString("maxLength"));
+            Long maxLength = (Long) ((BMap<?, ?>) annotValue).get(StringUtils.fromString("maxLength"));
             BArray array = (BArray) value;
             if (maxLength < array.getLength()) {
                 return ErrorCreator.createError(
@@ -389,7 +390,7 @@ public final class Values {
                 return constraintError;
             }
             annotValue = annotations.get(intAnnotation);
-            Long minValue = (Long) ((BMap) annotValue).get(StringUtils.fromString("minValue"));
+            Long minValue = (Long) ((BMap<?, ?>) annotValue).get(StringUtils.fromString("minValue"));
             for (int i = 0; i < array.getLength(); i++) {
                 if (((Long) array.get(i)) < minValue) {
                     return constraintError;
@@ -399,7 +400,7 @@ public final class Values {
         return value;
     }
 
-    public static Object validateFunctionParameterExtern(BFunctionPointer fpValue) {
+    public static Object validateFunctionParameterExtern(BFunctionPointer<?, ?> fpValue) {
         return validateFunctionType((FunctionType) fpValue.getType());
     }
 
@@ -473,10 +474,10 @@ public final class Values {
             throw ErrorCreator.createError(StringUtils.fromString("Annotation is not available."));
         }
         BString annotKey = StringUtils.fromString("testorg/types.typeref:1:String");
-        return TypeChecker.checkIsType(((BMap) annotation).get(annotKey), constraint.getDescribingType());
+        return TypeChecker.checkIsType(((BMap<?, ?>) annotation).get(annotKey), constraint.getDescribingType());
     }
 
-    public static BString getParameterName(BFunctionPointer fpValue) {
+    public static BString getParameterName(BFunctionPointer<?, ?> fpValue) {
         Parameter parameter = ((BFunctionType) fpValue.getType()).getParameters()[0];
         return StringUtils.fromString(parameter.name);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/servicetests/ServiceAnnotValue.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/servicetests/ServiceAnnotValue.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
  */
 public final class ServiceAnnotValue {
 
-    static HashMap<Integer, MapValue> serviceAnnotMap = new HashMap();
+    static HashMap<Integer, MapValue<?, ?>> serviceAnnotMap = new HashMap<>();
     private static BObject listener;
     private static boolean started;
     private static int serviceCount = 0;
@@ -47,7 +47,7 @@ public final class ServiceAnnotValue {
         try {
             Field annotations = BAnnotatableType.class.getDeclaredField("annotations");
             annotations.setAccessible(true);
-            MapValue annotationMap = (MapValue) annotations.get(serviceType);
+            MapValue<?, ?> annotationMap = (MapValue<?, ?>) annotations.get(serviceType);
             serviceCount++;
             serviceAnnotMap.put(serviceCount, annotationMap);
         } catch (NoSuchFieldException | IllegalAccessException e) {
@@ -82,7 +82,7 @@ public final class ServiceAnnotValue {
         return serviceCount;
     }
 
-    public static BMap getAnnotationsAtServiceAttach(int serviceNum) {
+    public static BMap<?, ?> getAnnotationsAtServiceAttach(int serviceNum) {
         return serviceAnnotMap.get(serviceNum);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/servicetests/ServiceValue.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/servicetests/ServiceValue.java
@@ -56,7 +56,7 @@ public final class ServiceValue {
     private static BObject listener;
     private static boolean started;
     private static String[] names;
-    private static MapValue annotationMap; // captured at attach method
+    private static MapValue<?, ?> annotationMap; // captured at attach method
 
     private ServiceValue() {
     }
@@ -122,7 +122,7 @@ public final class ServiceValue {
             Field annotations = BAnnotatableType.class.getDeclaredField("annotations");
             annotations.setAccessible(true);
             Object annotationMap = annotations.get(serviceType);
-            ServiceValue.annotationMap = (MapValue) annotationMap;
+            ServiceValue.annotationMap = (MapValue<?, ?>) annotationMap;
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new AssertionError();
         }
@@ -145,7 +145,7 @@ public final class ServiceValue {
         ServiceValue.listener = null;
         ServiceValue.started = false;
         ServiceValue.names = new String[0];
-        ServiceValue.annotationMap = new MapValueImpl();
+        ServiceValue.annotationMap = new MapValueImpl<>();
     }
 
     public static BObject getListener() {
@@ -180,7 +180,7 @@ public final class ServiceValue {
         return new ArrayValueImpl(names, false);
     }
 
-    public static BMap getAnnotationsAtServiceAttach() {
+    public static BMap<?, ?> getAnnotationsAtServiceAttach() {
         return ServiceValue.annotationMap;
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
@@ -131,7 +131,7 @@ public final class StaticMethods {
     }
 
     // This scenario is for map value to be passed to interop and return array value.
-    public static ArrayValue getArrayValueFromMap(BString key, MapValue mapValue) {
+    public static ArrayValue getArrayValueFromMap(BString key, MapValue<?, ?> mapValue) {
         ArrayValue arrayValue = (ArrayValue) ValueCreator.createArrayValue(intArrayType);
         arrayValue.add(0, 1);
         long fromMap = (long) mapValue.get(key);
@@ -140,7 +140,7 @@ public final class StaticMethods {
     }
 
     public static BMap<BString, Object> acceptRefTypesAndReturnMap(ObjectValue a, ArrayValue b, Object c,
-                                                                   ErrorValue d, Object e, Object f, MapValue g) {
+                                                                   ErrorValue d, Object e, Object f, MapValue<?, ?> g) {
         BMap<BString, Object> mapValue = ValueCreator.createMapValue();
         mapValue.put(StringUtils.fromString("a"), a);
         mapValue.put(StringUtils.fromString("b"), b);
@@ -195,7 +195,7 @@ public final class StaticMethods {
         return ((Long) p.get(StringUtils.fromString("age"))).intValue();
     }
 
-    public static MapValue acceptRecordAndRecordReturn(MapValue e, BString newVal) {
+    public static MapValue<BString, Object> acceptRecordAndRecordReturn(MapValue<BString, Object> e, BString newVal) {
         e.put(StringUtils.fromString("name"), newVal);
         return e;
     }
@@ -274,7 +274,7 @@ public final class StaticMethods {
         }
     }
 
-    public static ArrayValue getArrayValueFromMapWhichThrowsCheckedException(BString key, MapValue mapValue)
+    public static ArrayValue getArrayValueFromMapWhichThrowsCheckedException(BString key, MapValue<?, ?> mapValue)
             throws JavaInteropTestCheckedException {
         ArrayValue arrayValue = (ArrayValue) ValueCreator.createArrayValue(intArrayType);
         arrayValue.add(0, 1);
@@ -287,7 +287,7 @@ public final class StaticMethods {
                                                                                               ArrayValue b, Object c,
                                                                                               ErrorValue d, Object e,
                                                                                               Object f,
-                                                                                              MapValue g)
+                                                                                              MapValue<?, ?> g)
             throws JavaInteropTestCheckedException {
         BMap<BString, Object> mapValue = ValueCreator.createMapValue();
         mapValue.put(StringUtils.fromString("a"), a);
@@ -347,21 +347,21 @@ public final class StaticMethods {
         return p;
     }
 
-    public static MapValue acceptRecordAndRecordReturnWhichThrowsCheckedException(
+    public static MapValue<BString, Object> acceptRecordAndRecordReturnWhichThrowsCheckedException(
             MapValue<BString, Object> e, BString newVal) throws JavaInteropTestCheckedException {
         e.put(StringUtils.fromString("name"), newVal);
         return e;
     }
 
-    public static BMap getMapOrError(BString swaggerFilePath, MapValue apiDef)
+    public static BMap<BString, Object> getMapOrError(BString swaggerFilePath, MapValue<?, ?> apiDef)
             throws JavaInteropTestCheckedException {
         BString finalBasePath = StringUtils.fromString("basePath");
         AtomicLong runCount = new AtomicLong(0L);
         ArrayValue arrayValue = new ArrayValueImpl(new BArrayType(ValueCreator.createRecordValue(new Module(
                 "", "."), "ResourceDefinition").getType()));
-        BMap apiDefinitions = ValueCreator.createRecordValue(new Module("",
+        BMap<BString, Object> apiDefinitions = ValueCreator.createRecordValue(new Module("",
                                                                         "."), "ApiDefinition");
-        BMap resource = ValueCreator.createRecordValue(new Module("",
+        BMap<BString, Object> resource = ValueCreator.createRecordValue(new Module("",
                                                                   "."), "ResourceDefinition");
         resource.put(StringUtils.fromString("path"), finalBasePath);
         resource.put(StringUtils.fromString("method"), StringUtils.fromString("Method string"));
@@ -501,7 +501,7 @@ public final class StaticMethods {
             entries[index++] = new ListInitialValueEntry.ExpressionEntry(stringEntry.getValue());
         }
 
-        return new ArrayValueImpl(new BArrayType(new BUnionType(new ArrayList(2) {{
+        return new ArrayValueImpl(new BArrayType(new BUnionType(new ArrayList<>(2) {{
             add(PredefinedTypes.TYPE_INT);
             add(PredefinedTypes.TYPE_STRING);
         }}), length, true), entries);
@@ -515,7 +515,7 @@ public final class StaticMethods {
         return obj;
     }
 
-    public static boolean echoImmutableRecordField(MapValue value, BString key) {
+    public static boolean echoImmutableRecordField(MapValue<?, ?> value, BString key) {
         return value.getBooleanValue(key);
     }
 
@@ -596,7 +596,7 @@ public final class StaticMethods {
             case TypeTags.ARRAY_TAG,
                  TypeTags.OBJECT_TYPE_TAG -> value;
             case TypeTags.RECORD_TYPE_TAG,
-                 TypeTags.MAP_TAG -> ((MapValue) value).get(StringUtils.fromString("first"));
+                 TypeTags.MAP_TAG -> ((MapValue<?, ?>) value).get(StringUtils.fromString("first"));
             default -> StringUtils.fromString("other");
         };
     }
@@ -628,7 +628,7 @@ public final class StaticMethods {
         return e;
     }
 
-    public static FPValue getFunctionPointerAsReadOnly(FPValue func) {
+    public static FPValue<?, ?> getFunctionPointerAsReadOnly(FPValue<?, ?> func) {
         return func;
     }
 
@@ -652,11 +652,11 @@ public final class StaticMethods {
         return list;
     }
 
-    public static MapValue getMappingAsReadOnly(MapValue mp) {
+    public static MapValue<?, ?> getMappingAsReadOnly(MapValue<?, ?> mp) {
         return mp;
     }
 
-    public static TableValue getTableAsReadOnly(TableValue tb) {
+    public static TableValue<?, ?> getTableAsReadOnly(TableValue<?, ?> tb) {
         return tb;
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
@@ -100,11 +100,11 @@ public final class VariableReturnType {
         return value;
     }
 
-    public static TableValue getTable(TableValue value, BTypedesc td) {
+    public static TableValue<?, ?> getTable(TableValue<?, ?> value, BTypedesc td) {
         return value;
     }
 
-    public static BFunctionPointer getFunction(BFunctionPointer fp, BTypedesc param, BTypedesc ret) {
+    public static BFunctionPointer<?, ?> getFunction(BFunctionPointer<?, ?> fp, BTypedesc param, BTypedesc ret) {
         return fp;
     }
 
@@ -135,20 +135,20 @@ public final class VariableReturnType {
         return getValue(td.getDescribingType());
     }
 
-    public static MapValue query(BString query, BTypedesc typedesc) {
+    public static MapValue<BString, Object> query(BString query, BTypedesc typedesc) {
         Type type = typedesc.getDescribingType();
-        MapValue map;
+        MapValue<BString, Object> map;
 
         if (type.getTag() == INT_TAG) {
-            map = new MapValueImpl(new BMapType(type));
+            map = new MapValueImpl<>(new BMapType(type));
             map.put(new BmpStringValue("one"), 10);
             map.put(new BmpStringValue("two"), 20);
         } else if (type.getTag() == STRING_TAG) {
-            map = new MapValueImpl(new BMapType(type));
+            map = new MapValueImpl<>(new BMapType(type));
             map.put(NAME, new BmpStringValue("Pubudu"));
             map.put(CITY, new BmpStringValue("Panadura"));
         } else {
-            map = new MapValueImpl(new BMapType(PredefinedTypes.TYPE_ANY));
+            map = new MapValueImpl<>(new BMapType(PredefinedTypes.TYPE_ANY));
         }
 
         return map;
@@ -194,9 +194,9 @@ public final class VariableReturnType {
         return arr;
     }
 
-    public static MapValue getRecord(BTypedesc td) {
+    public static MapValue<BString, Object> getRecord(BTypedesc td) {
         BRecordType recType = (BRecordType) td.getDescribingType();
-        MapValueImpl person = new MapValueImpl(recType);
+        MapValueImpl<BString, Object> person = new MapValueImpl<>(recType);
 
         if (recType.getName().equals("Person")) {
             person.put(NAME, JOHN_DOE);
@@ -225,7 +225,7 @@ public final class VariableReturnType {
             }
         }
 
-        MapValueImpl rec = new MapValueImpl(type2);
+        MapValueImpl<BString, Object> rec = new MapValueImpl<>(type2);
         if (type2.getName().equals("Person")) {
             rec.put(NAME, JOHN_DOE);
             rec.put(AGE, 20);
@@ -277,7 +277,7 @@ public final class VariableReturnType {
                 return 32;
             case RECORD_TYPE_TAG:
                 BRecordType recType = (BRecordType) type;
-                MapValueImpl person = new MapValueImpl(recType);
+                MapValueImpl<BString, Object> person = new MapValueImpl<>(recType);
 
                 if (recType.getName().equals("Person")) {
                     person.put(NAME, JOHN_DOE);
@@ -358,8 +358,8 @@ public final class VariableReturnType {
         BMap<BString, Object> annotations = ((AnnotatableType) describingType).getAnnotations();
         if (annotations.containsKey(annotationName)) {
             Object annotValue = annotations.get(annotationName);
-            Long minValue = (Long) ((BMap) annotValue).get(StringUtils.fromString("minValue"));
-            Long maxValue = (Long) ((BMap) annotValue).get(StringUtils.fromString("maxValue"));
+            Long minValue = (Long) ((BMap<?, ?>) annotValue).get(StringUtils.fromString("minValue"));
+            Long maxValue = (Long) ((BMap<?, ?>) annotValue).get(StringUtils.fromString("maxValue"));
             if (minValue == min && maxValue == max) {
                 return value;
             }
@@ -394,7 +394,7 @@ public final class VariableReturnType {
         return true;
     }
 
-    public static Object clientPost(BObject client, BTypedesc targetType, MapValue options) {
+    public static Object clientPost(BObject client, BTypedesc targetType, MapValue<?, ?> options) {
         BString mediaType =
                 Optional.ofNullable(options.getStringValue(StringUtils.fromString("mediaType")))
                         .orElse(StringUtils.fromString(""));
@@ -409,7 +409,7 @@ public final class VariableReturnType {
         return mediaType.length() + header.length();
     }
 
-    public static Object calculate(BObject client, long i, BTypedesc targetType, MapValue options) {
+    public static Object calculate(BObject client, long i, BTypedesc targetType, MapValue<?, ?> options) {
         BString mediaType =
                 Optional.ofNullable(options.getStringValue(StringUtils.fromString("mediaType")))
                         .orElse(StringUtils.fromString(""));
@@ -517,7 +517,7 @@ public final class VariableReturnType {
         return !((boolean) val);
     }
 
-    public static BFunctionPointer getFunctionWithAnyFunctionParamType(BFunctionPointer x, BTypedesc td) {
+    public static BFunctionPointer<?, ?> getFunctionWithAnyFunctionParamType(BFunctionPointer<?, ?> x, BTypedesc td) {
         Assert.assertEquals(td.getDescribingType().getTag(), INT_TAG);
         return x;
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnonymousTupleAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnonymousTupleAnnotationTest.java
@@ -62,8 +62,8 @@ public class AnonymousTupleAnnotationTest {
         };
     }
 
-    public static BMap getAnonymousTupleAnnotations(TypedescValue typedescValue, BString annotName) {
-        return (BMap) TypeChecker.getAnnotValue(typedescValue, annotName);
+    public static BMap<?, ?> getAnonymousTupleAnnotations(TypedescValue typedescValue, BString annotName) {
+        return (BMap<?, ?>) TypeChecker.getAnnotValue(typedescValue, annotName);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/DisplayAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/DisplayAnnotationTest.java
@@ -65,8 +65,8 @@ public class DisplayAnnotationTest {
 
     @Test
     public void testDisplayAnnotOnFunction() {
-        BLangFunction fooFunction = (BLangFunction) ((List) ((BLangPackage) result.getAST()).functions).get(0);
-        BLangAnnotationAttachment annot = (BLangAnnotationAttachment) ((List) fooFunction.annAttachments).get(0);
+        BLangFunction fooFunction = (BLangFunction) ((List<?>) ((BLangPackage) result.getAST()).functions).get(0);
+        BLangAnnotationAttachment annot = (BLangAnnotationAttachment) ((List<?>) fooFunction.annAttachments).get(0);
         Assert.assertEquals(getActualExpressionFromAnnotationAttachmentExpr(annot.expr).toString(),
                 " {iconPath: <string?> fooIconPath.icon,label: Foo function}");
     }
@@ -127,7 +127,7 @@ public class DisplayAnnotationTest {
     @Test
     public void testDisplayAnnotOnExternalFunctionBody() {
         BLangExternalFunctionBody body = (BLangExternalFunctionBody) result.getAST().getFunctions().get(3).getBody();
-        BLangAnnotationAttachment annot = (BLangAnnotationAttachment) ((List) body.annAttachments).get(0);
+        BLangAnnotationAttachment annot = (BLangAnnotationAttachment) ((List<?>) body.annAttachments).get(0);
         Assert.assertEquals(getActualExpressionFromAnnotationAttachmentExpr(annot.expr).toString(),
                 " {label: external,id: <anydata> hash}");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/LocalRecordAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/LocalRecordAnnotationTest.java
@@ -64,8 +64,8 @@ public class LocalRecordAnnotationTest {
         };
     }
 
-    public static BMap getLocalRecordAnnotations(TypedescValue typedescValue, BString annotName) {
-        return (BMap) TypeChecker.getAnnotValue(typedescValue, annotName);
+    public static BMap<?, ?> getLocalRecordAnnotations(TypedescValue typedescValue, BString annotName) {
+        return (BMap<?, ?>) TypeChecker.getAnnotValue(typedescValue, annotName);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/record/ClosedRecordTypeInclusionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/record/ClosedRecordTypeInclusionTest.java
@@ -90,7 +90,7 @@ public class ClosedRecordTypeInclusionTest {
     @Test(description = "Test case for type referencing all value-typed fields")
     public void testValRefType() {
         Object returns = BRunUtil.invoke(compileResult, "testValRefType");
-        BMap foo1 = (BMap) returns;
+        BMap<?, ?> foo1 = (BMap<?, ?>) returns;
         assertEquals(foo1.get(StringUtils.fromString("a")), 10L);
         assertEquals(foo1.get(StringUtils.fromString("b")), 23.45);
         assertEquals(foo1.get(StringUtils.fromString("s")).toString(), "hello foo");
@@ -109,7 +109,7 @@ public class ClosedRecordTypeInclusionTest {
     @Test(description = "Test case for type referencing records with complex ref types")
     public void testRefTypes() {
         Object returns = BRunUtil.invoke(compileResult, "testRefTypes");
-        BMap foo2 = (BMap) returns;
+        BMap<?, ?> foo2 = (BMap<?, ?>) returns;
         assertEquals(foo2.get(StringUtils.fromString("s")).toString(), "qwerty");
         assertEquals(foo2.get(StringUtils.fromString("i")), 10L);
         assertEquals(getType(foo2.get(StringUtils.fromString("rj"))).getTag(), TypeTags.MAP_TAG);
@@ -139,7 +139,7 @@ public class ClosedRecordTypeInclusionTest {
     @Test(description = "Test case for order of resolving")
     public void testOrdering() {
         Object returns = BRunUtil.invoke(compileResult, "testOrdering");
-        BMap foo3 = (BMap) returns;
+        BMap<?, ?> foo3 = (BMap<?, ?>) returns;
         assertEquals(foo3.get(StringUtils.fromString("s")).toString(), "qwerty");
         assertEquals(foo3.get(StringUtils.fromString("ri")), 10L);
         assertEquals(foo3.get(StringUtils.fromString("rs")).toString(), "asdf");
@@ -148,7 +148,7 @@ public class ClosedRecordTypeInclusionTest {
     @Test(description = "Test case for reference chains")
     public void testReferenceChains() {
         Object returns = BRunUtil.invoke(compileResult, "testReferenceChains");
-        BMap foo4 = (BMap) returns;
+        BMap<?, ?> foo4 = (BMap<?, ?>) returns;
         assertEquals(foo4.get(StringUtils.fromString("s")).toString(), "qwerty");
         assertEquals(foo4.get(StringUtils.fromString("abi")), 10L);
         assertEquals(foo4.get(StringUtils.fromString("efs")).toString(), "asdf");
@@ -158,7 +158,7 @@ public class ClosedRecordTypeInclusionTest {
     @Test(description = "Test case for type referencing in BALAs")
     public void testTypeReferencingInBALAs() {
         Object returns = BRunUtil.invoke(compileResult, "testTypeReferencingInBALAs");
-        BMap manager = (BMap) returns;
+        BMap<?, ?> manager = (BMap<?, ?>) returns;
         assertEquals(manager.get(StringUtils.fromString("name")).toString(), "John Doe");
         assertEquals(manager.get(StringUtils.fromString("age")), 25L);
         assertEquals(manager.get(StringUtils.fromString("adr")).toString(), "{\"city\":\"Colombo\",\"country\":\"Sri " +
@@ -170,7 +170,7 @@ public class ClosedRecordTypeInclusionTest {
     @Test(description = "Test case for default value initializing in type referenced fields")
     public void testDefaultValueInit() {
         Object returns = BRunUtil.invoke(compileResult, "testDefaultValueInit");
-        BMap manager = (BMap) returns;
+        BMap<?, ?> manager = (BMap<?, ?>) returns;
         assertEquals(manager.get(StringUtils.fromString("name")).toString(), "John Doe");
         assertEquals(manager.get(StringUtils.fromString("age")), 25L);
         assertEquals(manager.get(StringUtils.fromString("adr")).toString(), "{\"city\":\"Colombo\",\"country\":\"Sri " +
@@ -182,7 +182,7 @@ public class ClosedRecordTypeInclusionTest {
     @Test(description = "Test case for default value initializing in type referenced fields from a bala")
     public void testDefaultValueInitInBALAs() {
         Object returns = BRunUtil.invoke(compileResult, "testDefaultValueInitInBALAs");
-        BMap manager = (BMap) returns;
+        BMap<?, ?> manager = (BMap<?, ?>) returns;
         assertEquals(manager.get(StringUtils.fromString("name")).toString(), "anonymous");
         assertEquals(manager.get(StringUtils.fromString("age")), 0L);
         assertEquals(manager.get(StringUtils.fromString("adr")).toString(), "{\"city\":\"\",\"country\":\"\"}");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/record/OpenRecordTypeInclusionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/record/OpenRecordTypeInclusionTest.java
@@ -82,7 +82,7 @@ public class OpenRecordTypeInclusionTest {
     @Test(description = "Test case for type referencing all value-typed fields")
     public void testValRefType() {
         Object returns = BRunUtil.invoke(compileResult, "testValRefType");
-        BMap foo1 = (BMap) returns;
+        BMap<?, ?> foo1 = (BMap<?, ?>) returns;
         assertEquals(foo1.get(StringUtils.fromString("a")), 10L);
         assertEquals(foo1.get(StringUtils.fromString("b")), 23.45);
         assertEquals(foo1.get(StringUtils.fromString("s")).toString(), "hello foo");
@@ -101,7 +101,7 @@ public class OpenRecordTypeInclusionTest {
     @Test(description = "Test case for type referencing records with complex ref types")
     public void testRefTypes() {
         Object returns = BRunUtil.invoke(compileResult, "testRefTypes");
-        BMap foo2 = (BMap) returns;
+        BMap<?, ?> foo2 = (BMap<?, ?>) returns;
         assertEquals(foo2.get(StringUtils.fromString("s")).toString(), "qwerty");
         assertEquals(foo2.get(StringUtils.fromString("i")), 10L);
         assertEquals(getType(foo2.get(StringUtils.fromString("rj"))).getTag(), TypeTags.MAP_TAG);
@@ -131,7 +131,7 @@ public class OpenRecordTypeInclusionTest {
     @Test(description = "Test case for order of resolving")
     public void testOrdering() {
         Object returns = BRunUtil.invoke(compileResult, "testOrdering");
-        BMap foo3 = (BMap) returns;
+        BMap<?, ?> foo3 = (BMap<?, ?>) returns;
         assertEquals(foo3.get(StringUtils.fromString("s")).toString(), "qwerty");
         assertEquals(foo3.get(StringUtils.fromString("ri")), 10L);
         assertEquals(foo3.get(StringUtils.fromString("rs")).toString(), "asdf");
@@ -140,7 +140,7 @@ public class OpenRecordTypeInclusionTest {
     @Test(description = "Test case for reference chains")
     public void testReferenceChains() {
         Object returns = BRunUtil.invoke(compileResult, "testReferenceChains");
-        BMap foo4 = (BMap) returns;
+        BMap<?, ?> foo4 = (BMap<?, ?>) returns;
         assertEquals(foo4.get(StringUtils.fromString("s")).toString(), "qwerty");
         assertEquals(foo4.get(StringUtils.fromString("abi")), 10L);
         assertEquals(foo4.get(StringUtils.fromString("efs")).toString(), "asdf");
@@ -150,7 +150,7 @@ public class OpenRecordTypeInclusionTest {
     @Test(description = "Test case for type referencing in BALAs")
     public void testTypeReferencingInBALAs() {
         Object returns = BRunUtil.invoke(compileResult, "testTypeReferencingInBALAs");
-        BMap manager = (BMap) returns;
+        BMap<?, ?> manager = (BMap<?, ?>) returns;
         assertEquals(manager.get(StringUtils.fromString("name")).toString(), "John Doe");
         assertEquals(manager.get(StringUtils.fromString("age")), 25L);
         assertEquals(manager.get(StringUtils.fromString("adr")).toString(),
@@ -162,7 +162,7 @@ public class OpenRecordTypeInclusionTest {
     @Test(description = "Test case for default value initializing in type referenced fields")
     public void testDefaultValueInit() {
         Object returns = BRunUtil.invoke(compileResult, "testDefaultValueInit");
-        BMap manager = (BMap) returns;
+        BMap<?, ?> manager = (BMap<?, ?>) returns;
         assertEquals(manager.get(StringUtils.fromString("name")).toString(), "John Doe");
         assertEquals(manager.get(StringUtils.fromString("age")), 25L);
         assertEquals(manager.get(StringUtils.fromString("adr")).toString(),
@@ -174,7 +174,7 @@ public class OpenRecordTypeInclusionTest {
     @Test(description = "Test case for default value initializing in type referenced fields from a bala")
     public void testDefaultValueInitInBALAs() {
         Object returns = BRunUtil.invoke(compileResult, "testDefaultValueInitInBALAs");
-        BMap manager = (BMap) returns;
+        BMap<?, ?> manager = (BMap<?, ?>) returns;
         assertEquals(manager.get(StringUtils.fromString("name")).toString(), "anonymous");
         assertEquals(manager.get(StringUtils.fromString("age")), 0L);
         assertEquals(manager.get(StringUtils.fromString("adr")).toString(), "{\"city\":\"\",\"country\":\"\"}");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/VarMutabilityClosureTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/closures/VarMutabilityClosureTest.java
@@ -102,15 +102,15 @@ public class VarMutabilityClosureTest {
     @Test(description = "Test variable mutability with maps")
     public void testVarMutabilityWithMaps() {
         Object returns = BRunUtil.invoke(compileResult, "test8");
-        Assert.assertEquals(((BMap) returns).size(), 8);
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("a")).toString(), "AAAA");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("b")).toString(), "BB");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("c")).toString(), "C");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("d")).toString(), "D");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("e")).toString(), "EE");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("x")).toString(), "XXXX");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("y")).toString(), "YY");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("z")).toString(), "ZZ");
+        Assert.assertEquals(((BMap<?, ?>) returns).size(), 8);
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("a")).toString(), "AAAA");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("b")).toString(), "BB");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("c")).toString(), "C");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("d")).toString(), "D");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("e")).toString(), "EE");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("x")).toString(), "XXXX");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("y")).toString(), "YY");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("z")).toString(), "ZZ");
     }
 
 
@@ -126,12 +126,12 @@ public class VarMutabilityClosureTest {
     public void testVarMutabilityWithRecords() {
         Object returns = BRunUtil.invoke(compileResult, "test10");
 
-        BMap resMap = ((BMap) returns);
+        BMap<?, ?> resMap = ((BMap<?, ?>) returns);
         Assert.assertEquals(resMap.get(StringUtils.fromString("age")).toString(), "17");
         Assert.assertEquals(resMap.get(StringUtils.fromString("name")).toString(), "Adam Page");
         Assert.assertEquals(resMap.get(StringUtils.fromString("email")).toString(), "adamp@wso2.com");
 
-        BMap gradesMap = (BMap) resMap.get(StringUtils.fromString("grades"));
+        BMap<?, ?> gradesMap = (BMap<?, ?>) resMap.get(StringUtils.fromString("grades"));
         Assert.assertEquals(gradesMap.get(StringUtils.fromString("bio")).toString(), "22");
         Assert.assertEquals(gradesMap.get(StringUtils.fromString("maths")).toString(), "80");
         Assert.assertEquals(gradesMap.get(StringUtils.fromString("physics")).toString(), "100");
@@ -141,12 +141,12 @@ public class VarMutabilityClosureTest {
     @Test(description = "Test variable mutability with json objects")
     public void testVarMutabilityWithJSONObjects() {
         Object returns = BRunUtil.invoke(compileResult, "test11");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("f1")).toString(), "{\"name\":\"apple\"," +
-                "\"color\":\"red\",\"price\":12.48}");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("f2")).toString(), "{\"name\":\"orange\"," +
-                "\"color\":\"orange\",\"price\":5.36}");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("f3")).toString(), "{\"name\":\"cherry\"," +
-                "\"color\":\"red\",\"price\":5.36}");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("f1")).toString(),
+                "{\"name\":\"apple\",\"color\":\"red\",\"price\":12.48}");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("f2")).toString(),
+                "{\"name\":\"orange\",\"color\":\"orange\",\"price\":5.36}");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("f3")).toString(),
+                "{\"name\":\"cherry\",\"color\":\"red\",\"price\":5.36}");
     }
 
     @Test(description = "Test variable mutability with xml")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -199,7 +199,7 @@ public class ErrorTest {
         Assert.assertTrue(returns instanceof BError);
         Assert.assertEquals(((BError) returns).getMessage(), CONST_ERROR_REASON);
         Assert.assertEquals(
-                ((BMap) ((BError) returns).getDetails()).get(StringUtils.fromString("message")).toString(),
+                ((BMap<?, ?>) ((BError) returns).getDetails()).get(StringUtils.fromString("message")).toString(),
                 "error detail message");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinoperations/CloneOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinoperations/CloneOperationTest.java
@@ -75,23 +75,23 @@ public class CloneOperationTest {
         BArray results = (BArray) returns;
         Assert.assertNotNull(results);
 
-        BMap record = (BMap) results.get(0);
-        BMap fieldA = (BMap) record.get(StringUtils.fromString("a"));
+        BMap<?, ?> record = (BMap<?, ?>) results.get(0);
+        BMap<?, ?> fieldA = (BMap<?, ?>) record.get(StringUtils.fromString("a"));
 
         BArray arr = (BArray) fieldA.get(StringUtils.fromString("arr"));
-        BMap fieldB = (BMap) record.get(StringUtils.fromString("b"));
-        BMap fieldAOfB = (BMap) fieldB.get(StringUtils.fromString("aa"));
+        BMap<?, ?> fieldB = (BMap<?, ?>) record.get(StringUtils.fromString("b"));
+        BMap<?, ?> fieldAOfB = (BMap<?, ?>) fieldB.get(StringUtils.fromString("aa"));
         BArray arrOfAA = (BArray) fieldAOfB.get(StringUtils.fromString("arr"));
 
         Assert.assertEquals(arr.getInt(0), 10);
         Assert.assertEquals(arrOfAA.getInt(0), 10);
 
-        record = (BMap) results.get(1);
-        BMap fieldA1 = (BMap) record.get(StringUtils.fromString("a"));
+        record = (BMap<?, ?>) results.get(1);
+        BMap<?, ?> fieldA1 = (BMap<?, ?>) record.get(StringUtils.fromString("a"));
 
         arr = (BArray) fieldA1.get(StringUtils.fromString("arr"));
-        fieldB = (BMap) record.get(StringUtils.fromString("b"));
-        BMap fieldAOfB1 = (BMap) fieldB.get(StringUtils.fromString("aa"));
+        fieldB = (BMap<?, ?>) record.get(StringUtils.fromString("b"));
+        BMap<?, ?> fieldAOfB1 = (BMap<?, ?>) fieldB.get(StringUtils.fromString("aa"));
         arrOfAA = (BArray) fieldAOfB1.get(StringUtils.fromString("arr"));
 
         Assert.assertEquals(arr.getInt(0), 1);
@@ -114,11 +114,11 @@ public class CloneOperationTest {
         arr[0] = (BArray) results.get(0);
         arr[1] = (BArray) results.get(1);
 
-        BMap record1 = (BMap) arr[0].getRefValue(2);
-        BMap record2 = (BMap) arr[0].getRefValue(3);
+        BMap<?, ?> record1 = (BMap<?, ?>) arr[0].getRefValue(2);
+        BMap<?, ?> record2 = (BMap<?, ?>) arr[0].getRefValue(3);
 
-        BMap record3 = (BMap) arr[1].getRefValue(2);
-        BMap record4 = (BMap) arr[1].getRefValue(3);
+        BMap<?, ?> record3 = (BMap<?, ?>) arr[1].getRefValue(2);
+        BMap<?, ?> record4 = (BMap<?, ?>) arr[1].getRefValue(3);
 
         BArray intArr1 = (BArray) record1.get(StringUtils.fromString("arr"));
         BArray intArr2 = (BArray) record2.get(StringUtils.fromString("arr"));

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionTest.java
@@ -213,7 +213,7 @@ public class NativeConversionTest {
     public void testAnyRecordToAnydataMap() {
         Object returns = BRunUtil.invoke(compileResult, "testAnyRecordToAnydataMap");
         Assert.assertTrue(returns instanceof BMap);
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("name")).toString(), "Waruna");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("name")).toString(), "Waruna");
     }
 
     @Test(description = "Test converting a map to json")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
@@ -104,8 +104,8 @@ public class ArrowExprTest {
     @Test(description = "Test arrow expression with input parameter and return type record")
     public void testRecordTypeWithArrowExpr() {
         Object returns = BRunUtil.invoke(basic, "testRecordTypeWithArrowExpr");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("name")).toString(), "John");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("age")).toString(), "12");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("name")).toString(), "John");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("age")).toString(), "12");
     }
 
     @Test(description = "Test arrow expression that takes one nillable input parameter")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableArrowExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableArrowExprTest.java
@@ -53,8 +53,8 @@ public class IterableArrowExprTest {
     @Test(description = "Test arrow expression inside map() with return string collection")
     public void testMapIterable() {
         Object returns = BRunUtil.invoke(basic, "testMapIterable");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("a")).toString(), "ANT");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("b")).toString(), "BEAR");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("a")).toString(), "ANT");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("b")).toString(), "BEAR");
     }
 
     @Test(description = "Test arrow expression inside filter() and then inside map() followed by average()")
@@ -66,14 +66,14 @@ public class IterableArrowExprTest {
     @Test(description = "Test arrow expression inside map() followed by map()")
     public void testTwoLevelMapIterable() {
         Object returns = BRunUtil.invoke(basic, "testTwoLevelMapIterable");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("a")).toString(), "ANT");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("b")).toString(), "BEAR");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("a")).toString(), "ANT");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("b")).toString(), "BEAR");
     }
 
     @Test(description = "Test arrow expression inside map() then filter() then map()")
     public void testTwoLevelMapIterableWithFilter() {
         Object returns = BRunUtil.invoke(basic, "testTwoLevelMapIterableWithFilter");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("b")).toString(), "BEAR");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("b")).toString(), "BEAR");
     }
 
     @Test(description = "Test arrow expression with filter() first and then map")
@@ -88,15 +88,15 @@ public class IterableArrowExprTest {
     @Test(description = "Test arrow expression inside map() with return a single string")
     public void testFilterWithArityOne() {
         Object returns = BRunUtil.invoke(basic, "testFilterWithArityOne");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("a")).toString(), "ANT");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("c")).toString(), "TIGER");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("a")).toString(), "ANT");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("c")).toString(), "TIGER");
     }
 
     @Test(description = "Test arrow expression inside map() which returns a lambda collection")
     public void testIterableReturnLambda() {
         Object returns = BRunUtil.invoke(basic, "testIterableReturnLambda");
         Assert.assertNotNull(returns);
-        BMap res = (BMap) returns;
+        BMap<?, ?> res = (BMap<?, ?>) returns;
         Assert.assertTrue(res.get(StringUtils.fromString("a")) instanceof BFunctionPointer);
         Assert.assertTrue(res.get(StringUtils.fromString("b")) instanceof BFunctionPointer);
         Assert.assertTrue(res.get(StringUtils.fromString("c")) instanceof BFunctionPointer);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralPackageTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralPackageTest.java
@@ -93,7 +93,7 @@ public class IdentifierLiteralPackageTest {
         BArray returns = (BArray) arr;
         Assert.assertEquals(returns.size(), 1);
         Assert.assertTrue(returns.get(0) instanceof BMap);
-        BMap bmap = (BMap) returns.get(0);
+        BMap<?, ?> bmap = (BMap<?, ?>) returns.get(0);
         Assert.assertEquals(bmap.get(StringUtils.fromString("name")).toString(), "Waruna");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/AnydataStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/AnydataStampInbuiltFunctionTest.java
@@ -92,10 +92,11 @@ public class AnydataStampInbuiltFunctionTest {
         Assert.assertTrue(((BMapType) getType(mapValue0)).getConstrainedType() instanceof BJsonType);
 
         Assert.assertEquals((mapValue0).size(), 5);
-        Assert.assertEquals(((LinkedHashMap) mapValue0).get(StringUtils.fromString("school")).toString(),
+        Assert.assertEquals(((LinkedHashMap<?, ?>) mapValue0).get(StringUtils.fromString("school")).toString(),
                 "Hindu College");
         Assert.assertTrue(
-                getType(((LinkedHashMap) mapValue0).get(StringUtils.fromString("school"))) instanceof BStringType);
+                getType(((LinkedHashMap<?, ?>) mapValue0).get(StringUtils.fromString("school")))
+                        instanceof BStringType);
 
     }
 
@@ -118,10 +119,10 @@ public class AnydataStampInbuiltFunctionTest {
         Assert.assertEquals(mapValue.size(), 2);
 
         Assert.assertEquals(getType(mapValue.get(StringUtils.fromString("a"))).getName(), "Employee");
-        Assert.assertEquals(((BMap) mapValue.get(StringUtils.fromString("a"))).size(), 5);
+        Assert.assertEquals(((BMap<?, ?>) mapValue.get(StringUtils.fromString("a"))).size(), 5);
 
         Assert.assertEquals(getType(mapValue.get(StringUtils.fromString("b"))).getName(), "Employee");
-        Assert.assertEquals(((BMap) mapValue.get(StringUtils.fromString("b"))).size(), 5);
+        Assert.assertEquals(((BMap<?, ?>) mapValue.get(StringUtils.fromString("b"))).size(), 5);
     }
 
     @Test
@@ -154,23 +155,28 @@ public class AnydataStampInbuiltFunctionTest {
         Assert.assertTrue(getType(tupleValue2) instanceof BRecordType);
         Assert.assertEquals(getType(tupleValue2).getName(), "Teacher");
 
-        Assert.assertEquals(((BMap) tupleValue2).size(), 5);
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).size(), 5);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("name")).toString(), "Raja");
-        Assert.assertTrue(getType(((BMap) tupleValue2).get(StringUtils.fromString("name"))) instanceof BStringType);
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("name")).toString(), "Raja");
+        Assert.assertTrue(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("name")))
+                instanceof BStringType);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("age")).toString(), "25");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("age"))).getTag(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("age")).toString(), "25");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("age"))).getTag(),
                 TypeTags.INT_TAG);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("status")).toString(), "single");
-        Assert.assertTrue(getType(((BMap) tupleValue2).get(StringUtils.fromString("status"))) instanceof BStringType);
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("status")).toString(), "single");
+        Assert.assertTrue(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("status")))
+                instanceof BStringType);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("batch")).toString(), "LK2014");
-        Assert.assertTrue(getType(((BMap) tupleValue2).get(StringUtils.fromString("batch"))) instanceof BStringType);
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("batch")).toString(), "LK2014");
+        Assert.assertTrue(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("batch")))
+                instanceof BStringType);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("school")).toString(), "Hindu College");
-        Assert.assertTrue(getType(((BMap) tupleValue2).get(StringUtils.fromString("school"))) instanceof BStringType);
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("school")).toString(),
+                "Hindu College");
+        Assert.assertTrue(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("school")))
+                instanceof BStringType);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/ArrayStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/ArrayStampInbuiltFunctionTest.java
@@ -137,17 +137,19 @@ public class ArrayStampInbuiltFunctionTest {
         Assert.assertEquals(getType(mapValue0).getClass(), BMapType.class);
         Assert.assertEquals(((BMapType) mapValue0.getType()).getConstrainedType().getClass(), BJsonType.class);
         Assert.assertEquals((mapValue0).size(), 4);
-        Assert.assertEquals(((LinkedHashMap) mapValue0).get(StringUtils.fromString("batch")).toString(), "LK2014");
+        Assert.assertEquals(((LinkedHashMap<?, ?>) mapValue0).get(StringUtils.fromString("batch")).toString(),
+                "LK2014");
         Assert.assertEquals(
-                getType(((LinkedHashMap) mapValue0).get(StringUtils.fromString("batch"))).getClass(),
+                getType(((LinkedHashMap<?, ?>) mapValue0).get(StringUtils.fromString("batch"))).getClass(),
                 BStringType.class);
 
         Assert.assertEquals(getType(mapValue1).getClass(), BMapType.class);
         Assert.assertEquals(((BMapType) mapValue0.getType()).getConstrainedType().getClass(), BJsonType.class);
         Assert.assertEquals((mapValue1).size(), 4);
-        Assert.assertEquals(((LinkedHashMap) mapValue1).get(StringUtils.fromString("batch")).toString(), "LK2014");
+        Assert.assertEquals(((LinkedHashMap<?, ?>) mapValue1).get(StringUtils.fromString("batch")).toString(),
+                "LK2014");
         Assert.assertEquals(
-                getType(((LinkedHashMap) mapValue0).get(StringUtils.fromString("batch"))).getClass(),
+                getType(((LinkedHashMap<?, ?>) mapValue0).get(StringUtils.fromString("batch"))).getClass(),
                 BStringType.class);
 
     }
@@ -220,26 +222,28 @@ public class ArrayStampInbuiltFunctionTest {
         Assert.assertEquals(getType(tupleValue2).getClass(), BRecordType.class);
         Assert.assertEquals(getType(tupleValue2).getName(), "Student");
 
-        Assert.assertEquals(((BMap) tupleValue2).size(), 4);
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).size(), 4);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("name")).toString(), "Raja");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("name"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("name")).toString(), "Raja");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("name"))).getClass(),
                 BStringType.class);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("status")).toString(), "single");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("status"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("status")).toString(), "single");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("status"))).getClass(),
                 BStringType.class);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("batch")).toString(), "LK2014");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("batch"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("batch")).toString(), "LK2014");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("batch"))).getClass(),
                 BStringType.class);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("school")).toString(), "Hindu College");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("school"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("school")).toString(),
+                "Hindu College");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("school"))).getClass(),
                 BStringType.class);
 
-        Assert.assertEquals(((BMap) tupleValue1).get(StringUtils.fromString("school")).toString(), "Royal College");
-        Assert.assertEquals(getType(((BMap) tupleValue1).get(StringUtils.fromString("school"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue1).get(StringUtils.fromString("school")).toString(),
+                "Royal College");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue1).get(StringUtils.fromString("school"))).getClass(),
                 BStringType.class);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/JSONStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/JSONStampInbuiltFunctionTest.java
@@ -95,9 +95,9 @@ public class JSONStampInbuiltFunctionTest {
         Assert.assertEquals(mapValue0.getType().getName(), "Employee");
 
         Assert.assertEquals((mapValue0).size(), 4);
-        Assert.assertEquals(((LinkedHashMap) mapValue0).get(StringUtils.fromString("school")).toString(),
+        Assert.assertEquals(((LinkedHashMap<?, ?>) mapValue0).get(StringUtils.fromString("school")).toString(),
                 "Hindu College");
-        Assert.assertEquals(getType(((LinkedHashMap) mapValue0).get(StringUtils.fromString("school"))).getClass(),
+        Assert.assertEquals(getType(((LinkedHashMap<?, ?>) mapValue0).get(StringUtils.fromString("school"))).getClass(),
                 BStringType.class);
 
     }
@@ -138,16 +138,18 @@ public class JSONStampInbuiltFunctionTest {
         Assert.assertEquals(mapValue0.getType().getName(), "Student");
 
         Assert.assertEquals((mapValue0).size(), 4);
-        Assert.assertEquals(((LinkedHashMap) mapValue0).get(StringUtils.fromString("batch")).toString(), "LK2014");
-        Assert.assertEquals(getType(((LinkedHashMap) mapValue0).get(StringUtils.fromString("batch"))).getClass(),
+        Assert.assertEquals(((LinkedHashMap<?, ?>) mapValue0).get(StringUtils.fromString("batch")).toString(),
+                "LK2014");
+        Assert.assertEquals(getType(((LinkedHashMap<?, ?>) mapValue0).get(StringUtils.fromString("batch"))).getClass(),
                 BStringType.class);
 
         Assert.assertEquals(mapValue1.getType().getClass(), BRecordType.class);
         Assert.assertEquals(mapValue1.getType().getName(), "Student");
 
         Assert.assertEquals((mapValue1).size(), 4);
-        Assert.assertEquals(((LinkedHashMap) mapValue1).get(StringUtils.fromString("batch")).toString(), "LK2014");
-        Assert.assertEquals(getType(((LinkedHashMap) mapValue0).get(StringUtils.fromString("batch"))).getClass(),
+        Assert.assertEquals(((LinkedHashMap<?, ?>) mapValue1).get(StringUtils.fromString("batch")).toString(),
+                "LK2014");
+        Assert.assertEquals(getType(((LinkedHashMap<?, ?>) mapValue0).get(StringUtils.fromString("batch"))).getClass(),
                 BStringType.class);
 
     }
@@ -164,7 +166,7 @@ public class JSONStampInbuiltFunctionTest {
         Assert.assertEquals(getType(results.get(1)).getTag(), TypeTags.BOOLEAN_TAG);
         Assert.assertEquals(results.get(2).toString(), "foo");
         Assert.assertEquals(getType(results.get(2)).getClass(), BStringType.class);
-        Assert.assertEquals((((BMap) results.get(3))).size(), 2);
+        Assert.assertEquals((((BMap<?, ?>) results.get(3))).size(), 2);
         Assert.assertEquals(getType(results.get(3)).getClass(), BMapType.class);
         Assert.assertEquals(((BMapType) getType(results.get(3))).getConstrainedType().getClass(), BAnydataType.class);
     }
@@ -197,7 +199,7 @@ public class JSONStampInbuiltFunctionTest {
         Assert.assertEquals(results.get(2).toString(), "foo");
         Assert.assertEquals(getType(results.get(2)).getClass(), BStringType.class);
         Assert.assertNull(results.get(3));
-        Assert.assertEquals((((BMap) results.get(4))).size(), 2);
+        Assert.assertEquals((((BMap<?, ?>) results.get(4))).size(), 2);
         Assert.assertEquals(getType(results.get(4)).getClass(), BMapType.class);
         Assert.assertEquals(((BMapType) getType(results.get(4))).getConstrainedType().getClass(), BAnydataType.class);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/MapStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/MapStampInbuiltFunctionTest.java
@@ -256,18 +256,18 @@ public class MapStampInbuiltFunctionTest {
         Assert.assertEquals(mapValue.size(), 2);
 
         Assert.assertEquals(getType(mapValue.get(StringUtils.fromString("a"))).getName(), "Employee");
-        Assert.assertEquals(getType(((BMap) mapValue.get(StringUtils.fromString("a"))).get(
+        Assert.assertEquals(getType(((BMap<?, ?>) mapValue.get(StringUtils.fromString("a"))).get(
                         StringUtils.fromString("age"))).getTag(),
                 TypeTags.INT_TAG);
-        Assert.assertEquals(getType(((BMap) mapValue.get(StringUtils.fromString("a"))).get(
+        Assert.assertEquals(getType(((BMap<?, ?>) mapValue.get(StringUtils.fromString("a"))).get(
                 StringUtils.fromString("school"))).
                 getClass(), BStringType.class);
 
         Assert.assertEquals(getType(mapValue.get(StringUtils.fromString("b"))).getName(), "Employee");
-        Assert.assertEquals(getType(((BMap) mapValue.get(StringUtils.fromString("b"))).get(
+        Assert.assertEquals(getType(((BMap<?, ?>) mapValue.get(StringUtils.fromString("b"))).get(
                         StringUtils.fromString("age"))).getTag(),
                 TypeTags.INT_TAG);
-        Assert.assertEquals(getType(((BMap) mapValue.get(StringUtils.fromString("b"))).get(
+        Assert.assertEquals(getType(((BMap<?, ?>) mapValue.get(StringUtils.fromString("b"))).get(
                 StringUtils.fromString("school"))).
                 getClass(), BStringType.class);
     }
@@ -291,9 +291,9 @@ public class MapStampInbuiltFunctionTest {
         Assert.assertEquals(mapValue.size(), 2);
 
         Assert.assertEquals(getType(mapValue.get(StringUtils.fromString("a"))).getClass(), BMapType.class);
-        Assert.assertEquals(((BMap) mapValue.get(StringUtils.fromString("a"))).size(), 5);
+        Assert.assertEquals(((BMap<?, ?>) mapValue.get(StringUtils.fromString("a"))).size(), 5);
         Assert.assertEquals(getType(mapValue.get(StringUtils.fromString("b"))).getClass(), BMapType.class);
-        Assert.assertEquals(((BMap) mapValue.get(StringUtils.fromString("b"))).size(), 5);
+        Assert.assertEquals(((BMap<?, ?>) mapValue.get(StringUtils.fromString("b"))).size(), 5);
     }
 
     @Test
@@ -306,18 +306,20 @@ public class MapStampInbuiltFunctionTest {
 
         Assert.assertEquals(getType(mapValue.get(StringUtils.fromString("a"))).getName(), "Employee");
         Assert.assertEquals(
-                getType(((BMap) mapValue.get(StringUtils.fromString("a"))).get(StringUtils.fromString("age"))).getTag(),
+                getType(((BMap<?, ?>) mapValue.get(StringUtils.fromString("a")))
+                        .get(StringUtils.fromString("age"))).getTag(),
                 TypeTags.INT_TAG);
         Assert.assertEquals(
-                getType(((BMap) mapValue.get(StringUtils.fromString("a"))).get(StringUtils.fromString("school"))).
+                getType(((BMap<?, ?>) mapValue.get(StringUtils.fromString("a"))).get(StringUtils.fromString("school"))).
                         getClass(), BStringType.class);
 
         Assert.assertEquals(getType(mapValue.get(StringUtils.fromString("b"))).getName(), "Employee");
         Assert.assertEquals(
-                getType(((BMap) mapValue.get(StringUtils.fromString("b"))).get(StringUtils.fromString("age"))).getTag(),
+                getType(((BMap<?, ?>) mapValue.get(StringUtils.fromString("b")))
+                        .get(StringUtils.fromString("age"))).getTag(),
                 TypeTags.INT_TAG);
         Assert.assertEquals(
-                getType(((BMap) mapValue.get(StringUtils.fromString("b"))).get(StringUtils.fromString("school"))).
+                getType(((BMap<?, ?>) mapValue.get(StringUtils.fromString("b"))).get(StringUtils.fromString("school"))).
                         getClass(), BStringType.class);
     }
 
@@ -346,10 +348,12 @@ public class MapStampInbuiltFunctionTest {
         Assert.assertEquals(mapValue.size(), 2);
 
         Assert.assertEquals(
-                getType(((BMap) ((BMap) mapValue.get(StringUtils.fromString("a"))).get(StringUtils.fromString("aa")))
+                getType(((BMap<?, ?>) ((BMap<?, ?>) mapValue.get(StringUtils.fromString("a")))
+                        .get(StringUtils.fromString("aa")))
                         .get(StringUtils.fromString("aa"))).getTag(), TypeTags.INT_TAG);
         Assert.assertEquals(
-                ((BMap) ((BMap) mapValue.get(StringUtils.fromString("a"))).get(StringUtils.fromString("aa")))
+                ((BMap<?, ?>) ((BMap<?, ?>) mapValue.get(StringUtils.fromString("a")))
+                        .get(StringUtils.fromString("aa")))
                         .get(StringUtils.fromString("aa")).toString(), "11");
     }
 
@@ -362,11 +366,12 @@ public class MapStampInbuiltFunctionTest {
         Assert.assertEquals(mapValue.size(), 2);
         Assert.assertEquals(mapValue.size(), 2);
 
-        Assert.assertEquals(getType(((BMap) ((BMap) mapValue.get(StringUtils.fromString("a"))).get(
+        Assert.assertEquals(getType(((BMap<?, ?>) ((BMap<?, ?>) mapValue.get(StringUtils.fromString("a"))).get(
                         StringUtils.fromString("aa"))).get(StringUtils.fromString("aa"))).getTag(),
                 TypeTags.INT_TAG);
         Assert.assertEquals(
-                ((BMap) ((BMap) mapValue.get(StringUtils.fromString("a"))).get(StringUtils.fromString("aa"))).get(
+                ((BMap<?, ?>) ((BMap<?, ?>) mapValue.get(StringUtils.fromString("a")))
+                        .get(StringUtils.fromString("aa"))).get(
                         StringUtils.fromString("aa")).toString(), "11");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/RecordStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/RecordStampInbuiltFunctionTest.java
@@ -127,9 +127,9 @@ public class RecordStampInbuiltFunctionTest {
         Assert.assertEquals(((BMapType) mapValue0.getType()).getConstrainedType().getClass(), BJsonType.class);
 
         Assert.assertEquals((mapValue0).size(), 4);
-        Assert.assertEquals(((LinkedHashMap) mapValue0).get(StringUtils.fromString("school")).toString(),
+        Assert.assertEquals(((LinkedHashMap<?, ?>) mapValue0).get(StringUtils.fromString("school")).toString(),
                 "Hindu College");
-        Assert.assertEquals(getType(((LinkedHashMap) mapValue0).get(StringUtils.fromString("school"))).getClass(),
+        Assert.assertEquals(getType(((LinkedHashMap<?, ?>) mapValue0).get(StringUtils.fromString("school"))).getClass(),
                 BStringType.class);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/TupleTypeStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/TupleTypeStampInbuiltFunctionTest.java
@@ -67,26 +67,27 @@ public class TupleTypeStampInbuiltFunctionTest {
         Assert.assertEquals(getType(tupleValue2).getClass(), BRecordType.class);
         Assert.assertEquals(getType(tupleValue2).getName(), "Teacher");
 
-        Assert.assertEquals(((BMap) tupleValue2).size(), 5);
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).size(), 5);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("name")).toString(), "Raja");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("name"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("name")).toString(), "Raja");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("name"))).getClass(),
                 BStringType.class);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("age")).toString(), "25");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("age"))).getTag(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("age")).toString(), "25");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("age"))).getTag(),
                 TypeTags.INT_TAG);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("status")).toString(), "single");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("status"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("status")).toString(), "single");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("status"))).getClass(),
                 BStringType.class);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("batch")).toString(), "LK2014");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("batch"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("batch")).toString(), "LK2014");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("batch"))).getClass(),
                 BStringType.class);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("school")).toString(), "Hindu College");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("school"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("school")).toString(),
+                "Hindu College");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("school"))).getClass(),
                 BStringType.class);
     }
 
@@ -106,26 +107,27 @@ public class TupleTypeStampInbuiltFunctionTest {
         Assert.assertEquals(getType(tupleValue2).getClass(), BRecordType.class);
         Assert.assertEquals(getType(tupleValue2).getName(), "Employee");
 
-        Assert.assertEquals(((BMap) tupleValue2).size(), 5);
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).size(), 5);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("name")).toString(), "Raja");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("name"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("name")).toString(), "Raja");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("name"))).getClass(),
                 BStringType.class);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("age")).toString(), "25");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("age"))).getTag(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("age")).toString(), "25");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("age"))).getTag(),
                 TypeTags.INT_TAG);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("status")).toString(), "single");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("status"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("status")).toString(), "single");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("status"))).getClass(),
                 BStringType.class);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("batch")).toString(), "LK2014");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("batch"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("batch")).toString(), "LK2014");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("batch"))).getClass(),
                 BStringType.class);
 
-        Assert.assertEquals(((BMap) tupleValue2).get(StringUtils.fromString("school")).toString(), "Hindu College");
-        Assert.assertEquals(getType(((BMap) tupleValue2).get(StringUtils.fromString("school"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("school")).toString(),
+                "Hindu College");
+        Assert.assertEquals(getType(((BMap<?, ?>) tupleValue2).get(StringUtils.fromString("school"))).getClass(),
                 BStringType.class);
     }
 
@@ -162,22 +164,23 @@ public class TupleTypeStampInbuiltFunctionTest {
         Assert.assertEquals(getType(arrayValue2).getClass(), BRecordType.class);
         Assert.assertEquals(getType(arrayValue2).getName(), "Employee");
 
-        Assert.assertEquals(((BMap) arrayValue2).size(), 4);
+        Assert.assertEquals(((BMap<?, ?>) arrayValue2).size(), 4);
 
-        Assert.assertEquals(((BMap) arrayValue2).get(StringUtils.fromString("name")).toString(), "Raja");
-        Assert.assertEquals(getType(((BMap) arrayValue2).get(StringUtils.fromString("name"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) arrayValue2).get(StringUtils.fromString("name")).toString(), "Raja");
+        Assert.assertEquals(getType(((BMap<?, ?>) arrayValue2).get(StringUtils.fromString("name"))).getClass(),
                 BStringType.class);
 
-        Assert.assertEquals(((BMap) arrayValue2).get(StringUtils.fromString("status")).toString(), "single");
-        Assert.assertEquals(getType(((BMap) arrayValue2).get(StringUtils.fromString("status"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) arrayValue2).get(StringUtils.fromString("status")).toString(), "single");
+        Assert.assertEquals(getType(((BMap<?, ?>) arrayValue2).get(StringUtils.fromString("status"))).getClass(),
                 BStringType.class);
 
-        Assert.assertEquals(((BMap) arrayValue2).get(StringUtils.fromString("batch")).toString(), "LK2014");
-        Assert.assertEquals(getType(((BMap) arrayValue2).get(StringUtils.fromString("batch"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) arrayValue2).get(StringUtils.fromString("batch")).toString(), "LK2014");
+        Assert.assertEquals(getType(((BMap<?, ?>) arrayValue2).get(StringUtils.fromString("batch"))).getClass(),
                 BStringType.class);
 
-        Assert.assertEquals(((BMap) arrayValue2).get(StringUtils.fromString("school")).toString(), "Hindu College");
-        Assert.assertEquals(getType(((BMap) arrayValue2).get(StringUtils.fromString("school"))).getClass(),
+        Assert.assertEquals(((BMap<?, ?>) arrayValue2).get(StringUtils.fromString("school")).toString(),
+                "Hindu College");
+        Assert.assertEquals(getType(((BMap<?, ?>) arrayValue2).get(StringUtils.fromString("school"))).getClass(),
                 BStringType.class);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/UnionTypeStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/UnionTypeStampInbuiltFunctionTest.java
@@ -150,24 +150,24 @@ public class UnionTypeStampInbuiltFunctionTest {
         Assert.assertEquals(constrainedType.getName(), "Teacher");
 
         Assert.assertEquals(getType(employee0.get(StringUtils.fromString("a"))).getName(), "Teacher");
-        Assert.assertEquals(getType(((BMap) employee0.get(StringUtils.fromString("a"))).get(
+        Assert.assertEquals(getType(((BMap<?, ?>) employee0.get(StringUtils.fromString("a"))).get(
                         StringUtils.fromString("age"))).getTag(),
                 TypeTags.INT_TAG);
-        Assert.assertEquals(getType(((BMap) employee0.get(StringUtils.fromString("a"))).get(
+        Assert.assertEquals(getType(((BMap<?, ?>) employee0.get(StringUtils.fromString("a"))).get(
                         StringUtils.fromString("school"))).getClass(),
                 BStringType.class);
-        Assert.assertEquals(getType(((BMap) employee0.get(StringUtils.fromString("a"))).get(
+        Assert.assertEquals(getType(((BMap<?, ?>) employee0.get(StringUtils.fromString("a"))).get(
                         StringUtils.fromString("batch"))).getClass(),
                 BStringType.class);
 
         Assert.assertEquals(getType(employee0.get(StringUtils.fromString("b"))).getName(), "Teacher");
-        Assert.assertEquals(getType(((BMap) employee0.get(StringUtils.fromString("b"))).get(
+        Assert.assertEquals(getType(((BMap<?, ?>) employee0.get(StringUtils.fromString("b"))).get(
                         StringUtils.fromString("age"))).getTag(),
                 TypeTags.INT_TAG);
-        Assert.assertEquals(getType(((BMap) employee0.get(StringUtils.fromString("b"))).get(
+        Assert.assertEquals(getType(((BMap<?, ?>) employee0.get(StringUtils.fromString("b"))).get(
                         StringUtils.fromString("school"))).getClass(),
                 BStringType.class);
-        Assert.assertEquals(getType(((BMap) employee0.get(StringUtils.fromString("b"))).get(
+        Assert.assertEquals(getType(((BMap<?, ?>) employee0.get(StringUtils.fromString("b"))).get(
                         StringUtils.fromString("batch"))).getClass(),
                 BStringType.class);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -88,7 +88,7 @@ public class TypeCastExprTest {
         Object returns = BRunUtil.invoke(result, "stringtofloat", args);
         Assert.assertTrue(returns instanceof BError);
         BError error = (BError) returns;
-        String errorMsg = ((BMap) error.getDetails()).get(StringUtils.fromString("message")).toString();
+        String errorMsg = ((BMap<?, ?>) error.getDetails()).get(StringUtils.fromString("message")).toString();
         Assert.assertEquals(errorMsg, "'string' value '2222.333f' cannot be converted to 'float'");
     }
 
@@ -226,7 +226,7 @@ public class TypeCastExprTest {
         Object returns = BRunUtil.invoke(result, "testIncompatibleJsonToInt");
         Assert.assertTrue(returns instanceof BError);
         BError error = (BError) returns;
-        String errorMsg = ((BMap) error.getDetails()).get(StringUtils.fromString("message")).toString();
+        String errorMsg = ((BMap<?, ?>) error.getDetails()).get(StringUtils.fromString("message")).toString();
         Assert.assertEquals(errorMsg, "'string' value '\"hello\"' cannot be converted to 'int'");
     }
 
@@ -235,7 +235,7 @@ public class TypeCastExprTest {
         Object returns = BRunUtil.invoke(result, "testIncompatibleJsonToFloat");
         Assert.assertTrue(returns instanceof BError);
         BError error = (BError) returns;
-        String errorMsg = ((BMap) error.getDetails()).get(StringUtils.fromString("message")).toString();
+        String errorMsg = ((BMap<?, ?>) error.getDetails()).get(StringUtils.fromString("message")).toString();
         Assert.assertEquals(errorMsg, "'string' value '\"hello\"' cannot be converted to 'float'");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExpressionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExpressionsTest.java
@@ -207,16 +207,16 @@ public class TypeCastExpressionsTest {
     public void testUntaintedWithoutType() {
         Object returns = BRunUtil.invoke(result, "testContexuallyExpectedType");
         Assert.assertTrue(returns instanceof BMap);
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("name")).toString(), "Em Zee");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("id")).toString(), "1100");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("name")).toString(), "Em Zee");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("id")).toString(), "1100");
     }
 
     @Test
     public void testUntaintedWithoutType2() {
         Object returns = BRunUtil.invoke(result, "testContexuallyExpectedTypeRecContext");
         Assert.assertTrue(returns instanceof BMap);
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("name")).toString(), "Em Zee");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("id")).toString(), "1100");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("name")).toString(), "Em Zee");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("id")).toString(), "1100");
     }
 
     @DataProvider

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/ValueTypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/ValueTypeCastExprTest.java
@@ -106,7 +106,7 @@ public class ValueTypeCastExprTest {
         Object returns = BRunUtil.invoke(result, "stringToFloat", args);
         Assert.assertTrue(returns instanceof BError);
         BError error = (BError) returns;
-        String errorMsg = ((BMap) error.getDetails()).get(StringUtils.fromString("message")).toString();
+        String errorMsg = ((BMap<?, ?>) error.getDetails()).get(StringUtils.fromString("message")).toString();
         Assert.assertEquals(errorMsg, "'string' value '2222.333f' cannot be converted to 'float'");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/ErrorVariableReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/ErrorVariableReferenceTest.java
@@ -57,11 +57,11 @@ public class ErrorVariableReferenceTest {
         Assert.assertEquals(returns.get(1).toString(), "Error One");
         Assert.assertEquals(returns.get(2).toString(), "Error Two");
         Assert.assertEquals(returns.get(3).toString(), "Error Two");
-        Assert.assertEquals(((BMap) returns.get(4)).get(StringUtils.fromString("message")).toString(), "Msg One");
+        Assert.assertEquals(((BMap<?, ?>) returns.get(4)).get(StringUtils.fromString("message")).toString(), "Msg One");
         Assert.assertEquals(returns.get(5).toString(), "Msg One");
         Assert.assertEquals(returns.get(6).toString(), "Detail Msg");
-        Assert.assertEquals(((BMap) returns.get(7)).get(StringUtils.fromString("message")).toString(), "Msg Two");
-        Assert.assertTrue((Boolean) ((BMap) returns.get(7)).get(StringUtils.fromString("fatal")));
+        Assert.assertEquals(((BMap<?, ?>) returns.get(7)).get(StringUtils.fromString("message")).toString(), "Msg Two");
+        Assert.assertTrue((Boolean) ((BMap<?, ?>) returns.get(7)).get(StringUtils.fromString("fatal")));
         Assert.assertEquals(returns.get(8).toString(), "Msg Two");
         Assert.assertTrue((Boolean) returns.get(9));
     }
@@ -75,11 +75,13 @@ public class ErrorVariableReferenceTest {
         Assert.assertEquals(returns.get(1).toString(), "Some Error One");
         Assert.assertEquals(returns.get(2).toString(), "Some Error Two");
         Assert.assertEquals(returns.get(3).toString(), "Some Error Two");
-        Assert.assertEquals(((BMap) returns.get(4)).get(StringUtils.fromString("message")).toString(), "Msg Three");
+        Assert.assertEquals(((BMap<?, ?>) returns.get(4)).get(StringUtils.fromString("message")).toString(),
+                "Msg Three");
         Assert.assertEquals(returns.get(5).toString(), "Msg Three");
         Assert.assertEquals(returns.get(6).toString(), "Detail Msg");
-        Assert.assertEquals(((BMap) returns.get(7)).get(StringUtils.fromString("message")).toString(), "Msg Four");
-        Assert.assertTrue((Boolean) ((BMap) returns.get(7)).get(StringUtils.fromString("fatal")));
+        Assert.assertEquals(((BMap<?, ?>) returns.get(7)).get(StringUtils.fromString("message")).toString(),
+                "Msg Four");
+        Assert.assertTrue((Boolean) ((BMap<?, ?>) returns.get(7)).get(StringUtils.fromString("fatal")));
         Assert.assertEquals(returns.get(8).toString(), "Msg Four");
         Assert.assertTrue((Boolean) returns.get(9));
         Assert.assertEquals(returns.get(10).toString(),
@@ -95,7 +97,7 @@ public class ErrorVariableReferenceTest {
         Assert.assertEquals(returns.get(1).toString(), "Error One");
         Assert.assertEquals(returns.get(2).toString(), "Something Wrong");
         Assert.assertTrue((Boolean) returns.get(3));
-        Assert.assertEquals(((BMap) returns.get(4)).get(StringUtils.fromString("message")).toString(),
+        Assert.assertEquals(((BMap<?, ?>) returns.get(4)).get(StringUtils.fromString("message")).toString(),
                 "Something Wrong");
     }
 
@@ -159,7 +161,7 @@ public class ErrorVariableReferenceTest {
     @Test(description = "Test simple error var def inside tuple with destructuring error")
     public void testErrorWithRestParam() {
         Object returns = BRunUtil.invoke(result, "testErrorWithRestParam");
-        BMap<BString, Object> results = (BMap) returns;
+        BMap<BString, Object> results = (BMap<BString, Object>) returns;
         Assert.assertEquals(results.get(StringUtils.fromString("fatal")).toString(), "true");
         Assert.assertEquals(results.get(StringUtils.fromString("extra")).toString(), "extra");
     }
@@ -170,7 +172,7 @@ public class ErrorVariableReferenceTest {
         BArray returns = (BArray) arr;
         Assert.assertEquals(returns.size(), 2);
         Assert.assertEquals(returns.get(0).toString(), "Error");
-        BMap<BString, Object> results = (BMap) returns.get(1);
+        BMap<BString, Object> results = (BMap<BString, Object>) returns.get(1);
         Assert.assertEquals(results.get(StringUtils.fromString("message")).toString(), "Fatal");
         Assert.assertEquals(results.get(StringUtils.fromString("fatal")).toString(), "true");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/RecordVariableReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/RecordVariableReferenceTest.java
@@ -62,8 +62,8 @@ public class RecordVariableReferenceTest {
         Object arr = BRunUtil.invoke(result, "testRecVarRefInsideRecVarRefInsideRecVarRef");
         BArray returns = (BArray) arr;
         Assert.assertEquals(returns.size(), 4);
-        Assert.assertEquals(((BMap) returns.get(0)).get(StringUtils.fromString("mKey1")), 1L);
-        Assert.assertEquals(((BMap) returns.get(0)).get(StringUtils.fromString("mKey2")), 2L);
+        Assert.assertEquals(((BMap<?, ?>) returns.get(0)).get(StringUtils.fromString("mKey1")), 1L);
+        Assert.assertEquals(((BMap<?, ?>) returns.get(0)).get(StringUtils.fromString("mKey2")), 2L);
         Assert.assertEquals(returns.get(1), 12L);
         Assert.assertEquals(returns.get(2).toString(), "SomeVar1");
         Assert.assertNull(returns.get(3));
@@ -72,8 +72,8 @@ public class RecordVariableReferenceTest {
     @Test(description = "Test simple record variable definition")
     public void testRestParam() {
         Object returns = BRunUtil.invoke(result, "testRestParam");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("var3")), 12L);
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("var4")).toString(), "text");
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("var3")), 12L);
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("var4")).toString(), "text");
     }
 
     @Test(description = "Test simple record variable definition")
@@ -81,11 +81,11 @@ public class RecordVariableReferenceTest {
         Object arr = BRunUtil.invoke(result, "testRecordTypeInRecordVarRef");
         BArray returns = (BArray) arr;
         Assert.assertEquals(returns.size(), 3);
-        Assert.assertEquals(((BMap) returns.get(0)).get(StringUtils.fromString("mKey1")), 1L);
-        Assert.assertEquals(((BMap) returns.get(0)).get(StringUtils.fromString("mKey2")), 2L);
+        Assert.assertEquals(((BMap<?, ?>) returns.get(0)).get(StringUtils.fromString("mKey1")), 1L);
+        Assert.assertEquals(((BMap<?, ?>) returns.get(0)).get(StringUtils.fromString("mKey2")), 2L);
         Assert.assertEquals(returns.get(1), 12L);
-        Assert.assertEquals((((BMap) returns.get(2)).get(StringUtils.fromString("var1"))).toString(), "SomeVar1");
-        Assert.assertNull(((BMap) returns.get(2)).get(StringUtils.fromString("var2")));
+        Assert.assertEquals((((BMap<?, ?>) returns.get(2)).get(StringUtils.fromString("var1"))).toString(), "SomeVar1");
+        Assert.assertNull(((BMap<?, ?>) returns.get(2)).get(StringUtils.fromString("var2")));
     }
 
     @Test(description = "Test tuple var ref inside record var ref")
@@ -112,11 +112,11 @@ public class RecordVariableReferenceTest {
         Assert.assertEquals(((BArray) returns.get(0)).getString(0), "A");
         Assert.assertEquals(((BArray) returns.get(0)).getString(1), "B");
         Assert.assertEquals(returns.get(1).toString(), "A");
-        BMap child = (BMap) ((BMap) returns.get(2)).get(StringUtils.fromString("child"));
+        BMap<?, ?> child = (BMap<?, ?>) ((BMap<?, ?>) returns.get(2)).get(StringUtils.fromString("child"));
         Assert.assertEquals(child.get(StringUtils.fromString("name")).toString(), "C");
         Assert.assertEquals((((BArray) child.get(StringUtils.fromString("yearAndAge"))).getRefValue(0)), 1996L);
-        Assert.assertEquals(((BMap) ((BArray) child.get(StringUtils.fromString("yearAndAge"))).getRefValue(1)).get(
-                        StringUtils.fromString("format")).toString(),
+        Assert.assertEquals(((BMap<?, ?>) ((BArray) child.get(StringUtils.fromString("yearAndAge")))
+                        .getRefValue(1)).get(StringUtils.fromString("format")).toString(),
                 "Z");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionsWithDefaultableParametersTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionsWithDefaultableParametersTest.java
@@ -91,25 +91,25 @@ public class FunctionsWithDefaultableParametersTest {
         Assert.assertTrue(returns.get(2) instanceof BMap);
         Assert.assertTrue(returns.get(3) instanceof BMap);
 
-        BMap bMap = (BMap) returns.get(0);
+        BMap<?, ?> bMap = (BMap<?, ?>) returns.get(0);
         Assert.assertEquals(bMap.get(StringUtils.fromString("a")).toString(), "default");
         Assert.assertEquals(bMap.get(StringUtils.fromString("b")), 50L);
         Assert.assertFalse((Boolean) bMap.get(StringUtils.fromString("c")));
         Assert.assertEquals(bMap.get(StringUtils.fromString("d")), 11.1);
 
-        bMap = (BMap) returns.get(1);
+        bMap = (BMap<?, ?>) returns.get(1);
         Assert.assertEquals(bMap.get(StringUtils.fromString("a")).toString(), "f2");
         Assert.assertEquals(bMap.get(StringUtils.fromString("b")), 200L);
         Assert.assertFalse((Boolean) bMap.get(StringUtils.fromString("c")));
         Assert.assertEquals(bMap.get(StringUtils.fromString("d")), 44.4);
 
-        bMap = (BMap) returns.get(2);
+        bMap = (BMap<?, ?>) returns.get(2);
         Assert.assertEquals(bMap.get(StringUtils.fromString("a")).toString(), "f1");
         Assert.assertEquals(bMap.get(StringUtils.fromString("b")), 100L);
         Assert.assertTrue((Boolean) bMap.get(StringUtils.fromString("c")));
         Assert.assertEquals(bMap.get(StringUtils.fromString("d")), 22.2);
 
-        bMap = (BMap) returns.get(3);
+        bMap = (BMap<?, ?>) returns.get(3);
         Assert.assertEquals(bMap.get(StringUtils.fromString("a")).toString(), "default2");
         Assert.assertEquals(bMap.get(StringUtils.fromString("b")), 150L);
         Assert.assertTrue((Boolean) bMap.get(StringUtils.fromString("c")));

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeNegativeTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeNegativeTests.java
@@ -104,7 +104,7 @@ public class RefTypeNegativeTests {
     public static void acceptReadOnlyValue(long r) {
     }
 
-    public static BFuture returnReadOnlyValue(FPValue f) {
+    public static BFuture returnReadOnlyValue(FPValue<?, ?> f) {
         return new FutureValue(null, null, null); // OK since not used anywhere.
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeTests.java
@@ -85,7 +85,7 @@ public class RefTypeTests {
         Object returns = BRunUtil.invoke(result, "interopWithRefTypesAndMapReturn");
 
         Assert.assertTrue(returns instanceof BMap);
-        BMap bMap = (BMap) returns;
+        BMap<?, ?> bMap = (BMap<?, ?>) returns;
         Assert.assertEquals(bMap.toString(), "{\"a\":object Person,\"b\":[5,\"hello\",object Person]," +
                 "\"c\":{\"name\":\"sameera\"},\"e\":object Person,\"f\":83,\"g\":{\"name\":\"sample\"}}");
     }
@@ -306,7 +306,7 @@ public class RefTypeTests {
         Assert.assertTrue(returns instanceof HandleValue);
         HandleValue handle = (HandleValue) returns;
         Assert.assertTrue(handle.getValue() instanceof Map);
-        Map map = (Map) handle.getValue();
+        Map<?, ?> map = (Map<?, ?>) handle.getValue();
         Assert.assertEquals(map.size(), 1);
         Assert.assertEquals(map.get("name"), "John");
     }
@@ -392,12 +392,12 @@ public class RefTypeTests {
         return x;
     }
 
-    public static int useFunctionPointer(FPValue fp) {
+    public static int useFunctionPointer(FPValue<Object[], Long> fp) {
         return ((Long) fp.call(new Object[]{Scheduler.getStrand(), 3, 4})).intValue();
     }
 
-    public static FPValue getFunctionPointer(Object fp) {
-        return (FPValue) fp;
+    public static FPValue<?, ?> getFunctionPointer(Object fp) {
+        return (FPValue<?, ?>) fp;
     }
 
     public static BString useTypeDesc(TypedescValue type) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeWithBValueAPITests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeWithBValueAPITests.java
@@ -90,7 +90,7 @@ public class RefTypeWithBValueAPITests {
         Object returns = BRunUtil.invoke(result, "interopWithRefTypesAndMapReturn");
 
         Assert.assertTrue(returns instanceof BMap);
-        BMap bMap = (BMap) returns;
+        BMap<?, ?> bMap = (BMap<?, ?>) returns;
         Assert.assertEquals(bMap.toString(), "{\"a\":object Person,\"b\":[5,\"hello\",object Person]," +
                 "\"c\":{\"name\":\"sameera\"},\"e\":object Person,\"f\":83,\"g\":{\"name\":\"sample\"}}");
     }
@@ -285,7 +285,7 @@ public class RefTypeWithBValueAPITests {
     // static methods
 
     // This scenario is for map value to be passed to interop and return array value.
-    public static BArray getArrayValueFromMap(BString key, BMap mapValue) {
+    public static BArray getArrayValueFromMap(BString key, BMap<?, ?> mapValue) {
         BArray arrayValue = new ArrayValueImpl(new BArrayType(PredefinedTypes.TYPE_INT));
         arrayValue.add(0, 1);
         long fromMap = (long) mapValue.get(key);
@@ -293,8 +293,9 @@ public class RefTypeWithBValueAPITests {
         return arrayValue;
     }
 
-    public static BMap acceptRefTypesAndReturnMap(BObject a, BArray b, Object c, BError d, Object e, Object f, BMap g) {
-        BMap<String, Object> mapValue = new MapValueImpl();
+    public static BMap<?, ?> acceptRefTypesAndReturnMap(BObject a, BArray b, Object c, BError d, Object e, Object f,
+                                                        BMap<?, ?> g) {
+        BMap<String, Object> mapValue = new MapValueImpl<>();
         mapValue.put("a", a);
         mapValue.put("b", b);
         mapValue.put("c", c);
@@ -318,7 +319,7 @@ public class RefTypeWithBValueAPITests {
         return p;
     }
 
-    public static BMap acceptRecordAndRecordReturn(BMap e, BString newVal) {
+    public static BMap<?, ?> acceptRecordAndRecordReturn(BMap<BString, Object> e, BString newVal) {
         e.put(StringUtils.fromString("name"), newVal);
         return e;
     }
@@ -327,8 +328,8 @@ public class RefTypeWithBValueAPITests {
         return (int) (a + 5);
     }
 
-    public static BMap acceptRecordAndRecordReturnWhichThrowsCheckedException(BMap e, BString newVal)
-            throws JavaInteropTestCheckedException {
+    public static BMap<?, ?> acceptRecordAndRecordReturnWhichThrowsCheckedException(
+            BMap<String, Object> e, BString newVal) throws JavaInteropTestCheckedException {
         e.put("name", newVal);
         return e;
     }
@@ -343,8 +344,8 @@ public class RefTypeWithBValueAPITests {
         };
     }
 
-    public static BMap acceptRefTypesAndReturnMapWhichThrowsCheckedException(BObject a, BArray b, Object c, BError d,
-                                                                             Object e, Object f, BMap g)
+    public static BMap<?, ?> acceptRefTypesAndReturnMapWhichThrowsCheckedException(
+            BObject a, BArray b, Object c, BError d, Object e, Object f, BMap<?, ?> g)
             throws JavaInteropTestCheckedException {
         BMap<String, Object> mapValue = new MapValueImpl<>();
         mapValue.put("a", a);
@@ -361,7 +362,7 @@ public class RefTypeWithBValueAPITests {
         return ErrorCreator.createError(msg, new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL));
     }
 
-    public static BArray getArrayValueFromMapWhichThrowsCheckedException(BString key, BMap mapValue)
+    public static BArray getArrayValueFromMapWhichThrowsCheckedException(BString key, BMap<?, ?> mapValue)
             throws JavaInteropTestCheckedException {
         BArray arrayValue = new ArrayValueImpl(new BArrayType(PredefinedTypes.TYPE_INT));
         arrayValue.add(0, 1);
@@ -448,12 +449,12 @@ public class RefTypeWithBValueAPITests {
         return x;
     }
 
-    public static int useFunctionPointer(BFunctionPointer fp) {
+    public static int useFunctionPointer(BFunctionPointer<Object, Long> fp) {
         return ((Long) fp.call(new Object[]{Scheduler.getStrand(), 3, 4})).intValue();
     }
 
-    public static BFunctionPointer getFunctionPointer(Object fp) {
-        return (FPValue) fp;
+    public static BFunctionPointer<?, ?> getFunctionPointer(Object fp) {
+        return (FPValue<?, ?>) fp;
     }
 
     public static BString useTypeDesc(BTypedesc type) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/InstanceMethodTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/InstanceMethodTest.java
@@ -222,12 +222,13 @@ public class InstanceMethodTest {
         Assert.assertEquals(getType(returns).getName(), "error");
         Assert.assertEquals(((BError) returns).getMessage(),
                 "org.ballerinalang.nativeimpl.jvm.tests.JavaInteropTestCheckedException");
-        Assert.assertEquals(((BMap) ((BError) returns).getDetails()).get(StringUtils.fromString("message")).toString(),
+        Assert.assertEquals(((BMap<?, ?>) ((BError) returns).getDetails()).get(StringUtils.fromString("message"))
+                        .toString(),
                 "Custom error");
-        BError cause = (BError) ((BMap) ((BError) returns).getDetails()).get(StringUtils.fromString("cause"));
+        BError cause = (BError) ((BMap<?, ?>) ((BError) returns).getDetails()).get(StringUtils.fromString("cause"));
         Assert.assertEquals(getType(cause).getName(), "error");
         Assert.assertEquals(cause.getMessage(), "java.lang.Throwable");
-        Assert.assertEquals(((BMap) cause.getDetails()).get(StringUtils.fromString("message")).toString(),
+        Assert.assertEquals(((BMap<?, ?>) cause.getDetails()).get(StringUtils.fromString("message")).toString(),
                 "Interop Throwable");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/BuiltinMethodTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/BuiltinMethodTest.java
@@ -45,7 +45,7 @@ public class BuiltinMethodTest {
     public void testClone() {
         Object result = BRunUtil.invoke(compileResult, "testClone");
         Assert.assertTrue(result instanceof BMap);
-        BMap bMap = (BMap) result;
+        BMap<?, ?> bMap = (BMap<?, ?>) result;
         Assert.assertEquals(bMap.get(StringUtils.fromString("test")).toString(), "sample");
     }
 
@@ -53,7 +53,7 @@ public class BuiltinMethodTest {
     public void testCloneAny() {
         Object result = BRunUtil.invoke(compileResult, "testCloneAny");
         Assert.assertTrue(result instanceof BMap);
-        BMap bMap = (BMap) result;
+        BMap<?, ?> bMap = (BMap<?, ?>) result;
         Assert.assertEquals(bMap.get(StringUtils.fromString("test")).toString(), "sample");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectFunctionsWithDefaultableArguments.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectFunctionsWithDefaultableArguments.java
@@ -57,7 +57,7 @@ public class ObjectFunctionsWithDefaultableArguments {
         Assert.assertEquals(bValueArray.getRefValue(2), 100L);
         Assert.assertEquals(bValueArray.getRefValue(3), 1.1);
 
-        BMap<String, Object> record = (BMap) bValueArray.getRefValue(4);
+        BMap<String, Object> record = (BMap<String, Object>) bValueArray.getRefValue(4);
         Assert.assertEquals(record.get(StringUtils.fromString("a")).toString(), "default");
         Assert.assertEquals(record.get(StringUtils.fromString("b")), 50L);
         Assert.assertFalse((Boolean) record.get(StringUtils.fromString("c")));
@@ -73,7 +73,7 @@ public class ObjectFunctionsWithDefaultableArguments {
         Assert.assertEquals(bValueArray.getRefValue(2), 99L);
         Assert.assertEquals(bValueArray.getRefValue(3), 1.1);
 
-        record = (BMap) bValueArray.getRefValue(4);
+        record = (BMap<String, Object>) bValueArray.getRefValue(4);
         Assert.assertEquals(record.get(StringUtils.fromString("a")).toString(), "given2");
         Assert.assertEquals(record.get(StringUtils.fromString("b")), 49L);
         Assert.assertTrue((Boolean) record.get(StringUtils.fromString("c")));
@@ -96,7 +96,7 @@ public class ObjectFunctionsWithDefaultableArguments {
         Assert.assertEquals(bValueArray.getRefValue(1).toString(), "defdefault");
         Assert.assertEquals(bValueArray.getRefValue(2), 101.1);
 
-        BMap<String, Object> record = (BMap) bValueArray.getRefValue(3);
+        BMap<String, Object> record = (BMap<String, Object>) bValueArray.getRefValue(3);
         Assert.assertEquals(record.get(StringUtils.fromString("a")).toString(), "default2");
         Assert.assertEquals(record.get(StringUtils.fromString("b")), 150L);
         Assert.assertTrue((Boolean) record.get(StringUtils.fromString("c")));
@@ -107,7 +107,7 @@ public class ObjectFunctionsWithDefaultableArguments {
         Assert.assertEquals(bValueArray.getRefValue(1).toString(), "defdefault");
         Assert.assertEquals(bValueArray.getRefValue(2), 101.1);
 
-        record = (BMap) bValueArray.getRefValue(3);
+        record = (BMap<String, Object>) bValueArray.getRefValue(3);
         Assert.assertEquals(record.get(StringUtils.fromString("a")).toString(), "given");
         Assert.assertEquals(record.get(StringUtils.fromString("b")), 49L);
         Assert.assertFalse((Boolean) record.get(StringUtils.fromString("c")));
@@ -125,7 +125,7 @@ public class ObjectFunctionsWithDefaultableArguments {
         Assert.assertEquals(bValueArray.getRefValue(0).toString(), "global");
         Assert.assertEquals(bValueArray.getRefValue(1), 200L);
 
-        BMap<String, Object> record = (BMap) bValueArray.getRefValue(2);
+        BMap<String, Object> record = (BMap<String, Object>) bValueArray.getRefValue(2);
         Assert.assertEquals(record.get(StringUtils.fromString("a")).toString(), "default");
         Assert.assertEquals(record.get(StringUtils.fromString("b")), 50L);
         Assert.assertFalse((Boolean) record.get(StringUtils.fromString("c")));
@@ -135,7 +135,7 @@ public class ObjectFunctionsWithDefaultableArguments {
         Assert.assertEquals(bValueArray.getRefValue(0).toString(), "given");
         Assert.assertEquals(bValueArray.getRefValue(1), 200L);
 
-        record = (BMap) bValueArray.getRefValue(2);
+        record = (BMap<String, Object>) bValueArray.getRefValue(2);
         Assert.assertEquals(record.get(StringUtils.fromString("a")).toString(), "given2");
         Assert.assertEquals(record.get(StringUtils.fromString("b")), 140L);
         Assert.assertTrue((Boolean) record.get(StringUtils.fromString("c")));
@@ -153,7 +153,7 @@ public class ObjectFunctionsWithDefaultableArguments {
         Assert.assertEquals(bValueArray.getRefValue(1).toString(), "defdefaultglobal");
         Assert.assertEquals(bValueArray.getRefValue(2), 101.1);
 
-        BMap<String, Object> record = (BMap) bValueArray.getRefValue(3);
+        BMap<String, Object> record = (BMap<String, Object>) bValueArray.getRefValue(3);
         Assert.assertEquals(record.get(StringUtils.fromString("a")).toString(), "default2");
         Assert.assertEquals(record.get(StringUtils.fromString("b")), 150L);
         Assert.assertTrue((Boolean) record.get(StringUtils.fromString("c")));
@@ -164,7 +164,7 @@ public class ObjectFunctionsWithDefaultableArguments {
         Assert.assertEquals(bValueArray.getRefValue(1).toString(), "given");
         Assert.assertEquals(bValueArray.getRefValue(2), 101.1);
 
-        record = (BMap) bValueArray.getRefValue(3);
+        record = (BMap<String, Object>) bValueArray.getRefValue(3);
         Assert.assertEquals(record.get(StringUtils.fromString("a")).toString(), "given2");
         Assert.assertEquals(record.get(StringUtils.fromString("b")), 140L);
         Assert.assertTrue((Boolean) record.get(StringUtils.fromString("c")));
@@ -181,7 +181,7 @@ public class ObjectFunctionsWithDefaultableArguments {
         Assert.assertEquals(bValueArray.getRefValue(0).toString(), "global");
         Assert.assertEquals(bValueArray.getRefValue(1), 200L);
 
-        BMap<String, Object> record = (BMap) bValueArray.getRefValue(2);
+        BMap<String, Object> record = (BMap<String, Object>) bValueArray.getRefValue(2);
         Assert.assertEquals(record.get(StringUtils.fromString("a")).toString(), "default");
         Assert.assertEquals(record.get(StringUtils.fromString("b")), 50L);
         Assert.assertFalse((Boolean) record.get(StringUtils.fromString("c")));
@@ -191,7 +191,7 @@ public class ObjectFunctionsWithDefaultableArguments {
         Assert.assertEquals(bValueArray.getRefValue(0).toString(), "given");
         Assert.assertEquals(bValueArray.getRefValue(1), 200L);
 
-        record = (BMap) bValueArray.getRefValue(2);
+        record = (BMap<String, Object>) bValueArray.getRefValue(2);
         Assert.assertEquals(record.get(StringUtils.fromString("a")).toString(), "given2");
         Assert.assertEquals(record.get(StringUtils.fromString("b")), 140L);
         Assert.assertTrue((Boolean) record.get(StringUtils.fromString("c")));
@@ -209,7 +209,7 @@ public class ObjectFunctionsWithDefaultableArguments {
         Assert.assertEquals(bValueArray.getRefValue(1).toString(), "defdefaultglobal");
         Assert.assertEquals(bValueArray.getRefValue(2), 101.1);
 
-        BMap<String, Object> record = (BMap) bValueArray.getRefValue(3);
+        BMap<String, Object> record = (BMap<String, Object>) bValueArray.getRefValue(3);
         Assert.assertEquals(record.get(StringUtils.fromString("a")).toString(), "default2");
         Assert.assertEquals((record.get(StringUtils.fromString("b"))), 150L);
         Assert.assertTrue((Boolean) record.get(StringUtils.fromString("c")));
@@ -220,7 +220,7 @@ public class ObjectFunctionsWithDefaultableArguments {
         Assert.assertEquals(bValueArray.getRefValue(1).toString(), "given");
         Assert.assertEquals(bValueArray.getRefValue(2), 101.1);
 
-        record = (BMap) bValueArray.getRefValue(3);
+        record = (BMap<String, Object>) bValueArray.getRefValue(3);
         Assert.assertEquals(record.get(StringUtils.fromString("a")).toString(), "given2");
         Assert.assertEquals(record.get(StringUtils.fromString("b")), 140L);
         Assert.assertTrue((Boolean) record.get(StringUtils.fromString("c")));

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/RepoTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/RepoTest.java
@@ -103,7 +103,7 @@ public class RepoTest {
     @Test
     public void testSystemOrgIsReserved() {
         PackageID pkg = newPackageID("ballerina", "any.pkg", "10.2.3");
-        Repo subject = new NonSysRepo<String>(null) {
+        Repo<String> subject = new NonSysRepo<>(null) {
             @Override
             public Patten calculateNonSysPkg(PackageID pkg) {
                 Assert.fail("Tried to calculate path for system packages");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/MultipleFromClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/MultipleFromClauseTest.java
@@ -326,10 +326,10 @@ public class MultipleFromClauseTest {
 
         Assert.assertEquals(returnValues.size(), 4, "Expected events are not received");
 
-        BMap section1 = (BMap) returnValues.get(0);
-        BMap section2 = (BMap) returnValues.get(1);
-        BMap section3 = (BMap) returnValues.get(2);
-        BMap section4 = (BMap) returnValues.get(3);
+        BMap<?, ?> section1 = (BMap<?, ?>) returnValues.get(0);
+        BMap<?, ?> section2 = (BMap<?, ?>) returnValues.get(1);
+        BMap<?, ?> section3 = (BMap<?, ?>) returnValues.get(2);
+        BMap<?, ?> section4 = (BMap<?, ?>) returnValues.get(3);
 
         Assert.assertTrue(section1.get(StringUtils.fromString("grades")) instanceof BMap);
         Assert.assertEquals(section1.get(StringUtils.fromString("grades")).toString(),
@@ -366,10 +366,10 @@ public class MultipleFromClauseTest {
 
         Assert.assertEquals(returnValues.size(), 4, "Expected events are not received");
 
-        BMap person1 = (BMap) returnValues.get(0);
-        BMap person2 = (BMap) returnValues.get(1);
-        BMap person3 = (BMap) returnValues.get(2);
-        BMap person4 = (BMap) returnValues.get(3);
+        BMap<?, ?> person1 = (BMap<?, ?>) returnValues.get(0);
+        BMap<?, ?> person2 = (BMap<?, ?>) returnValues.get(1);
+        BMap<?, ?> person3 = (BMap<?, ?>) returnValues.get(2);
+        BMap<?, ?> person4 = (BMap<?, ?>) returnValues.get(3);
 
         Assert.assertTrue(person1.get(StringUtils.fromString("address")) instanceof BMap);
         Assert.assertEquals(person1.toString(), "{\"firstName\":\"Alex\",\"lastName\":\"George\"," +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
@@ -252,8 +252,8 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertNotNull(returnValues);
         Assert.assertEquals(returnValues.size(), 2, "Expected events are not received");
 
-        BMap teacher1 = (BMap) returnValues.get(0);
-        BMap teacher2 = (BMap) returnValues.get(1);
+        BMap<?, ?> teacher1 = (BMap<?, ?>) returnValues.get(0);
+        BMap<?, ?> teacher2 = (BMap<?, ?>) returnValues.get(1);
 
         Assert.assertTrue(teacher1.get(StringUtils.fromString("classStudents")) instanceof BArray);
         Assert.assertTrue(teacher1.get(StringUtils.fromString("experience")) instanceof BMap);
@@ -298,8 +298,8 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertNotNull(returnValues);
         Assert.assertEquals(returnValues.size(), 2, "Expected events are not received");
 
-        BMap person1 = (BMap) returnValues.get(0);
-        BMap person2 = (BMap) returnValues.get(1);
+        BMap<?, ?> person1 = (BMap<?, ?>) returnValues.get(0);
+        BMap<?, ?> person2 = (BMap<?, ?>) returnValues.get(1);
 
         Assert.assertEquals(person1.toString(), "{\"firstName\":\"Alex\",\"lastName\":\"George\"," +
                 "\"deptAccess\":\"XYZ\",\"address\":{\"city\":\"New York\",\"country\":\"America\"}}");
@@ -312,7 +312,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         BArray returnValues = (BArray) BRunUtil.invoke(result, "testQueryExprWithStreamMapAndFilter");
         Assert.assertNotNull(returnValues);
 
-        BMap subscription = (BMap) returnValues.get(0);
+        BMap<?, ?> subscription = (BMap<?, ?>) returnValues.get(0);
 
         Assert.assertEquals(subscription.toString(),
                 "{\"firstName\":\"Ranjan\",\"lastName\":\"Fonseka\",\"score\":90.6,\"" +
@@ -332,8 +332,8 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         BArray returnValues = (BArray) BRunUtil.invoke(result, "testQueryWithRecordVarInLetClause");
         Assert.assertNotNull(returnValues);
         Assert.assertEquals(returnValues.size(), 2, "Expected events are not received");
-        BMap person1 = (BMap) returnValues.get(0);
-        BMap person2 = (BMap) returnValues.get(1);
+        BMap<?, ?> person1 = (BMap<?, ?>) returnValues.get(0);
+        BMap<?, ?> person2 = (BMap<?, ?>) returnValues.get(1);
 
         Assert.assertEquals(person1.toString(), "{\"firstName\":\"Ranjan\",\"lastName\":\"Fonseka\"," +
                 "\"deptAccess\":\"XYZ\",\"address\":{\"city\":\"Colombo\",\"country\":\"SL\"}}");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordEquivalencyTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordEquivalencyTest.java
@@ -105,7 +105,7 @@ public class ClosedRecordEquivalencyTest {
     @Test(description = "Test case for record equivalence")
     public void testRecordEquivalence() {
         Object returns = BRunUtil.invoke(compileResult, "testRecordEquivalence");
-        BMap foo = (BMap) returns;
+        BMap<?, ?> foo = (BMap<?, ?>) returns;
 
         Assert.assertEquals(foo.size(), 6);
         Assert.assertEquals(foo.get(StringUtils.fromString("a")).toString(), "A");
@@ -119,7 +119,7 @@ public class ClosedRecordEquivalencyTest {
     @Test(description = "Test case for using records with unordered fields in a match")
     public void testUnorderedFieldRecordsInAMatch() {
         Object returns = BRunUtil.invoke(compileResult, "testUnorderedFieldRecordsInAMatch");
-        BMap foo = (BMap) returns;
+        BMap<?, ?> foo = (BMap<?, ?>) returns;
 
         Assert.assertEquals(foo.size(), 6);
         Assert.assertEquals(foo.get(StringUtils.fromString("a")).toString(), "A");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordIterationTest.java
@@ -124,7 +124,7 @@ public class ClosedRecordIterationTest {
         Assert.assertEquals(values.getRefValue(1), 25L);
         Assert.assertTrue(values.getRefValue(2) instanceof BMap);
 
-        BMap addressRecord = (BMap) values.getRefValue(2);
+        BMap<?, ?> addressRecord = (BMap<?, ?>) values.getRefValue(2);
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("street")).toString(), "Palm Grove");
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("city")).toString(), "Colombo 3");
     }
@@ -137,7 +137,7 @@ public class ClosedRecordIterationTest {
         Assert.assertEquals(returns.get(1), 25L);
         Assert.assertTrue(returns.get(2) instanceof BMap);
 
-        BMap addressRecord = (BMap) returns.get(2);
+        BMap<?, ?> addressRecord = (BMap<?, ?>) returns.get(2);
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("street")).toString(), "Palm Grove");
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("city")).toString(), "Colombo 3");
     }
@@ -150,7 +150,7 @@ public class ClosedRecordIterationTest {
         Assert.assertEquals(returns.get(1), 25L);
         Assert.assertTrue(returns.get(2) instanceof BMap);
 
-        BMap addressRecord = (BMap) returns.get(2);
+        BMap<?, ?> addressRecord = (BMap<?, ?>) returns.get(2);
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("street")).toString(), "Palm Grove");
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("city")).toString(), "Colombo 3");
     }
@@ -160,12 +160,12 @@ public class ClosedRecordIterationTest {
         String[] expectedFields = new String[]{"name", "age", "address"};
         Object returns = BRunUtil.invoke(result, "testMapOpWithClosedRecords");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertEquals(person.get(StringUtils.fromString(expectedFields[0])).toString(), "john doe");
         Assert.assertEquals((person.get(StringUtils.fromString(expectedFields[1]))), 25L);
         Assert.assertTrue(person.get(StringUtils.fromString(expectedFields[2])) instanceof BMap);
 
-        BMap addressRecord = (BMap) person.get(StringUtils.fromString(expectedFields[2]));
+        BMap<?, ?> addressRecord = (BMap<?, ?>) person.get(StringUtils.fromString(expectedFields[2]));
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("street")).toString(), "Palm Grove");
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("city")).toString(), "Colombo 3");
     }
@@ -175,7 +175,7 @@ public class ClosedRecordIterationTest {
         String[] expectedFields = new String[]{"a", "b", "c", "d", "e"};
         Object returns = BRunUtil.invoke(result, "testFilterOpWithClosedRecords");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertEquals(person.get(StringUtils.fromString(expectedFields[0])).toString(), "A");
         Assert.assertNull(person.get(StringUtils.fromString(expectedFields[1])));
         Assert.assertNull(person.get(StringUtils.fromString(expectedFields[2])));
@@ -192,7 +192,7 @@ public class ClosedRecordIterationTest {
     @Test(description = "Test case for chained iterable operations on closed records")
     public void testChainedOpsWithClosedRecords() {
         Object returns = BRunUtil.invoke(result, "testChainedOpsWithClosedRecords");
-        BMap foo = (BMap) returns;
+        BMap<?, ?> foo = (BMap<?, ?>) returns;
 
         Assert.assertNull(foo.get(StringUtils.fromString("a")));
         Assert.assertEquals(foo.get(StringUtils.fromString("b")).toString(), "bb");
@@ -205,7 +205,7 @@ public class ClosedRecordIterationTest {
     public void testMapWithAllStringClosedRecord() {
         Object returns = BRunUtil.invoke(result, "testMapWithAllStringClosedRecord");
 
-        BMap foo = (BMap) returns;
+        BMap<?, ?> foo = (BMap<?, ?>) returns;
         Assert.assertEquals(foo.get(StringUtils.fromString("a")).toString(), "aa");
         Assert.assertEquals(foo.get(StringUtils.fromString("b")).toString(), "bb");
         Assert.assertEquals(foo.get(StringUtils.fromString("c")).toString(), "cc");
@@ -218,7 +218,7 @@ public class ClosedRecordIterationTest {
         Object[] args = new Object[]{(80), (75), (65)};
         Object returns = BRunUtil.invoke(result, "testMapWithAllIntClosedRecord", args);
 
-        BMap gradesMap = (BMap) returns;
+        BMap<?, ?> gradesMap = (BMap<?, ?>) returns;
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("maths"))), 90L);
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("physics"))), 85L);
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("chemistry"))), 75L);
@@ -230,7 +230,7 @@ public class ClosedRecordIterationTest {
         Object[] args = new Object[]{(a), (b), (c)};
         Object returns = BRunUtil.invoke(result, "testMapWithAllFloatClosedRecord", args);
 
-        BMap gradesMap = (BMap) returns;
+        BMap<?, ?> gradesMap = (BMap<?, ?>) returns;
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("x"))), a + 10);
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("y"))), b + 10);
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("z"))), c + 10);
@@ -241,7 +241,7 @@ public class ClosedRecordIterationTest {
         final String a = "AA", e = "EE";
         Object returns = BRunUtil.invoke(result, "testFilterWithAllStringClosedRecord");
 
-        BMap foo = (BMap) returns;
+        BMap<?, ?> foo = (BMap<?, ?>) returns;
         Assert.assertEquals(foo.get(StringUtils.fromString("a")).toString(), a);
         Assert.assertNull(foo.get(StringUtils.fromString("b")));
         Assert.assertNull(foo.get(StringUtils.fromString("c")));
@@ -254,7 +254,7 @@ public class ClosedRecordIterationTest {
         final long m = 80, p = 75;
         Object returns = BRunUtil.invoke(result, "testFilterWithAllIntClosedRecord");
 
-        BMap gradesMap = (BMap) returns;
+        BMap<?, ?> gradesMap = (BMap<?, ?>) returns;
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("maths"))), m);
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("physics"))), p);
         Assert.assertNull(gradesMap.get(StringUtils.fromString("chemistry")));
@@ -266,7 +266,7 @@ public class ClosedRecordIterationTest {
         Object[] args = new Object[]{(a), (b), (c)};
         Object returns = BRunUtil.invoke(result, "testFilterWithAllFloatClosedRecord", args);
 
-        BMap gradesMap = (BMap) returns;
+        BMap<?, ?> gradesMap = (BMap<?, ?>) returns;
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("x"))), a);
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("y"))), b);
         Assert.assertNull(gradesMap.get(StringUtils.fromString("z")));
@@ -302,7 +302,7 @@ public class ClosedRecordIterationTest {
     @Test(description = "Test case for chained iterable operations on closed records")
     public void testChainedOpsWithClosedRecords2() {
         Object returns = BRunUtil.invoke(result, "testChainedOpsWithClosedRecords2");
-        BMap grades = (BMap) returns;
+        BMap<?, ?> grades = (BMap<?, ?>) returns;
 
         Assert.assertEquals((grades.get(StringUtils.fromString("maths"))), 4.2);
         Assert.assertEquals((grades.get(StringUtils.fromString("physics"))), 4.2);
@@ -325,7 +325,7 @@ public class ClosedRecordIterationTest {
     @Test(description = "Test case for checking whether iterable ops mutate the original record")
     public void testMutability() {
         Object returns = BRunUtil.invoke(result, "testMutability");
-        BMap grades = (BMap) returns;
+        BMap<?, ?> grades = (BMap<?, ?>) returns;
         Assert.assertEquals(grades.size(), 3);
         Assert.assertEquals(grades.get(StringUtils.fromString("maths")), 80L);
         Assert.assertEquals(grades.get(StringUtils.fromString("physics")), 75L);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordOptionalFieldsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordOptionalFieldsTest.java
@@ -62,12 +62,12 @@ public class ClosedRecordOptionalFieldsTest {
     public void testNonDefReqField() {
         Object returns = BRunUtil.invoke(compileResult, "testNonDefReqField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertEquals(person.get(StringUtils.fromString("fname")).toString(), "default");
         Assert.assertNull(person.get(StringUtils.fromString("lname")));
         Assert.assertNull(person.get(StringUtils.fromString("age")));
 
-        BMap adrs = (BMap) person.get(StringUtils.fromString("adrs"));
+        BMap<?, ?> adrs = (BMap<?, ?>) person.get(StringUtils.fromString("adrs"));
         Assert.assertEquals(adrs.get(StringUtils.fromString("street")).toString(), "");
         Assert.assertEquals(adrs.get(StringUtils.fromString("city")).toString(), "");
         Assert.assertEquals(adrs.get(StringUtils.fromString("country")).toString(), "LK");
@@ -78,12 +78,12 @@ public class ClosedRecordOptionalFieldsTest {
     public void testNonDefReqField2() {
         Object returns = BRunUtil.invoke(compileResult, "testNonDefReqField2");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertEquals(person.get(StringUtils.fromString("fname")).toString(), "John");
         Assert.assertEquals(person.get(StringUtils.fromString("lname")).toString(), "Doe");
         Assert.assertNull(person.get(StringUtils.fromString("age")));
 
-        BMap adrs = (BMap) person.get(StringUtils.fromString("adrs"));
+        BMap<?, ?> adrs = (BMap<?, ?>) person.get(StringUtils.fromString("adrs"));
         Assert.assertEquals(adrs.get(StringUtils.fromString("street")).toString(), "");
         Assert.assertEquals(adrs.get(StringUtils.fromString("city")).toString(), "");
         Assert.assertEquals(adrs.get(StringUtils.fromString("country")).toString(), "LK");
@@ -93,12 +93,12 @@ public class ClosedRecordOptionalFieldsTest {
     public void testDefaultableReqField() {
         Object returns = BRunUtil.invoke(compileResult, "testDefaultableReqField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertEquals(person.get(StringUtils.fromString("fname")).toString(), "default");
         Assert.assertNull(person.get(StringUtils.fromString("lname")));
         Assert.assertNull(person.get(StringUtils.fromString("age")));
 
-        BMap adrs = (BMap) person.get(StringUtils.fromString("adrs"));
+        BMap<?, ?> adrs = (BMap<?, ?>) person.get(StringUtils.fromString("adrs"));
         Assert.assertEquals(adrs.get(StringUtils.fromString("street")).toString(), "");
         Assert.assertEquals(adrs.get(StringUtils.fromString("city")).toString(), "");
         Assert.assertEquals(adrs.get(StringUtils.fromString("country")).toString(), "LK");
@@ -107,7 +107,7 @@ public class ClosedRecordOptionalFieldsTest {
     @Test(description = "Test non-defaultable user defined type as an optional field")
     public void testOptionalNonDefField() {
         Object returns = BRunUtil.invoke(compileResult, "testOptionalNonDefField");
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertEquals(person.get(StringUtils.fromString("fname")).toString(), "default");
         Assert.assertNull(person.get(StringUtils.fromString("lname")));
         Assert.assertNull(person.get(StringUtils.fromString("age")));
@@ -145,7 +145,7 @@ public class ClosedRecordOptionalFieldsTest {
     public void testOptionalDefaultableField() {
         Object returns = BRunUtil.invoke(compileResult, "testOptionalDefaultableField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertEquals(person.get(StringUtils.fromString("fname")).toString(), "default");
         Assert.assertNull(person.get(StringUtils.fromString("lname")));
         Assert.assertNull(person.get(StringUtils.fromString("age")));

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordEquivalencyTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordEquivalencyTest.java
@@ -107,7 +107,7 @@ public class OpenRecordEquivalencyTest {
     @Test(description = "Test case for record equivalence")
     public void testRecordEquivalence() {
         Object returns = BRunUtil.invoke(compileResult, "testRecordEquivalence");
-        BMap foo = (BMap) returns;
+        BMap<?, ?> foo = (BMap<?, ?>) returns;
 
         Assert.assertEquals(foo.size(), 7);
         Assert.assertEquals(foo.get(StringUtils.fromString("a")).toString(), "A");
@@ -122,7 +122,7 @@ public class OpenRecordEquivalencyTest {
     @Test(description = "Test case for using records with unordered fields in a match")
     public void testUnorderedFieldRecordsInAMatch() {
         Object returns = BRunUtil.invoke(compileResult, "testUnorderedFieldRecordsInAMatch");
-        BMap foo = (BMap) returns;
+        BMap<?, ?> foo = (BMap<?, ?>) returns;
 
         Assert.assertEquals(foo.size(), 7);
         Assert.assertEquals(foo.get(StringUtils.fromString("a")).toString(), "A");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordIterationTest.java
@@ -118,7 +118,7 @@ public class OpenRecordIterationTest {
         Assert.assertEquals((values.getRefValue(1)), 25L);
         Assert.assertTrue(values.getRefValue(2) instanceof BMap);
 
-        BMap addressRecord = (BMap) values.getRefValue(2);
+        BMap<?, ?> addressRecord = (BMap<?, ?>) values.getRefValue(2);
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("street")).toString(), "Palm Grove");
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("city")).toString(), "Colombo 3");
     }
@@ -139,7 +139,7 @@ public class OpenRecordIterationTest {
         Assert.assertTrue(values.getRefValue(2) instanceof BMap);
         Assert.assertEquals((values.getRefValue(3)), 5.9);
 
-        BMap addressRecord = (BMap) values.getRefValue(2);
+        BMap<?, ?> addressRecord = (BMap<?, ?>) values.getRefValue(2);
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("street")).toString(), "Palm Grove");
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("city")).toString(), "Colombo 3");
     }
@@ -152,7 +152,7 @@ public class OpenRecordIterationTest {
         Assert.assertEquals(returns.get(1), 25L);
         Assert.assertTrue(returns.get(2) instanceof BMap);
 
-        BMap addressRecord = (BMap) returns.get(2);
+        BMap<?, ?> addressRecord = (BMap<?, ?>) returns.get(2);
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("street")).toString(), "Palm Grove");
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("city")).toString(), "Colombo 3");
     }
@@ -165,7 +165,7 @@ public class OpenRecordIterationTest {
         Assert.assertEquals(returns.get(1), 25L);
         Assert.assertTrue(returns.get(2) instanceof BMap);
 
-        BMap addressRecord = (BMap) returns.get(2);
+        BMap<?, ?> addressRecord = (BMap<?, ?>) returns.get(2);
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("street")).toString(), "Palm Grove");
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("city")).toString(), "Colombo 3");
 
@@ -177,13 +177,13 @@ public class OpenRecordIterationTest {
         String[] expectedFields = new String[]{"name", "age", "address", "profession"};
         Object returns = BRunUtil.invoke(result, "testMapOpWithOpenRecords");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertEquals(person.get(StringUtils.fromString(expectedFields[0])).toString(), "john doe");
         Assert.assertEquals((person.get(StringUtils.fromString(expectedFields[1]))), 25L);
         Assert.assertTrue(person.get(StringUtils.fromString(expectedFields[2])) instanceof BMap);
         Assert.assertEquals(person.get(StringUtils.fromString(expectedFields[3])).toString(), "software engineer");
 
-        BMap addressRecord = (BMap) person.get(StringUtils.fromString(expectedFields[2]));
+        BMap<?, ?> addressRecord = (BMap<?, ?>) person.get(StringUtils.fromString(expectedFields[2]));
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("street")).toString(), "Palm Grove");
         Assert.assertEquals(addressRecord.get(StringUtils.fromString("city")).toString(), "Colombo 3");
     }
@@ -191,7 +191,7 @@ public class OpenRecordIterationTest {
     @Test(description = "Tests filter iterable operation on open records")
     public void testFilterOpWithOpenRecords() {
         Object returns = BRunUtil.invoke(result, "testFilterOpWithOpenRecords");
-        BMap foo = (BMap) returns;
+        BMap<?, ?> foo = (BMap<?, ?>) returns;
 
         Assert.assertNull(foo.get(StringUtils.fromString("a")));
         Assert.assertEquals(foo.get(StringUtils.fromString("b")).toString(), "B");
@@ -210,7 +210,7 @@ public class OpenRecordIterationTest {
     @Test(description = "Test case for chained iterable operations on open records")
     public void testChainedOpsWithOpenRecords() {
         Object returns = BRunUtil.invoke(result, "testChainedOpsWithOpenRecords");
-        BMap foo = (BMap) returns;
+        BMap<?, ?> foo = (BMap<?, ?>) returns;
 
         Assert.assertNull(foo.get(StringUtils.fromString("a")));
         Assert.assertEquals(foo.get(StringUtils.fromString("b")).toString(), "bb");
@@ -224,7 +224,7 @@ public class OpenRecordIterationTest {
     public void testMapWithAllStringOpenRecord() {
         Object returns = BRunUtil.invoke(result, "testMapWithAllStringOpenRecord");
 
-        BMap foo = (BMap) returns;
+        BMap<?, ?> foo = (BMap<?, ?>) returns;
         Assert.assertEquals(foo.get(StringUtils.fromString("a")).toString(), "aa");
         Assert.assertEquals(foo.get(StringUtils.fromString("b")).toString(), "bb");
         Assert.assertEquals(foo.get(StringUtils.fromString("c")).toString(), "cc");
@@ -237,7 +237,7 @@ public class OpenRecordIterationTest {
         Object[] args = new Object[]{(80), (75), (65), (78)};
         Object returns = BRunUtil.invoke(result, "testMapWithAllIntOpenRecord", args);
 
-        BMap gradesMap = (BMap) returns;
+        BMap<?, ?> gradesMap = (BMap<?, ?>) returns;
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("maths"))), 90L);
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("physics"))), 85L);
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("chemistry"))), 75L);
@@ -250,7 +250,7 @@ public class OpenRecordIterationTest {
         Object[] args = new Object[]{(a), (b), (c)};
         Object returns = BRunUtil.invoke(result, "testMapWithAllFloatOpenRecord", args);
 
-        BMap gradesMap = (BMap) returns;
+        BMap<?, ?> gradesMap = (BMap<?, ?>) returns;
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("x"))), a + 10);
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("y"))), b + 10);
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("z"))), c + 10);
@@ -262,7 +262,7 @@ public class OpenRecordIterationTest {
         final String a = "AA", e = "EE", f = "FF";
         Object returns = BRunUtil.invoke(result, "testFilterWithAllStringOpenRecord");
 
-        BMap foo = (BMap) returns;
+        BMap<?, ?> foo = (BMap<?, ?>) returns;
         Assert.assertEquals(foo.get(StringUtils.fromString("a")).toString(), a);
         Assert.assertNull(foo.get(StringUtils.fromString("b")));
         Assert.assertNull(foo.get(StringUtils.fromString("c")));
@@ -276,7 +276,7 @@ public class OpenRecordIterationTest {
         final long m = 80, p = 75, e = 78;
         Object returns = BRunUtil.invoke(result, "testFilterWithAllIntOpenRecord");
 
-        BMap gradesMap = (BMap) returns;
+        BMap<?, ?> gradesMap = (BMap<?, ?>) returns;
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("maths"))), m);
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("physics"))), p);
         Assert.assertNull(gradesMap.get(StringUtils.fromString("chemistry")));
@@ -289,7 +289,7 @@ public class OpenRecordIterationTest {
         Object[] args = new Object[]{(a), (b), (c)};
         Object returns = BRunUtil.invoke(result, "testFilterWithAllFloatOpenRecord", args);
 
-        BMap gradesMap = (BMap) returns;
+        BMap<?, ?> gradesMap = (BMap<?, ?>) returns;
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("x"))), a);
         Assert.assertEquals((gradesMap.get(StringUtils.fromString("y"))), b);
         Assert.assertNull(gradesMap.get(StringUtils.fromString("z")));
@@ -313,7 +313,7 @@ public class OpenRecordIterationTest {
     @Test(description = "Test case for chained iterable operations on open records")
     public void testChainedOpsWithOpenRecords2() {
         Object returns = BRunUtil.invoke(result, "testChainedOpsWithOpenRecords2");
-        BMap grades = (BMap) returns;
+        BMap<?, ?> grades = (BMap<?, ?>) returns;
 
         Assert.assertEquals((grades.get(StringUtils.fromString("maths"))), 4.2);
         Assert.assertEquals((grades.get(StringUtils.fromString("physics"))), 4.2);
@@ -324,7 +324,7 @@ public class OpenRecordIterationTest {
     @Test(description = "Test case for chained iterable operations on open records")
     public void testChainedOpsWithOpenRecords3() {
         Object returns = BRunUtil.invoke(result, "testChainedOpsWithOpenRecords3");
-        BMap grades = (BMap) returns;
+        BMap<?, ?> grades = (BMap<?, ?>) returns;
 
         Assert.assertEquals((grades.get(StringUtils.fromString("maths"))), 4.2);
         Assert.assertEquals((grades.get(StringUtils.fromString("physics"))), 4.2);
@@ -363,7 +363,7 @@ public class OpenRecordIterationTest {
     @Test(description = "Test case for checking whether iterable ops mutate the original record")
     public void testMutability() {
         Object returns = BRunUtil.invoke(result, "testMutability");
-        BMap grades = (BMap) returns;
+        BMap<?, ?> grades = (BMap<?, ?>) returns;
         Assert.assertEquals(grades.size(), 4);
         Assert.assertEquals(grades.get(StringUtils.fromString("maths")), 80L);
         Assert.assertEquals(grades.get(StringUtils.fromString("physics")), 75L);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordOptionalFieldsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordOptionalFieldsTest.java
@@ -64,12 +64,12 @@ public class OpenRecordOptionalFieldsTest {
     public void testNonDefReqField() {
         Object returns = BRunUtil.invoke(compileResult, "testNonDefReqField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertEquals(person.get(StringUtils.fromString("fname")).toString(), "default");
         Assert.assertNull(person.get(StringUtils.fromString("lname")));
         Assert.assertNull(person.get(StringUtils.fromString("age")));
 
-        BMap adrs = (BMap) person.get(StringUtils.fromString("adrs"));
+        BMap<?, ?> adrs = (BMap<?, ?>) person.get(StringUtils.fromString("adrs"));
         Assert.assertEquals(adrs.get(StringUtils.fromString("street")).toString(), "");
         Assert.assertEquals(adrs.get(StringUtils.fromString("city")).toString(), "");
         Assert.assertEquals(adrs.get(StringUtils.fromString("country")).toString(), "LK");
@@ -80,12 +80,12 @@ public class OpenRecordOptionalFieldsTest {
     public void testNonDefReqField2() {
         Object returns = BRunUtil.invoke(compileResult, "testNonDefReqField2");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertEquals(person.get(StringUtils.fromString("fname")).toString(), "John");
         Assert.assertEquals(person.get(StringUtils.fromString("lname")).toString(), "Doe");
         Assert.assertNull(person.get(StringUtils.fromString("age")));
 
-        BMap adrs = (BMap) person.get(StringUtils.fromString("adrs"));
+        BMap<?, ?> adrs = (BMap<?, ?>) person.get(StringUtils.fromString("adrs"));
         Assert.assertEquals(adrs.get(StringUtils.fromString("street")).toString(), "");
         Assert.assertEquals(adrs.get(StringUtils.fromString("city")).toString(), "");
         Assert.assertEquals(adrs.get(StringUtils.fromString("country")).toString(), "LK");
@@ -95,12 +95,12 @@ public class OpenRecordOptionalFieldsTest {
     public void testDefaultableReqField() {
         Object returns = BRunUtil.invoke(compileResult, "testDefaultableReqField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertEquals(person.get(StringUtils.fromString("fname")).toString(), "default");
         Assert.assertNull(person.get(StringUtils.fromString("lname")));
         Assert.assertNull(person.get(StringUtils.fromString("age")));
 
-        BMap adrs = (BMap) person.get(StringUtils.fromString("adrs"));
+        BMap<?, ?> adrs = (BMap<?, ?>) person.get(StringUtils.fromString("adrs"));
         Assert.assertEquals(adrs.get(StringUtils.fromString("street")).toString(), "");
         Assert.assertEquals(adrs.get(StringUtils.fromString("city")).toString(), "");
         Assert.assertEquals(adrs.get(StringUtils.fromString("country")).toString(), "LK");
@@ -109,7 +109,7 @@ public class OpenRecordOptionalFieldsTest {
     @Test(description = "Test non-defaultable user defined type as an optional field")
     public void testOptionalNonDefField() {
         Object returns = BRunUtil.invoke(compileResult, "testOptionalNonDefField");
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertEquals(person.get(StringUtils.fromString("fname")).toString(), "default");
         Assert.assertNull(person.get(StringUtils.fromString("lname")));
         Assert.assertNull(person.get(StringUtils.fromString("age")));
@@ -148,7 +148,7 @@ public class OpenRecordOptionalFieldsTest {
     public void testOptionalDefaultableField() {
         Object returns = BRunUtil.invoke(compileResult, "testOptionalDefaultableField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertEquals(person.get(StringUtils.fromString("fname")).toString(), "default");
         Assert.assertNull(person.get(StringUtils.fromString("lname")));
         Assert.assertNull(person.get(StringUtils.fromString("age")));

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordTest.java
@@ -179,7 +179,7 @@ public class OpenRecordTest {
     public void testAdditionOfARestField() {
         Object returns = BRunUtil.invoke(compileResult, "testAdditionOfARestField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertTrue(person.get(StringUtils.fromString("mname")) instanceof BString);
         Assert.assertEquals(person.get(StringUtils.fromString("mname")).toString(), "Bar");
 
@@ -204,7 +204,7 @@ public class OpenRecordTest {
     public void testStringRestField() {
         Object returns = BRunUtil.invoke(compileResult, "testStringRestField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertTrue(person.get(StringUtils.fromString("lname")) instanceof BString);
         Assert.assertEquals(person.get(StringUtils.fromString("lname")).toString(), "Bar");
 
@@ -227,7 +227,7 @@ public class OpenRecordTest {
     public void testIntRestField() {
         Object returns = BRunUtil.invoke(compileResult, "testIntRestField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertTrue(person.get(StringUtils.fromString("year")) instanceof Long);
         Assert.assertEquals((person.get(StringUtils.fromString("year"))), 3L);
 
@@ -246,7 +246,7 @@ public class OpenRecordTest {
     public void testFloatRestField() {
         Object returns = BRunUtil.invoke(compileResult, "testFloatRestField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertTrue(person.get(StringUtils.fromString("height")) instanceof Double);
         Assert.assertEquals((person.get(StringUtils.fromString("height"))), 5.9D);
 
@@ -265,7 +265,7 @@ public class OpenRecordTest {
     public void testBooleanRestField() {
         Object returns = BRunUtil.invoke(compileResult, "testBooleanRestField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertTrue(person.get(StringUtils.fromString("isEmployed")) instanceof Boolean);
         Assert.assertTrue((Boolean) person.get(StringUtils.fromString("isEmployed")));
 
@@ -284,7 +284,7 @@ public class OpenRecordTest {
     public void testMapRestField() {
         Object returns = BRunUtil.invoke(compileResult, "testMapRestField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertTrue(person.get(StringUtils.fromString("misc")) instanceof BMap);
         Assert.assertEquals(person.get(StringUtils.fromString("misc")).toString(),
                 "{\"lname\":\"Bar\",\"height\":5.9,\"isEmployed\":true}");
@@ -297,7 +297,7 @@ public class OpenRecordTest {
     public void testMapRestFieldRHSIndexAccess() {
         BArray returns = (BArray) BRunUtil.invoke(compileResult, "testMapRestFieldRHSIndexAccess");
         Assert.assertNotNull(returns.get(0));
-        Assert.assertEquals(((BMap) returns.get(0)).size(), 0);
+        Assert.assertEquals(((BMap<?, ?>) returns.get(0)).size(), 0);
         Assert.assertNull(returns.get(1));
     }
 
@@ -305,7 +305,7 @@ public class OpenRecordTest {
     public void testUnionRestField() {
         Object returns = BRunUtil.invoke(compileResult, "testUnionRestField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertTrue(person.get(StringUtils.fromString("lname")) instanceof BString);
         Assert.assertTrue(person.get(StringUtils.fromString("height")) instanceof Double);
         Assert.assertTrue(person.get(StringUtils.fromString("isEmployed")) instanceof Boolean);
@@ -326,7 +326,7 @@ public class OpenRecordTest {
     public void testNilRestField() {
         Object returns = BRunUtil.invoke(compileResult, "testNilRestField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertNull(person.get(StringUtils.fromString("lname")));
 
         Assert.assertEquals(person.toString(), "{\"name\":\"Foo\",\"age\":25,\"lname\":null}");
@@ -336,7 +336,7 @@ public class OpenRecordTest {
     public void testRecordRestField() {
         Object returns = BRunUtil.invoke(compileResult, "testRecordRestField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertTrue(person.get(StringUtils.fromString("dpt")) instanceof BMap);
         Assert.assertEquals(person.get(StringUtils.fromString("dpt")).toString(), "{\"dptName\":\"Engineering\"," +
                 "\"employees\":[]}");
@@ -356,7 +356,7 @@ public class OpenRecordTest {
     public void testObjectRestField() {
         Object returns = BRunUtil.invoke(compileResult, "testObjectRestField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         Assert.assertTrue(person.get(StringUtils.fromString("pet")) instanceof BObject);
         Assert.assertEquals(person.get(StringUtils.fromString("pet")).toString(), "{kind:Cat, name:Miaw}");
 
@@ -377,7 +377,7 @@ public class OpenRecordTest {
     public void testTupleRestField() {
         Object returns = BRunUtil.invoke(compileResult, "testTupleRestField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         BArray miscInfo = (BArray) person.get(StringUtils.fromString("misc"));
         Assert.assertTrue(person.get(StringUtils.fromString("misc")) instanceof BArray);
 
@@ -406,7 +406,7 @@ public class OpenRecordTest {
     public void testAnyRestField() {
         Object returns = BRunUtil.invoke(compileResult, "testAnyRestField");
 
-        BMap person = (BMap) returns;
+        BMap<?, ?> person = (BMap<?, ?>) returns;
         BArray pets = (BArray) person.get(StringUtils.fromString("pets"));
         Assert.assertEquals(getType(pets).toString(), "Animal?[]");
         Assert.assertEquals(person.toString(),
@@ -434,7 +434,7 @@ public class OpenRecordTest {
     @Test(description = "Test case for default value initializing in type referenced fields")
     public void testDefaultValueInit() {
         Object returns = BRunUtil.invoke(compileResult, "testDefaultValueInit");
-        BMap manager = (BMap) returns;
+        BMap<?, ?> manager = (BMap<?, ?>) returns;
         Assert.assertEquals(manager.get(StringUtils.fromString("name")).toString(), "John Doe");
         Assert.assertEquals((manager.get(StringUtils.fromString("age"))), 25L);
         Assert.assertEquals(manager.get(StringUtils.fromString("adr")).toString(), "{\"city\":\"Colombo\"," +
@@ -467,7 +467,7 @@ public class OpenRecordTest {
     @Test
     public void testLangFuncOnRecord() {
         Object returns = BRunUtil.invoke(compileResult, "testLangFuncOnRecord");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("toJson")), 44L);
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("toJson")), 44L);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordAccessWithIndexTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordAccessWithIndexTest.java
@@ -53,7 +53,7 @@ public class RecordAccessWithIndexTest {
         Assert.assertEquals(returns.get(0).toString(), "Jack");
 
         Assert.assertTrue(returns.get(1) instanceof BMap);
-        BMap<String, ?> adrsMap = ((BMap) returns.get(1));
+        BMap<String, ?> adrsMap = ((BMap<String, ?>) returns.get(1));
         Assert.assertEquals(adrsMap.get(StringUtils.fromString("country")), StringUtils.fromString("USA"));
         Assert.assertEquals(adrsMap.get(StringUtils.fromString("state")), StringUtils.fromString("CA"));
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
@@ -202,8 +202,9 @@ public class ArrayFillTest {
 
     @Test
     public void testMapArrayFill() {
-        var emptyMap = ValueCreator.createMapValue(TypeCreator.createMapType(PredefinedTypes.TYPE_ANY));
-        var map = ValueCreator.createMapValue(TypeCreator.createMapType(PredefinedTypes.TYPE_ANY));
+        BMap<BString, Object> emptyMap =
+                ValueCreator.createMapValue(TypeCreator.createMapType(PredefinedTypes.TYPE_ANY));
+        BMap<BString, Object> map = ValueCreator.createMapValue(TypeCreator.createMapType(PredefinedTypes.TYPE_ANY));
         map.put(StringUtils.fromString("1"), 1);
         Object[] args = new Object[]{(index), map};
         Object returns = BRunUtil.invoke(compileResult, "testMapArrayFill", args);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
@@ -25,6 +25,7 @@ import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BString;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
@@ -201,19 +202,19 @@ public class ArrayFillTest {
 
     @Test
     public void testMapArrayFill() {
-        BMap emptyMap = ValueCreator.createMapValue(TypeCreator.createMapType(PredefinedTypes.TYPE_ANY));
-        BMap map = ValueCreator.createMapValue(TypeCreator.createMapType(PredefinedTypes.TYPE_ANY));
-        map.put("1", 1);
+        var emptyMap = ValueCreator.createMapValue(TypeCreator.createMapType(PredefinedTypes.TYPE_ANY));
+        var map = ValueCreator.createMapValue(TypeCreator.createMapType(PredefinedTypes.TYPE_ANY));
+        map.put(StringUtils.fromString("1"), 1);
         Object[] args = new Object[]{(index), map};
         Object returns = BRunUtil.invoke(compileResult, "testMapArrayFill", args);
         BArray mapArr = (BArray) returns;
         assertEquals(mapArr.size(), index + 1);
 
         for (int i = 0; i < index; i++) {
-            validateMapValue((BMap<String, Object>) mapArr.get(i), emptyMap);
+            validateMapValue((BMap<BString, Object>) mapArr.get(i), emptyMap);
         }
 
-        validateMapValue((BMap<String, Object>) mapArr.get(index), map);
+        validateMapValue((BMap<BString, Object>) mapArr.get(index), map);
     }
 
     @Test
@@ -534,10 +535,10 @@ public class ArrayFillTest {
         BRunUtil.invoke(compileResult, "testFiniteTypeUnionArrayFill");
     }
 
-    private void validateMapValue(BMap<String, Object> actual, BMap<String, Object> expected) {
+    private void validateMapValue(BMap<BString, Object> actual, BMap<BString, Object> expected) {
         assertEquals(actual.size(), expected.size());
 
-        for (Map.Entry<String, Object> entry : expected.entrySet()) {
+        for (Map.Entry<BString, Object> entry : expected.entrySet()) {
             assertEquals(actual.get(entry.getKey()), entry.getValue());
         }
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayInitializerExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayInitializerExprTest.java
@@ -122,21 +122,21 @@ public class ArrayInitializerExprTest {
 
         Object adrs1 = arrayValue.getRefValue(0);
         Assert.assertTrue(adrs1 instanceof BMap<?, ?>);
-        Object address = ((BMap) adrs1).get(StringUtils.fromString("address"));
+        Object address = ((BMap<?, ?>) adrs1).get(StringUtils.fromString("address"));
         Assert.assertTrue(address instanceof BMap<?, ?>);
-        Assert.assertEquals(((BMap) address).get(StringUtils.fromString("city")).toString(), "Colombo");
+        Assert.assertEquals(((BMap<?, ?>) address).get(StringUtils.fromString("city")).toString(), "Colombo");
 
         Object adrs2 = arrayValue.getRefValue(1);
         Assert.assertTrue(adrs2 instanceof BMap<?, ?>);
-        address = ((BMap) adrs2).get(StringUtils.fromString("address"));
+        address = ((BMap<?, ?>) adrs2).get(StringUtils.fromString("address"));
         Assert.assertTrue(address instanceof BMap<?, ?>);
-        Assert.assertEquals(((BMap) address).get(StringUtils.fromString("city")).toString(), "Kandy");
+        Assert.assertEquals(((BMap<?, ?>) address).get(StringUtils.fromString("city")).toString(), "Kandy");
 
         Object adrs3 = arrayValue.getRefValue(2);
         Assert.assertTrue(adrs3 instanceof BMap<?, ?>);
-        address = ((BMap) adrs3).get(StringUtils.fromString("address"));
+        address = ((BMap<?, ?>) adrs3).get(StringUtils.fromString("address"));
         Assert.assertTrue(address instanceof BMap<?, ?>);
-        Assert.assertEquals(((BMap) address).get(StringUtils.fromString("city")).toString(), "Galle");
+        Assert.assertEquals(((BMap<?, ?>) address).get(StringUtils.fromString("city")).toString(), "Galle");
     }
 
     @Test(description = "Test float array initialization with integer values")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
@@ -157,7 +157,7 @@ public class ArrayTest {
     @Test
     public void testArrayFieldInRecord() {
         Object retVals = BRunUtil.invoke(compileResult, "testArrayFieldInRecord");
-        BMap barRec = (BMap) retVals;
+        BMap<?, ?> barRec = (BMap<?, ?>) retVals;
         BArray arr = (BArray) barRec.get(StringUtils.fromString("fArr"));
         Assert.assertEquals(((BArrayType) arr.getType()).getState().getValue(), BArrayState.CLOSED.getValue());
         Assert.assertEquals(arr.toString(), "[1,2]");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ErrorVariableDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ErrorVariableDefinitionTest.java
@@ -55,8 +55,8 @@ public class ErrorVariableDefinitionTest {
         Assert.assertEquals(returns.get(3).toString(), "Error Two");
         Assert.assertEquals(returns.get(4).toString(), "{\"detail\":\"Detail Msg\"}");
         Assert.assertEquals(returns.get(5).toString(), "Msg One");
-        Assert.assertEquals(((BMap) returns.get(6)).get(StringUtils.fromString("message")).toString(), "Msg Two");
-        Assert.assertTrue((Boolean) ((BMap) returns.get(6)).get(StringUtils.fromString("fatal")));
+        Assert.assertEquals(((BMap<?, ?>) returns.get(6)).get(StringUtils.fromString("message")).toString(), "Msg Two");
+        Assert.assertTrue((Boolean) ((BMap<?, ?>) returns.get(6)).get(StringUtils.fromString("fatal")));
         Assert.assertEquals(returns.get(7).toString(), "Msg Two");
     }
 
@@ -68,10 +68,12 @@ public class ErrorVariableDefinitionTest {
         Assert.assertEquals(returns.get(1).toString(), "Some Error One");
         Assert.assertEquals(returns.get(2).toString(), "Some Error Two");
         Assert.assertEquals(returns.get(3).toString(), "Some Error Two");
-        Assert.assertEquals(((BMap) returns.get(4)).get(StringUtils.fromString("message")).toString(), "Msg Three");
+        Assert.assertEquals(((BMap<?, ?>) returns.get(4)).get(StringUtils.fromString("message")).toString(),
+                "Msg Three");
         Assert.assertEquals(returns.get(5).toString(), "Msg Three");
-        Assert.assertEquals(((BMap) returns.get(6)).get(StringUtils.fromString("message")).toString(), "Msg Four");
-        Assert.assertTrue((Boolean) ((BMap) returns.get(6)).get(StringUtils.fromString("fatal")));
+        Assert.assertEquals(((BMap<?, ?>) returns.get(6)).get(StringUtils.fromString("message")).toString(),
+                "Msg Four");
+        Assert.assertTrue((Boolean) ((BMap<?, ?>) returns.get(6)).get(StringUtils.fromString("fatal")));
         Assert.assertEquals(returns.get(7).toString(), "Msg Four");
     }
 
@@ -83,10 +85,10 @@ public class ErrorVariableDefinitionTest {
         Assert.assertEquals(returns.get(1).toString(), "Error One");
         Assert.assertEquals(returns.get(2).toString(), "Error Two");
         Assert.assertEquals(returns.get(3).toString(), "Error Two");
-        Assert.assertEquals(((BMap) returns.get(4)).get(StringUtils.fromString("message")).toString(), "Msg One");
+        Assert.assertEquals(((BMap<?, ?>) returns.get(4)).get(StringUtils.fromString("message")).toString(), "Msg One");
         Assert.assertEquals(returns.get(5).toString(), "Msg One");
-        Assert.assertEquals(((BMap) returns.get(6)).get(StringUtils.fromString("message")).toString(), "Msg Two");
-        Assert.assertTrue((Boolean) ((BMap) returns.get(6)).get(StringUtils.fromString("fatal")));
+        Assert.assertEquals(((BMap<?, ?>) returns.get(6)).get(StringUtils.fromString("message")).toString(), "Msg Two");
+        Assert.assertTrue((Boolean) ((BMap<?, ?>) returns.get(6)).get(StringUtils.fromString("fatal")));
         Assert.assertEquals(returns.get(7).toString(), "Msg Two");
     }
 
@@ -98,10 +100,12 @@ public class ErrorVariableDefinitionTest {
         Assert.assertEquals(returns.get(1).toString(), "Some Error One");
         Assert.assertEquals(returns.get(2).toString(), "Some Error Two");
         Assert.assertEquals(returns.get(3).toString(), "Some Error Two");
-        Assert.assertEquals(((BMap) returns.get(4)).get(StringUtils.fromString("message")).toString(), "Msg Three");
+        Assert.assertEquals(((BMap<?, ?>) returns.get(4)).get(StringUtils.fromString("message")).toString(),
+                "Msg Three");
         Assert.assertEquals(returns.get(5).toString(), "Msg Three");
-        Assert.assertEquals(((BMap) returns.get(6)).get(StringUtils.fromString("message")).toString(), "Msg Four");
-        Assert.assertTrue((Boolean) ((BMap) returns.get(6)).get(StringUtils.fromString("fatal")));
+        Assert.assertEquals(((BMap<?, ?>) returns.get(6)).get(StringUtils.fromString("message")).toString(),
+                "Msg Four");
+        Assert.assertTrue((Boolean) ((BMap<?, ?>) returns.get(6)).get(StringUtils.fromString("fatal")));
         Assert.assertEquals(returns.get(7).toString(), "Msg Four");
     }
 
@@ -113,7 +117,7 @@ public class ErrorVariableDefinitionTest {
         Assert.assertEquals(returns.get(1).toString(), "Error One");
         Assert.assertEquals(returns.get(2).toString(), "Something Wrong");
         Assert.assertTrue((Boolean) returns.get(3));
-        Assert.assertEquals(((BMap) returns.get(4)).get(StringUtils.fromString("message")).toString(),
+        Assert.assertEquals(((BMap<?, ?>) returns.get(4)).get(StringUtils.fromString("message")).toString(),
                 "Something Wrong");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ForwardReferencingGlobalDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ForwardReferencingGlobalDefinitionTest.java
@@ -54,7 +54,7 @@ public class ForwardReferencingGlobalDefinitionTest {
         Assert.assertEquals(diagnostics.length, 0);
 
         Object employee = BRunUtil.invoke(resultReOrdered, "getEmployee");
-        String employeeName = ((BMap) employee).get(StringUtils.fromString("name")).toString();
+        String employeeName = ((BMap<?, ?>) employee).get(StringUtils.fromString("name")).toString();
         Assert.assertEquals(employeeName, "Sumedha");
     }
 
@@ -75,11 +75,11 @@ public class ForwardReferencingGlobalDefinitionTest {
                 compile("test-src/statements/variabledef/inFunctionGlobalRefProject");
 
         Object employee = BRunUtil.invoke(resultReOrdered, "getEmployee");
-        String employeeName = ((BMap) employee).get(StringUtils.fromString("name")).toString();
+        String employeeName = ((BMap<?, ?>) employee).get(StringUtils.fromString("name")).toString();
         Assert.assertEquals(employeeName, "Sumedha");
 
         Object employee2 = BRunUtil.invoke(resultReOrdered, "getfromFuncA");
-        String employee2Name = ((BMap) employee2).get(StringUtils.fromString("name")).toString();
+        String employee2Name = ((BMap<?, ?>) employee2).get(StringUtils.fromString("name")).toString();
         Assert.assertEquals(employee2Name, "Sumedha");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/RecordVariableDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/RecordVariableDefinitionTest.java
@@ -73,8 +73,8 @@ public class RecordVariableDefinitionTest {
         BArray returns = (BArray) BRunUtil.invoke(result, "recordVarInRecordVar2");
         Assert.assertEquals(returns.size(), 2);
         Assert.assertEquals(returns.get(0).toString(), "Peter");
-        Assert.assertEquals((((BMap) returns.get(1)).get(StringUtils.fromString("age"))), 29L);
-        Assert.assertEquals(((BMap) returns.get(1)).get(StringUtils.fromString("format")).toString(), "Y");
+        Assert.assertEquals((((BMap<?, ?>) returns.get(1)).get(StringUtils.fromString("age"))), 29L);
+        Assert.assertEquals(((BMap<?, ?>) returns.get(1)).get(StringUtils.fromString("format")).toString(), "Y");
     }
 
     @Test(description = "Test record variable inside record variable inside record variable")
@@ -121,13 +121,15 @@ public class RecordVariableDefinitionTest {
     public void testRestParameter() {
         Object returns = BRunUtil.invoke(result, "testRestParameter");
         Assert.assertTrue(returns instanceof BMap);
-        BMap bMap = (BMap) returns;
+        BMap<?, ?> bMap = (BMap<?, ?>) returns;
         Assert.assertEquals(bMap.size(), 2);
         Assert.assertEquals(bMap.get(StringUtils.fromString("work")).toString(), "SE");
-        Assert.assertEquals((((BMap) bMap.get(StringUtils.fromString("other"))).get(StringUtils.fromString("age"))),
+        Assert.assertEquals((((BMap<?, ?>) bMap.get(StringUtils.fromString("other")))
+                        .get(StringUtils.fromString("age"))),
                 99L);
         Assert.assertEquals(
-                ((BMap) bMap.get(StringUtils.fromString("other"))).get(StringUtils.fromString("format")).toString(),
+                ((BMap<?, ?>) bMap.get(StringUtils.fromString("other")))
+                        .get(StringUtils.fromString("format")).toString(),
                 "MM");
     }
 
@@ -135,11 +137,11 @@ public class RecordVariableDefinitionTest {
     public void testNestedRestParameter() {
         BArray returns = (BArray) BRunUtil.invoke(result, "testNestedRestParameter");
         Assert.assertTrue(returns.get(0) instanceof BMap);
-        BMap bMap = (BMap) returns.get(0);
+        BMap<?, ?> bMap = (BMap<?, ?>) returns.get(0);
         Assert.assertEquals(bMap.size(), 1);
         Assert.assertEquals((bMap.get(StringUtils.fromString("year"))), 1990L);
 
-        BMap bMap2 = (BMap) returns.get(1);
+        BMap<?, ?> bMap2 = (BMap<?, ?>) returns.get(1);
         Assert.assertEquals(bMap2.size(), 1);
         Assert.assertEquals(bMap2.get(StringUtils.fromString("work")).toString(), "SE");
     }
@@ -152,7 +154,7 @@ public class RecordVariableDefinitionTest {
         Assert.assertEquals(returns.get(1), 29L);
         Assert.assertEquals(returns.get(2).toString(), "Y");
         Assert.assertTrue((Boolean) returns.get(3));
-        Assert.assertEquals(((BMap) returns.get(4)).get(StringUtils.fromString("work")).toString(), "SE");
+        Assert.assertEquals(((BMap<?, ?>) returns.get(4)).get(StringUtils.fromString("work")).toString(), "SE");
     }
 
     @Test(description = "Test rest parameter in nested record variable")
@@ -163,7 +165,7 @@ public class RecordVariableDefinitionTest {
         Assert.assertEquals(returns.get(1), 30L);
         Assert.assertEquals(returns.get(2).toString(), "N");
         Assert.assertFalse((Boolean) returns.get(3));
-        Assert.assertEquals(((BMap) returns.get(4)).get(StringUtils.fromString("added")).toString(), "later");
+        Assert.assertEquals(((BMap<?, ?>) returns.get(4)).get(StringUtils.fromString("added")).toString(), "later");
     }
 
     @Test(description = "Test tuple var def inside record var def")
@@ -188,10 +190,11 @@ public class RecordVariableDefinitionTest {
         Assert.assertEquals(((BArray) returns.get(0)).getString(0), "A");
         Assert.assertEquals(((BArray) returns.get(0)).getString(1), "B");
         Assert.assertEquals(returns.get(1).toString(), "A");
-        BMap child = (BMap) ((BMap) returns.get(2)).get(StringUtils.fromString("child"));
+        BMap<?, ?> child = (BMap<?, ?>) ((BMap<?, ?>) returns.get(2)).get(StringUtils.fromString("child"));
         Assert.assertEquals(child.get(StringUtils.fromString("name")).toString(), "C");
         Assert.assertEquals((((BArray) child.get(StringUtils.fromString("yearAndAge"))).getRefValue(0)), 1996L);
-        Assert.assertEquals(((BMap) ((BArray) child.get(StringUtils.fromString("yearAndAge"))).getRefValue(1)).get(
+        Assert.assertEquals(((BMap<?, ?>) ((BArray) child.get(StringUtils.fromString("yearAndAge")))
+                        .getRefValue(1)).get(
                         StringUtils.fromString("format")).toString(),
                 "Z");
     }
@@ -213,10 +216,11 @@ public class RecordVariableDefinitionTest {
         Assert.assertEquals(((BArray) returns.get(0)).getString(0), "A");
         Assert.assertEquals(((BArray) returns.get(0)).getString(1), "B");
         Assert.assertEquals(returns.get(1).toString(), "A");
-        BMap child = (BMap) ((BMap) returns.get(2)).get(StringUtils.fromString("child"));
+        BMap<?, ?> child = (BMap<?, ?>) ((BMap<?, ?>) returns.get(2)).get(StringUtils.fromString("child"));
         Assert.assertEquals(child.get(StringUtils.fromString("name")).toString(), "C");
         Assert.assertEquals((((BArray) child.get(StringUtils.fromString("yearAndAge"))).getRefValue(0)), 1996L);
-        Assert.assertEquals(((BMap) ((BArray) child.get(StringUtils.fromString("yearAndAge"))).getRefValue(1)).get(
+        Assert.assertEquals(((BMap<?, ?>) ((BArray) child.get(StringUtils.fromString("yearAndAge")))
+                        .getRefValue(1)).get(
                         StringUtils.fromString("format")).toString(),
                 "Z");
     }
@@ -238,7 +242,7 @@ public class RecordVariableDefinitionTest {
         Assert.assertEquals(returns.get(0), 50L);
         Assert.assertEquals(returns.get(1), 51.1);
         Assert.assertEquals(getType(returns.get(2)).getName(), "UnionOne");
-        Assert.assertEquals(((BMap) returns.get(2)).get(StringUtils.fromString("restP1")).toString(), "stringP1");
+        Assert.assertEquals(((BMap<?, ?>) returns.get(2)).get(StringUtils.fromString("restP1")).toString(), "stringP1");
     }
 
     @Test(description = "Test record variable with Union Type")
@@ -261,7 +265,7 @@ public class RecordVariableDefinitionTest {
 
     @Test(description = "Test record variable with only a rest parameter")
     public void testRecordVariableWithOnlyRestParam() {
-        BMap returns = (BMap) BRunUtil.invoke(result, "testRecordVariableWithOnlyRestParam");
+        BMap<?, ?> returns = (BMap<?, ?>) BRunUtil.invoke(result, "testRecordVariableWithOnlyRestParam");
 
         Assert.assertEquals(returns.toString(),
                 "{\"name\":\"John\",\"age\":{\"age\":30,\"format\":\"YY\",\"year\":1990},\"married\":true," +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructAccessWithIndexTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructAccessWithIndexTest.java
@@ -54,7 +54,7 @@ public class StructAccessWithIndexTest {
         Assert.assertEquals(returns.get(0).toString(), "Jack");
 
         Assert.assertTrue(returns.get(1) instanceof BMap);
-        BMap<String, ?> adrsMap = ((BMap) returns.get(1));
+        BMap<String, ?> adrsMap = ((BMap<String, ?>) returns.get(1));
         Assert.assertEquals(adrsMap.get(StringUtils.fromString("country")), StringUtils.fromString("USA"));
         Assert.assertEquals(adrsMap.get(StringUtils.fromString("state")), StringUtils.fromString("CA"));
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructTest.java
@@ -49,7 +49,7 @@ public class StructTest {
         Assert.assertEquals(returns.get(0).toString(), "Jack");
 
         Assert.assertTrue(returns.get(1) instanceof BMap);
-        BMap<String, ?> adrsMap = ((BMap) returns.get(1));
+        BMap<String, ?> adrsMap = ((BMap<String, ?>) returns.get(1));
         Assert.assertEquals(adrsMap.get(StringUtils.fromString("country")), StringUtils.fromString("USA"));
         Assert.assertEquals(adrsMap.get(StringUtils.fromString("state")), StringUtils.fromString("CA"));
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
@@ -74,11 +74,11 @@ public class AnydataTest {
     public void testRecordAssignment() {
         BArray returns = (BArray) BRunUtil.invoke(result, "testRecordAssignment");
 
-        BMap foo = (BMap) returns.get(0);
+        BMap<?, ?> foo = (BMap<?, ?>) returns.get(0);
         assertEquals(getType(foo).getName(), "Foo");
         assertEquals((foo.get(StringUtils.fromString("a"))), 20L);
 
-        BMap closedFoo = (BMap) returns.get(1);
+        BMap<?, ?> closedFoo = (BMap<?, ?>) returns.get(1);
         assertEquals(getType(closedFoo).getName(), "ClosedFoo");
         assertEquals((closedFoo.get(StringUtils.fromString("ca"))), 35L);
     }
@@ -87,11 +87,12 @@ public class AnydataTest {
     public void testCyclicRecordAssignment() {
         Object returns = BRunUtil.invoke(result, "testCyclicRecordAssignment");
         Assert.assertTrue(returns instanceof BMap<?, ?>);
-        BMap bMap = (BMap) returns;
+        BMap<?, ?> bMap = (BMap<?, ?>) returns;
         Assert.assertEquals(bMap.get(StringUtils.fromString("name")).toString(), "Child");
         Assert.assertEquals(bMap.get(StringUtils.fromString("age")), 25L);
         Assert.assertEquals(
-                ((BMap) bMap.get(StringUtils.fromString("parent"))).get(StringUtils.fromString("name")).toString(),
+                ((BMap<?, ?>) bMap.get(StringUtils.fromString("parent")))
+                        .get(StringUtils.fromString("name")).toString(),
                 "Parent");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/JSONTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/JSONTest.java
@@ -156,7 +156,7 @@ public class JSONTest {
         Object returns = BRunUtil.invoke(compileResult, "testParse", args);
         Assert.assertTrue(returns instanceof BError);
         String errorMsg =
-                (((BMap) ((BError) returns).getDetails()).get(StringUtils.fromString("message"))).toString();
+                (((BMap<?, ?>) ((BError) returns).getDetails()).get(StringUtils.fromString("message"))).toString();
         Assert.assertEquals(errorMsg, "unrecognized token 'some' at line: 1 column: 6");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/BMapValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/BMapValueTest.java
@@ -44,7 +44,7 @@ public class BMapValueTest {
     @Test
     public void testBMap() {
 
-        BMap map = ValueCreator.createMapValue();
+        BMap<BString, Object> map = ValueCreator.createMapValue();
         map.put(StringUtils.fromString("Chanaka"), 1L);
         map.put(StringUtils.fromString("Udaya"), 2L);
         map.put(StringUtils.fromString("Chanaka"), 1L);
@@ -64,7 +64,7 @@ public class BMapValueTest {
 
     @Test
     public void testBMapClear() {
-        BMap map = ValueCreator.createMapValue();
+        BMap<BString, Object> map = ValueCreator.createMapValue();
         map.put(StringUtils.fromString("IS"), 0L);
         map.put(StringUtils.fromString("ESB"), 1L);
         map.put(StringUtils.fromString("APIM"), 2L);
@@ -75,7 +75,7 @@ public class BMapValueTest {
 
     @Test
     public void testBMapHasKey() {
-        BMap map = ValueCreator.createMapValue();
+        BMap<BString, Object> map = ValueCreator.createMapValue();
         map.put(StringUtils.fromString("IS"), (0));
         map.put(StringUtils.fromString("ESB"), (1));
         map.put(StringUtils.fromString("APIM"), (2));
@@ -179,7 +179,7 @@ public class BMapValueTest {
     @Test(dependsOnMethods = "testGrammar")
     public void testMapOrder() {
         Object returnVals = BRunUtil.invoke(programFile, "testMapOrder", new Object[0]);
-        BMap m = (BMap) returnVals;
+        BMap<?, ?> m = (BMap<?, ?>) returnVals;
         Object[] keys = m.getKeys();
         int counter = 0;
         String[] values = {"Element 1", "Element 2", "Element 3"};
@@ -194,14 +194,14 @@ public class BMapValueTest {
     @Test(description = "Test string representations of a map with a nil value", dependsOnMethods = "testGrammar")
     public void testMapStringRepresentation() {
         Object returnVals = BRunUtil.invoke(programFile, "testMapStringRepresentation", new Object[0]);
-        BMap m = (BMap) returnVals;
+        BMap<?, ?> m = (BMap<?, ?>) returnVals;
         String mapString = m.toString();
         Assert.assertEquals(mapString, "{\"key1\":\"Element 1\",\"key2\":\"Element 2\",\"key3\":null}");
     }
 
     @Test
     public void testBMapOrder() {
-        BMap map = ValueCreator.createMapValue();
+        BMap<BString, Object> map = ValueCreator.createMapValue();
         map.put(StringUtils.fromString("Entry1"), StringUtils.fromString("foo"));
         map.put(StringUtils.fromString("Entry2"), StringUtils.fromString("bar"));
         map.put(StringUtils.fromString("Entry3"), StringUtils.fromString("foobar"));

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapAccessExprTest.java
@@ -78,7 +78,7 @@ public class MapAccessExprTest {
 
         Assert.assertTrue(returns instanceof  BMap);
 
-        BMap mapValue = (BMap) returns;
+        BMap<?, ?> mapValue = (BMap<?, ?>) returns;
         Assert.assertEquals(mapValue.size(), 3);
 
         Assert.assertEquals(mapValue.get(StringUtils.fromString("fname")).toString(), "Chanaka");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapInitializerExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapInitializerExprTest.java
@@ -103,21 +103,21 @@ public class MapInitializerExprTest {
 
         Object adrs1 = addressArray.getRefValue(0);
         Assert.assertTrue(adrs1 instanceof BMap<?, ?>);
-        Object address = ((BMap) adrs1).get(StringUtils.fromString("address"));
+        Object address = ((BMap<?, ?>) adrs1).get(StringUtils.fromString("address"));
         Assert.assertTrue(address instanceof BMap<?, ?>);
-        Assert.assertEquals(((BMap) address).get(StringUtils.fromString("city")).toString(), "Colombo");
+        Assert.assertEquals(((BMap<?, ?>) address).get(StringUtils.fromString("city")).toString(), "Colombo");
 
         Object adrs2 = addressArray.getRefValue(1);
         Assert.assertTrue(adrs2 instanceof BMap<?, ?>);
-        address = ((BMap) adrs2).get(StringUtils.fromString("address"));
+        address = ((BMap<?, ?>) adrs2).get(StringUtils.fromString("address"));
         Assert.assertTrue(address instanceof BMap<?, ?>);
-        Assert.assertEquals(((BMap) address).get(StringUtils.fromString("city")).toString(), "Kandy");
+        Assert.assertEquals(((BMap<?, ?>) address).get(StringUtils.fromString("city")).toString(), "Kandy");
 
         Object adrs3 = addressArray.getRefValue(2);
         Assert.assertTrue(adrs3 instanceof BMap<?, ?>);
-        address = ((BMap) adrs3).get(StringUtils.fromString("address"));
+        address = ((BMap<?, ?>) adrs3).get(StringUtils.fromString("address"));
         Assert.assertTrue(address instanceof BMap<?, ?>);
-        Assert.assertEquals(((BMap) address).get(StringUtils.fromString("city")).toString(), "Galle");
+        Assert.assertEquals(((BMap<?, ?>) address).get(StringUtils.fromString("city")).toString(), "Galle");
     }
 
     @Test()
@@ -162,7 +162,7 @@ public class MapInitializerExprTest {
         Object returns = BRunUtil.invoke(compileResult, "testEmptyMap", new Object[]{});
 
         Assert.assertTrue(returns instanceof BMap<?, ?>, "empty map initialization with {}");
-        Assert.assertEquals(((BMap) returns).size(), 0, "incorrect empty map size");
+        Assert.assertEquals(((BMap<?, ?>) returns).size(), 0, "incorrect empty map size");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/ReadonlyArrayCreator.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/ReadonlyArrayCreator.java
@@ -58,7 +58,7 @@ public final class ReadonlyArrayCreator {
         return ValueCreator.createReadonlyArrayValue(numbers);
     }
 
-    public static BArray createArrayOfMaps(BMap map) {
+    public static BArray createArrayOfMaps(BMap<?, ?> map) {
         return ValueCreator.createArrayValue(TypeCreator.createArrayType(map.getType(), 0, true));
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
@@ -353,7 +353,7 @@ public class XMLLiteralTest {
     private String arrayToString(Object aReturn) {
         BArray ar = ((BArray) aReturn);
         StringBuilder builder = new StringBuilder();
-        BIterator bIterator = ar.getIterator();
+        BIterator<?> bIterator = ar.getIterator();
         while (bIterator.hasNext()) {
             String str = bIterator.next().toString();
             builder.append(str);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerTest.java
@@ -18,6 +18,7 @@ package org.ballerinalang.test.worker;
 
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BString;
 import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
@@ -87,7 +88,7 @@ public class BasicWorkerTest {
     @Test
     public void workerSameThreadSchedulingTest() {
         Object vals = BRunUtil.invoke(result, "workerSameThreadTest", new Object[0]);
-        BMap result = (BMap) vals;
+        BMap<BString, Object> result = (BMap<BString, Object>) vals;
         Assert.assertEquals(result.get(StringUtils.fromString("w")), result.get(StringUtils.fromString("w1")));
         Assert.assertEquals(result.get(StringUtils.fromString("w")), result.get(StringUtils.fromString("w2")));
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/VarMutabilityWithWorkersTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/VarMutabilityWithWorkersTest.java
@@ -63,7 +63,7 @@ public class VarMutabilityWithWorkersTest {
     @Test(description = "Test variable mutability with maps")
     public void testWithMaps() {
         Object returns = BRunUtil.invoke(compileResult, "testWithMaps");
-        BMap resMap = (BMap) returns;
+        BMap<?, ?> resMap = (BMap<?, ?>) returns;
         Assert.assertEquals(resMap.size(), 7);
         Assert.assertEquals(resMap.get(StringUtils.fromString("a")).toString(), "AAAA");
         Assert.assertEquals(resMap.get(StringUtils.fromString("b")).toString(), "B");
@@ -80,7 +80,7 @@ public class VarMutabilityWithWorkersTest {
         Assert.assertEquals(returns.size(), 2);
         Assert.assertEquals(returns.get(0), 400L);
 
-        BMap resMap = (BMap) returns.get(1);
+        BMap<?, ?> resMap = (BMap<?, ?>) returns.get(1);
         Assert.assertEquals(resMap.size(), 6);
         Assert.assertEquals(resMap.get(StringUtils.fromString("a")).toString(), "AAAA");
         Assert.assertEquals(resMap.get(StringUtils.fromString("b")).toString(), "BBBB");
@@ -93,7 +93,7 @@ public class VarMutabilityWithWorkersTest {
     @Test(description = "Test variable mutability with records")
     public void testWithRecords() {
         Object returns = BRunUtil.invoke(compileResult, "testWithRecords");
-        Assert.assertEquals(((BMap) returns).size(), 3);
+        Assert.assertEquals(((BMap<?, ?>) returns).size(), 3);
         Assert.assertEquals(returns.toString(),
                 "{\"name\":\"Adam Page\",\"age\":24,\"email\":\"adamp@wso2.com\"}");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForAllActionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForAllActionsTest.java
@@ -55,7 +55,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("f3", "hello foo");
         expectedMap.put("f4", "true");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -68,7 +68,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("f3", "150");
         expectedMap.put("str2", "hello xyz");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -80,7 +80,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("f3", "150");
         expectedMap.put("f5", "hello bar");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -92,7 +92,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("f4", "hello foo");
         expectedMap.put("f2", "22");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -103,7 +103,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("id", "66");
         expectedMap.put("name", "hello foo");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -114,7 +114,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("idField", "150");
         expectedMap.put("stringField", "hello foo");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -132,7 +132,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("id", "8");
         expectedMap.put("name", "hello moo");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -143,7 +143,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("f1", "20");
         expectedMap.put("f5", "hello foo");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -154,7 +154,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("f1", "30");
         expectedMap.put("f5", "hello xyz");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -165,7 +165,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("f1", "30");
         expectedMap.put("field", "hello bar");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -175,7 +175,7 @@ public class WaitForAllActionsTest {
         Map<String, String> expectedMap = new HashMap<>();
         expectedMap.put("id", "86");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test(expectedExceptions = {BLangTestException.class},
@@ -207,9 +207,9 @@ public class WaitForAllActionsTest {
     public void waitTest17() {
         Object returns = BRunUtil.invoke(result, "waitTest17");
 
-        Assert.assertEquals(((BMap) returns).values().size(), 2);
-        BMap val1 = (BMap) ((BMap) returns).get(StringUtils.fromString("f1"));
-        BMap val2 = (BMap) ((BMap) returns).get(StringUtils.fromString("f2"));
+        Assert.assertEquals(((BMap<?, ?>) returns).values().size(), 2);
+        BMap<?, ?> val1 = (BMap<?, ?>) ((BMap<?, ?>) returns).get(StringUtils.fromString("f1"));
+        BMap<?, ?> val2 = (BMap<?, ?>) ((BMap<?, ?>) returns).get(StringUtils.fromString("f2"));
         Assert.assertEquals(val1.get(StringUtils.fromString("f1")), 7L);
         Assert.assertEquals(val1.get(StringUtils.fromString("f2")), 150L);
         Assert.assertEquals(val2.get(StringUtils.fromString("name")).toString(), "hello foo");
@@ -224,7 +224,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("f5", "hello foo");
         expectedMap.put("f1", "7");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -235,7 +235,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("w1", "30");
         expectedMap.put("w2", "16");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -246,7 +246,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("w2", "hello world");
         expectedMap.put("w3", "15");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -257,7 +257,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("id", "7");
         expectedMap.put("name", "hello foo");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -269,7 +269,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("name", "hello foo");
         expectedMap.put("status", "hello bar");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -281,7 +281,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("name", "hello foo");
         expectedMap.put("status", "20");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -293,7 +293,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("name", "hello foo");
         expectedMap.put("status", "hello bar");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -303,7 +303,7 @@ public class WaitForAllActionsTest {
         Map<String, String> expectedMap = new HashMap<>();
         expectedMap.put("id", "7");
         expectedMap.put("name", "hello foo");
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     @Test
@@ -315,10 +315,10 @@ public class WaitForAllActionsTest {
         expectedMap.put("name", "hello world");
         expectedMap.put("status", "hello moo");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap(((BMap) returns))));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap(((BMap<?, ?>) returns))));
     }
 
-    private Map<String, String> getResultMap(BMap returns) {
+    private Map<String, String> getResultMap(BMap<?, ?> returns) {
         Map<String, String> resultMap = new HashMap<>();
         for (Object key : returns.getKeys()) {
             resultMap.put(key.toString(), returns.get(key).toString());
@@ -335,7 +335,7 @@ public class WaitForAllActionsTest {
         expectedMap.put("name", "hello mello");
         expectedMap.put("greet", "hello sunshine");
 
-        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap) returns)));
+        Assert.assertTrue(mapsAreEqual(expectedMap, getResultMap((BMap<?, ?>) returns)));
     }
 
     /**

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerSyncSendTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerSyncSendTest.java
@@ -171,7 +171,7 @@ public class WorkerSyncSendTest {
     public void testComplexTypeSend() {
         Object returns = BRunUtil.invoke(result, "testComplexType");
         Assert.assertEquals(getType(returns).getName(), "Rec");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("k")), 10L);
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("k")), 10L);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
@@ -278,7 +278,7 @@ public class WorkerTest {
         Object returns = BRunUtil.invoke(result, "testComplexType");
 
         Assert.assertEquals(getType(returns).getName(), "Rec");
-        Assert.assertEquals(((BMap) returns).get(StringUtils.fromString("k")), 10L);
+        Assert.assertEquals(((BMap<?, ?>) returns).get(StringUtils.fromString("k")), 10L);
     }
 
     @Test
@@ -296,7 +296,7 @@ public class WorkerTest {
         Object returns = BRunUtil.invoke(result, "waitInReturn");
 
         Assert.assertTrue(returns instanceof BMap);
-        BMap mapResult = (BMap) returns;
+        BMap<?, ?> mapResult = (BMap<?, ?>) returns;
         Assert.assertEquals(mapResult.get(StringUtils.fromString("w1")).toString(), "w1");
         Assert.assertEquals(mapResult.get(StringUtils.fromString("w2")).toString(), "w2");
     }


### PR DESCRIPTION
## Purpose
To ensure type-safety, generics should always be filled out (= no more raw types).

Some issues I encountered:
- Some casts could not easily be made, like converting a `List<Object>` to a `List<String>`. For this I used the approach from [this Stackoverflow post](https://stackoverflow.com/questions/15427624/could-not-downcast-using-list-class-in-java) to cast `List<Object>` -> `List<?>` -> `List<String>`.
- Some generics can't be filled out since they are returned by a library or because of `ServiceLoader.load(Service.class)` which does not work with generics.
- In `TableValueImpl.entrySet()` there was a type error which I could only fix with a semantic change. But I think this was a bug.

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
