### PR TITLE
Fix missing javadoc in docerina gradle plugin

### DIFF
--- a/misc/ballerina-gradle-plugins/docerina-gradle-plugin/src/main/java/org/ballerinalang/plugin/gradle/doc/DocerinaGen.java
+++ b/misc/ballerina-gradle-plugins/docerina-gradle-plugin/src/main/java/org/ballerinalang/plugin/gradle/doc/DocerinaGen.java
@@ -30,6 +30,10 @@ public class DocerinaGen {
 
     private static final PrintStream out = System.out;
 
+    /**
+     * Main method to generate Ballerina API docs.
+     * @param args command line arguments
+     */
     public static void main(String[] args) {
         BallerinaDocGenerator.mergeApiDocs(Path.of(args[0]));
     }


### PR DESCRIPTION
## Purpose
Running `./gradlew :docerina-gradle-plugin:createJavadoc` throws an error, since a javadoc comment is missing.

See also: https://github.com/ballerina-platform/ballerina-lang/issues/42844#issuecomment-2158105563
Part of #42844

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
