### PR TITLE
Replace `collect(Collectors.toList())` with `toList()`

### DIFF
--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/ShellSnippetsInvoker.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/ShellSnippetsInvoker.java
@@ -391,8 +391,8 @@ public abstract class ShellSnippetsInvoker extends DiagnosticReporter {
             List<String> stacktrace = Arrays.stream(panicError.getCause().getStackTrace())
                     .filter(element -> !(element.toString().contains(MODULE_STATEMENT_METHOD_NAME) ||
                                         element.toString().contains(MODULE_RUN_METHOD_NAME)))
-                    .collect(Collectors.toList())
-                    .stream().map(element -> "at " + element.getMethodName() + "()").collect(Collectors.toList());
+                    .toList()
+                    .stream().map(element -> "at " + element.getMethodName() + "()").toList();
             errorStream.println("panic: " + StringUtils.getErrorStringValue(panicError.getCause()));
             stacktrace.forEach(errorStream::println);
             addErrorDiagnostic("Execution aborted due to unhandled runtime error.");

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/ShellSnippetsInvoker.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/ShellSnippetsInvoker.java
@@ -60,7 +60,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Invoker that invokes a command to evaluate a list of snippets.

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -1013,7 +1013,7 @@ public class TypeChecker {
                 BUnionType unionType = (BUnionType) constraintType;
                 List<Type> memTypes = unionType.getMemberTypes();
                 List<BField> fields = memTypes.stream().map(type -> getTableConstraintField(type, fieldName))
-                        .filter(Objects::nonNull).collect(Collectors.toList());
+                        .filter(Objects::nonNull).toList();
 
                 if (fields.size() != memTypes.size()) {
                     return null;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -93,7 +93,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static io.ballerina.runtime.api.PredefinedTypes.TYPE_ANY;
 import static io.ballerina.runtime.api.PredefinedTypes.TYPE_ANYDATA;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/MetricRegistry.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/MetricRegistry.java
@@ -191,7 +191,7 @@ public class MetricRegistry {
      */
     public void remove(String name) {
         List<MetricId> ids = metrics.keySet().stream()
-                .filter(id -> id.getName().equals(name)).collect(Collectors.toList());
+                .filter(id -> id.getName().equals(name)).toList();
         ids.forEach(metrics::remove);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/MetricRegistry.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/MetricRegistry.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
-import java.util.stream.Collectors;
 
 /**
  * Registry for keeping metrics by name.

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
@@ -294,7 +294,7 @@ public class CommandUtil {
         Path moduleMdDirRoot = balaPath.resolve("docs").resolve(ProjectConstants.MODULES_ROOT);
         List<Path> modulesList;
         try (Stream<Path> pathStream = Files.list(modulesRoot)) {
-            modulesList = pathStream.collect(Collectors.toList());
+            modulesList = pathStream.toList();
         }
         for (Path moduleRoot : modulesList) {
             Path moduleDir = Optional.of(moduleRoot.getFileName()).get();
@@ -326,7 +326,7 @@ public class CommandUtil {
         try (Stream<Path> pathStream = Files.walk(docsPath, 1)) {
             List<Path> icon = pathStream
                     .filter(FileSystems.getDefault().getPathMatcher("glob:**.png")::matches)
-                    .collect(Collectors.toList());
+                    .toList();
             if (!icon.isEmpty()) {
                 Path projectDocsDir = projectPath.resolve(ProjectConstants.BALA_DOCS_DIR);
                 Files.createDirectory(projectDocsDir);
@@ -485,7 +485,7 @@ public class CommandUtil {
         Files.writeString(balTomlPath, "\nversion = \"" + packageJson.getVersion() + "\"",
                 StandardOpenOption.APPEND);
         List<String> newModuleNames = packageJson.getExport().stream().map(module ->
-                module.replaceFirst(packageJson.getName(), packageName)).collect(Collectors.toList());
+                module.replaceFirst(packageJson.getName(), packageName)).toList();
 
         StringJoiner stringJoiner = new StringJoiner(",");
         for (String newModuleName : newModuleNames) {
@@ -1036,7 +1036,7 @@ public class CommandUtil {
             } catch (IOException e) {
                 throw new RuntimeException("Error while accessing Distribution cache: " + e.getMessage());
             }
-            versions.addAll(collectVersions.collect(Collectors.toList()));
+            versions.addAll(collectVersions.toList());
         }
         return pathToVersions(versions);
     }
@@ -1091,7 +1091,7 @@ public class CommandUtil {
             IOException {
         Path templateDir = getTemplatePath().resolve(template);
         Stream<Path> paths = Files.list(templateDir);
-        List<Path> templateFilePathList = paths.collect(Collectors.toList());
+        List<Path> templateFilePathList = paths.toList();
         StringBuilder existingFiles = new StringBuilder();
         for (Path path : templateFilePathList) {
             Optional<String> fileNameOptional = Optional.ofNullable(path.getFileName()).map(path1 -> path1.toString());

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
@@ -457,7 +457,7 @@ public class Utils {
 
         try (FileSystem zipFileSystem = FileSystems.newFileSystem(zipURI, new HashMap<>())) {
             Path packageRoot = zipFileSystem.getPath("/");
-            List<Path> paths = Files.walk(packageRoot).filter(path -> path != packageRoot).collect(Collectors.toList());
+            List<Path> paths = Files.walk(packageRoot).filter(path -> path != packageRoot).toList();
             for (Path path : paths) {
                 Path destPath = balaFileDestPath.resolve(packageRoot.relativize(path).toString());
                 // Handle overwriting existing bala

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
@@ -60,7 +60,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.central.client.CentralClientConstants.APPLICATION_JSON;
 import static org.ballerinalang.central.client.CentralClientConstants.BALLERINA_DEV_CENTRAL;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ExpectedTypeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ExpectedTypeFinder.java
@@ -885,7 +885,7 @@ public class ExpectedTypeFinder extends NodeTransformer<Optional<TypeSymbol>> {
             //`params` contains path params and path rest params as well. We need to skip those
             List<BVarSymbol> params = symbol.params.stream().filter(param ->
                     param.getKind() != SymbolKind.PATH_PARAMETER
-                            && param.getKind() != SymbolKind.PATH_REST_PARAMETER).collect(Collectors.toList());
+                            && param.getKind() != SymbolKind.PATH_REST_PARAMETER).toList();
             BVarSymbol restPram = ((BInvokableSymbol) bLangInvocation.symbol).restParam;
             TypeSymbol restParamMemberType = null;
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibFunctionBinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibFunctionBinder.java
@@ -31,7 +31,6 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * A util class for creating type param resolved version of the lang lib functions.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibFunctionBinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibFunctionBinder.java
@@ -126,7 +126,7 @@ public class LangLibFunctionBinder {
 
         List<BType> paramTypes = new ArrayList<>();
         if (newParams.size() == original.paramTypes.size()) {
-            paramTypes.addAll(newParams.stream().map(BSymbol::getType).collect(Collectors.toList()));
+            paramTypes.addAll(newParams.stream().map(BSymbol::getType).toList());
         } else {
             paramTypes.addAll(original.paramTypes);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
@@ -136,7 +136,7 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
             this.typeDefs = this.allSymbols().stream()
                     .filter(symbol -> symbol.kind() == SymbolKind.TYPE_DEFINITION)
                     .map(symbol -> (TypeDefinitionSymbol) symbol)
-                    .collect(Collectors.toUnmodifiableList());
+                    .toList();
         }
 
         return this.typeDefs;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
@@ -46,7 +46,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.model.symbols.SymbolOrigin.BUILTIN;
 import static org.ballerinalang.model.symbols.SymbolOrigin.COMPILED_SOURCE;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/resourcepath/BallerinaPathSegmentList.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/resourcepath/BallerinaPathSegmentList.java
@@ -69,7 +69,7 @@ public class BallerinaPathSegmentList implements PathSegmentList {
         List<PathParameterSymbol> pathParams = new ArrayList<>();
 
         int internalPathParamCount = 0;
-        List<Name> segments = this.internalPathSegmentSymbols.stream().map(s -> s.name).collect(Collectors.toList());
+        List<Name> segments = this.internalPathSegmentSymbols.stream().map(s -> s.name).toList();
         for (int i = 0; i < segments.size(); i++) {
             Name internalSegment = segments.get(i);
             BResourcePathSegmentSymbol pathSegSymbol = this.internalPathSegmentSymbols.get(i);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/resourcepath/BallerinaPathSegmentList.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/resourcepath/BallerinaPathSegmentList.java
@@ -32,7 +32,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 /**
  * Represents an implementation of a path segment list.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -503,7 +503,7 @@ public class JBallerinaBackend extends CompilerBackend {
 
         List<JarLibrary> sortedJarLibraries = jarLibraries.stream()
                 .sorted(Comparator.comparing(jarLibrary -> jarLibrary.path().getFileName()))
-                .collect(Collectors.toList());
+                .toList();
 
         // Copy all the jars
         for (JarLibrary library : sortedJarLibraries) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ResolutionEngine.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ResolutionEngine.java
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Responsible for creating the dependency graph with automatic version updates.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ResolutionEngine.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ResolutionEngine.java
@@ -163,7 +163,7 @@ public class ResolutionEngine {
 
     private void populateStaticDependencyGraph(Collection<DependencyNode> directDependencies) {
         List<DependencyNode> errorNodes = directDependencies.stream()
-                .filter(DependencyNode::errorNode).collect(Collectors.toList());
+                .filter(DependencyNode::errorNode).toList();
         for (DependencyNode errorNode : errorNodes) {
             graphBuilder.addErroneousDependency(
                     rootPkgDesc, errorNode.pkgDesc, errorNode.scope, errorNode.resolutionType);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/TransactionImportValidator.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/TransactionImportValidator.java
@@ -31,7 +31,6 @@ import io.ballerina.compiler.syntax.tree.TransactionStatementNode;
 import io.ballerina.compiler.syntax.tree.TransactionalExpressionNode;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * This class will check whether an import statement to internal transaction repo is needed or not.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/TransactionImportValidator.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/TransactionImportValidator.java
@@ -72,7 +72,7 @@ public class TransactionImportValidator extends NodeVisitor {
     @Override
     public void visit(FunctionDefinitionNode functionDefinitionNode) {
         List<String> qualifiers = functionDefinitionNode.qualifierList().stream().map(Token::text)
-                .collect(Collectors.toList());
+                .toList();
         if (qualifiers.contains(SyntaxKind.TRANSACTIONAL_KEYWORD.stringValue()) &&
                 qualifiers.contains(SyntaxKind.RESOURCE_KEYWORD.stringValue())) {
             importTransactionPackage = true;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
@@ -128,10 +128,10 @@ public abstract class AbstractPackageRepository implements PackageRepository {
         // If the module is not found in the possible packages locked in the Dependencies.toml
         // we continue looking for the module in the remaining possible packages.
         List<PackageName> existing = importModuleRequest.possiblePackages().stream().map(PackageDescriptor::name)
-                .collect(Collectors.toList());
+                .toList();
         List<PackageName> remainingPackageNames = ProjectUtils.getPossiblePackageNames(
                 importModuleRequest.packageOrg(), importModuleRequest.moduleName()).stream()
-                .filter(o -> !existing.contains(o)).collect(Collectors.toList());
+                .filter(o -> !existing.contains(o)).toList();
 
         for (PackageName possiblePackageName : remainingPackageNames) {
             List<PackageVersion> packageVersions = getPackageVersions(importModuleRequest.packageOrg(),

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.projects.util.ProjectConstants.BALLERINA_TOML;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
@@ -170,7 +170,7 @@ public class FileUtils {
         }
 
         if (Files.isDirectory(path)) {
-            for (Path dir : Files.list(path).collect(Collectors.toList())) {
+            for (Path dir : Files.list(path).toList()) {
                 deletePath(dir);
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/GeneralFSPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/GeneralFSPackageRepository.java
@@ -236,7 +236,7 @@ public class GeneralFSPackageRepository implements PackageRepository {
                 try {
                     List<Path> files = Files.walk(this.pkgPath, 1).filter(
                             Files::isRegularFile).filter(e -> e.getFileName().toString().endsWith(BAL_SOURCE_EXT)).
-                            collect(Collectors.toList());
+                            toList();
                     this.cachedEntryNames = new ArrayList<>(files.size());
                     files.stream().forEach(e -> this.cachedEntryNames.add(e.getFileName().toString()));
                 } catch (IOException e) {

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/model/Manifest.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/model/Manifest.java
@@ -108,7 +108,7 @@ public class Manifest {
             List<Library> deps = platform.libraries.stream().filter(library -> {
                 return library.getModules() == null ||
                         Arrays.stream(library.getModules()).anyMatch(moduleName::equals);
-            }).collect(Collectors.toList());
+            }).toList();
             // If not return any
             if (!deps.isEmpty()) {
                 return platform.target;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -132,7 +132,7 @@ public class BIRBinaryWriter {
     private void writeTypeDefBodies(ByteBuf buf, BIRTypeWriter typeWriter,
                                     List<BIRTypeDefinition> birTypeDefList) {
         List<BIRTypeDefinition> filtered = birTypeDefList.stream().filter(t -> t.type.tag == TypeTags.OBJECT
-                || t.type.tag == TypeTags.RECORD).collect(Collectors.toList());
+                || t.type.tag == TypeTags.RECORD).toList();
         buf.writeInt(filtered.size());
         filtered.forEach(typeDef -> {
             writeFunctions(buf, typeWriter, typeDef.attachedFuncs);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -38,7 +38,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.wso2.ballerinalang.compiler.bir.writer.BIRWriterUtils.writeConstValue;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -7015,7 +7015,7 @@ public class Desugar extends BLangNodeVisitor {
         if (pathSegmentCount > 0 && lastPathSegmentSym.kind != SymbolKind.RESOURCE_ROOT_PATH_SEGMENT) {
             invocationParams.addAll(pathSegmentSymbols.subList(0, pathSegmentCount).stream()
                     .map(s -> new BVarSymbol(0, Names.EMPTY, this.env.scope.owner.pkgID, s.type,
-                            this.env.scope.owner, s.pos, VIRTUAL)).collect(Collectors.toList()));
+                            this.env.scope.owner, s.pos, VIRTUAL)).toList());
         }
 
         invokableSymbol.params = invocationParams;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
@@ -38,7 +38,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
@@ -89,7 +89,7 @@ public class PathConverter implements Converter<Path> {
                             .sorted(Comparator.reverseOrder())
                             .limit(1)
                             .map(SortablePath::getPath)
-                            .collect(Collectors.toList());
+                            .toList();
                 }
                 if (packageID != null) {
                     if (packageID.version.value.isEmpty() && !packageID.orgName.equals(Names.BUILTIN_ORG)

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/ZipConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/ZipConverter.java
@@ -114,7 +114,7 @@ public class ZipConverter extends PathConverter {
                             .sorted(Comparator.reverseOrder())
                             .limit(1)
                             .map(SortablePath::getPath)
-                            .collect(Collectors.toList());
+                            .toList();
                 }
                 if (packageID.version.value.isEmpty() && !packageID.orgName.equals(Names.BUILTIN_ORG)
                         && !packageID.orgName.equals(Names.ANON_ORG) && !pathList.isEmpty()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/ZipConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/ZipConverter.java
@@ -40,7 +40,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipError;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -1908,7 +1908,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
         if (varRef.cause != null) {
             varRefs.add(varRef.cause);
         }
-        varRefs.addAll(varRef.detail.stream().map(e -> e.expr).collect(Collectors.toList()));
+        varRefs.addAll(varRef.detail.stream().map(e -> e.expr).toList());
         if (varRef.restVar != null) {
             varRefs.add(varRef.restVar);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
@@ -974,7 +974,7 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
         if (varRef.cause != null) {
             varRefs.add(varRef.cause);
         }
-        varRefs.addAll(varRef.detail.stream().map(e -> e.expr).collect(Collectors.toList()));
+        varRefs.addAll(varRef.detail.stream().map(e -> e.expr).toList());
         varRefs.add(varRef.restVar);
         return varRefs;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1752,7 +1752,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
                 List<BErrorType> errorMembers = members.stream()
                         .filter(m -> Types.getImpliedType(m).tag == TypeTags.ERROR)
                         .map(m -> (BErrorType) Types.getImpliedType(m))
-                        .collect(Collectors.toList());
+                        .toList();
 
                 if (errorMembers.isEmpty()) {
                     dlog.error(varNode.pos, DiagnosticErrorCode.INVALID_ERROR_MATCH_PATTERN);
@@ -2470,7 +2470,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         for (BField rhsField : rhsRecordType.fields.values()) {
             List<BLangRecordVarRefKeyValue> expField = lhsVarRef.recordRefFields.stream()
                     .filter(field -> field.variableName.value.equals(rhsField.name.toString()))
-                    .collect(Collectors.toList());
+                    .toList();
 
             if (expField.isEmpty()) {
                 continue;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1033,7 +1033,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         List<Name> nameComps = importPkgNode.pkgNameComps.stream()
                 .map(identifier -> names.fromIdNode(identifier))
-                .collect(Collectors.toList());
+                .toList();
         Name moduleName = new Name(nameComps.stream().map(Name::getValue).collect(Collectors.joining(".")));
 
         if (pkgName == null) {
@@ -1513,7 +1513,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             // Check whether the current type node is in the unresolved list. If it is in the list, we need to
             // check it recursively.
             List<BLangNode> typeDefinitions = unresolvedTypes.stream()
-                    .filter(node -> getTypeOrClassName(node).equals(currentTypeNodeName)).collect(Collectors.toList());
+                    .filter(node -> getTypeOrClassName(node).equals(currentTypeNodeName)).toList();
 
             if (typeDefinitions.isEmpty()) {
                 BType referredType = symResolver.resolveTypeNode(currentTypeOrClassNode, env);
@@ -3265,7 +3265,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 List<BErrorType> possibleTypes = types.getAllTypes(unionType, true).stream()
                         .filter(type -> TypeTags.ERROR == Types.getImpliedType(type).tag)
                         .map(BErrorType.class::cast)
-                        .collect(Collectors.toList());
+                        .toList();
 
                 if (possibleTypes.isEmpty()) {
                     dlog.error(errorVariable.pos, DiagnosticErrorCode.INVALID_ERROR_BINDING_PATTERN, varType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1003,7 +1003,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         List<BFiniteType> finiteTypeMembers = types.getAllTypes(unionType, true).stream()
                 .filter(memType -> Types.getImpliedType(memType).tag == TypeTags.FINITE)
                 .map(memFiniteType -> (BFiniteType) memFiniteType)
-                .collect(Collectors.toList());
+                .toList();
 
         if (finiteTypeMembers.isEmpty()) {
             return symTable.semanticError;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1172,7 +1172,7 @@ public class Types {
                 BUnionType unionType = (BUnionType) constraintType;
                 Set<BType> memTypes = unionType.getMemberTypes();
                 List<BField> fields = memTypes.stream().map(type -> getTableConstraintField(type, fieldName))
-                        .filter(Objects::nonNull).collect(Collectors.toList());
+                        .filter(Objects::nonNull).toList();
 
                 if (fields.size() != memTypes.size()) {
                     return null;
@@ -5180,7 +5180,7 @@ public class Types {
                     .filter(t -> getImpliedType(t).tag != TypeTags.READONLY)
                     .map(t -> getIntersection(intersectionContext, t, env, finalType, visitedTypes))
                     .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
+                    .toList();
             if (types.size() == 1) {
                 BType bType = types.get(0);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -130,7 +130,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
-import java.util.stream.Collectors;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.UNDERSCORE;
 import static org.ballerinalang.model.symbols.SymbolOrigin.SOURCE;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
@@ -387,7 +387,7 @@ public class GlobalVariableRefAnalyzer {
         if (sortedGlobalVars.size() != this.pkgNode.globalVars.size()) {
             List<BLangVariable> symbolLessGlobalVars = this.pkgNode.globalVars.stream()
                     .filter(g -> g.symbol == null)
-                    .collect(Collectors.toList());
+                    .toList();
             sortedGlobalVars.addAll(symbolLessGlobalVars);
         }
         this.pkgNode.globalVars.clear();
@@ -406,7 +406,7 @@ public class GlobalVariableRefAnalyzer {
         if (sortedConstants.size() != this.pkgNode.constants.size()) {
             List<BLangConstant> symbolLessGlobalVars = this.pkgNode.constants.stream()
                     .filter(c -> !sortedConstants.contains(c))
-                    .collect(Collectors.toList());
+                    .toList();
             sortedConstants.addAll(symbolLessGlobalVars);
         }
         this.pkgNode.constants.clear();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/NodeUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/NodeUtils.java
@@ -39,7 +39,7 @@ public class NodeUtils {
     public static Name getName(Names names, List<BLangIdentifier> pkgNameComps) {
         String pkgName = String.join(".", pkgNameComps.stream()
                 .map(id -> id.value)
-                .collect(Collectors.toList()));
+                .toList());
         return names.fromString(pkgName);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirs.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirs.java
@@ -84,7 +84,7 @@ public class ProjectDirs {
         List<Path> sourceFiles = new ArrayList<>();
         try {
             sourceFiles = Files.find(pkgPath, Integer.MAX_VALUE, (path, attrs) ->
-                    path.toString().endsWith(ProjectDirConstants.BLANG_SOURCE_EXT)).collect(Collectors.toList());
+                    path.toString().endsWith(ProjectDirConstants.BLANG_SOURCE_EXT)).toList();
         } catch (IOException ignored) {
             // Here we are trying to check if there are source files inside the package to be compiled. If an error
             // occurs when trying to visit the files inside the package then we simply return the empty list created.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirs.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirs.java
@@ -30,7 +30,6 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BLANG_SOURCE_EXT;
 

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/VersionConflictResolutionTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/VersionConflictResolutionTests.java
@@ -272,7 +272,7 @@ public class VersionConflictResolutionTests {
         DependencyGraph<DependencyNode> dependencyGraph =
                 getDependencyGraph(testSourcesDirectory.resolve("conflicts_negative_1.json"));
         List<DependencyNode> errorNodes = dependencyGraph.getNodes().stream().filter(
-                DependencyNode::errorNode).collect(Collectors.toList());
+                DependencyNode::errorNode).toList();
         Assert.assertEquals(errorNodes.size(), 1);
         Assert.assertEquals(errorNodes.get(0).pkgDesc().toString(), "samjs/package_b:2.1.0");
         Assert.assertEquals(dependencyGraph.getDirectDependencies(errorNodes.get(0)).size(), 0);

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/VersionConflictResolutionTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/VersionConflictResolutionTests.java
@@ -33,7 +33,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Contain cases to test the version conflict resolution logic.

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/common/completion/TomlCompletionUtil.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/common/completion/TomlCompletionUtil.java
@@ -156,7 +156,7 @@ public class TomlCompletionUtil {
         List<String> existingKeys = completions.keySet().stream()
                 .filter(key -> documentNode.members().stream().filter(node -> node.kind() == SyntaxKind.TABLE)
                         .map(node -> TomlSyntaxTreeUtil.toQualifiedName(((TableNode) node).identifier().value()))
-                        .collect(Collectors.toSet()).contains(key)).collect(Collectors.toList());
+                        .collect(Collectors.toSet()).contains(key)).toList();
         for (String key : existingKeys) {
             completions.remove(key);
         }
@@ -204,7 +204,7 @@ public class TomlCompletionUtil {
             CompletionItem>> snippets, String topLevelNodeKey) {
         List<Map.Entry<TomlNode, Map<String, CompletionItem>>> filteredMap =
                 snippets.entrySet().stream().filter(entry ->
-                        topLevelNodeKey.equals((entry.getKey().getKey()))).collect(Collectors.toList());
+                        topLevelNodeKey.equals((entry.getKey().getKey()))).toList();
         if (filteredMap.size() == 1) {
             return filteredMap.get(0).getValue();
         }

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/visitor/TomlSchemaVisitor.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/visitor/TomlSchemaVisitor.java
@@ -35,7 +35,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Schema Visitor for visiting toml validation schema.

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/visitor/TomlSchemaVisitor.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/visitor/TomlSchemaVisitor.java
@@ -194,7 +194,7 @@ public class TomlSchemaVisitor extends SchemaVisitor {
         for (Map.Entry<TomlNode, Map<String, CompletionItem>> entry : completions.entrySet()) {
             TomlNode key = entry.getKey();
             Map<String, CompletionItem> completionItemList = entry.getValue();
-            if (!completionItemList.entrySet().stream().filter(filter).collect(Collectors.toList()).isEmpty()) {
+            if (!completionItemList.entrySet().stream().filter(filter).toList().isEmpty()) {
                 optimizedCompletions.put(key, completionItemList);
             }
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionModuleId.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionModuleId.java
@@ -48,7 +48,7 @@ public class CodeActionModuleId implements ModuleID {
     }
 
     public static CodeActionModuleId from(String orgName, String moduleName, String version) {
-        List<String> names = Arrays.stream(moduleName.split("\\.")).collect(Collectors.toList());
+        List<String> names = Arrays.stream(moduleName.split("\\.")).toList();
         String alias = moduleName.equals(".") ? moduleName : names.get(names.size() - 1);
         return new CodeActionModuleId(orgName, moduleName, alias, version);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -399,7 +399,7 @@ public class CodeActionUtil {
 
         List<TypeSymbol> errorMembers = unionType.memberTypeDescriptors().stream()
                 .filter(typeSymbol -> CommonUtil.getRawType(typeSymbol).typeKind() == TypeDescKind.ERROR)
-                .collect(Collectors.toList());
+                .toList();
 
         List<TypeSymbol> members = new ArrayList<>(unionType.memberTypeDescriptors());
 
@@ -519,7 +519,7 @@ public class CodeActionUtil {
                                 .anyMatch(typeSymbol -> typeSymbol.typeKind() == TypeDescKind.NIL);
                         memberTypes.addAll(errorAndNonErrorTypedSymbols.getLeft().stream()
                                 .filter(typeSymbol -> typeSymbol.typeKind() != TypeDescKind.NIL)
-                                .collect(Collectors.toList()));
+                                .toList());
                         memberTypes.addAll(errorSymbolsToAdd);
                         UnionTypeSymbol newType = semanticModel.get().types().builder().UNION_TYPE
                                 .withMemberTypes(memberTypes.toArray(new TypeSymbol[0])).build();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AbstractImplementMethodCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AbstractImplementMethodCodeAction.java
@@ -125,7 +125,7 @@ public abstract class AbstractImplementMethodCodeAction {
         List<FunctionDefinitionNode> concreteMethods = members.stream()
                 .filter(member -> member.kind() == SyntaxKind.FUNCTION_DEFINITION)
                 .map(member -> (FunctionDefinitionNode) member)
-                .collect(Collectors.toList());
+                .toList();
 
         String offsetStr;
         int enclosingNodeOffset;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AbstractImplementMethodCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AbstractImplementMethodCodeAction.java
@@ -51,7 +51,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.langserver.common.utils.CommonUtil.LINE_SEPARATOR;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddConditionalDefaultValueCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddConditionalDefaultValueCodeAction.java
@@ -39,7 +39,6 @@ import org.eclipse.lsp4j.TextEdit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Code action to add conditional default value.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddConditionalDefaultValueCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddConditionalDefaultValueCodeAction.java
@@ -96,7 +96,7 @@ public class AddConditionalDefaultValueCodeAction implements DiagnosticBasedCode
             return Optional.empty();
         }
         List<TypeSymbol> memberTypes = ((UnionTypeSymbol) actualType).memberTypeDescriptors().stream()
-                .filter(typeSymbol -> typeSymbol.typeKind() != TypeDescKind.NIL).collect(Collectors.toList());
+                .filter(typeSymbol -> typeSymbol.typeKind() != TypeDescKind.NIL).toList();
         UnionTypeSymbol unionType = semanticModel.get().types().builder().UNION_TYPE
                 .withMemberTypes(memberTypes.toArray(TypeSymbol[]::new)).build();
         return Optional.of(unionType);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToFunctionCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToFunctionCodeAction.java
@@ -252,13 +252,13 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
         List<Symbol> updatedModVarSymbols = updatedSymbols.stream()
                 .filter(symbol -> symbol.getLocation().isPresent() && !PositionUtil
                         .isWithinLineRange(symbol.getLocation().get().lineRange(), enclosingNode.lineRange()))
-                .collect(Collectors.toList());
+                .toList();
 
         List<Symbol> updatedButNotDeclaredLocVarSymbolsInRange = updatedSymbols.stream()
                 .filter(symbol -> symbol.getLocation().isPresent() && !PositionUtil.isRangeWithinRange
                         (PositionUtil.toRange(symbol.getLocation().get().lineRange()), context.range()))
                 .filter(symbol -> !updatedModVarSymbols.contains(symbol))
-                .collect(Collectors.toList());
+                .toList();
 
         // LocalVarSymbols which are declared or updated inside the selected range and also referred after the range
         List<VariableSymbol> localVarSymbols = updatedOrDeclaredLocVarSymbolsInRange.stream()
@@ -268,7 +268,7 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
                                 (PositionUtil.toRange(location.lineRange()),
                                         getRangeAfterHighlightedRange(context, enclosingNode))))
                 .map(symbol -> (VariableSymbol) symbol)
-                .collect(Collectors.toList());
+                .toList();
 
         /*
          * Following checks are done when deciding whether the selected range R is extractable to a function.
@@ -314,7 +314,7 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
                 // this check is done to filter the local variables defined inside the function
                 .filter(symbol -> PositionUtil
                         .isWithinLineRange(symbol.getLocation().get().lineRange(), enclosingNode.lineRange()))
-                .collect(Collectors.toList());
+                .toList();
 
         // Declare a HashSet to collect local var symbols and param symbols and add param symbols
         HashSet<Symbol> paramAndLocVarSymbolsVisibleToRange = visibleSymbols.stream()
@@ -539,7 +539,7 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
                                 .anyMatch(location -> PositionUtil.isRangeWithinRange(PositionUtil
                                                 .getRangeFromLineRange(location.lineRange()),
                                         PositionUtil.toRange(matchedLineRange))))
-                        .collect(Collectors.toList());
+                        .toList();
 
         if (varAndParamSymbols.stream().anyMatch(symbol -> symbol.getLocation().isEmpty())) {
             return Optional.empty();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
@@ -255,7 +255,7 @@ public class ExtractToLocalVarCodeAction implements RangeBasedCodeActionProvider
                                 PositionUtil.isWithinLineRange(location.lineRange(), matchedNode.lineRange())))
                 .filter(symbol -> symbol.getLocation().isPresent() && PositionUtil.isWithinLineRange(
                         symbol.getLocation().get().lineRange(), getStatementNode(matchedNode).lineRange()))
-                .collect(Collectors.toList());
+                .toList();
 
         if (symbolsWithinRange.isEmpty()) {
             return false;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableWithTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableWithTypeCodeAction.java
@@ -347,7 +347,7 @@ public class CreateVariableWithTypeCodeAction extends CreateVariableCodeAction {
 
         List<TypeSymbol> memberTypes = ((UnionTypeSymbol) returnTypeDesc.get()).memberTypeDescriptors().stream()
                 .filter(member -> CommonUtil.getRawType(member).typeKind() != TypeDescKind.ERROR)
-                .collect(Collectors.toList());
+                .toList();
 
         if (memberTypes.isEmpty()) {
             // If there are no non-error members (which is highly unlikely), there's no return type

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/ImportModuleCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/ImportModuleCodeAction.java
@@ -102,7 +102,7 @@ public class ImportModuleCodeAction implements DiagnosticBasedCodeActionProvider
 
         List<ModuleSymbol> existingModules = symbolMap.values().stream()
                 .filter(moduleSymbol -> moduleSymbol.getModule().isPresent())
-                .map(moduleSymbol -> moduleSymbol.getModule().get()).collect(Collectors.toList());
+                .map(moduleSymbol -> moduleSymbol.getModule().get()).toList();
 
         List<CodeAction> actions = new ArrayList<>();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/OptimizeImportsCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/OptimizeImportsCodeAction.java
@@ -141,7 +141,7 @@ public class OptimizeImportsCodeAction implements RangeBasedCodeActionProvider {
         List<LineRange> reDeclaredImportLocations = context.diagnostics(context.filePath()).stream()
                 .filter(diag -> REDECLARED_IMPORT_DIAGNOSTIC_CODE.equals(diag.diagnosticInfo().code()))
                 .map(diag -> diag.location().lineRange())
-                .collect(Collectors.toList());
+                .toList();
 
         Iterator<ImportDeclarationNode> iterator = fileImports.iterator();
         while (iterator.hasNext()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/DefaultValueGenerationUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/DefaultValueGenerationUtil.java
@@ -165,7 +165,7 @@ public class DefaultValueGenerationUtil {
                 TupleTypeSymbol tupleType = (TupleTypeSymbol) rawType;
                 List<String> memberDefaultValues = tupleType.memberTypeDescriptors().stream()
                         .map(member -> getDefaultValueForTypeDescKind(member).orElse(""))
-                        .collect(Collectors.toList());
+                        .toList();
 
                 if (memberDefaultValues.isEmpty()) {
                     valueString = isSnippet ? "[${" + context.incrementAndGetPlaceholderCount() + "}]" : "[]";
@@ -199,7 +199,7 @@ public class DefaultValueGenerationUtil {
                 List<RecordFieldSymbol> mandatoryFieldSymbols = RecordUtil
                         .getMandatoryRecordFields(recordTypeSymbol).stream()
                         .filter(recordFieldSymbol -> recordFieldSymbol.getName().isPresent())
-                        .collect(Collectors.toList());
+                        .toList();
                 for (RecordFieldSymbol mandatoryField : mandatoryFieldSymbols) {
                     String value = getDefaultValueForTypeDescKind(CommonUtil.getRawType(mandatoryField
                             .typeDescriptor())).orElse("");
@@ -238,7 +238,7 @@ public class DefaultValueGenerationUtil {
                 List<TypeSymbol> members =
                         new ArrayList<>(((UnionTypeSymbol) rawType).memberTypeDescriptors());
                 List<TypeSymbol> nilMembers = members.stream()
-                        .filter(member -> member.typeKind() == TypeDescKind.NIL).collect(Collectors.toList());
+                        .filter(member -> member.typeKind() == TypeDescKind.NIL).toList();
                 if (nilMembers.isEmpty()) {
                     valueString = getDefaultValueForTypeDescKind(CommonUtil.getRawType(members.get(0))).orElse("");
                     valueString = isSnippet ?

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/DefaultValueGenerationUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/DefaultValueGenerationUtil.java
@@ -33,7 +33,6 @@ import org.ballerinalang.langserver.commons.SnippetContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Carries a set of utilities used in default value generation.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/ModuleUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/ModuleUtil.java
@@ -130,7 +130,7 @@ public class ModuleUtil {
             List<ImportDeclarationNode> existingModuleImports = context.currentDocImportsMap().keySet().stream()
                     .filter(importDeclarationNode ->
                             CodeActionModuleId.from(importDeclarationNode).moduleName().equals(moduleID.moduleName()))
-                    .collect(Collectors.toList());
+                    .toList();
 
             if (existingModuleImports.size() == 1) {
                 ImportDeclarationNode importDeclarationNode = existingModuleImports.get(0);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/NameUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/NameUtil.java
@@ -174,7 +174,7 @@ public class NameUtil {
             }
 
             return -3;
-        }).filter(integer -> integer >= 0).sorted().collect(Collectors.toList());
+        }).filter(integer -> integer >= 0).sorted().toList();
 
         for (int i = 0; i < suffixList.size(); i++) {
             Integer suffix = suffixList.get(i);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
@@ -200,7 +200,7 @@ public final class FunctionCompletionItemBuilder {
             functionParameters.addAll(functionTypeDesc.params().get());
             defaultParams.addAll(functionParameters.stream()
                     .filter(parameter -> parameter.paramKind() == ParameterKind.DEFAULTABLE)
-                    .collect(Collectors.toList()));
+                    .toList());
         }
 
         MarkupContent docMarkupContent = new MarkupContent();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
@@ -64,7 +64,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationAccessExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationAccessExpressionNodeContext.java
@@ -144,7 +144,7 @@ public class AnnotationAccessExpressionNodeContext extends AbstractCompletionPro
             case UNION:
                 List<TypeDescKind> typeDescKinds = ((UnionTypeSymbol) symbol).memberTypeDescriptors().stream()
                         .map(TypeSymbol::typeKind)
-                        .collect(Collectors.toList());
+                        .toList();
                 if (typeDescKinds.contains(TypeDescKind.ANY) || !typeDescKinds.contains(TypeDescKind.ANYDATA)) {
                     annotationAttachPoints.addAll(Arrays.asList(
                             AnnotationAttachPoint.TYPE,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ClientResourceAccessActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ClientResourceAccessActionNodeContext.java
@@ -112,7 +112,7 @@ public class ClientResourceAccessActionNodeContext
             } else {
                 List<Node> arguments = new ArrayList<>();
                 node.arguments().ifPresent(argList ->
-                        arguments.addAll(argList.arguments().stream().collect(Collectors.toList())));
+                        arguments.addAll(argList.arguments().stream().toList()));
                 if (isNotInNamedArgOnlyContext(context, arguments)) {
                     completionItems.addAll(this.actionKWCompletions(context));
                     completionItems.addAll(this.expressionCompletions(context));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/EnumMemberNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/EnumMemberNodeContext.java
@@ -66,7 +66,7 @@ public class EnumMemberNodeContext extends AbstractCompletionProvider<EnumMember
             completionItems.addAll(this.getModuleCompletionItems(ctx));
             List<Symbol> filteredSymbols = ctx.visibleSymbols(ctx.getCursorPosition()).stream()
                     .filter(filter)
-                    .collect(Collectors.toList());
+                    .toList();
             visibleSymbols.addAll(filteredSymbols);
         }
         completionItems.addAll(this.getCompletionItemList(visibleSymbols, ctx));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/EnumMemberNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/EnumMemberNodeContext.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link EnumMemberNode} context.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ErrorConstructorExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ErrorConstructorExpressionNodeContext.java
@@ -259,7 +259,7 @@ public class ErrorConstructorExpressionNodeContext extends
             return completionItems;
         }
         List<String> existingNamedArgs = node.arguments().stream().filter(arg -> arg.kind() == SyntaxKind.NAMED_ARG)
-                .map(arg -> ((NamedArgumentNode) arg).argumentName().name().text()).collect(Collectors.toList());
+                .map(arg -> ((NamedArgumentNode) arg).argumentName().name().text()).toList();
 
         fields.entrySet().forEach(field -> {
             Optional<String> fieldName = field.getValue().getName();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImplicitNewExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImplicitNewExpressionNodeContext.java
@@ -73,7 +73,7 @@ public class ImplicitNewExpressionNodeContext extends InvocationNodeContextProvi
             */
             List<Symbol> filteredSymbols = context.visibleSymbols(context.getCursorPosition()).stream()
                     .filter(this.getSymbolFilterPredicate(node))
-                    .collect(Collectors.toList());
+                    .toList();
             filteredSymbols.forEach(symbol -> {
                 Optional<LSCompletionItem> cItem = this.getExplicitNewCompletionItem(symbol, context);
                 cItem.ifPresent(completionItems::add);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
@@ -264,7 +264,7 @@ public class ImportDeclarationNodeContext extends AbstractCompletionProvider<Imp
          */
         List<String> modNameString = moduleName.stream()
                 .map(token -> token.text().replace("'", ""))
-                .collect(Collectors.toList());
+                .toList();
         Optional<Project> currentProject = context.workspace().project(context.filePath());
         if (currentProject.isEmpty() || currentProject.get().kind() == ProjectKind.SINGLE_FILE_PROJECT
                 || !modNameString.get(0).equals(pkgName)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ModulePartNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ModulePartNodeContext.java
@@ -181,7 +181,7 @@ public class ModulePartNodeContext extends AbstractCompletionProvider<ModulePart
         List<Token> qualifiers = CommonUtil.getQualifiersOfNode(context, node)
                 .stream()
                 .filter(qualifier -> qualifier.lineRange().endLine().line() == cursorPos.getLine())
-                .collect(Collectors.toList());
+                .toList();
         if (qualifiers.isEmpty()) {
             return false;
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ModuleVariableDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ModuleVariableDeclarationNodeContext.java
@@ -220,7 +220,7 @@ public class ModuleVariableDeclarationNodeContext extends
                                                   ModuleVariableDeclarationNode node) {
         List<String> leadingInvalidTokens = node.leadingInvalidTokens().stream()
                 .map(Token::text)
-                .collect(Collectors.toList());
+                .toList();
         boolean onServiceContext = leadingInvalidTokens.contains(SyntaxKind.SERVICE_KEYWORD.stringValue());
         CompleteExpressionValidator expressionValidator = new CompleteExpressionValidator();
         int cursor = ctx.getCursorPositionInTree();
@@ -233,7 +233,7 @@ public class ModuleVariableDeclarationNodeContext extends
     private boolean onServiceTypeDescriptorContext(BallerinaCompletionContext ctx, ModuleVariableDeclarationNode node) {
         List<String> leadingInvalidTokens = node.leadingInvalidTokens().stream()
                 .map(Token::text)
-                .collect(Collectors.toList());
+                .toList();
         boolean onServiceContext = leadingInvalidTokens.contains(SyntaxKind.SERVICE_KEYWORD.stringValue());
         CompleteExpressionValidator expressionValidator = new CompleteExpressionValidator();
         int cursor = ctx.getCursorPositionInTree();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ModulePartNodeContextUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ModulePartNodeContextUtil.java
@@ -277,7 +277,7 @@ public class ModulePartNodeContextUtil {
         List<Token> qualifiers = CommonUtil.getQualifiersOfNode(context, node)
                 .stream()
                 .filter(qualifier -> qualifier.lineRange().endLine().line() == cursorPos.getLine())
-                .collect(Collectors.toList());
+                .toList();
         if (qualifiers.isEmpty()) {
             return Optional.empty();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
@@ -64,7 +64,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Generates Service Template Snippet completion items.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
@@ -251,7 +251,7 @@ public class ServiceTemplateGenerator {
             List<String> args = new ArrayList<>();
             List<ParameterSymbol> requiredParams = initMethod.get().typeDescriptor().params().get().stream()
                     .filter(parameterSymbol ->
-                            parameterSymbol.paramKind() == ParameterKind.REQUIRED).collect(Collectors.toList());
+                            parameterSymbol.paramKind() == ParameterKind.REQUIRED).toList();
             for (ParameterSymbol parameterSymbol : requiredParams) {
                 args.add("${" + snippetIndex + ":" +
                         DefaultValueGenerationUtil.getDefaultPlaceholderForType(parameterSymbol.typeDescriptor())

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
@@ -259,7 +259,7 @@ public class FieldAccessCompletionResolver extends NodeTransformer<Optional<Type
                 ObjectTypeSymbol objTypeDesc = (ObjectTypeSymbol) rawType;
                 visibleEntries.addAll(objTypeDesc.fieldDescriptors().values().stream()
                         .filter(objectFieldSymbol -> withValidAccessModifiers(node, objectFieldSymbol, currentPkg.get(),
-                                currentModule.get().moduleId())).collect(Collectors.toList()));
+                                currentModule.get().moduleId())).toList());
                 boolean isClient = SymbolUtil.isClient(objTypeDesc);
                 boolean isService = SymbolUtil.getTypeDescForObjectSymbol(objTypeDesc)
                         .qualifiers().contains(Qualifier.SERVICE);
@@ -270,7 +270,7 @@ public class FieldAccessCompletionResolver extends NodeTransformer<Optional<Type
                                 && !methodSymbol.qualifiers().contains(Qualifier.RESOURCE)
                                 && withValidAccessModifiers(node, methodSymbol, currentPkg.get(),
                                 currentModule.get().moduleId()))
-                        .collect(Collectors.toList());
+                        .toList();
                 visibleEntries.addAll(methodSymbols);
                 break;
             case UNION:
@@ -280,7 +280,7 @@ public class FieldAccessCompletionResolver extends NodeTransformer<Optional<Type
                 }
                 List<TypeSymbol> members = ((UnionTypeSymbol) rawType).memberTypeDescriptors().stream()
                         .map(CommonUtil::getRawType)
-                        .collect(Collectors.toList());
+                        .toList();
                 if (!members.stream().allMatch(
                         member -> member.typeKind() == TypeDescKind.NIL || member.typeKind() == TypeDescKind.RECORD)) {
                     break;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolUtil.java
@@ -32,7 +32,6 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Finds Symbols within a document.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolUtil.java
@@ -84,6 +84,6 @@ public class DocumentSymbolUtil {
         return !metadata.annotations().stream().filter(annotation ->
                 annotation.annotReference().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE
                         && ((SimpleNameReferenceNode) annotation.annotReference()).name().text()
-                        .equals("deprecated")).collect(Collectors.toList()).isEmpty();
+                        .equals("deprecated")).toList().isEmpty();
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTreeModifyUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTreeModifyUtil.java
@@ -174,7 +174,7 @@ public class BallerinaTreeModifyUtil {
         List<TextEdit> edits = new ArrayList<>();
         List<ASTModification> importModifications = Arrays.stream(astModifications)
                 .filter(ASTModification::isImport)
-                .collect(Collectors.toList());
+                .toList();
         for (ASTModification importModification : importModifications) {
             if (importExist(unusedSymbolsVisitor, importModification)) {
                 continue;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTreeModifyUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTreeModifyUtil.java
@@ -46,7 +46,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
-import java.util.stream.Collectors;
 
 /**
  * Represents a request for a Ballerina AST Modify.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTriggerModifyUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTriggerModifyUtil.java
@@ -46,7 +46,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Represents a request for a Ballerina AST Modify.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTriggerModifyUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTriggerModifyUtil.java
@@ -147,7 +147,7 @@ public class BallerinaTriggerModifyUtil {
             if (node.kind() == SyntaxKind.FUNCTION_DEFINITION) {
                 FunctionDefinitionNode functionDefinitionNode = (FunctionDefinitionNode) node;
                 List<String> qualifiers = functionDefinitionNode.qualifierList().stream().map(Token::text)
-                        .collect(Collectors.toList());
+                        .toList();
                 if (qualifiers.contains(SyntaxKind.RESOURCE_KEYWORD.stringValue())) {
                     resources.add(functionDefinitionNode);
                 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/ExecutorPositionsUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/ExecutorPositionsUtil.java
@@ -40,7 +40,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Executor positions evaluation utilities.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/ExecutorPositionsUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/ExecutorPositionsUtil.java
@@ -99,7 +99,7 @@ public class ExecutorPositionsUtil {
                     }
                 })
                 .map(symbol -> (FunctionSymbol) symbol)
-                .collect(Collectors.toList());
+                .toList();
 
         if (defaultModuleFunctionList.size() == 1) {
             JsonObject mainFunctionObject = new JsonObject();
@@ -124,7 +124,7 @@ public class ExecutorPositionsUtil {
                     }
                 })
                 .map(symbol -> (ServiceDeclarationSymbol) symbol)
-                .collect(Collectors.toList())
+                .toList()
                 .forEach(serviceSymbol -> {
                     JsonObject serviceObject = new JsonObject();
                     serviceObject.addProperty(KIND, SOURCE);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/TestCaseVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/TestCaseVisitor.java
@@ -46,7 +46,7 @@ public class TestCaseVisitor extends NodeVisitor {
             functionDefinitionNode.metadata().get().annotations().stream()
                     .filter(annotationNode -> annotationNode.annotReference().toString().trim()
                             .equals(ExecutorPositionsUtil.TEST_CONFIG))
-                    .collect(Collectors.toList())
+                    .toList()
                     .forEach(annotationNode -> {
                         JsonObject testCase = new JsonObject();
                         testCase.addProperty(ExecutorPositionsUtil.KIND, ExecutorPositionsUtil.TEST);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/TestCaseVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/TestCaseVisitor.java
@@ -22,7 +22,6 @@ import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;
 
 import java.nio.file.Path;
-import java.util.stream.Collectors;
 
 /**
  * Visitor class for testcases.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverObjectResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverObjectResolver.java
@@ -197,7 +197,7 @@ public class HoverObjectResolver {
                 String desc = paramsMap.getOrDefault(paramName, "");
                 return MarkupUtils.quotedString(NameUtil.getModifiedTypeName(context, param.typeDescriptor())) + " "
                         + MarkupUtils.italicString(MarkupUtils.boldString(paramName)) + " : " + desc;
-            }).collect(Collectors.toList()));
+            }).toList());
             params.addAll(functionSymbol.typeDescriptor().params().get().stream().map(param -> {
                 if (param.getName().isEmpty()) {
                     return MarkupUtils.quotedString(NameUtil
@@ -226,7 +226,7 @@ public class HoverObjectResolver {
                 }
                 return MarkupUtils.quotedString(NameUtil.getModifiedTypeName(context, param.typeDescriptor())) + " "
                         + MarkupUtils.italicString(MarkupUtils.boldString(paramName)) + " : " + desc + defaultValueEdit;
-            }).collect(Collectors.toList()));
+            }).toList());
 
             Optional<ParameterSymbol> restParam = functionSymbol.typeDescriptor().restParam();
             if (restParam.isPresent()) {
@@ -280,7 +280,7 @@ public class HoverObjectResolver {
                                 .getModifiedTypeName(context, fieldEntry.getValue().typeDescriptor());
                         return MarkupUtils.quotedString(typeName) + " "
                                 + MarkupUtils.italicString(MarkupUtils.boldString(fieldEntry.getKey())) + " : " + desc;
-                    }).collect(Collectors.toList()));
+                    }).toList());
             Optional<TypeSymbol> restTypeDesc = recordType.restTypeDescriptor();
             restTypeDesc.ifPresent(typeSymbol ->
                     params.add(MarkupUtils.quotedString(NameUtil.getModifiedTypeName(context, typeSymbol) + "...")));
@@ -317,7 +317,7 @@ public class HoverObjectResolver {
                             return MarkupUtils.quotedString(modifiedTypeName) + " " +
                                     MarkupUtils.italicString(MarkupUtils.boldString(fieldEntry.getKey()))
                                     + " : " + desc;
-                        }).collect(Collectors.toList()));
+                        }).toList());
                 if (params.size() > 1) {
                     hoverContent.add(String.join(CommonUtil.MD_LINE_SEPARATOR, params));
                 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -485,7 +485,7 @@ public class SignatureHelpUtil {
             }
 
             List<Node> resourcePathSegments = resourceNode.resourceAccessPath().stream()
-                    .filter(segmentNode -> !segmentNode.isMissing()).collect(Collectors.toList());
+                    .filter(segmentNode -> !segmentNode.isMissing()).toList();
 
             List<PathSegment> segments;
             if (resourcePath.kind() == ResourcePath.Kind.PATH_SEGMENT_LIST) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/AbstractLSTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/AbstractLSTest.java
@@ -46,7 +46,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * An abstract class for LS unit tests.

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/AbstractLSTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/AbstractLSTest.java
@@ -79,10 +79,10 @@ public abstract class AbstractLSTest {
         try {
             REMOTE_PACKAGES.addAll(getPackages(REMOTE_PROJECTS,
                     languageServer.getWorkspaceManager(), context).stream().map(LSPackageLoader.ModuleInfo::new)
-                    .collect(Collectors.toList()));
+                    .toList());
             LOCAL_PACKAGES.addAll(getPackages(LOCAL_PROJECTS,
                     languageServer.getWorkspaceManager(), context).stream().map(LSPackageLoader.ModuleInfo::new)
-                    .collect(Collectors.toList()));
+                    .toList());
             DISTRIBUTION_PACKAGES.addAll(mockDistRepoPackages(LSPackageLoader.getInstance(context)));
             mockCentralPackages();
         } catch (Exception e) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
@@ -78,9 +78,9 @@ public abstract class CompletionTest extends AbstractLSTest {
             // Fix test cases replacing expected using responses
 //            updateConfig(configJsonPath, testConfig, responseItemList);
             List<CompletionItem> mismatchedList1 = responseItemList.stream()
-                    .filter(item -> !testConfig.getItems().contains(item)).collect(Collectors.toList());
+                    .filter(item -> !testConfig.getItems().contains(item)).toList();
             List<CompletionItem> mismatchedList2 = testConfig.getItems().stream()
-                    .filter(item -> !responseItemList.contains(item)).collect(Collectors.toList());
+                    .filter(item -> !responseItemList.contains(item)).toList();
             LOG.info("Completion items which are in response but not in test config : " + mismatchedList1);
             LOG.info("Completion items which are in test config but not in response : " + mismatchedList2);
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.getDescription(), configPath));

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
@@ -46,7 +46,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Completion Test Interface.

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/inlayhint/InlayHintTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/inlayhint/InlayHintTest.java
@@ -44,7 +44,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Test class for inlay hints.

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/inlayhint/InlayHintTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/inlayhint/InlayHintTest.java
@@ -83,9 +83,9 @@ public class InlayHintTest extends AbstractLSTest {
         if (responseItemList.size() != testConfig.getResult().size()) {
 //            updateConfig(configPath, testConfig, responseItemList);
             List<InlayHint> mismatchedList1 = responseItemList.stream()
-                    .filter(item -> !testConfig.getResult().contains(item)).collect(Collectors.toList());
+                    .filter(item -> !testConfig.getResult().contains(item)).toList();
             List<InlayHint> mismatchedList2 = testConfig.getResult().stream()
-                    .filter(item -> !responseItemList.contains(item)).collect(Collectors.toList());
+                    .filter(item -> !responseItemList.contains(item)).toList();
             LOG.info("Inlay-hint results which are in response but not in test config : " + mismatchedList1);
             LOG.info("Inlay-hint results which are in test config but not in response : " + mismatchedList2);
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.getDescription(), configPath));

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
@@ -99,7 +99,7 @@ public class LSPackageLoaderTest extends AbstractLSTest {
                 LSPackageLoader.ModuleInfo moduleInfo = getPackages(REMOTE_PROJECTS,
                         context.workspace(), context.languageServercontext()).stream()
                         .map(LSPackageLoader.ModuleInfo::new)
-                        .collect(Collectors.toList()).get(0);
+                        .toList().get(0);
                 this.remoteRepoPackages.add(moduleInfo);
                 return List.of(moduleInfo);
             }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
@@ -41,7 +41,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Tests {@link org.ballerinalang.langserver.LSPackageLoader}.

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -120,7 +120,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.debugadapter.DebugExecutionManager.LOCAL_HOST;
 import static org.ballerinalang.debugadapter.completion.util.CompletionUtil.getInjectedExpressionNode;

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -312,7 +312,7 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
             return CompletableFuture.completedFuture(threadsResponse);
         }
         Thread[] threads = new Thread[threadsMap.size()];
-        threadsMap.values().stream().map(this::toDapThread).collect(Collectors.toList()).toArray(threads);
+        threadsMap.values().stream().map(this::toDapThread).toList().toArray(threads);
         threadsResponse.setThreads(threads);
         return CompletableFuture.completedFuture(threadsResponse);
     }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/resolver/FieldAccessCompletionResolver.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/resolver/FieldAccessCompletionResolver.java
@@ -68,7 +68,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Symbol resolver for the field access expressions.

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/resolver/FieldAccessCompletionResolver.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/resolver/FieldAccessCompletionResolver.java
@@ -253,7 +253,7 @@ public class FieldAccessCompletionResolver extends NodeTransformer<Optional<Type
                 ObjectTypeSymbol objTypeDesc = (ObjectTypeSymbol) rawType;
                 visibleEntries.addAll(objTypeDesc.fieldDescriptors().values().stream()
                         .filter(objectFieldSymbol -> withValidAccessModifiers(node, objectFieldSymbol, currentPkg,
-                                currentModule.module().moduleId())).collect(Collectors.toList()));
+                                currentModule.module().moduleId())).toList());
                 boolean isClient = isClient(objTypeDesc);
                 boolean isService = getTypeDescForObjectSymbol(objTypeDesc)
                         .qualifiers().contains(Qualifier.SERVICE);
@@ -264,7 +264,7 @@ public class FieldAccessCompletionResolver extends NodeTransformer<Optional<Type
                                 && !methodSymbol.qualifiers().contains(Qualifier.RESOURCE)
                                 && withValidAccessModifiers(node, methodSymbol, currentPkg,
                                 currentModule.module().moduleId()))
-                        .collect(Collectors.toList());
+                        .toList();
                 visibleEntries.addAll(methodSymbols);
                 break;
             default:

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/EvaluationImportResolver.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/EvaluationImportResolver.java
@@ -140,7 +140,7 @@ public class EvaluationImportResolver extends NodeVisitor {
                 List<ModuleSymbol> matchingModuleSymbols = visibleModuleSymbols.stream()
                         .filter(moduleSymbol -> moduleSymbol.id().orgName().equals(bImport.orgName())
                                 && moduleSymbol.id().moduleName().equals(bImport.moduleName()))
-                        .collect(Collectors.toList());
+                        .toList();
 
                 if (matchingModuleSymbols.isEmpty()) {
                     capturedErrors.add(createEvaluationException(IMPORT_RESOLVING_ERROR, importAlias));
@@ -165,7 +165,7 @@ public class EvaluationImportResolver extends NodeVisitor {
                 .stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.MODULE)
                 .map(symbol -> ((ModuleSymbol) symbol))
-                .collect(Collectors.toList()));
+                .toList());
     }
 
     private Optional<String> resolveImportOrgName(ImportDeclarationNode importNode) {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/EvaluationImportResolver.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/EvaluationImportResolver.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.debugadapter.evaluation.EvaluationException.createEvaluationException;
 import static org.ballerinalang.debugadapter.evaluation.EvaluationExceptionKind.IMPORT_RESOLVING_ERROR;

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/InvocationArgProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/InvocationArgProcessor.java
@@ -98,7 +98,7 @@ public abstract class InvocationArgProcessor {
             List<String> argNames = args.stream()
                     .filter(LocalVariable::isArgument)
                     .map(LocalVariable::name)
-                    .collect(Collectors.toList());
+                    .toList();
 
             for (int i = 0, argNamesSize = argNames.size(); i < argNamesSize; i++) {
                 String argName = argNames.get(i);

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/InvocationArgProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/InvocationArgProcessor.java
@@ -44,7 +44,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.debugadapter.evaluation.EvaluationException.createEvaluationException;
 import static org.ballerinalang.debugadapter.evaluation.EvaluationExceptionKind.CANNOT_INFER_PARAM_TYPE;

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/EvaluationUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/EvaluationUtils.java
@@ -218,7 +218,7 @@ public class EvaluationUtils {
             throw createEvaluationException(HELPER_UTIL_NOT_FOUND, methodName);
         }
         methods = methods.stream().filter(method -> method.isPublic() && method.isStatic() &&
-                compare(method.argumentTypeNames(), argTypeNames)).collect(Collectors.toList());
+                compare(method.argumentTypeNames(), argTypeNames)).toList();
         if (methods.size() != 1) {
             throw createEvaluationException(HELPER_UTIL_NOT_FOUND, methodName);
         }
@@ -239,7 +239,7 @@ public class EvaluationUtils {
         }
         methods = methods.stream()
                 .filter(method -> method.isPublic() && method.isStatic())
-                .collect(Collectors.toList());
+                .toList();
 
         if (methods.size() != 1) {
             throw createEvaluationException(HELPER_UTIL_NOT_FOUND, methodName);
@@ -633,7 +633,7 @@ public class EvaluationUtils {
             // during the runtime code generation, such local variables should be accessed in a different manner.
             List<LocalVariableProxyImpl> lambdaParamMaps = context.getFrame().visibleVariables().stream()
                     .filter(org.ballerinalang.debugadapter.variable.VariableUtils::isLambdaParamMap)
-                    .collect(Collectors.toList());
+                    .toList();
 
             Optional<Value> localVariableMatch = lambdaParamMaps.stream()
                     .map(localVariableProxy -> {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/EvaluationUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/EvaluationUtils.java
@@ -59,7 +59,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.ballerinalang.debugadapter.evaluation.EvaluationException.createEvaluationException;

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/validator/impl/TopLevelDeclarationValidator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/validator/impl/TopLevelDeclarationValidator.java
@@ -62,7 +62,7 @@ public class TopLevelDeclarationValidator extends Validator {
         // module-level variable declaration during this validation phase.
         List<ModuleMemberDeclarationNode> members = memberNodes.stream()
                 .filter(node -> node.kind() != SyntaxKind.MODULE_VAR_DECL && !node.hasDiagnostics())
-                .collect(Collectors.toList());
+                .toList();
         failIf(!members.isEmpty(), UNSUPPORTED_INPUT_TOPLEVEL_DCLN);
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/validator/impl/TopLevelDeclarationValidator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/validator/impl/TopLevelDeclarationValidator.java
@@ -26,7 +26,6 @@ import org.ballerinalang.debugadapter.evaluation.parser.DebugParser;
 import org.ballerinalang.debugadapter.evaluation.validator.Validator;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.debugadapter.evaluation.validator.ValidatorException.UNSUPPORTED_INPUT_IMPORT;
 import static org.ballerinalang.debugadapter.evaluation.validator.ValidatorException.UNSUPPORTED_INPUT_TOPLEVEL_DCLN;

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BArray.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BArray.java
@@ -29,7 +29,6 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.debugadapter.variable.VariableUtils.UNKNOWN_VALUE;
 import static org.ballerinalang.debugadapter.variable.VariableUtils.getStringFrom;

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BArray.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BArray.java
@@ -70,7 +70,7 @@ public class BArray extends IndexedCompoundVariable {
             List<Field> fields = jvmValueRef.referenceType().allFields();
             Field arrayValueField = jvmValueRef.getValues(fields).entrySet().stream().filter(fieldValueEntry ->
                     fieldValueEntry.getValue() != null && fieldValueEntry.getKey().toString().endsWith("Values"))
-                    .map(Map.Entry::getKey).collect(Collectors.toList()).get(0);
+                    .map(Map.Entry::getKey).toList().get(0);
 
             // If count > 0, returns a sublist of the child variables
             // If count == 0, returns all child variables
@@ -126,7 +126,7 @@ public class BArray extends IndexedCompoundVariable {
                 .filter(fieldValueEntry -> fieldValueEntry.getValue() != null &&
                         fieldValueEntry.getKey().toString().endsWith("ArrayValue.size"))
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toList()).get(0);
+                .toList().get(0);
         arraySize = ((IntegerValue) arrayRef.getValue(arraySizeField)).value();
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BTuple.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BTuple.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.debugadapter.variable.VariableUtils.UNKNOWN_VALUE;
 import static org.ballerinalang.debugadapter.variable.VariableUtils.getStringFrom;

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BTuple.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BTuple.java
@@ -135,7 +135,7 @@ public class BTuple extends IndexedCompoundVariable {
         Field arraySizeField = arrayRef.getValues(fields).entrySet().stream().filter(fieldValueEntry ->
                 fieldValueEntry.getValue() != null &&
                         fieldValueEntry.getKey().toString().endsWith("ArrayValue.size"))
-                .map(Map.Entry::getKey).collect(Collectors.toList()).get(0);
+                .map(Map.Entry::getKey).toList().get(0);
         tupleSize = ((IntegerValue) arrayRef.getValue(arraySizeField)).value();
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -464,7 +464,7 @@ public class Generator {
                                            Module module) {
         List<Type> memberTypes = new ArrayList<>();
         memberTypes.addAll(typeDescriptor.memberTypeDesc().stream().map(type ->
-                Type.fromNode(type, semanticModel, module)).collect(Collectors.toList()));
+                Type.fromNode(type, semanticModel, module)).toList());
         BType bType = new BType(tupleTypeName, getDocFromMetadata(optionalMetadataNode),
                 getDescSectionsDocFromMetaDataList(optionalMetadataNode), isDeprecated(optionalMetadataNode),
                 memberTypes);
@@ -815,7 +815,7 @@ public class Generator {
                 if (!originType.isPublic) {
                     variables.addAll(originType.memberTypes.stream()
                             .map(type -> new DefaultableVariable(type.name, type.description, false,
-                                    type.elementType, "")).collect(Collectors.toList()));
+                                    type.elementType, "")).toList());
                 } else if (!originType.memberTypes.isEmpty()) {
                     variables.add(new DefaultableVariable(originType));
                 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -278,7 +278,7 @@ public class Type {
                         Generator.getDefaultableVariableList(functionSignature.parameters(), Optional.empty(),
                                 semanticModel, module);
                 functionType.paramTypes.addAll(variables.stream().map((defaultableVariable) -> defaultableVariable.type)
-                        .collect(Collectors.toList()));
+                        .toList());
                 if (functionSignature.returnTypeDesc().isPresent()) {
                     ReturnTypeDescriptorNode returnType = functionSignature.returnTypeDesc().get();
                     functionType.returnType = Type.fromNode(returnType.type(), semanticModel, module);
@@ -328,7 +328,7 @@ public class Type {
         } else if (node instanceof TupleTypeDescriptorNode) {
             TupleTypeDescriptorNode typeDescriptor = (TupleTypeDescriptorNode) node;
             type.memberTypes.addAll(typeDescriptor.memberTypeDesc().stream().map(memberType ->
-                    Type.fromNode(memberType, semanticModel, module)).collect(Collectors.toList()));
+                    Type.fromNode(memberType, semanticModel, module)).toList());
             type.isTuple = true;
         } else if (node instanceof MemberTypeDescriptorNode) {
             MemberTypeDescriptorNode member = (MemberTypeDescriptorNode) node;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -78,7 +78,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Represents a Ballerina Type.

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -4918,9 +4918,9 @@ public class FormattingTreeModifier extends TreeModifier {
                 formatNodeList(NodeFactory.createNodeList(thirdPartyImports), 0, 1, 0, 2);
 
         List<ImportDeclarationNode> imports = new ArrayList<>();
-        imports.addAll(moduleImportNodes.stream().collect(Collectors.toList()));
-        imports.addAll(stdLibImportNodes.stream().collect(Collectors.toList()));
-        imports.addAll(thirdPartyImportNodes.stream().collect(Collectors.toList()));
+        imports.addAll(moduleImportNodes.stream().toList());
+        imports.addAll(stdLibImportNodes.stream().toList());
+        imports.addAll(thirdPartyImportNodes.stream().toList());
 
         if (hasLeadingComments(firstImport)) {
             // This is to ensure license header remains at top of the file

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -261,7 +261,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.formatter.core.FormatterUtils.isInlineRange;
 import static org.ballerinalang.formatter.core.FormatterUtils.openBraceTrailingNLs;

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
@@ -209,7 +209,7 @@ public class ParserTestFormatter extends FormatterTest {
         try {
             return Optional.ofNullable(Files.walk(Paths.get(directoryPath))
                     .filter(f -> f.getFileName().toString().equals(fileName))
-                    .collect(Collectors.toList()).get(0).toString());
+                    .toList().get(0).toString());
         } catch (IOException e) {
             return Optional.empty();
         }

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
@@ -24,7 +24,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Test the formatting of parser test cases.

--- a/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/JsonToRecordMapper.java
+++ b/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/JsonToRecordMapper.java
@@ -279,7 +279,7 @@ public class JsonToRecordMapper {
             recordToTypeDescNodes.put(recordName, recordTypeDescriptorNode);
         } else {
             List<Map.Entry<String, NonTerminalNode>> typeDescNodes = new ArrayList<>(recordToTypeDescNodes.entrySet());
-            List<String> recordNames = typeDescNodes.stream().map(Map.Entry::getKey).collect(Collectors.toList());
+            List<String> recordNames = typeDescNodes.stream().map(Map.Entry::getKey).toList();
             Map.Entry<String, NonTerminalNode> mapEntry =
                     new AbstractMap.SimpleEntry<>(recordName, recordTypeDescriptorNode);
             typeDescNodes.add(recordNames.indexOf(moveBefore), mapEntry);
@@ -335,14 +335,14 @@ public class JsonToRecordMapper {
         RecordTypeDescriptorNode previousRecordTypeDescriptorNode =
                 (RecordTypeDescriptorNode) recordToTypeDescNodes.get(recordName);
         List<RecordFieldNode> previousRecordFields = previousRecordTypeDescriptorNode.fields().stream()
-                .map(node -> (RecordFieldNode) node).collect(Collectors.toList());
+                .map(node -> (RecordFieldNode) node).toList();
         Map<String, RecordFieldNode> previousRecordFieldToNodes = previousRecordFields.stream()
                 .collect(Collectors.toMap(node -> node.fieldName().text(), Function.identity(),
                         (val1, val2) -> val1, LinkedHashMap::new));
         Map<String, RecordFieldNode> newRecordFieldToNodes = jsonObject.entrySet().stream()
                 .map(entry ->
                         (RecordFieldNode) getRecordField(entry, existingFieldNames, updatedFieldNames, false))
-                .collect(Collectors.toList()).stream()
+                .toList().stream()
                 .collect(Collectors.toMap(node -> node.fieldName().text(), Function.identity(),
                         (val1, val2) -> val1, LinkedHashMap::new));
         if (prepareForNestedSameField) {
@@ -519,7 +519,7 @@ public class JsonToRecordMapper {
         for (TypeDefinitionNode typeDefNode : typeDefNodes) {
             RecordTypeDescriptorNode recordTypeDescNode = (RecordTypeDescriptorNode) typeDefNode.typeDescriptor();
             List<RecordFieldNode> recordFieldNodes = recordTypeDescNode.fields().stream()
-                    .map(node -> (RecordFieldNode) node).collect(Collectors.toList());
+                    .map(node -> (RecordFieldNode) node).toList();
             List<Node> intermediateRecordFieldNodes = new ArrayList<>();
             for (RecordFieldNode recordFieldNode : recordFieldNodes) {
                 TypeDescriptorNode fieldTypeName = (TypeDescriptorNode) recordFieldNode.typeName();
@@ -578,7 +578,7 @@ public class JsonToRecordMapper {
                 TypeDescriptorNode tempTypeNode =
                         NodeFactory.createBuiltinSimpleNameReferenceNode(tempTypeName.kind(), tempTypeName);
                 if (!typeDescriptorNodes.stream().map(Node::toSourceCode)
-                        .collect(Collectors.toList()).contains(tempTypeNode.toSourceCode())) {
+                        .toList().contains(tempTypeNode.toSourceCode())) {
                     typeDescriptorNodes.add(tempTypeNode);
                 }
             } else if (element.isJsonNull()) {
@@ -586,7 +586,7 @@ public class JsonToRecordMapper {
                 TypeDescriptorNode tempTypeNode =
                         NodeFactory.createBuiltinSimpleNameReferenceNode(tempTypeName.kind(), tempTypeName);
                 if (!typeDescriptorNodes.stream().map(Node::toSourceCode)
-                        .collect(Collectors.toList()).contains(tempTypeNode.toSourceCode())) {
+                        .toList().contains(tempTypeNode.toSourceCode())) {
                     typeDescriptorNodes.add(tempTypeNode);
                 }
             } else if (element.isJsonObject()) {
@@ -598,7 +598,7 @@ public class JsonToRecordMapper {
                 TypeDescriptorNode tempTypeNode =
                         NodeFactory.createBuiltinSimpleNameReferenceNode(tempTypeName.kind(), tempTypeName);
                 if (!typeDescriptorNodes.stream().map(Node::toSourceCode)
-                        .collect(Collectors.toList()).contains(tempTypeNode.toSourceCode())) {
+                        .toList().contains(tempTypeNode.toSourceCode())) {
                     typeDescriptorNodes.add(tempTypeNode);
                 }
             } else if (element.isJsonArray()) {
@@ -607,7 +607,7 @@ public class JsonToRecordMapper {
                 TypeDescriptorNode tempTypeNode =
                         getArrayTypeDescriptorNode(arrayEntry, existingFieldNames, updatedFieldNames);
                 if (!typeDescriptorNodes.stream().map(Node::toSourceCode)
-                        .collect(Collectors.toList()).contains(tempTypeNode.toSourceCode())) {
+                        .toList().contains(tempTypeNode.toSourceCode())) {
                     typeDescriptorNodes.add(tempTypeNode);
                 }
             }

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/SemverChecker.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/SemverChecker.java
@@ -32,7 +32,6 @@ import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static io.ballerina.semver.checker.util.SemverUtils.BAL_FILE_EXT;
 

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/SemverChecker.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/SemverChecker.java
@@ -129,7 +129,7 @@ public class SemverChecker {
             // Todo - support toml changes validation
             List<Diagnostic> srcErrors = compilation.diagnosticResult().errors().stream()
                     .filter(diagnostic -> diagnostic.location().lineRange().fileName().endsWith(BAL_FILE_EXT))
-                    .collect(Collectors.toList());
+                    .toList();
             if (srcErrors.isEmpty()) {
                 return;
             }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/DependencyGraphTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/DependencyGraphTests.java
@@ -133,7 +133,7 @@ public class DependencyGraphTests extends BaseTest {
 
         ResolvedPackageDependency packageDep = dependencyGraphOld.getNodes().stream().filter(
                 resolvedPackageDependency -> resolvedPackageDependency.packageInstance().packageName().toString()
-                        .equals("package_dep")).collect(Collectors.toList()).get(0);
+                        .equals("package_dep")).toList().get(0);
         PackageID packageDepPkgID = new PackageID(new Name(packageDep.packageInstance().packageOrg().value()),
                 new Name(packageDep.packageInstance().getDefaultModule().moduleName().toString()),
                 new Name(packageDep.packageInstance().packageVersion().toString()));
@@ -192,7 +192,7 @@ public class DependencyGraphTests extends BaseTest {
         project.currentPackage().getCompilation();
         ResolvedPackageDependency packageC = dependencyGraphOld.getNodes().stream().filter(resolvedPackageDependency ->
                 resolvedPackageDependency.packageInstance().packageName().toString().equals("package_c"))
-                .collect(Collectors.toList()).get(0);
+                .toList().get(0);
         PackageID packageCPkgID = new PackageID(new Name(packageC.packageInstance().packageOrg().value()),
                 new Name(packageC.packageInstance().getDefaultModule().moduleName().toString()),
                 new Name(packageC.packageInstance().packageVersion().toString()));
@@ -236,7 +236,7 @@ public class DependencyGraphTests extends BaseTest {
 
         ResolvedPackageDependency packageC = dependencyGraphOld.getNodes().stream().filter(resolvedPackageDependency ->
                 resolvedPackageDependency.packageInstance().packageName().toString().equals("package_c"))
-                .collect(Collectors.toList()).get(0);
+                .toList().get(0);
         PackageID packageCPkgID = new PackageID(new Name(packageC.packageInstance().packageOrg().value()),
                 new Name(packageC.packageInstance().getDefaultModule().moduleName().toString()),
                 new Name(packageC.packageInstance().packageVersion().toString()));
@@ -286,7 +286,7 @@ public class DependencyGraphTests extends BaseTest {
         project.currentPackage().getCompilation();
         ResolvedPackageDependency packageC = dependencyGraphOld.getNodes().stream().filter(resolvedPackageDependency ->
                 resolvedPackageDependency.packageInstance().packageName().toString().equals("package_c"))
-                .collect(Collectors.toList()).get(0);
+                .toList().get(0);
         PackageID packageID = new PackageID(new Name(packageC.packageInstance().packageOrg().value()),
                 new Name(packageC.packageInstance().getDefaultModule().moduleName().toString()),
                 new Name(packageC.packageInstance().packageVersion().toString()));
@@ -329,7 +329,7 @@ public class DependencyGraphTests extends BaseTest {
         project.currentPackage().getCompilation();
         ResolvedPackageDependency packageC = dependencyGraphOld.getNodes().stream().filter(resolvedPackageDependency ->
                 resolvedPackageDependency.packageInstance().packageName().toString().equals("package_c"))
-                .collect(Collectors.toList()).get(0);
+                .toList().get(0);
         PackageID packageCPkgID = new PackageID(new Name(packageC.packageInstance().packageOrg().value()),
                 new Name(packageC.packageInstance().getDefaultModule().moduleName().toString()),
                 new Name(packageC.packageInstance().packageVersion().toString()));

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/DependencyGraphTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/DependencyGraphTests.java
@@ -68,7 +68,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static io.ballerina.projects.test.TestUtils.replaceDistributionVersionOfDependenciesToml;
 

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/PackageResolutionTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/PackageResolutionTests.java
@@ -670,7 +670,7 @@ public class PackageResolutionTests extends BaseTest {
         // 4) The dependency is expected to load from distribution cache, hence zero diagnostics
         Assert.assertEquals(diagnosticResult.errorCount(), 3);
         List<String> diagnosticMsgs = diagnosticResult.errors().stream()
-                .map(Diagnostic::message).collect(Collectors.toList());
+                .map(Diagnostic::message).toList();
         Assert.assertTrue(diagnosticMsgs.contains("cannot resolve module 'samjs/package_c.mod_c1 as mod_c1'"));
     }
 

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/PackageResolutionTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/PackageResolutionTests.java
@@ -85,7 +85,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static io.ballerina.projects.test.TestUtils.isWindows;
 import static io.ballerina.projects.test.TestUtils.replaceDistributionVersionOfDependenciesToml;

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBirAndJarCache.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBirAndJarCache.java
@@ -43,7 +43,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.projects.util.ProjectConstants.BLANG_COMPILED_JAR_EXT;

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBirAndJarCache.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBirAndJarCache.java
@@ -95,7 +95,7 @@ public class TestBirAndJarCache {
 
         List<String> foundPaths = pathStream
                 .map(path -> path.getFileName().toString())
-                .collect(Collectors.toList());
+                .toList();
         for (ModuleId moduleId : currentPackage.moduleIds()) {
             Module module = currentPackage.module(moduleId);
             ModuleName moduleName = module.moduleName();

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -317,7 +317,7 @@ public class TestBuildProject extends BaseTest {
 
         // Verify paths in jBallerina backend diagnostics
         diagnosticFilePaths = jBallerinaBackend.diagnosticResult().diagnostics().stream().map(diagnostic ->
-                diagnostic.location().lineRange().fileName()).distinct().collect(Collectors.toList());
+                diagnostic.location().lineRange().fileName()).distinct().toList();
 
         for (String path : expectedPaths) {
             Assert.assertTrue(diagnosticFilePaths.contains(path), diagnosticFilePaths.toString());

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/CompilerPluginTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/CompilerPluginTests.java
@@ -58,7 +58,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Contains cases to test compiler plugin loading and running.

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/CompilerPluginTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/CompilerPluginTests.java
@@ -493,7 +493,7 @@ public class CompilerPluginTests {
         List<Diagnostic> reportedDiagnostics = diagnosticResult.diagnostics()
                 .stream()
                 .sorted(Comparator.comparing(Diagnostic::message))
-                .collect(Collectors.toList());
+                .toList();
 
         Assert.assertEquals(reportedDiagnostics.get(0).diagnosticInfo().severity(), DiagnosticSeverity.ERROR);
         Assert.assertEquals(reportedDiagnostics.get(1).diagnosticInfo().severity(), DiagnosticSeverity.WARNING);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
@@ -180,7 +180,7 @@ public class ServiceSemanticAPITest {
         List<ServiceDeclarationSymbol> services = model.moduleSymbols().stream()
                 .filter(s -> s.kind() == SERVICE_DECLARATION)
                 .map(s -> (ServiceDeclarationSymbol) s)
-                .collect(Collectors.toList());
+                .toList();
 
         assertEquals(services.size(), expVals.length);
 
@@ -263,7 +263,7 @@ public class ServiceSemanticAPITest {
         SemanticModel model = getDefaultModulesSemanticModel("test-src/service_with_multiple_listeners.bal");
         List<Symbol> services = model.moduleSymbols().stream()
                 .filter(s -> s.kind() == SERVICE_DECLARATION)
-                .collect(Collectors.toList());
+                .toList();
         ServiceDeclarationSymbol service = (ServiceDeclarationSymbol) services.get(0);
         List<TypeSymbol> listenerTypes = service.listenerTypes();
         assertEquals(listenerTypes.size(), 3);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
@@ -93,7 +93,7 @@ public class SymbolEquivalenceTest {
                                                from(20, 11), from(49, 5), from(40, 4));
         List<Symbol> symbols = positions.stream()
                 .map(pos -> model.symbol(srcFile, pos).get())
-                .collect(Collectors.toList());
+                .toList();
 
         for (int i = 0; i < symbols.size(); i++) {
             Symbol symbol = symbols.get(i);
@@ -153,7 +153,7 @@ public class SymbolEquivalenceTest {
                 .map(pos -> typesModel.symbol(typesSrcFile, pos).get())
                 .map(s -> s.kind() == RECORD_FIELD ?
                         ((RecordFieldSymbol) s).typeDescriptor() : ((ParameterSymbol) s).typeDescriptor())
-                .collect(Collectors.toList());
+                .toList();
 
         for (int i = 0; i < types.size(); i++) {
             TypeSymbol type = types.get(i);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
@@ -151,8 +151,8 @@ public class SymbolLookupTest {
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
 
         List<Symbol> symbolList = model.visibleSymbols(srcFile, LinePosition.from(24, 5)).stream()
-                .filter(s -> s.getModule().get().id().equals(moduleID)).collect(Collectors.toList());
-        List<String> symbolStringList = symbolList.stream().map(this::createSymbolString).collect(Collectors.toList());
+                .filter(s -> s.getModule().get().id().equals(moduleID)).toList();
+        List<String> symbolStringList = symbolList.stream().map(this::createSymbolString).toList();
 
         List<String> expectedNameList = asList("SimpleRecordTYPE_DEFINITION", "func1ANNOTATION", "func1FUNCTION");
 

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
@@ -35,7 +35,6 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Utility methods for doing file operations.

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
@@ -133,7 +133,7 @@ public class BFileUtil {
             return;
         }
         List<Path> files = Files.find(path, Integer.MAX_VALUE, (p, attribute) ->
-                p.toString().contains(pattern)).collect(Collectors.toList());
+                p.toString().contains(pattern)).toList();
         for (Path file : files) {
             BFileUtil.delete(file);
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentTest.java
@@ -221,7 +221,7 @@ public class AnnotationAttachmentTest {
                         .get().getAnnotationAttachments()
                         .stream()
                         .filter(ann -> !isServiceIntropAnnot((BLangAnnotationAttachment) ann))
-                        .collect(Collectors.toList());
+                        .toList();
         Assert.assertEquals(attachments.size(), 1);
         assertAnnotationNameAndKeyValuePair(attachments.get(0), "v8", "val", "v82");
     }
@@ -377,7 +377,7 @@ public class AnnotationAttachmentTest {
                 .getClassDefinitions().get(0).getAnnotationAttachments()
                 .stream()
                 .filter(ann -> !isServiceIntropAnnot((BLangAnnotationAttachment) ann))
-                .collect(Collectors.toList());
+                .toList();
         Assert.assertEquals(attachments.size(), 1);
         BLangAnnotationAttachment attachment = attachments.get(0);
         BLangRecordLiteral recordLiteral = getMappingConstructor(attachment, "v1");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/JarIntegrationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/JarIntegrationTest.java
@@ -54,7 +54,7 @@ public class JarIntegrationTest {
 
         PackageID moduleID = new PackageID(Names.ANON_ORG, Names.DEFAULT_PACKAGE, Names.DEFAULT_VERSION);
         List<CompilerInput> sources = balPatten.convertToSources(subject, moduleID)
-                .collect(Collectors.toList());
+                .toList();
 
         Assert.assertEquals(sources.size(), 1);
         Assert.assertEquals(sources.get(0).getCode(), BAL_CONTENT);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/JarIntegrationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/JarIntegrationTest.java
@@ -16,7 +16,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/PathConverterIntegrationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/PathConverterIntegrationTest.java
@@ -50,7 +50,7 @@ public class PathConverterIntegrationTest {
 
         Stream<Path> pathStream = patten.convert(subject, null);
 
-        List<Path> paths = pathStream.collect(Collectors.toList());
+        List<Path> paths = pathStream.toList();
         Assert.assertEquals(paths.size(), 1);
         Assert.assertEquals(paths.get(0).toString(), tempSemVerFile.toString());
     }
@@ -63,7 +63,7 @@ public class PathConverterIntegrationTest {
 
         Stream<Path> pathStream = patten.convert(subject, null);
 
-        List<Path> paths = pathStream.collect(Collectors.toList());
+        List<Path> paths = pathStream.toList();
         Assert.assertEquals(paths.size(), 0);
     }
 
@@ -74,7 +74,7 @@ public class PathConverterIntegrationTest {
 
         Stream<Path> pathStream = patten.convert(subject, null);
 
-        List<Path> paths = pathStream.collect(Collectors.toList());
+        List<Path> paths = pathStream.toList();
         Assert.assertEquals(paths.size(), 1);
         Assert.assertEquals(paths.get(0).toString(), tempFile.toString());
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/PathConverterIntegrationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/PathConverterIntegrationTest.java
@@ -13,7 +13,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.wso2.ballerinalang.compiler.packaging.Patten.LATEST_VERSION_DIR;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/PattenTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/PattenTest.java
@@ -140,7 +140,7 @@ public class PattenTest {
                                               null, null);
         Patten subject = new Patten(Patten.LATEST_VERSION_DIR);
 
-        List<String> strings = subject.convert(mock, null).limit(1).collect(Collectors.toList());
+        List<String> strings = subject.convert(mock, null).limit(1).toList();
 
         Assert.assertTrue(strings.isEmpty());
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BaseTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BaseTestCase.java
@@ -72,7 +72,7 @@ public class BaseTestCase {
         try {
             packageDirs = Files.walk(projectBasedTestsPath, 1)
                     .filter(Files::isDirectory)
-                    .collect(Collectors.toList());
+                    .toList();
             for (Path dir : packageDirs) {
                 try {
                     FileUtils.copyBallerinaExec(dir, "");

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BaseTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BaseTestCase.java
@@ -29,7 +29,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**


### PR DESCRIPTION
## Purpose
In Java 8 Streams were introduced to support chaining of operations over collections in a functional style. The most common way to save a result of such chains is to save them to some collection (usually List). To do so there is a terminal method collect that can be used with a library of Collectors. The key problem is that .collect(Collectors.toList()) actually returns a mutable kind of List while in the majority of cases unmodifiable lists are preferred. In Java 10 a new collector appeared to return an unmodifiable list: toUnmodifiableList(). This does the trick but results in verbose code. Since Java 16 there is now a better variant to produce an unmodifiable list directly from a stream: Stream.toList().

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
