### PR TITLE
Use `replace` instead of `replaceAll` if no regex is needed

### DIFF
--- a/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/handlers/HelpCommand.java
+++ b/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/handlers/HelpCommand.java
@@ -73,8 +73,8 @@ public class HelpCommand extends AbstractCommand {
             } else {
                 try {
                     ballerinaShell.outputInfo(NEW_LINE + bbeHelpProvider.getDescription(topic)
-                            .replaceAll(TAGS, EMPTY_STRING));
-                    ballerinaShell.outputInfo(URL_PREFIX + URL + topic.replaceAll(" ", "-"));
+                            .replace(TAGS, EMPTY_STRING));
+                    ballerinaShell.outputInfo(URL_PREFIX + URL + topic.replace(" ", "-"));
 
                 } catch (HelpProviderException e) {
                     ballerinaShell.outputError(NEW_LINE + "Can not find the topic : " + topic  + NEW_LINE + NEW_LINE +

--- a/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/handlers/help/BbeTopicsProvider.java
+++ b/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/handlers/help/BbeTopicsProvider.java
@@ -66,7 +66,7 @@ public class BbeTopicsProvider extends DiagnosticReporter {
                     Stream<BbeRecord> sampleList = Arrays.stream(samples);
                     sampleList.forEach((bbeRecordElement) -> {
                         if (bbeRecordElement != null) {
-                            topicList.add(bbeRecordElement.getUrl().replaceAll("-", " "));
+                            topicList.add(bbeRecordElement.getUrl().replace("-", " "));
                         }
                     });
                 }

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/utils/StringUtils.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/utils/StringUtils.java
@@ -62,7 +62,7 @@ public class StringUtils {
      */
     public static String shortenedString(Object input) {
         String value = String.valueOf(input);
-        value = value.replaceAll("\n", "");
+        value = value.replace("\n", "");
         if (value.length() > MAX_VAR_STRING_LENGTH) {
             int subStrLength = MAX_VAR_STRING_LENGTH / 2;
             return value.substring(0, subStrLength)

--- a/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/runtime/StackTraceMap.java
+++ b/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/runtime/StackTraceMap.java
@@ -62,6 +62,6 @@ public class StackTraceMap {
     }
 
     private static String decodeStackElement(String stackElement) {
-        return Utils.decodeIdentifier(stackElement.replaceAll("\\$value\\$", ""));
+        return Utils.decodeIdentifier(stackElement.replace("$value$", ""));
     }
 }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
@@ -954,9 +954,9 @@ public class CommandUtil {
         String defaultManifest = FileUtils.readFileAsString(NEW_CMD_DEFAULTS + "/" + "manifest-app.toml");
         // replace manifest distribution with a guessed value
         defaultManifest = defaultManifest
-                .replaceAll(ORG_NAME, ProjectUtils.guessOrgName())
-                .replaceAll(PKG_NAME, guessPkgName(packageName, "app"))
-                .replaceAll(DIST_VERSION, RepoUtils.getBallerinaShortVersion());
+                .replace(ORG_NAME, ProjectUtils.guessOrgName())
+                .replace(PKG_NAME, guessPkgName(packageName, "app"))
+                .replace(DIST_VERSION, RepoUtils.getBallerinaShortVersion());
         Files.write(ballerinaToml, defaultManifest.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -966,9 +966,9 @@ public class CommandUtil {
 
         String defaultManifest = FileUtils.readFileAsString(NEW_CMD_DEFAULTS + "/" + "manifest-lib.toml");
         // replace manifest org and name with a guessed value.
-        defaultManifest = defaultManifest.replaceAll(ORG_NAME, ProjectUtils.guessOrgName())
-                .replaceAll(PKG_NAME, guessPkgName(packageName, "lib"))
-                .replaceAll(DIST_VERSION, RepoUtils.getBallerinaShortVersion());
+        defaultManifest = defaultManifest.replace(ORG_NAME, ProjectUtils.guessOrgName())
+                .replace(PKG_NAME, guessPkgName(packageName, "lib"))
+                .replace(DIST_VERSION, RepoUtils.getBallerinaShortVersion());
 
         write(ballerinaToml, defaultManifest.getBytes(StandardCharsets.UTF_8));
 
@@ -990,16 +990,16 @@ public class CommandUtil {
 
         String defaultManifest = FileUtils.readFileAsString(NEW_CMD_DEFAULTS + "/" + "manifest-app.toml");
         defaultManifest = defaultManifest
-                .replaceAll(ORG_NAME, ProjectUtils.guessOrgName())
-                .replaceAll(PKG_NAME, guessPkgName(packageName, TOOL_DIR))
-                .replaceAll(DIST_VERSION, RepoUtils.getBallerinaShortVersion());
+                .replace(ORG_NAME, ProjectUtils.guessOrgName())
+                .replace(PKG_NAME, guessPkgName(packageName, TOOL_DIR))
+                .replace(DIST_VERSION, RepoUtils.getBallerinaShortVersion());
         Files.write(ballerinaToml, defaultManifest.getBytes(StandardCharsets.UTF_8));
 
         Path balToolToml = path.resolve(ProjectConstants.BAL_TOOL_TOML);
         Files.createFile(balToolToml);
 
         String balToolManifest = FileUtils.readFileAsString(NEW_CMD_DEFAULTS + "/" + "manifest-tool.toml");
-        balToolManifest = balToolManifest.replaceAll(TOOL_ID, guessPkgName(packageName, TOOL_DIR));
+        balToolManifest = balToolManifest.replace(TOOL_ID, guessPkgName(packageName, TOOL_DIR));
 
         write(balToolToml, balToolManifest.getBytes(StandardCharsets.UTF_8));
     }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
@@ -515,7 +515,7 @@ public class PushCommand implements BLauncherCmd {
                         errorMessage = errorMessage.substring(0, errorMessage.indexOf("\n\tat"));
                     }
 
-                    errorMessage = errorMessage.replaceAll("error: ", "");
+                    errorMessage = errorMessage.replace("error: ", "");
 
                     // when unauthorized access token for organization is given
                     if (errorMessage.contains("subject claims missing in the user info repsonse")) {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/NativeUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/NativeUtils.java
@@ -303,7 +303,7 @@ public class NativeUtils {
                         functionToMock = key.substring(key.indexOf(MOCK_LEGACY_DELIMITER) + 1);
                     }
                 }
-                functionToMock = functionToMock.replaceAll("\\\\", "");
+                functionToMock = functionToMock.replace("\\", "");
                 mockFunctionClassMapping.computeIfAbsent(functionToMockClassName,
                         k -> new ArrayList<>()).add("$ORIG_" + functionToMock);
             }
@@ -444,7 +444,7 @@ public class NativeUtils {
             for (Map.Entry<String, byte[]> modifiedClassDef : modifiedClassDefs.entrySet()) {
                 if (modifiedClassDef.getValue().length > 0) {
                     String entry = modifiedClassDef.getKey();
-                    String path = entry.replaceAll("\\.", PATH_SEPARATOR) + CLASS_EXTENSION;
+                    String path = entry.replace(".", PATH_SEPARATOR) + CLASS_EXTENSION;
                     duplicatePaths.add(path);
                     jarOutputStream.putNextEntry(new ZipEntry(path));
                     jarOutputStream.write(modifiedClassDefs.get(entry));
@@ -502,7 +502,7 @@ public class NativeUtils {
                     functionToMock = key.substring(key.indexOf(MOCK_LEGACY_DELIMITER));
                 }
             }
-            functionToMock = functionToMock.replaceAll("\\\\", "");
+            functionToMock = functionToMock.replace("\\", "");
             classVsMockFunctionsMap.computeIfAbsent(functionToMockClassName,
                     k -> new ArrayList<>()).add(functionToMock);
         }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TestUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TestUtils.java
@@ -180,7 +180,7 @@ public class TestUtils {
         testReport.finalizeTestResults(project.buildOptions().codeCoverage());
 
         Gson gson = new Gson();
-        String json = gson.toJson(testReport).replaceAll("\\\\\\(", "(");
+        String json = gson.toJson(testReport).replace("\\(", "(");
 
         File jsonFile = new File(reportDir.resolve(RESULTS_JSON_FILE).toString());
         try (FileOutputStream fileOutputStream = new FileOutputStream(jsonFile)) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectUtils.java
@@ -388,7 +388,7 @@ public class ProjectUtils {
 
         // if package name has consecutive underscores, replace them with a single underscore
         if (packageName.contains("__")) {
-            packageName = packageName.replaceAll("__", "_");
+            packageName = packageName.replace("__", "_");
         }
 
         // if package name has trailing underscore remove it

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
@@ -759,7 +759,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
             case CLASS_DEFN:
                 return generateName(((BLangClassDefinition) parent).name.getValue() + UNDERSCORE + name, parent.parent);
             case FUNCTION:
-                name = ((BLangFunction) parent).symbol.name.value.replaceAll("\\.", UNDERSCORE) + UNDERSCORE + name;
+                name = ((BLangFunction) parent).symbol.name.value.replace(".", UNDERSCORE) + UNDERSCORE + name;
                 return generateName(name, parent.parent);
             case RESOURCE_FUNC:
                 return generateName(((BLangResourceFunction) parent).name.value + UNDERSCORE + name, parent.parent);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangMarkdownDocumentation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangMarkdownDocumentation.java
@@ -107,7 +107,7 @@ public class BLangMarkdownDocumentation extends BLangNode implements MarkdownDoc
     public String getDocumentation() {
         return documentationLines.stream()
                 .map(BLangMarkdownDocumentationLine::getText)
-                .collect(Collectors.joining("\n")).replaceAll("\r", "");
+                .collect(Collectors.joining("\n")).replace("\r", "");
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangMarkDownDeprecationDocumentation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangMarkDownDeprecationDocumentation.java
@@ -60,7 +60,7 @@ public class BLangMarkDownDeprecationDocumentation extends BLangExpression
 
     @Override
     public String getDocumentation() {
-        return String.join("\n", this.deprecationDocumentationLines).replaceAll("\r", "");
+        return String.join("\n", this.deprecationDocumentationLines).replace("\r", "");
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangMarkdownParameterDocumentation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangMarkdownParameterDocumentation.java
@@ -56,7 +56,7 @@ public class BLangMarkdownParameterDocumentation extends BLangExpression
 
     @Override
     public String getParameterDocumentation() {
-        return parameterDocumentationLines.stream().collect(Collectors.joining("\n")).replaceAll("\r", "");
+        return parameterDocumentationLines.stream().collect(Collectors.joining("\n")).replace("\r", "");
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangMarkdownReturnParameterDocumentation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangMarkdownReturnParameterDocumentation.java
@@ -59,7 +59,7 @@ public class BLangMarkdownReturnParameterDocumentation extends BLangExpression
 
     @Override
     public String getReturnParameterDocumentation() {
-        return returnParameterDocumentationLines.stream().collect(Collectors.joining("\n")).replaceAll("\r", "");
+        return returnParameterDocumentationLines.stream().collect(Collectors.joining("\n")).replace("\r", "");
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -61,7 +61,6 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.wso2.ballerinalang.compiler.util.Names;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,6 +74,8 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.PARAMETER;
 import static org.ballerinalang.langserver.common.utils.CommonKeys.SEMI_COLON_SYMBOL_KEY;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -61,6 +61,7 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.wso2.ballerinalang.compiler.util.Names;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -74,8 +75,6 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import javax.annotation.Nonnull;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.PARAMETER;
 import static org.ballerinalang.langserver.common.utils.CommonKeys.SEMI_COLON_SYMBOL_KEY;
@@ -269,7 +268,7 @@ public class CommonUtil {
      * @return The identifier with escape characters escaped
      */
     public static String escapeEscapeCharsInIdentifier(String identifier) {
-        return identifier.replace("\\", "\\\\\\\\");
+        return identifier.replace("\\", "\\\\");
     }
 
     /**
@@ -279,8 +278,8 @@ public class CommonUtil {
      * @return Processed text
      */
     public static String escapeSpecialCharsInInsertText(String text) {
-        return text.replace("\\", "\\\\\\\\")
-                .replace("$", Matcher.quoteReplacement("\\$"));
+        return text.replace("\\", "\\\\")
+                .replace("$", "\\$");
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -269,7 +269,7 @@ public class CommonUtil {
      * @return The identifier with escape characters escaped
      */
     public static String escapeEscapeCharsInIdentifier(String identifier) {
-        return identifier.replaceAll("\\\\", "\\\\\\\\");
+        return identifier.replace("\\", "\\\\\\\\");
     }
 
     /**
@@ -279,8 +279,8 @@ public class CommonUtil {
      * @return Processed text
      */
     public static String escapeSpecialCharsInInsertText(String text) {
-        return text.replaceAll("\\\\", "\\\\\\\\")
-                .replaceAll("\\$", Matcher.quoteReplacement("\\$"));
+        return text.replace("\\", "\\\\\\\\")
+                .replace("$", Matcher.quoteReplacement("\\$"));
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/telemetry/LSTelemetryEvent.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/telemetry/LSTelemetryEvent.java
@@ -46,7 +46,7 @@ public abstract class LSTelemetryEvent {
         if (operation == null) {
             return LS_TELEMETRY_COMPONENT_NAME;
         }
-        return LS_TELEMETRY_COMPONENT_NAME + "." + operation.getName().replaceAll("/", "_");
+        return LS_TELEMETRY_COMPONENT_NAME + "." + operation.getName().replace("/", "_");
     }
 
     public String getComponent() {

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -789,9 +789,9 @@ class AIDataMapperCodeActionUtil {
             rightType = rhsSignature;
         }
 
-        mappingFromServer = mappingFromServer.replaceAll("\"", "");
-        mappingFromServer = mappingFromServer.replaceAll(",", ", ");
-        mappingFromServer = mappingFromServer.replaceAll(":", ": ");
+        mappingFromServer = mappingFromServer.replace("\"", "");
+        mappingFromServer = mappingFromServer.replace(",", ", ");
+        mappingFromServer = mappingFromServer.replace(":", ": ");
 
 
         // change the generated mapping function to be compatible with spread fields.

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/DataMapperNodeVisitor.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/DataMapperNodeVisitor.java
@@ -95,7 +95,7 @@ public class DataMapperNodeVisitor extends NodeVisitor {
                     SpecificFieldNode specificFieldNode = (SpecificFieldNode) field;
                     if (specificFieldNode.fieldName().kind() == SyntaxKind.STRING_LITERAL) {
                         String fieldName = ((BasicLiteralNode) specificFieldNode.fieldName()).literalToken().text();
-                        fieldName = fieldName.replaceAll("\"", "");
+                        fieldName = fieldName.replace("\"", "");
                         Optional<Symbol> symbol = this.model.symbol(variableDeclarationNode);
                         if (symbol.isPresent()) {
                             TypeSymbol typeSymbol = ((VariableSymbol) symbol.get()).typeDescriptor();

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/PackageUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/PackageUtils.java
@@ -262,7 +262,7 @@ public class PackageUtils {
         String[] moduleParts;
         // Makes the path os-independent, as some of the incoming windows source paths can contain both of the
         // separator types(possibly due to a potential JDI bug).
-        path = path.replaceAll("\\\\", "/");
+        path = path.replace("\\", "/");
         if (path.contains("/")) {
             moduleParts = path.split("/");
         } else {
@@ -349,9 +349,9 @@ public class PackageUtils {
 
     private static String replaceSeparators(String path) {
         if (path.contains("/")) {
-            return path.replaceAll("/", ".");
+            return path.replace("/", ".");
         } else if (path.contains("\\")) {
-            return path.replaceAll("\\\\", ".");
+            return path.replace("\\", ".");
         }
         return path;
     }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BTypeDesc.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BTypeDesc.java
@@ -40,7 +40,7 @@ public class BTypeDesc extends BSimpleVariable {
         try {
             String stringValue = getStringValue(context, jvmValue);
             if (stringValue.startsWith(TYPEDESC_VALUE_PREFIX)) {
-                stringValue = stringValue.replaceAll(TYPEDESC_VALUE_PREFIX, "");
+                stringValue = stringValue.replace(TYPEDESC_VALUE_PREFIX, "");
             }
             return stringValue;
         } catch (Exception e) {

--- a/misc/debug-adapter/modules/debug-adapter-runtime/src/main/java/org/ballerinalang/debugadapter/runtime/DebuggerRuntime.java
+++ b/misc/debug-adapter/modules/debug-adapter-runtime/src/main/java/org/ballerinalang/debugadapter/runtime/DebuggerRuntime.java
@@ -366,7 +366,7 @@ public class DebuggerRuntime {
 
     private static BString[] processXMLNamePattern(String xmlNamePattern) {
         // removes LT and GT tokens if presents.
-        xmlNamePattern = xmlNamePattern.replaceAll("<", "").replaceAll(">", "");
+        xmlNamePattern = xmlNamePattern.replace("<", "").replace(">", "");
 
         if (xmlNamePattern.contains(XML_STEP_SEPARATOR)) {
             String[] stepParts = xmlNamePattern.split(XML_ALL_CHILDREN_STEP);

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/util/SyntaxTreeUtils.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/util/SyntaxTreeUtils.java
@@ -49,7 +49,7 @@ public class SyntaxTreeUtils {
      * @return node typename
      */
     public static String getNodeKindName(SyntaxKind nodeKind) {
-        return nodeKind.name().toLowerCase(Locale.ROOT).toLowerCase(Locale.ENGLISH).replaceAll("_", " ");
+        return nodeKind.name().toLowerCase(Locale.ROOT).toLowerCase(Locale.ENGLISH).replace("_", " ");
     }
 
     /**

--- a/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TestExecutionGenerationTask.java
+++ b/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TestExecutionGenerationTask.java
@@ -248,7 +248,7 @@ public class TestExecutionGenerationTask implements GeneratorTask<SourceGenerato
             if ("test".equals(modulePrefix) && "call".equals(methodName)
                     && "when".equals(identifier)) {
                 String mockedFunction = methodCallExpressionNode.arguments()
-                        .get(0).toString().replaceAll("\"", "");
+                        .get(0).toString().replace("\"", "");
                 mockedFunctionList.add(mockedFunction);
             }
         }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/AssertionDiffEvaluator.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/AssertionDiffEvaluator.java
@@ -99,7 +99,7 @@ public class AssertionDiffEvaluator {
                 }
             }
         }
-        output = output.replaceAll("\n\n", " \n \n ");
+        output = output.replace("\n\n", " \n \n ");
         return StringUtils.fromString(output);
     }
 

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/MockAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/MockAnnotationProcessor.java
@@ -265,7 +265,7 @@ public class MockAnnotationProcessor extends AbstractCompilerPlugin {
                     // Adding `<className> # <functionToMock> --> <MockFnObjectName>` to registry
                     String className = getQualifiedClassName(bLangTestablePackage,
                             functionToMockID.toString(), vals[1]);
-                    vals[1] = vals[1].replaceAll("\\\\", "");
+                    vals[1] = vals[1].replace("\\", "");
                     registry.addMockFunctionsSourceMap(bLangTestablePackage.packageID.getName().toString()
                                     + MODULE_DELIMITER + className + MOCK_LEGACY_DELIMITER + vals[1], functionName);
                 } else {

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
@@ -405,7 +405,7 @@ public class TestProcessor {
      * @return String
      */
     private String getStringValue(Node valueExpr) {
-        return valueExpr.toString().replaceAll("\\\"", "").trim();
+        return valueExpr.toString().replace("\"", "").trim();
     }
 
     /**

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/io/StringUtils.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/io/StringUtils.java
@@ -163,7 +163,7 @@ public class StringUtils {
         try {
             String javaStr = str.getValue();
             javaStr = javaStr.replaceAll("%(?![0-9a-fA-F]{2})", "%25");
-            javaStr = javaStr.replaceAll("\\+", "%2B");
+            javaStr = javaStr.replace("+", "%2B");
             return io.ballerina.runtime.api.utils.StringUtils.fromString(
                     URLDecoder.decode(javaStr, charset.getValue()));
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/FunctionMock.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/FunctionMock.java
@@ -112,7 +112,7 @@ public class FunctionMock {
         if (Thread.currentThread().getStackTrace().length >= 5) {
             String classname = Thread.currentThread().getStackTrace()[4].getClassName();
             if (classname.contains("/")) {
-                classname = classname.replaceAll("/", ".");
+                classname = classname.replace("/", ".");
             }
             String[] projectInfo = classname.split(Pattern.quote("."));
             // Set project info

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestMain.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestMain.java
@@ -329,7 +329,7 @@ public class BTestMain {
         try {
             InputStream ins;
             if (coverage) {
-                String instrumentedClassPath = instrumentDir + "/" + clazz.getName().replaceAll("\\.", "/") + ".class";
+                String instrumentedClassPath = instrumentDir + "/" + clazz.getName().replace(".", "/") + ".class";
                 ins = new FileInputStream(instrumentedClassPath);
             } else {
                 ins = clazz.getResourceAsStream(clazz.getSimpleName() + ".class");

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/JacocoInstrumentUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/JacocoInstrumentUtils.java
@@ -45,7 +45,7 @@ public class JacocoInstrumentUtils {
         URLClassLoader classLoader = new URLClassLoader(projectModuleJarList.toArray(new URL[0]));
         for (String className : mockClassNames) {
             Class<?> clazz = classLoader.loadClass(className);
-            File file = new File(destDir.toString(), className.replaceAll("\\.", "/") + ".class");
+            File file = new File(destDir.toString(), className.replace(".", "/") + ".class");
             file.getParentFile().mkdirs();
             try (InputStream input = clazz.getResourceAsStream(clazz.getSimpleName() + ".class");
                  OutputStream output = new FileOutputStream(file)) {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaUtils.java
@@ -168,7 +168,7 @@ public class TesterinaUtils {
      */
     public static String formatError(String errorMsg) {
         StringBuilder newErrMsg = new StringBuilder();
-        errorMsg = errorMsg.replaceAll("\n", "\n\t");
+        errorMsg = errorMsg.replace("\n", "\n\t");
         List<String> msgParts = Arrays.asList(errorMsg.split("\n"));
         boolean stackTraceStartFlag = true;
 


### PR DESCRIPTION
## Purpose
The underlying implementation of String::replaceAll calls the java.util.regex.Pattern.compile() method each time it is called even if the first argument is not a regular expression. This has a significant performance cost and therefore should be used with care.

When String::replaceAll is used, the first argument should be a real regular expression. If it’s not the case, String::replace does exactly the same thing as String::replaceAll without the performance drawback of the regex.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
