### PR TITLE
Replace lambda statements with expression lambdas where applicable

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BLockStore.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BLockStore.java
@@ -45,9 +45,7 @@ public class BLockStore {
     }
 
     public BLock getLockFromMap(String lockName) {
-        return globalLockMap.computeIfAbsent(lockName, (k) -> {
-            return new BLock();
-        });
+        return globalLockMap.computeIfAbsent(lockName, (k) -> new BLock());
     }
 
     public void panicIfInLock(Strand strand) {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/launcher/LauncherUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/launcher/LauncherUtils.java
@@ -124,9 +124,7 @@ public class LauncherUtils {
             toolNames.forEach(toolName ->
                 balToolsManifest.getActiveTool(toolName).ifPresent(tool ->
                     activeToolsVsRepos.put(toolName, tool.repository() == null ? "" : "[" + tool.repository()
-                            .toUpperCase() + "] ")
-                )
-            );
+                            .toUpperCase() + "] ")));
             helpBuilder.append("\n\n   Tool Commands:");
             toolNames.forEach(key -> generateCommandDescription(subCommands.get(key), helpBuilder,
                     activeToolsVsRepos.get(key)));

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/launcher/LauncherUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/launcher/LauncherUtils.java
@@ -121,12 +121,12 @@ public class LauncherUtils {
                 .sorted().toList();
 
         if (!toolNames.isEmpty()) {
-            toolNames.forEach(toolName -> {
-                balToolsManifest.getActiveTool(toolName).ifPresent(tool -> {
+            toolNames.forEach(toolName ->
+                balToolsManifest.getActiveTool(toolName).ifPresent(tool ->
                     activeToolsVsRepos.put(toolName, tool.repository() == null ? "" : "[" + tool.repository()
-                            .toUpperCase() + "] ");
-                });
-            });
+                            .toUpperCase() + "] ")
+                )
+            );
             helpBuilder.append("\n\n   Tool Commands:");
             toolNames.forEach(key -> generateCommandDescription(subCommands.get(key), helpBuilder,
                     activeToolsVsRepos.get(key)));

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
@@ -477,9 +477,7 @@ public class TestCommandTest extends BaseCommandTest {
         int exitCode = -1;
         try {
             try (BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                br.lines().forEach(line -> {
-                    output.append(line).append("\n");
-                });
+                br.lines().forEach(line -> output.append(line).append("\n"));
             }
             exitCode = process.waitFor();
         } catch (InterruptedException e) {
@@ -537,9 +535,7 @@ public class TestCommandTest extends BaseCommandTest {
         int exitCode = -1;
         try {
             try (BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                br.lines().forEach(line -> {
-                    output.append(line).append("\n");
-                });
+                br.lines().forEach(line -> output.append(line).append("\n"));
             }
             exitCode = process.waitFor();
         } catch (InterruptedException e) {
@@ -627,9 +623,7 @@ public class TestCommandTest extends BaseCommandTest {
             int exitCode = -1;
             try {
                 try (BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                    br.lines().forEach(line -> {
-                        output.append(line).append("\n");
-                    });
+                    br.lines().forEach(line -> output.append(line).append("\n"));
                 }
                 exitCode = process.waitFor();
             } catch (InterruptedException e) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
@@ -113,9 +113,7 @@ public class BallerinaRecordTypeSymbol extends AbstractStructuredTypeSymbol impl
             joiner.add(ballerinaFieldSignature);
         }
 
-        restTypeDescriptor().ifPresent(typeDescriptor -> {
-            joiner.add(typeDescriptor.signature() + "...;");
-        });
+        restTypeDescriptor().ifPresent(typeDescriptor -> joiner.add(typeDescriptor.signature() + "...;"));
 
         return "record " + joiner.toString();
     }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/model/Manifest.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/model/Manifest.java
@@ -105,10 +105,10 @@ public class Manifest {
                         "\nSupported platforms : " + supportedPlatforms());
             }
             // Check if module have platform specific libraries
-            List<Library> deps = platform.libraries.stream().filter(library -> {
-                return library.getModules() == null ||
-                        Arrays.stream(library.getModules()).anyMatch(moduleName::equals);
-            }).collect(Collectors.toList());
+            List<Library> deps = platform.libraries.stream().filter(library ->
+                library.getModules() == null ||
+                        Arrays.stream(library.getModules()).anyMatch(moduleName::equals)
+            ).collect(Collectors.toList());
             // If not return any
             if (!deps.isEmpty()) {
                 return platform.target;

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/model/Manifest.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/model/Manifest.java
@@ -105,10 +105,8 @@ public class Manifest {
                         "\nSupported platforms : " + supportedPlatforms());
             }
             // Check if module have platform specific libraries
-            List<Library> deps = platform.libraries.stream().filter(library ->
-                library.getModules() == null ||
-                        Arrays.stream(library.getModules()).anyMatch(moduleName::equals)
-            ).toList();
+            List<Library> deps = platform.libraries.stream().filter(library -> library.getModules() == null ||
+                Arrays.stream(library.getModules()).anyMatch(moduleName::equals)).toList();
             // If not return any
             if (!deps.isEmpty()) {
                 return platform.target;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1072,9 +1072,7 @@ public class Desugar extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangObjectTypeNode objectTypeNode) {
-        objectTypeNode.fields.forEach(field -> {
-            rewrite(field, env);
-        });
+        objectTypeNode.fields.forEach(field -> rewrite(field, env));
         // Merge the fields defined within the object and the fields that
         // get inherited via the type references.
         objectTypeNode.fields.addAll(objectTypeNode.includedFields);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
@@ -1354,8 +1354,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
 
         Optional<TypeDescriptorNode> typeReference = objectConstructorExpressionNode.typeReference();
         typeReference.ifPresent(typeReferenceNode ->
-                objectCtorExpression.addTypeReference(createTypeNode(typeReferenceNode))
-        );
+            objectCtorExpression.addTypeReference(createTypeNode(typeReferenceNode)));
 
         anonClass.annAttachments = applyAll(objectConstructorExpressionNode.annotations());
 //        addToTop(anonClass);
@@ -1725,8 +1724,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         foreach.setCollection(createExpression(forEachStatementNode.actionOrExpressionNode()));
 
         forEachStatementNode.onFailClause().ifPresent(onFailClauseNode -> foreach.setOnFailClause(
-                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
-        );
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this))));
 
         return foreach;
     }
@@ -2947,8 +2945,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         bLBlockStmt.pos = getPosition(doStatementNode.blockStatement());
         bLDo.setBody(bLBlockStmt);
         doStatementNode.onFailClause().ifPresent(onFailClauseNode -> bLDo.setOnFailClause(
-                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
-        );
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this))));
         return bLDo;
     }
 
@@ -2970,8 +2967,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         bLBlockStmt.pos = getPosition(whileStmtNode.whileBody());
         bLWhile.setBody(bLBlockStmt);
         whileStmtNode.onFailClause().ifPresent(onFailClauseNode -> bLWhile.setOnFailClause(
-                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
-        );
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this))));
         return bLWhile;
     }
 
@@ -3020,8 +3016,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         lockNode.setBody(lockBlock);
 
         lockStatementNode.onFailClause().ifPresent(onFailClauseNode -> lockNode.setOnFailClause(
-                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
-        );
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this))));
 
         return lockNode;
     }
@@ -3279,8 +3274,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         transaction.pos = getPosition(transactionStatementNode);
 
         transactionStatementNode.onFailClause().ifPresent(onFailClauseNode -> transaction.setOnFailClause(
-                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
-        );
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this))));
 
         return transaction;
     }
@@ -4381,8 +4375,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         retryNode.setRetryBody(retryBlock);
 
         retryStatementNode.onFailClause().ifPresent(onFailClauseNode -> retryNode.setOnFailClause(
-                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
-        );
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this))));
 
         return retryNode;
     }
@@ -4502,8 +4495,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         }
 
         matchStatementNode.onFailClause().ifPresent(onFailClauseNode -> matchStatement.setOnFailClause(
-                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
-        );
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this))));
         matchStatement.pos = getPosition(matchStatementNode);
         return matchStatement;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
@@ -1353,9 +1353,9 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         anonClass.isObjectContructorDecl = true; // not available for service
 
         Optional<TypeDescriptorNode> typeReference = objectConstructorExpressionNode.typeReference();
-        typeReference.ifPresent(typeReferenceNode -> {
-            objectCtorExpression.addTypeReference(createTypeNode(typeReferenceNode));
-        });
+        typeReference.ifPresent(typeReferenceNode ->
+                objectCtorExpression.addTypeReference(createTypeNode(typeReferenceNode))
+        );
 
         anonClass.annAttachments = applyAll(objectConstructorExpressionNode.annotations());
 //        addToTop(anonClass);
@@ -1724,10 +1724,9 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         foreach.setBody(foreachBlock);
         foreach.setCollection(createExpression(forEachStatementNode.actionOrExpressionNode()));
 
-        forEachStatementNode.onFailClause().ifPresent(onFailClauseNode -> {
-            foreach.setOnFailClause(
-                    (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)));
-        });
+        forEachStatementNode.onFailClause().ifPresent(onFailClauseNode -> foreach.setOnFailClause(
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
+        );
 
         return foreach;
     }
@@ -2947,10 +2946,9 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         BLangBlockStmt bLBlockStmt = (BLangBlockStmt) doStatementNode.blockStatement().apply(this);
         bLBlockStmt.pos = getPosition(doStatementNode.blockStatement());
         bLDo.setBody(bLBlockStmt);
-        doStatementNode.onFailClause().ifPresent(onFailClauseNode -> {
-            bLDo.setOnFailClause(
-                    (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)));
-        });
+        doStatementNode.onFailClause().ifPresent(onFailClauseNode -> bLDo.setOnFailClause(
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
+        );
         return bLDo;
     }
 
@@ -2971,10 +2969,9 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         BLangBlockStmt bLBlockStmt = (BLangBlockStmt) whileStmtNode.whileBody().apply(this);
         bLBlockStmt.pos = getPosition(whileStmtNode.whileBody());
         bLWhile.setBody(bLBlockStmt);
-        whileStmtNode.onFailClause().ifPresent(onFailClauseNode -> {
-            bLWhile.setOnFailClause(
-                    (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)));
-        });
+        whileStmtNode.onFailClause().ifPresent(onFailClauseNode -> bLWhile.setOnFailClause(
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
+        );
         return bLWhile;
     }
 
@@ -3022,10 +3019,9 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         lockBlock.pos = getPosition(lockStatementNode.blockStatement());
         lockNode.setBody(lockBlock);
 
-        lockStatementNode.onFailClause().ifPresent(onFailClauseNode -> {
-            lockNode.setOnFailClause(
-                    (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)));
-        });
+        lockStatementNode.onFailClause().ifPresent(onFailClauseNode -> lockNode.setOnFailClause(
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
+        );
 
         return lockNode;
     }
@@ -3282,10 +3278,9 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         transaction.setTransactionBody(transactionBlock);
         transaction.pos = getPosition(transactionStatementNode);
 
-        transactionStatementNode.onFailClause().ifPresent(onFailClauseNode -> {
-            transaction.setOnFailClause(
-                    (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)));
-        });
+        transactionStatementNode.onFailClause().ifPresent(onFailClauseNode -> transaction.setOnFailClause(
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
+        );
 
         return transaction;
     }
@@ -4385,10 +4380,9 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         BLangBlockStmt retryBlock = (BLangBlockStmt) retryBody.apply(this);
         retryNode.setRetryBody(retryBlock);
 
-        retryStatementNode.onFailClause().ifPresent(onFailClauseNode -> {
-            retryNode.setOnFailClause(
-                    (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)));
-        });
+        retryStatementNode.onFailClause().ifPresent(onFailClauseNode -> retryNode.setOnFailClause(
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
+        );
 
         return retryNode;
     }
@@ -4507,10 +4501,9 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
             matchStatement.addMatchClause(bLangMatchClause);
         }
 
-        matchStatementNode.onFailClause().ifPresent(onFailClauseNode -> {
-            matchStatement.setOnFailClause(
-                    (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)));
-        });
+        matchStatementNode.onFailClause().ifPresent(onFailClauseNode -> matchStatement.setOnFailClause(
+                (org.ballerinalang.model.clauses.OnFailClauseNode) (onFailClauseNode.apply(this)))
+        );
         matchStatement.pos = getPosition(matchStatementNode);
         return matchStatement;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -4583,8 +4583,7 @@ public class Types {
                     Set<BType> constraintUnionTypes =
                             expandAndGetMemberTypesRecursiveHelper(mapConstraintType, visited);
                     constraintUnionTypes.forEach(constraintUnionType ->
-                        memberTypes.add(new BMapType(TypeTags.MAP, constraintUnionType, symTable.mapType.tsymbol))
-                    );
+                        memberTypes.add(new BMapType(TypeTags.MAP, constraintUnionType, symTable.mapType.tsymbol)));
                 }
                 memberTypes.add(bType);
                 break;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -4552,18 +4552,16 @@ public class Types {
                 break;
             case TypeTags.FINITE:
                 BFiniteType expType = (BFiniteType) referredType;
-                expType.getValueSpace().forEach(value -> {
-                    memberTypes.add(value.getBType());
-                });
+                expType.getValueSpace().forEach(value -> memberTypes.add(value.getBType()));
                 break;
             case TypeTags.UNION:
                 BUnionType unionType = (BUnionType) referredType;
                 if (!visited.add(unionType)) {
                     return memberTypes;
                 }
-                unionType.getMemberTypes().forEach(member -> {
-                    memberTypes.addAll(expandAndGetMemberTypesRecursiveHelper(member, visited));
-                });
+                unionType.getMemberTypes().forEach(member ->
+                    memberTypes.addAll(expandAndGetMemberTypesRecursiveHelper(member, visited))
+                );
                 break;
             case TypeTags.ARRAY:
                 BType arrayElementType = ((BArrayType) referredType).getElementType();
@@ -4576,9 +4574,7 @@ public class Types {
 
                 if (getImpliedType(arrayElementType).tag == TypeTags.UNION) {
                     Set<BType> elementUnionTypes = expandAndGetMemberTypesRecursiveHelper(arrayElementType, visited);
-                    elementUnionTypes.forEach(elementUnionType -> {
-                        memberTypes.add(new BArrayType(elementUnionType));
-                    });
+                    elementUnionTypes.forEach(elementUnionType -> memberTypes.add(new BArrayType(elementUnionType)));
                 }
                 memberTypes.add(bType);
                 break;
@@ -4587,9 +4583,9 @@ public class Types {
                 if (getImpliedType(mapConstraintType).tag == TypeTags.UNION) {
                     Set<BType> constraintUnionTypes =
                             expandAndGetMemberTypesRecursiveHelper(mapConstraintType, visited);
-                    constraintUnionTypes.forEach(constraintUnionType -> {
-                        memberTypes.add(new BMapType(TypeTags.MAP, constraintUnionType, symTable.mapType.tsymbol));
-                    });
+                    constraintUnionTypes.forEach(constraintUnionType ->
+                        memberTypes.add(new BMapType(TypeTags.MAP, constraintUnionType, symTable.mapType.tsymbol))
+                    );
                 }
                 memberTypes.add(bType);
                 break;

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/ProjectUtilsTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/ProjectUtilsTests.java
@@ -71,17 +71,13 @@ public class ProjectUtilsTests {
     @Test()
     public void testReadBuildJsonForNonExistingBuildFile() {
         Path buildFilePath = PROJECT_UTILS_RESOURCES.resolve("xyz").resolve(ProjectConstants.BUILD_FILE);
-        Assert.assertThrows(IOException.class, () -> {
-            ProjectUtils.readBuildJson(buildFilePath);
-        });
+        Assert.assertThrows(IOException.class, () -> ProjectUtils.readBuildJson(buildFilePath));
     }
 
     @Test()
     public void testReadBuildJsonForInvalidBuildFile() {
         Path buildFilePath = PROJECT_UTILS_RESOURCES.resolve("invalid-build");
-        Assert.assertThrows(JsonSyntaxException.class, () -> {
-            ProjectUtils.readBuildJson(buildFilePath);
-        });
+        Assert.assertThrows(JsonSyntaxException.class, () -> ProjectUtils.readBuildJson(buildFilePath));
     }
 
     @Test()

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CompilerPluginCodeActionExtension.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CompilerPluginCodeActionExtension.java
@@ -119,8 +119,7 @@ public class CompilerPluginCodeActionExtension implements CodeActionExtension {
                     codeActionResult.getErrors().forEach(ex ->
                         clientLogger.logError(LSContextOperation.TXT_CODE_ACTION,
                                 "Exception thrown while getting code action: '%s'" + ex.getCodeActionName(),
-                                ex.getCause(), new TextDocumentIdentifier(context.fileUri()))
-                    );
+                                ex.getCause(), new TextDocumentIdentifier(context.fileUri())));
                 })
                 .flatMap(codeActionResult -> codeActionResult.getCodeActions().stream())
                 .map(codeActionInfo -> {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CompilerPluginCodeActionExtension.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CompilerPluginCodeActionExtension.java
@@ -116,11 +116,11 @@ public class CompilerPluginCodeActionExtension implements CodeActionExtension {
                 })
                 .peek(codeActionResult -> {
                     // Log all the errors captured while calculating code actions
-                    codeActionResult.getErrors().forEach(ex -> {
+                    codeActionResult.getErrors().forEach(ex ->
                         clientLogger.logError(LSContextOperation.TXT_CODE_ACTION,
                                 "Exception thrown while getting code action: '%s'" + ex.getCodeActionName(),
-                                ex.getCause(), new TextDocumentIdentifier(context.fileUri()));
-                    });
+                                ex.getCause(), new TextDocumentIdentifier(context.fileUri()))
+                    );
                 })
                 .flatMap(codeActionResult -> codeActionResult.getCodeActions().stream())
                 .map(codeActionInfo -> {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
@@ -134,8 +134,7 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
         LinkedHashMap<String, List<TextEdit>> textEditMap = new LinkedHashMap<>();
         nodeList.forEach(extractableNode ->
             textEditMap.put(extractableNode.toSourceCode().strip(),
-                    getTextEdits(extractableNode, typeSymbol.get(), constName, constDeclPosition, addNewLineAtStart))
-        );
+                    getTextEdits(extractableNode, typeSymbol.get(), constName, constDeclPosition, addNewLineAtStart)));
 
         if (lsClientCapabilities.getInitializationOptions().isPositionalRefactorRenameSupported()) {
             LinkedHashMap<String, Position> renamePositionMap = new LinkedHashMap<>();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
@@ -132,10 +132,10 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
         }
 
         LinkedHashMap<String, List<TextEdit>> textEditMap = new LinkedHashMap<>();
-        nodeList.forEach(extractableNode -> {
+        nodeList.forEach(extractableNode ->
             textEditMap.put(extractableNode.toSourceCode().strip(),
-                    getTextEdits(extractableNode, typeSymbol.get(), constName, constDeclPosition, addNewLineAtStart));
-        });
+                    getTextEdits(extractableNode, typeSymbol.get(), constName, constDeclPosition, addNewLineAtStart))
+        );
 
         if (lsClientCapabilities.getInitializationOptions().isPositionalRefactorRenameSupported()) {
             LinkedHashMap<String, Position> renamePositionMap = new LinkedHashMap<>();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/RecordUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/RecordUtil.java
@@ -59,9 +59,9 @@ public class RecordUtil {
                                                                Map<RecordField.RecordFieldIdentifier,
                                                                List<RecordField>> fieldsMap) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
-        fieldsMap.forEach((recordFieldIdentifier, fields) -> {
-            completionItems.add(getRecordFieldCompletionItem(context, recordFieldIdentifier, fields));
-        });
+        fieldsMap.forEach((recordFieldIdentifier, fields) ->
+            completionItems.add(getRecordFieldCompletionItem(context, recordFieldIdentifier, fields))
+        );
 
         return completionItems;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/RecordUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/RecordUtil.java
@@ -60,8 +60,7 @@ public class RecordUtil {
                                                                List<RecordField>> fieldsMap) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         fieldsMap.forEach((recordFieldIdentifier, fields) ->
-            completionItems.add(getRecordFieldCompletionItem(context, recordFieldIdentifier, fields))
-        );
+            completionItems.add(getRecordFieldCompletionItem(context, recordFieldIdentifier, fields)));
 
         return completionItems;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
@@ -163,9 +163,9 @@ public class ServiceTemplateGenerator {
                     || moduleInfo.isModuleFromCurrentPackage()) {
                 return;
             }
-            moduleInfo.getListenerMetaData().forEach(listenerMetaData -> {
-                completionItems.add(generateServiceSnippet(listenerMetaData, ctx));
-            });
+            moduleInfo.getListenerMetaData().forEach(listenerMetaData ->
+                completionItems.add(generateServiceSnippet(listenerMetaData, ctx))
+            );
             processedModuleList.add(moduleInfo.getModuleIdentifier());
         });
         return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
@@ -163,8 +163,7 @@ public class ServiceTemplateGenerator {
                 return;
             }
             moduleInfo.getListenerMetaData().forEach(listenerMetaData ->
-                completionItems.add(generateServiceSnippet(listenerMetaData, ctx))
-            );
+                completionItems.add(generateServiceSnippet(listenerMetaData, ctx)));
             processedModuleList.add(moduleInfo.getModuleIdentifier());
         });
         return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolResolver.java
@@ -409,9 +409,7 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
      */
     private List<DocumentSymbol> transformMembers(NodeList<? extends Node> nodes) {
         List<DocumentSymbol> childSymbols = new ArrayList<>();
-        nodes.forEach(node -> {
-            node.apply(this).ifPresent(childSymbols::add);
-        });
+        nodes.forEach(node -> node.apply(this).ifPresent(childSymbols::add));
         return childSymbols;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorService.java
@@ -271,9 +271,9 @@ public class BallerinaConnectorService implements ExtendedLanguageServerService 
 
                 Map<String, JsonElement> recordDefJsonMap = new HashMap<>();
                 ConnectorNodeVisitor connectorNodeVisitor = new ConnectorNodeVisitor(request.getName(), semanticModel);
-                module.documentIds().forEach(documentId -> {
-                    module.document(documentId).syntaxTree().rootNode().accept(connectorNodeVisitor);
-                });
+                module.documentIds().forEach(documentId ->
+                        module.document(documentId).syntaxTree().rootNode().accept(connectorNodeVisitor)
+                );
 
 
                 TypeDefinitionNode recordNode = null;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorService.java
@@ -272,8 +272,7 @@ public class BallerinaConnectorService implements ExtendedLanguageServerService 
                 Map<String, JsonElement> recordDefJsonMap = new HashMap<>();
                 ConnectorNodeVisitor connectorNodeVisitor = new ConnectorNodeVisitor(request.getName(), semanticModel);
                 module.documentIds().forEach(documentId ->
-                        module.document(documentId).syntaxTree().rootNode().accept(connectorNodeVisitor)
-                );
+                    module.document(documentId).syntaxTree().rootNode().accept(connectorNodeVisitor));
 
 
                 TypeDefinitionNode recordNode = null;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentService.java
@@ -336,7 +336,7 @@ public class BallerinaDocumentService implements ExtendedLanguageServerService {
                 Optional<Project> project = workspaceManager.project(filePath.get());
 
                 // Loop through project modules to find the document of the function declaration
-                project.get().currentPackage().modules().forEach(module -> {
+                project.get().currentPackage().modules().forEach(module ->
                     module.documentIds().forEach(id -> {
                         Document document = module.document(id);
                         if (functionPath.equals(document.name())) {
@@ -375,8 +375,8 @@ public class BallerinaDocumentService implements ExtendedLanguageServerService {
                                 }
                             });
                         }
-                    });
-                });
+                    })
+                );
                 return reply;
             } catch (Throwable e) {
                 reply.setParseSuccess(false);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentService.java
@@ -375,8 +375,7 @@ public class BallerinaDocumentService implements ExtendedLanguageServerService {
                                 }
                             });
                         }
-                    })
-                );
+                    }));
                 return reply;
             } catch (Throwable e) {
                 reply.setParseSuccess(false);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/ExecutorPositionsUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/ExecutorPositionsUtil.java
@@ -172,8 +172,7 @@ public class ExecutorPositionsUtil {
         TestCaseVisitor testCaseVisitor = new TestCaseVisitor(execPositions, filePath);
         if (project.kind() == ProjectKind.SINGLE_FILE_PROJECT) {
             module.documentIds().forEach(documentId ->
-                testCaseVisitor.visitTestCases(module.document(documentId).syntaxTree().rootNode())
-            );
+                testCaseVisitor.visitTestCases(module.document(documentId).syntaxTree().rootNode()));
 
         } else if (project.kind() == ProjectKind.BUILD_PROJECT) {
             module.testDocumentIds().forEach(testDocumentId -> {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/ExecutorPositionsUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/ExecutorPositionsUtil.java
@@ -172,9 +172,9 @@ public class ExecutorPositionsUtil {
                 module.moduleName().moduleNamePart();
         TestCaseVisitor testCaseVisitor = new TestCaseVisitor(execPositions, filePath);
         if (project.kind() == ProjectKind.SINGLE_FILE_PROJECT) {
-            module.documentIds().forEach(documentId -> {
-                testCaseVisitor.visitTestCases(module.document(documentId).syntaxTree().rootNode());
-            });
+            module.documentIds().forEach(documentId ->
+                testCaseVisitor.visitTestCases(module.document(documentId).syntaxTree().rootNode())
+            );
 
         } else if (project.kind() == ProjectKind.BUILD_PROJECT) {
             module.testDocumentIds().forEach(testDocumentId -> {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
@@ -179,15 +179,11 @@ public class UnusedSymbolsVisitor extends NodeVisitor {
     @Override
     public void visit(ModulePartNode modulePartNode) {
         if (!modulePartNode.imports().isEmpty()) {
-            modulePartNode.imports().forEach(importDeclarationNode -> {
-                importDeclarationNode.accept(this);
-            });
+            modulePartNode.imports().forEach(importDeclarationNode -> importDeclarationNode.accept(this));
         }
 
         if (!modulePartNode.members().isEmpty()) {
-            modulePartNode.members().forEach(moduleMemberDeclarationNode -> {
-                moduleMemberDeclarationNode.accept(this);
-            });
+            modulePartNode.members().forEach(moduleMemberDeclarationNode -> moduleMemberDeclarationNode.accept(this));
         }
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/packages/BallerinaPackageService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/packages/BallerinaPackageService.java
@@ -96,7 +96,7 @@ public class BallerinaPackageService implements ExtendedLanguageServerService {
             JsonArray jsonPackages = new JsonArray();
             TextDocumentIdentifier[] documentIdentifiers = request.getDocumentIdentifiers();
             try {
-                Arrays.stream(documentIdentifiers).iterator().forEachRemaining(documentIdentifier -> {
+                Arrays.stream(documentIdentifiers).iterator().forEachRemaining(documentIdentifier ->
                     PathUtil.getPathFromURI(documentIdentifier.getUri()).ifPresent(path -> {
                         Project project = null;
                         try {
@@ -106,8 +106,8 @@ public class BallerinaPackageService implements ExtendedLanguageServerService {
                             String msg = "Operation 'ballerinaPackage/components' load project failed!";
                             this.clientLogger.logError(PackageContext.PACKAGE_COMPONENTS, msg, e, null);
                         }
-                    });
-                });
+                    })
+                );
             } catch (Throwable e) {
                 String msg = "Operation 'ballerinaPackage/components' failed!";
                 this.clientLogger.logError(PackageContext.PACKAGE_COMPONENTS, msg, e, null, (Position) null);
@@ -167,10 +167,9 @@ public class BallerinaPackageService implements ExtendedLanguageServerService {
             if (module.moduleName().moduleNamePart() != null) {
                 moduleObject.setName(module.moduleName().moduleNamePart());
             }
-            module.documentIds().forEach(documentId -> {
-                new DocumentComponentTransformer(moduleObject)
-                        .getModuleObject(module.document(documentId).syntaxTree().rootNode());
-            });
+            module.documentIds().forEach(documentId -> new DocumentComponentTransformer(moduleObject)
+                    .getModuleObject(module.document(documentId).syntaxTree().rootNode())
+            );
             packageObject.addModule(moduleObject);
         });
         return new Gson().toJsonTree(packageObject).getAsJsonObject();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/packages/BallerinaPackageService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/packages/BallerinaPackageService.java
@@ -106,8 +106,7 @@ public class BallerinaPackageService implements ExtendedLanguageServerService {
                             String msg = "Operation 'ballerinaPackage/components' load project failed!";
                             this.clientLogger.logError(PackageContext.PACKAGE_COMPONENTS, msg, e, null);
                         }
-                    })
-                );
+                    }));
             } catch (Throwable e) {
                 String msg = "Operation 'ballerinaPackage/components' failed!";
                 this.clientLogger.logError(PackageContext.PACKAGE_COMPONENTS, msg, e, null, (Position) null);
@@ -168,8 +167,7 @@ public class BallerinaPackageService implements ExtendedLanguageServerService {
                 moduleObject.setName(module.moduleName().moduleNamePart());
             }
             module.documentIds().forEach(documentId -> new DocumentComponentTransformer(moduleObject)
-                    .getModuleObject(module.document(documentId).syntaxTree().rootNode())
-            );
+                    .getModuleObject(module.document(documentId).syntaxTree().rootNode()));
             packageObject.addModule(moduleObject);
         });
         return new Gson().toJsonTree(packageObject).getAsJsonObject();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolService.java
@@ -406,14 +406,12 @@ public class BallerinaSymbolService implements ExtendedLanguageServerService {
                 parameterSymbolList
                         .subList(skipFirstParam(symbolAtCursor, nodeAtCursor) ? 1 : 0, parameterSymbolList.size())
                         .stream().filter((parameterSymbol) -> parameterSymbol.getName().isPresent())
-                        .forEach(parameterSymbol -> {
-
-                            symbolParams.add(new SymbolDocumentation.ParameterInfo(
-                                    parameterSymbol.getName().get(),
-                                    documentation.get().parameterMap().get(parameterSymbol.getName().get()),
-                                    parameterSymbol.paramKind().name(),
-                                    NameUtil.getModifiedTypeName(context, parameterSymbol.typeDescriptor())));
-                        });
+                        .forEach(parameterSymbol -> symbolParams.add(new SymbolDocumentation.ParameterInfo(
+                                parameterSymbol.getName().get(),
+                                documentation.get().parameterMap().get(parameterSymbol.getName().get()),
+                                parameterSymbol.paramKind().name(),
+                                NameUtil.getModifiedTypeName(context, parameterSymbol.typeDescriptor())))
+                        );
             }
 
             Optional<ParameterSymbol> restParam = functionSymbol.typeDescriptor().restParam();
@@ -431,9 +429,9 @@ public class BallerinaSymbolService implements ExtendedLanguageServerService {
         List<SymbolDocumentation.ParameterInfo> deprecatedParams = new ArrayList<>(
                 documentation.get().deprecatedParametersMap().size());
         Map<String, String> deprecatedParamMap = documentation.get().deprecatedParametersMap();
-        deprecatedParamMap.forEach((param, desc) -> {
-            deprecatedParams.add(new SymbolDocumentation.ParameterInfo(param, desc));
-        });
+        deprecatedParamMap.forEach((param, desc) ->
+            deprecatedParams.add(new SymbolDocumentation.ParameterInfo(param, desc))
+        );
 
         SymbolDocumentation symbolDoc = new SymbolDocumentation(documentation.get(), symbolParams,
                 deprecatedParams);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolService.java
@@ -410,8 +410,7 @@ public class BallerinaSymbolService implements ExtendedLanguageServerService {
                                 parameterSymbol.getName().get(),
                                 documentation.get().parameterMap().get(parameterSymbol.getName().get()),
                                 parameterSymbol.paramKind().name(),
-                                NameUtil.getModifiedTypeName(context, parameterSymbol.typeDescriptor())))
-                        );
+                                NameUtil.getModifiedTypeName(context, parameterSymbol.typeDescriptor()))));
             }
 
             Optional<ParameterSymbol> restParam = functionSymbol.typeDescriptor().restParam();
@@ -430,8 +429,7 @@ public class BallerinaSymbolService implements ExtendedLanguageServerService {
                 documentation.get().deprecatedParametersMap().size());
         Map<String, String> deprecatedParamMap = documentation.get().deprecatedParametersMap();
         deprecatedParamMap.forEach((param, desc) ->
-            deprecatedParams.add(new SymbolDocumentation.ParameterInfo(param, desc))
-        );
+            deprecatedParams.add(new SymbolDocumentation.ParameterInfo(param, desc)));
 
         SymbolDocumentation symbolDoc = new SymbolDocumentation(documentation.get(), symbolParams,
                 deprecatedParams);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/semantictokens/SemanticTokensVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/semantictokens/SemanticTokensVisitor.java
@@ -128,8 +128,7 @@ public class SemanticTokensVisitor extends NodeVisitor {
             functionDefinitionNode.relativeResourcePath().stream()
                     .filter(resourcePath -> resourcePath.kind() == SyntaxKind.IDENTIFIER_TOKEN)
                     .forEach(resourcePath ->
-                    this.addSemanticToken(resourcePath, type, TokenTypeModifiers.DECLARATION.getId(), false, -1, -1)
-            );
+                    this.addSemanticToken(resourcePath, type, TokenTypeModifiers.DECLARATION.getId(), false, -1, -1));
         } else {
             this.addSemanticToken(functionDefinitionNode.functionName(), type, TokenTypeModifiers.DECLARATION.getId(),
                     true, type, 0);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/semantictokens/SemanticTokensVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/semantictokens/SemanticTokensVisitor.java
@@ -127,9 +127,9 @@ public class SemanticTokensVisitor extends NodeVisitor {
                     false, -1, -1);
             functionDefinitionNode.relativeResourcePath().stream()
                     .filter(resourcePath -> resourcePath.kind() == SyntaxKind.IDENTIFIER_TOKEN)
-                    .forEach(resourcePath -> {
-                    this.addSemanticToken(resourcePath, type, TokenTypeModifiers.DECLARATION.getId(), false, -1, -1);
-            });
+                    .forEach(resourcePath ->
+                    this.addSemanticToken(resourcePath, type, TokenTypeModifiers.DECLARATION.getId(), false, -1, -1)
+            );
         } else {
             this.addSemanticToken(functionDefinitionNode.functionName(), type, TokenTypeModifiers.DECLARATION.getId(),
                     true, type, 0);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/TestUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/TestUtil.java
@@ -457,9 +457,7 @@ public class TestUtil {
     public static String getPackageComponentsResponse(Endpoint serviceEndpoint, Iterator<String> filePaths) {
         PackageComponentsRequest packageComponentsRequest = new PackageComponentsRequest();
         List<TextDocumentIdentifier> documentIdentifiers = new ArrayList<>();
-        filePaths.forEachRemaining(filePath -> {
-            documentIdentifiers.add(getTextDocumentIdentifier(filePath));
-        });
+        filePaths.forEachRemaining(filePath -> documentIdentifiers.add(getTextDocumentIdentifier(filePath)));
         packageComponentsRequest.setDocumentIdentifiers(documentIdentifiers.toArray(new TextDocumentIdentifier[0]));
         return getResponseString(serviceEndpoint.request(PACKAGE_COMPONENTS, packageComponentsRequest));
     }

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -654,8 +654,7 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
         } else {
             JsonElement memberValues = node.apply(this);
             memberValues.getAsJsonObject().entrySet().forEach(memberEntry ->
-                nodeInfo.add(memberEntry.getKey(), memberEntry.getValue())
-            );
+                nodeInfo.add(memberEntry.getKey(), memberEntry.getValue()));
         }
         // Skip trailing minutiae if node doesn't have trailing minutiae (eg: ReTag)
         try {

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -653,9 +653,9 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
             }
         } else {
             JsonElement memberValues = node.apply(this);
-            memberValues.getAsJsonObject().entrySet().forEach(memberEntry -> {
-                nodeInfo.add(memberEntry.getKey(), memberEntry.getValue());
-            });
+            memberValues.getAsJsonObject().entrySet().forEach(memberEntry ->
+                nodeInfo.add(memberEntry.getKey(), memberEntry.getValue())
+            );
         }
         // Skip trailing minutiae if node doesn't have trailing minutiae (eg: ReTag)
         try {

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/FunctionComparator.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/FunctionComparator.java
@@ -168,9 +168,9 @@ public class FunctionComparator extends NodeComparator<FunctionDefinitionNode> {
         List<ParameterNode> oldParams = oldNode.functionSignature().parameters().stream().collect(Collectors.toList());
 
         ParamListComparator paramComparator = new ParamListComparator(newParams, oldParams);
-        paramComparator.computeDiff().ifPresent(diff -> {
-            paramDiffs.addAll(extractTerminalDiffs(diff, new LinkedList<>()));
-        });
+        paramComparator.computeDiff().ifPresent(diff ->
+            paramDiffs.addAll(extractTerminalDiffs(diff, new LinkedList<>()))
+        );
 
         return paramDiffs;
     }

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/FunctionComparator.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/FunctionComparator.java
@@ -169,8 +169,7 @@ public class FunctionComparator extends NodeComparator<FunctionDefinitionNode> {
 
         ParamListComparator paramComparator = new ParamListComparator(newParams, oldParams);
         paramComparator.computeDiff().ifPresent(diff ->
-            paramDiffs.addAll(extractTerminalDiffs(diff, new LinkedList<>()))
-        );
+            paramDiffs.addAll(extractTerminalDiffs(diff, new LinkedList<>())));
 
         return paramDiffs;
     }

--- a/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TesterinaCodeAnalyzer.java
+++ b/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TesterinaCodeAnalyzer.java
@@ -53,14 +53,12 @@ public class TesterinaCodeAnalyzer extends CodeAnalyzer {
             if (syntaxNodeAnalysisContext.node() instanceof ClassDefinitionNode) {
                 ClassDefinitionNode classDefinitionNode = (ClassDefinitionNode) syntaxNodeAnalysisContext.node();
                 classDefinitionNode.members().forEach(member ->
-                    validateTestAnnotation(syntaxNodeAnalysisContext, member)
-                );
+                    validateTestAnnotation(syntaxNodeAnalysisContext, member));
             } else if (syntaxNodeAnalysisContext.node() instanceof ServiceDeclarationNode) {
                 ServiceDeclarationNode serviceDeclarationNode =
                         (ServiceDeclarationNode) syntaxNodeAnalysisContext.node();
                 serviceDeclarationNode.members().forEach(member ->
-                    validateTestAnnotation(syntaxNodeAnalysisContext, member)
-                );
+                    validateTestAnnotation(syntaxNodeAnalysisContext, member));
             }
         }, Arrays.asList(SyntaxKind.CLASS_DEFINITION, SyntaxKind.SERVICE_DECLARATION));
     }
@@ -83,8 +81,7 @@ public class TesterinaCodeAnalyzer extends CodeAnalyzer {
                             syntaxNodeAnalysisContext.reportDiagnostic(diagnostic);
                         }
                     }
-                })
-            );
+                }));
         }
     }
 }

--- a/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TesterinaCodeAnalyzer.java
+++ b/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TesterinaCodeAnalyzer.java
@@ -52,15 +52,15 @@ public class TesterinaCodeAnalyzer extends CodeAnalyzer {
             // the class for functions
             if (syntaxNodeAnalysisContext.node() instanceof ClassDefinitionNode) {
                 ClassDefinitionNode classDefinitionNode = (ClassDefinitionNode) syntaxNodeAnalysisContext.node();
-                classDefinitionNode.members().forEach(member -> {
-                    validateTestAnnotation(syntaxNodeAnalysisContext, member);
-                });
+                classDefinitionNode.members().forEach(member ->
+                    validateTestAnnotation(syntaxNodeAnalysisContext, member)
+                );
             } else if (syntaxNodeAnalysisContext.node() instanceof ServiceDeclarationNode) {
                 ServiceDeclarationNode serviceDeclarationNode =
                         (ServiceDeclarationNode) syntaxNodeAnalysisContext.node();
-                serviceDeclarationNode.members().forEach(member -> {
-                    validateTestAnnotation(syntaxNodeAnalysisContext, member);
-                });
+                serviceDeclarationNode.members().forEach(member ->
+                    validateTestAnnotation(syntaxNodeAnalysisContext, member)
+                );
             }
         }, Arrays.asList(SyntaxKind.CLASS_DEFINITION, SyntaxKind.SERVICE_DECLARATION));
     }
@@ -68,7 +68,7 @@ public class TesterinaCodeAnalyzer extends CodeAnalyzer {
     private static void validateTestAnnotation(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext, Node member) {
         if (member instanceof FunctionDefinitionNode) {
             FunctionDefinitionNode funcDefNode = (FunctionDefinitionNode) member;
-            funcDefNode.metadata().ifPresent(metadata -> {
+            funcDefNode.metadata().ifPresent(metadata ->
                 metadata.annotations().forEach(annotation -> {
                     if (annotation.annotReference().kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
                         QualifiedNameReferenceNode qualifiedNameReferenceNode =
@@ -83,8 +83,8 @@ public class TesterinaCodeAnalyzer extends CodeAnalyzer {
                             syntaxNodeAnalysisContext.reportDiagnostic(diagnostic);
                         }
                     }
-                });
-            });
+                })
+            );
         }
     }
 }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestSuite.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestSuite.java
@@ -336,9 +336,7 @@ public class TestSuite {
     }
 
     public void addTestExecutionDependencies(Collection<Path> dependencies) {
-        dependencies.forEach((path) -> {
-            this.testExecutionDependencies.add(path.toString());
-        });
+        dependencies.forEach((path) -> this.testExecutionDependencies.add(path.toString()));
     }
 
     public List<String> getTestExecutionDependencies() {

--- a/project-api/test-artifacts/compiler-plugin-with-two-dependencies/src/main/java/io/samjs/plugins/twodependencies/CompilerPluginWithTwoDependencies.java
+++ b/project-api/test-artifacts/compiler-plugin-with-two-dependencies/src/main/java/io/samjs/plugins/twodependencies/CompilerPluginWithTwoDependencies.java
@@ -95,12 +95,12 @@ public class CompilerPluginWithTwoDependencies extends CompilerPlugin {
                 }
             });
 
-            analysisContext.addSyntaxNodeAnalysisTask(syntaxNodeAnalysisContext -> {
+            analysisContext.addSyntaxNodeAnalysisTask(syntaxNodeAnalysisContext ->
                 syntaxNodeAnalysisContext.reportDiagnostic(
                         DiagnosticUtils.createDiagnostic("COMP_PLUGIN_2_SYNTAX_WARNING",
                                 "Local var decl test warning message",
-                                syntaxNodeAnalysisContext.node().location(), DiagnosticSeverity.WARNING));
-            }, SyntaxKind.LOCAL_VAR_DECL);
+                                syntaxNodeAnalysisContext.node().location(), DiagnosticSeverity.WARNING)),
+                    SyntaxKind.LOCAL_VAR_DECL);
         }
 
         SyntaxTree getSyntaxTree(Package currentPkg) {

--- a/project-api/test-artifacts/function-node-analyzer-compiler-plugin/src/main/java/io/samjs/plugins/funcnodeanalyzer/FunctionNodeAnalyzerPlugin.java
+++ b/project-api/test-artifacts/function-node-analyzer-compiler-plugin/src/main/java/io/samjs/plugins/funcnodeanalyzer/FunctionNodeAnalyzerPlugin.java
@@ -85,8 +85,7 @@ public class FunctionNodeAnalyzerPlugin extends CompilerPlugin {
                     syntaxNodeAnalysisContext.reportDiagnostic(
                             DiagnosticUtils.createDiagnostic("FUNC_NODE_INVALID_FUNC_CALL",
                                     "Function call related error message",
-                                    syntaxNodeAnalysisContext.node().location(), DiagnosticSeverity.ERROR)
-                );
+                                    syntaxNodeAnalysisContext.node().location(), DiagnosticSeverity.ERROR));
 
         private final AnalysisTask<SyntaxNodeAnalysisContext> moduleLevelNodeAnalysisTask =
                 syntaxNodeAnalysisContext -> {

--- a/project-api/test-artifacts/function-node-analyzer-compiler-plugin/src/main/java/io/samjs/plugins/funcnodeanalyzer/FunctionNodeAnalyzerPlugin.java
+++ b/project-api/test-artifacts/function-node-analyzer-compiler-plugin/src/main/java/io/samjs/plugins/funcnodeanalyzer/FunctionNodeAnalyzerPlugin.java
@@ -81,12 +81,12 @@ public class FunctionNodeAnalyzerPlugin extends CompilerPlugin {
         }
 
         private final AnalysisTask<SyntaxNodeAnalysisContext> functionCallAnalysisTask =
-                syntaxNodeAnalysisContext -> {
+                syntaxNodeAnalysisContext ->
                     syntaxNodeAnalysisContext.reportDiagnostic(
                             DiagnosticUtils.createDiagnostic("FUNC_NODE_INVALID_FUNC_CALL",
                                     "Function call related error message",
-                                    syntaxNodeAnalysisContext.node().location(), DiagnosticSeverity.ERROR));
-                };
+                                    syntaxNodeAnalysisContext.node().location(), DiagnosticSeverity.ERROR)
+                );
 
         private final AnalysisTask<SyntaxNodeAnalysisContext> moduleLevelNodeAnalysisTask =
                 syntaxNodeAnalysisContext -> {

--- a/project-api/test-artifacts/function-node-analyzer-compiler-plugin/src/main/java/io/samjs/plugins/lifecycle/CompilationEventPlugin.java
+++ b/project-api/test-artifacts/function-node-analyzer-compiler-plugin/src/main/java/io/samjs/plugins/lifecycle/CompilationEventPlugin.java
@@ -48,8 +48,7 @@ public class CompilationEventPlugin extends CompilerPlugin {
                 compilerLifecycleEventContext.reportDiagnostic(DiagnosticUtils.createDiagnostic(
                         "CODE_GEN_COMPLETED_TEST_EVENT",
                         "End of codegen", new NullLocation(),
-                        DiagnosticSeverity.WARNING))
-            );
+                        DiagnosticSeverity.WARNING)));
         }
     }
 

--- a/project-api/test-artifacts/function-node-analyzer-compiler-plugin/src/main/java/io/samjs/plugins/lifecycle/CompilationEventPlugin.java
+++ b/project-api/test-artifacts/function-node-analyzer-compiler-plugin/src/main/java/io/samjs/plugins/lifecycle/CompilationEventPlugin.java
@@ -44,12 +44,12 @@ public class CompilationEventPlugin extends CompilerPlugin {
     private static class CompilationListener extends CompilerLifecycleListener {
         @Override
         public void init(CompilerLifecycleContext lifecycleContext) {
-            lifecycleContext.addCodeGenerationCompletedTask(compilerLifecycleEventContext -> {
+            lifecycleContext.addCodeGenerationCompletedTask(compilerLifecycleEventContext ->
                 compilerLifecycleEventContext.reportDiagnostic(DiagnosticUtils.createDiagnostic(
                         "CODE_GEN_COMPLETED_TEST_EVENT",
                         "End of codegen", new NullLocation(),
-                        DiagnosticSeverity.WARNING));
-            });
+                        DiagnosticSeverity.WARNING))
+            );
         }
     }
 

--- a/project-api/test-artifacts/init-function-codegen-compiler-plugin/src/main/java/io/samjs/plugins/init/codegen/CodegenFunctionPlugin.java
+++ b/project-api/test-artifacts/init-function-codegen-compiler-plugin/src/main/java/io/samjs/plugins/init/codegen/CodegenFunctionPlugin.java
@@ -54,9 +54,9 @@ public class CodegenFunctionPlugin extends CompilerPlugin {
     public static class OpenApiSpecGenerator extends CodeGenerator {
         @Override
         public void init(CodeGeneratorContext generatorContext) {
-            generatorContext.addSourceGeneratorTask(sourceGeneratorContext -> {
-                sourceGeneratorContext.addResourceFile("".getBytes(Charset.defaultCharset()), "openapi-spec.yaml");
-            });
+            generatorContext.addSourceGeneratorTask(sourceGeneratorContext ->
+                sourceGeneratorContext.addResourceFile("".getBytes(Charset.defaultCharset()), "openapi-spec.yaml")
+            );
         }
     }
 
@@ -68,9 +68,9 @@ public class CodegenFunctionPlugin extends CompilerPlugin {
     public static class SampleJsonGenerator extends CodeGenerator {
         @Override
         public void init(CodeGeneratorContext generatorContext) {
-            generatorContext.addSourceGeneratorTask(sourceGeneratorContext -> {
-                sourceGeneratorContext.addTestResourceFile("".getBytes(Charset.defaultCharset()), "sample.json");
-            });
+            generatorContext.addSourceGeneratorTask(sourceGeneratorContext ->
+                sourceGeneratorContext.addTestResourceFile("".getBytes(Charset.defaultCharset()), "sample.json")
+            );
         }
     }
 

--- a/project-api/test-artifacts/init-function-codegen-compiler-plugin/src/main/java/io/samjs/plugins/init/codegen/CodegenFunctionPlugin.java
+++ b/project-api/test-artifacts/init-function-codegen-compiler-plugin/src/main/java/io/samjs/plugins/init/codegen/CodegenFunctionPlugin.java
@@ -55,8 +55,7 @@ public class CodegenFunctionPlugin extends CompilerPlugin {
         @Override
         public void init(CodeGeneratorContext generatorContext) {
             generatorContext.addSourceGeneratorTask(sourceGeneratorContext ->
-                sourceGeneratorContext.addResourceFile("".getBytes(Charset.defaultCharset()), "openapi-spec.yaml")
-            );
+                sourceGeneratorContext.addResourceFile("".getBytes(Charset.defaultCharset()), "openapi-spec.yaml"));
         }
     }
 
@@ -69,8 +68,7 @@ public class CodegenFunctionPlugin extends CompilerPlugin {
         @Override
         public void init(CodeGeneratorContext generatorContext) {
             generatorContext.addSourceGeneratorTask(sourceGeneratorContext ->
-                sourceGeneratorContext.addTestResourceFile("".getBytes(Charset.defaultCharset()), "sample.json")
-            );
+                sourceGeneratorContext.addTestResourceFile("".getBytes(Charset.defaultCharset()), "sample.json"));
         }
     }
 

--- a/project-api/test-artifacts/log-creator-in-built-code-analyzer/src/main/java/io/luhee/plugins/inbuilt/analyzer/LogCodeAnalyzerInBuiltPlugin.java
+++ b/project-api/test-artifacts/log-creator-in-built-code-analyzer/src/main/java/io/luhee/plugins/inbuilt/analyzer/LogCodeAnalyzerInBuiltPlugin.java
@@ -52,8 +52,7 @@ public class LogCodeAnalyzerInBuiltPlugin extends CompilerPlugin {
         @Override
         public void init(CodeAnalysisContext analysisContext) {
             analysisContext.addCompilationAnalysisTask(compilationAnalysisContext ->
-                    appendToOutputFile(filePath, "source-analyzer")
-            );
+                appendToOutputFile(filePath, "source-analyzer"));
 
             analysisContext.addSyntaxNodeAnalysisTask(new LogSyntaxNodeAnalysis(), SyntaxKind.FUNCTION_DEFINITION);
         }

--- a/project-api/test-artifacts/log-creator-in-built-code-analyzer/src/main/java/io/luhee/plugins/inbuilt/analyzer/LogCodeAnalyzerInBuiltPlugin.java
+++ b/project-api/test-artifacts/log-creator-in-built-code-analyzer/src/main/java/io/luhee/plugins/inbuilt/analyzer/LogCodeAnalyzerInBuiltPlugin.java
@@ -51,9 +51,9 @@ public class LogCodeAnalyzerInBuiltPlugin extends CompilerPlugin {
 
         @Override
         public void init(CodeAnalysisContext analysisContext) {
-            analysisContext.addCompilationAnalysisTask(compilationAnalysisContext -> {
-                appendToOutputFile(filePath, "source-analyzer");
-            });
+            analysisContext.addCompilationAnalysisTask(compilationAnalysisContext ->
+                    appendToOutputFile(filePath, "source-analyzer")
+            );
 
             analysisContext.addSyntaxNodeAnalysisTask(new LogSyntaxNodeAnalysis(), SyntaxKind.FUNCTION_DEFINITION);
         }

--- a/project-api/test-artifacts/log-creator-in-built-code-generator/src/main/java/io/luhee/plugins/inbuilt/generator/LogCodeGeneratorInBuiltPlugin.java
+++ b/project-api/test-artifacts/log-creator-in-built-code-generator/src/main/java/io/luhee/plugins/inbuilt/generator/LogCodeGeneratorInBuiltPlugin.java
@@ -51,9 +51,9 @@ public class LogCodeGeneratorInBuiltPlugin extends CompilerPlugin {
     public static class LogCodeGenerator extends CodeGenerator {
         @Override
         public void init(CodeGeneratorContext generatorContext) {
-            generatorContext.addSourceGeneratorTask(sourceGeneratorContext -> {
-                appendToOutputFile(filePath, "source-generator");
-            });
+            generatorContext.addSourceGeneratorTask(sourceGeneratorContext ->
+                appendToOutputFile(filePath, "source-generator")
+            );
 
             generatorContext.addSyntaxNodeAnalysisTask(new LogSyntaxNodeAnalysis(), SyntaxKind.FUNCTION_DEFINITION);
         }

--- a/project-api/test-artifacts/log-creator-in-built-code-generator/src/main/java/io/luhee/plugins/inbuilt/generator/LogCodeGeneratorInBuiltPlugin.java
+++ b/project-api/test-artifacts/log-creator-in-built-code-generator/src/main/java/io/luhee/plugins/inbuilt/generator/LogCodeGeneratorInBuiltPlugin.java
@@ -52,8 +52,7 @@ public class LogCodeGeneratorInBuiltPlugin extends CompilerPlugin {
         @Override
         public void init(CodeGeneratorContext generatorContext) {
             generatorContext.addSourceGeneratorTask(sourceGeneratorContext ->
-                appendToOutputFile(filePath, "source-generator")
-            );
+                appendToOutputFile(filePath, "source-generator"));
 
             generatorContext.addSyntaxNodeAnalysisTask(new LogSyntaxNodeAnalysis(), SyntaxKind.FUNCTION_DEFINITION);
         }

--- a/project-api/test-artifacts/log-creator-in-built-code-modifier/src/main/java/io/luhee/plugins/inbuilt/modifier/LogCodeModifierInBuiltPlugin.java
+++ b/project-api/test-artifacts/log-creator-in-built-code-modifier/src/main/java/io/luhee/plugins/inbuilt/modifier/LogCodeModifierInBuiltPlugin.java
@@ -52,9 +52,9 @@ public class LogCodeModifierInBuiltPlugin extends CompilerPlugin {
     public static class LogCodeModifier extends CodeModifier {
         @Override
         public void init(CodeModifierContext modifierContext) {
-            modifierContext.addSourceModifierTask(sourceGeneratorContext -> {
-                appendToOutputFile(filePath, "source-modifier");
-            });
+            modifierContext.addSourceModifierTask(sourceGeneratorContext ->
+                appendToOutputFile(filePath, "source-modifier")
+            );
 
             modifierContext.addSyntaxNodeAnalysisTask(new LogSyntaxNodeAnalysis(), SyntaxKind.FUNCTION_DEFINITION);
         }

--- a/project-api/test-artifacts/log-creator-in-built-code-modifier/src/main/java/io/luhee/plugins/inbuilt/modifier/LogCodeModifierInBuiltPlugin.java
+++ b/project-api/test-artifacts/log-creator-in-built-code-modifier/src/main/java/io/luhee/plugins/inbuilt/modifier/LogCodeModifierInBuiltPlugin.java
@@ -53,8 +53,7 @@ public class LogCodeModifierInBuiltPlugin extends CompilerPlugin {
         @Override
         public void init(CodeModifierContext modifierContext) {
             modifierContext.addSourceModifierTask(sourceGeneratorContext ->
-                appendToOutputFile(filePath, "source-modifier")
-            );
+                appendToOutputFile(filePath, "source-modifier"));
 
             modifierContext.addSyntaxNodeAnalysisTask(new LogSyntaxNodeAnalysis(), SyntaxKind.FUNCTION_DEFINITION);
         }

--- a/project-api/test-artifacts/log-creator-pkg-provided-code-analyzer/src/main/java/io/luhee/plugins/pkg/analyzer/LogCodeAnalyzerPkgPlugin.java
+++ b/project-api/test-artifacts/log-creator-pkg-provided-code-analyzer/src/main/java/io/luhee/plugins/pkg/analyzer/LogCodeAnalyzerPkgPlugin.java
@@ -53,9 +53,9 @@ public class LogCodeAnalyzerPkgPlugin extends CompilerPlugin {
     public static class LogCodeAnalyzer extends CodeAnalyzer {
         @Override
         public void init(CodeAnalysisContext analysisContext) {
-            analysisContext.addCompilationAnalysisTask(sourceGeneratorContext -> {
-                appendToOutputFile(filePath, "source-analyzer");
-            });
+            analysisContext.addCompilationAnalysisTask(sourceGeneratorContext ->
+                appendToOutputFile(filePath, "source-analyzer")
+            );
 
             analysisContext.addSyntaxNodeAnalysisTask(new LogSyntaxNodeAnalysis(), SyntaxKind.FUNCTION_DEFINITION);
         }

--- a/project-api/test-artifacts/log-creator-pkg-provided-code-analyzer/src/main/java/io/luhee/plugins/pkg/analyzer/LogCodeAnalyzerPkgPlugin.java
+++ b/project-api/test-artifacts/log-creator-pkg-provided-code-analyzer/src/main/java/io/luhee/plugins/pkg/analyzer/LogCodeAnalyzerPkgPlugin.java
@@ -54,8 +54,7 @@ public class LogCodeAnalyzerPkgPlugin extends CompilerPlugin {
         @Override
         public void init(CodeAnalysisContext analysisContext) {
             analysisContext.addCompilationAnalysisTask(sourceGeneratorContext ->
-                appendToOutputFile(filePath, "source-analyzer")
-            );
+                appendToOutputFile(filePath, "source-analyzer"));
 
             analysisContext.addSyntaxNodeAnalysisTask(new LogSyntaxNodeAnalysis(), SyntaxKind.FUNCTION_DEFINITION);
         }

--- a/project-api/test-artifacts/log-creator-pkg-provided-code-generator/src/main/java/io/luhee/plugins/pkg/generator/LogCodeGeneratorPkgPlugin.java
+++ b/project-api/test-artifacts/log-creator-pkg-provided-code-generator/src/main/java/io/luhee/plugins/pkg/generator/LogCodeGeneratorPkgPlugin.java
@@ -52,9 +52,9 @@ public class LogCodeGeneratorPkgPlugin extends CompilerPlugin {
     public static class LogCodeGenerator extends CodeGenerator {
         @Override
         public void init(CodeGeneratorContext generatorContext) {
-            generatorContext.addSourceGeneratorTask(sourceGeneratorContext -> {
-                appendToOutputFile(filePath, "source-generator");
-            });
+            generatorContext.addSourceGeneratorTask(sourceGeneratorContext ->
+                appendToOutputFile(filePath, "source-generator")
+            );
 
             generatorContext.addSyntaxNodeAnalysisTask(new LogSyntaxNodeAnalysis(), SyntaxKind.FUNCTION_DEFINITION);
         }

--- a/project-api/test-artifacts/log-creator-pkg-provided-code-generator/src/main/java/io/luhee/plugins/pkg/generator/LogCodeGeneratorPkgPlugin.java
+++ b/project-api/test-artifacts/log-creator-pkg-provided-code-generator/src/main/java/io/luhee/plugins/pkg/generator/LogCodeGeneratorPkgPlugin.java
@@ -53,8 +53,7 @@ public class LogCodeGeneratorPkgPlugin extends CompilerPlugin {
         @Override
         public void init(CodeGeneratorContext generatorContext) {
             generatorContext.addSourceGeneratorTask(sourceGeneratorContext ->
-                appendToOutputFile(filePath, "source-generator")
-            );
+                appendToOutputFile(filePath, "source-generator"));
 
             generatorContext.addSyntaxNodeAnalysisTask(new LogSyntaxNodeAnalysis(), SyntaxKind.FUNCTION_DEFINITION);
         }

--- a/project-api/test-artifacts/log-creator-pkg-provided-code-modifier/src/main/java/io/luhee/plugins/pkg/modifier/LogCodeModifierPkgPlugin.java
+++ b/project-api/test-artifacts/log-creator-pkg-provided-code-modifier/src/main/java/io/luhee/plugins/pkg/modifier/LogCodeModifierPkgPlugin.java
@@ -54,8 +54,7 @@ public class LogCodeModifierPkgPlugin extends CompilerPlugin {
         @Override
         public void init(CodeModifierContext modifierContext) {
             modifierContext.addSourceModifierTask(sourceGeneratorContext ->
-                appendToOutputFile(filePath, "source-modifier")
-            );
+                appendToOutputFile(filePath, "source-modifier"));
             modifierContext.addSyntaxNodeAnalysisTask(new LogSyntaxNodeAnalysis(), SyntaxKind.FUNCTION_DEFINITION);
         }
     }

--- a/project-api/test-artifacts/log-creator-pkg-provided-code-modifier/src/main/java/io/luhee/plugins/pkg/modifier/LogCodeModifierPkgPlugin.java
+++ b/project-api/test-artifacts/log-creator-pkg-provided-code-modifier/src/main/java/io/luhee/plugins/pkg/modifier/LogCodeModifierPkgPlugin.java
@@ -53,9 +53,9 @@ public class LogCodeModifierPkgPlugin extends CompilerPlugin {
     public static class LogCodeModifier extends CodeModifier {
         @Override
         public void init(CodeModifierContext modifierContext) {
-            modifierContext.addSourceModifierTask(sourceGeneratorContext -> {
-                appendToOutputFile(filePath, "source-modifier");
-            });
+            modifierContext.addSourceModifierTask(sourceGeneratorContext ->
+                appendToOutputFile(filePath, "source-modifier")
+            );
             modifierContext.addSyntaxNodeAnalysisTask(new LogSyntaxNodeAnalysis(), SyntaxKind.FUNCTION_DEFINITION);
         }
     }

--- a/project-api/test-artifacts/simple-code-gen-plugin-with-resource-gen/src/main/java/io/asmaj/plugins/simple/codegen/CodegenFunctionPlugin.java
+++ b/project-api/test-artifacts/simple-code-gen-plugin-with-resource-gen/src/main/java/io/asmaj/plugins/simple/codegen/CodegenFunctionPlugin.java
@@ -47,9 +47,9 @@ public class CodegenFunctionPlugin extends CompilerPlugin {
     public static class OpenApiSpecGenerator extends CodeGenerator {
         @Override
         public void init(CodeGeneratorContext generatorContext) {
-            generatorContext.addSourceGeneratorTask(sourceGeneratorContext -> {
-                sourceGeneratorContext.addResourceFile("".getBytes(Charset.defaultCharset()), "openapi-spec.yaml");
-            });
+            generatorContext.addSourceGeneratorTask(sourceGeneratorContext ->
+                sourceGeneratorContext.addResourceFile("".getBytes(Charset.defaultCharset()), "openapi-spec.yaml")
+            );
         }
     }
 

--- a/project-api/test-artifacts/simple-code-gen-plugin-with-resource-gen/src/main/java/io/asmaj/plugins/simple/codegen/CodegenFunctionPlugin.java
+++ b/project-api/test-artifacts/simple-code-gen-plugin-with-resource-gen/src/main/java/io/asmaj/plugins/simple/codegen/CodegenFunctionPlugin.java
@@ -48,8 +48,7 @@ public class CodegenFunctionPlugin extends CompilerPlugin {
         @Override
         public void init(CodeGeneratorContext generatorContext) {
             generatorContext.addSourceGeneratorTask(sourceGeneratorContext ->
-                sourceGeneratorContext.addResourceFile("".getBytes(Charset.defaultCharset()), "openapi-spec.yaml")
-            );
+                sourceGeneratorContext.addResourceFile("".getBytes(Charset.defaultCharset()), "openapi-spec.yaml"));
         }
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -1040,9 +1040,7 @@ public class TypedescriptorTest {
         Collection<ModuleId> moduleIds = currentPackage.moduleIds();
         PackageCompilation packageCompilation = currentPackage.getCompilation();
         List<Symbol> symbolList = new ArrayList<>();
-        moduleIds.forEach(moduleId -> {
-            symbolList.addAll(packageCompilation.getSemanticModel(moduleId).moduleSymbols());
-        });
+        moduleIds.forEach(moduleId -> symbolList.addAll(packageCompilation.getSemanticModel(moduleId).moduleSymbols()));
 
         List<SymbolInfo> expectedSymbolList = createSymbolInfoList(getSymbolModuleInfo());
         assertList(symbolList, expectedSymbolList);


### PR DESCRIPTION
## Purpose
Remove useless curly braces around statement and then remove useless return keyword.
The right-hand side of a lambda expression can be written in two ways:

1. Expression notation: the right-hand side is as an expression, such as in (a, b) → a + b
2. Block notation: the right-hand side is a conventional function body with a code block and an optional return statement, such as in (a, b) → {return a + b;}
By convention, expression notation is preferred over block notation. Block notation must be used when the function implementation requires more than one statement. However, when the code block consists of only one statement (which may or may not be a return statement), it can be rewritten using expression notation.

This convention exists because expression notation has a cleaner, more concise, functional programming style and is regarded as more readable.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
