### PR TITLE
[Refactoring] Replace `collect(Collectors.toList())` with `toList()`

### DIFF
--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ClassLoadInvoker.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ClassLoadInvoker.java
@@ -558,7 +558,7 @@ public class ClassLoadInvoker extends ShellSnippetsInvoker {
         return compilation.getSemanticModel(moduleId).moduleSymbols().stream()
                 .filter(s -> s instanceof VariableSymbol || s instanceof FunctionSymbol)
                 .map(GlobalVariableSymbol::fromSymbol)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ImportsManager.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ImportsManager.java
@@ -42,7 +42,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Imports that were stored to be able to search with the prefix.
@@ -364,7 +363,7 @@ public class ImportsManager {
                         }
                     })
                     .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (ClassNotFoundException e) {
             return Collections.emptyList();
         }

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/snippet/types/ImportDeclarationSnippet.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/snippet/types/ImportDeclarationSnippet.java
@@ -25,7 +25,6 @@ import io.ballerina.shell.utils.Identifier;
 import io.ballerina.shell.utils.QuotedImport;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Snippet that represent a import statement.
@@ -59,7 +58,7 @@ public class ImportDeclarationSnippet extends AbstractSnippet<ImportDeclarationN
      */
     public QuotedImport getImportedModule() {
         List<String> moduleNames = rootNode.moduleName().stream().map(IdentifierToken::text)
-                .collect(Collectors.toList());
+                .toList();
         if (rootNode.orgName().isPresent()) {
             String orgName = rootNode.orgName().get().orgName().text();
             return new QuotedImport(orgName, moduleNames);

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/utils/ModuleImporter.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/utils/ModuleImporter.java
@@ -39,7 +39,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Support class to add required import statements.
@@ -113,7 +112,7 @@ public class ModuleImporter {
             }
         }
 
-        return moduleErrors.stream().distinct().collect(Collectors.toList());
+        return moduleErrors.stream().distinct().toList();
     }
 
     /**

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/utils/QuotedImport.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/utils/QuotedImport.java
@@ -36,7 +36,7 @@ public class QuotedImport {
         this.orgName = orgName;
         this.moduleNames = moduleNames.stream()
                 .map(Identifier::new)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public QuotedImport(List<String> moduleNames) {

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/utils/QuotedImport.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/utils/QuotedImport.java
@@ -21,7 +21,6 @@ package io.ballerina.shell.utils;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 /**
  * An import that has quoted orgname and module names.

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/unit/EvaluatorMiscTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/unit/EvaluatorMiscTest.java
@@ -31,7 +31,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Misc functionality testing of evaluator.
@@ -169,6 +168,6 @@ public class EvaluatorMiscTest {
         return evaluator.availableVariables().stream().filter(s -> !s.equals("Variable declarations")
                                                                 && !s.equals("Final variable declarations")
                                                                 && !s.equals("Constant Variable Declarations"))
-                                                                .collect(Collectors.toList());
+                                                                .toList();
     }
 }

--- a/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/Profiler.java
+++ b/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/Profiler.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarFile;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -236,7 +235,7 @@ public class Profiler {
             final File userDirectory = new File(System.getProperty("user.dir")); // Get the user directory
             listAllFiles(userDirectory); // List all files in the user directory and its subdirectories
             // Get a list of the directories containing instrumented files
-            List<String> changedDirectories = instrumentedFiles.stream().distinct().collect(Collectors.toList());
+            List<String> changedDirectories = instrumentedFiles.stream().distinct().toList();
             loadDirectories(changedDirectories);
         } finally {
             for (String instrumentedFilePath : instrumentedPaths) {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
@@ -883,12 +883,12 @@ public final class CommandUtil {
                     .map(directory -> directory.getFileName())
                     .filter(Objects::nonNull)
                     .map(Path::toString)
-                    .collect(Collectors.toList());
+                    .toList();
 
                 if (null != jarFs) {
                     return templates.stream().map(t -> t
                             .replace(jarFs.getSeparator(), ""))
-                        .collect(Collectors.toList());
+                        .toList();
                 } else {
                     return templates;
                 }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/launcher/util/BalToolsUtil.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/launcher/util/BalToolsUtil.java
@@ -44,7 +44,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.cli.cmd.Constants.ADD_COMMAND;
@@ -189,7 +188,7 @@ public final class BalToolsUtil {
                                             .resolve(TOOL).resolve(LIBS)
                         .toFile()))
                     .flatMap(List::stream)
-                    .collect(Collectors.toList());
+                    .toList();
         }
 
         Optional<BalToolsManifest.Tool> toolOpt = balToolsManifest.getActiveTool(commandName);
@@ -280,7 +279,7 @@ public final class BalToolsUtil {
                     } catch (ProjectException ignore) {
                         return false;
                     }
-                })).map(File::getName).collect(Collectors.toList());
+                })).map(File::getName).toList();
 
                 Optional<String> latestVersion = getLatestVersion(versions);
                 versions.stream().forEach(version -> {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunBuildToolsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunBuildToolsTask.java
@@ -368,6 +368,6 @@ public class RunBuildToolsTask implements Task {
                         .resolve(TOOL).resolve(LIBS)
                         .toFile()))
                 .flatMap(List::stream)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -54,7 +54,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
@@ -362,7 +361,7 @@ public class RunTestsTask implements Task {
     private static List<Path> filterPathStream(Stream<Path> pathStream, String combinedPattern) {
         return pathStream.filter(
                         FileSystems.getDefault().getPathMatcher("glob:" + combinedPattern)::matches)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private void getclassFromSourceFilePath(List<String> sourcePatternList, Package currentPackage,

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/NativeUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/NativeUtils.java
@@ -602,9 +602,8 @@ public final class NativeUtils {
             dependencies.addAll(testSuiteEntry.getValue().getTestExecutionDependencies());
 
         }
-        dependencies = dependencies.stream().distinct().toList();
-        dependencies = dependencies.stream().map((x) -> convertWinPathToUnixFormat(addQuotationMarkToString(x)))
-                .toList();
+        dependencies = dependencies.stream().distinct()
+                .map((x) -> convertWinPathToUnixFormat(addQuotationMarkToString(x))).toList();
 
         StringJoiner classPath = new StringJoiner(File.pathSeparator);
         dependencies.forEach(classPath::add);

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/NativeUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/NativeUtils.java
@@ -61,7 +61,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.jar.JarOutputStream;
-import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -603,9 +602,9 @@ public final class NativeUtils {
             dependencies.addAll(testSuiteEntry.getValue().getTestExecutionDependencies());
 
         }
-        dependencies = dependencies.stream().distinct().collect(Collectors.toList());
+        dependencies = dependencies.stream().distinct().toList();
         dependencies = dependencies.stream().map((x) -> convertWinPathToUnixFormat(addQuotationMarkToString(x)))
-                .collect(Collectors.toList());
+                .toList();
 
         StringJoiner classPath = new StringJoiner(File.pathSeparator);
         dependencies.forEach(classPath::add);

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TestUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TestUtils.java
@@ -482,10 +482,10 @@ public final class TestUtils {
     public static String getClassPath(JBallerinaBackend jBallerinaBackend, Package currentPackage) {
         JarResolver jarResolver = jBallerinaBackend.jarResolver();
 
-        List<Path> dependencies = getTestDependencyPaths(currentPackage, jarResolver);
-
         List<Path> jarList = getModuleJarPaths(jBallerinaBackend, currentPackage);
-        dependencies.removeAll(jarList);
+
+        List<Path> dependencies = getTestDependencyPaths(currentPackage, jarResolver)
+                .stream().filter(dependency -> !jarList.contains(dependency)).toList();
 
         StringJoiner classPath = joinClassPaths(dependencies);
         return classPath.toString();

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TestUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TestUtils.java
@@ -67,7 +67,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.COVERAGE_DIR;
@@ -522,7 +521,7 @@ public final class TestUtils {
                 }
             }
         }
-        return dependencies.stream().distinct().collect(Collectors.toList());
+        return dependencies.stream().distinct().toList();
     }
 
     /**
@@ -549,7 +548,7 @@ public final class TestUtils {
             }
         }
 
-        return moduleJarPaths.stream().distinct().collect(Collectors.toList());
+        return moduleJarPaths.stream().distinct().toList();
     }
 
     private static PlatformLibrary getCodeGeneratedTestLibrary(JBallerinaBackend jBallerinaBackend,

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TestUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TestUtils.java
@@ -62,6 +62,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -481,11 +482,10 @@ public final class TestUtils {
      */
     public static String getClassPath(JBallerinaBackend jBallerinaBackend, Package currentPackage) {
         JarResolver jarResolver = jBallerinaBackend.jarResolver();
-
-        List<Path> jarList = getModuleJarPaths(jBallerinaBackend, currentPackage);
+        Set<Path> jars = new HashSet<>(getModuleJarPaths(jBallerinaBackend, currentPackage));
 
         List<Path> dependencies = getTestDependencyPaths(currentPackage, jarResolver)
-                .stream().filter(dependency -> !jarList.contains(dependency)).toList();
+                .stream().filter(dependency -> !jars.contains(dependency)).toList();
 
         StringJoiner classPath = joinClassPaths(dependencies);
         return classPath.toString();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaKeywordsProvider.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaKeywordsProvider.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Provides the set of Ballerina Reserved Keywords to be used at the symbol factory.
@@ -55,7 +54,7 @@ public final class BallerinaKeywordsProvider {
                         }
                     })
                     .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (ClassNotFoundException e) {
             return Collections.emptyList();
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ExpectedTypeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ExpectedTypeFinder.java
@@ -132,7 +132,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.api.impl.PositionUtil.isPosWithinOpenCloseLineRanges;
 import static io.ballerina.compiler.api.impl.PositionUtil.isPosWithinRange;
@@ -1062,7 +1061,7 @@ public class ExpectedTypeFinder extends NodeTransformer<Optional<TypeSymbol>> {
         Optional<ModuleSymbol> module = searchModuleForAlias(alias);
         return module.map(moduleSymbol -> moduleSymbol.allSymbols().stream()
                         .filter(predicate)
-                        .collect(Collectors.toList()))
+                        .toList())
                 .orElseGet(ArrayList::new);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -265,10 +265,10 @@ public class ReferenceFinder extends BaseVisitor {
         find(pkgNode.typeDefinitions);
         find(pkgNode.classDefinitions.stream()
                      .filter(c -> !isGeneratedClassDefForService(c))
-                     .collect(Collectors.toList()));
+                     .toList());
         find(pkgNode.functions.stream()
                      .filter(f -> !f.flagSet.contains(Flag.LAMBDA))
-                     .collect(Collectors.toList()));
+                     .toList());
 
         if (!(pkgNode instanceof BLangTestablePackage)) {
             find(pkgNode.getTestablePkg());

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -213,7 +213,6 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -208,7 +208,7 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
                 .filter(functionSymbol -> functionSymbol.getModule().isPresent())
                 .filter(functionSymbol -> !ORG_NAME_BALLERINA.equals(functionSymbol.getModule().get().id().orgName()) ||
                         !MODULE_NAME_LANG_VALUE.equals(functionSymbol.getModule().get().id().moduleName()))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private void addIfFlagSet(List<Qualifier> quals, final long mask, final long flag, Qualifier qualifier) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -204,11 +204,11 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
     @Override
     protected List<FunctionSymbol> filterLangLibMethods(List<FunctionSymbol> functions, BType internalType) {
         List<FunctionSymbol> functionSymbols = super.filterLangLibMethods(functions, internalType);
-        return functionSymbols.stream()
+        return new ArrayList<>(functionSymbols.stream()
                 .filter(functionSymbol -> functionSymbol.getModule().isPresent())
                 .filter(functionSymbol -> !ORG_NAME_BALLERINA.equals(functionSymbol.getModule().get().id().orgName()) ||
                         !MODULE_NAME_LANG_VALUE.equals(functionSymbol.getModule().get().id().moduleName()))
-                .toList();
+                .toList());
     }
 
     private void addIfFlagSet(List<Qualifier> quals, final long mask, final long flag, Qualifier qualifier) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -204,11 +204,11 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
     @Override
     protected List<FunctionSymbol> filterLangLibMethods(List<FunctionSymbol> functions, BType internalType) {
         List<FunctionSymbol> functionSymbols = super.filterLangLibMethods(functions, internalType);
-        return new ArrayList<>(functionSymbols.stream()
+        return functionSymbols.stream()
                 .filter(functionSymbol -> functionSymbol.getModule().isPresent())
                 .filter(functionSymbol -> !ORG_NAME_BALLERINA.equals(functionSymbol.getModule().get().id().orgName()) ||
                         !MODULE_NAME_LANG_VALUE.equals(functionSymbol.getModule().get().id().moduleName()))
-                .toList());
+                .collect(Collectors.toList());
     }
 
     private void addIfFlagSet(List<Qualifier> quals, final long mask, final long flag, Qualifier qualifier) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
@@ -34,7 +34,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 /**
  * Represents a table type descriptor.
@@ -89,7 +88,7 @@ public class BallerinaTableTypeSymbol extends AbstractStructuredTypeSymbol imple
 
                     return !isKeyedLangLibFunction(functionSymbol, types) || !isNeverTypeKeyConstraint(types);
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 /**
  * Represents a table type descriptor.
@@ -79,7 +80,7 @@ public class BallerinaTableTypeSymbol extends AbstractStructuredTypeSymbol imple
         Types types = Types.getInstance(this.context);
 
         // Skip key-ed langlib functions if the table's type-constraint is never-typed
-        return new ArrayList<>(super.filterLangLibMethods(functions, internalType).stream()
+        return super.filterLangLibMethods(functions, internalType).stream()
                 .filter(functionSymbol -> {
                     if (!ORG_NAME_BALLERINA.equals(functionSymbol.getModule().get().id().orgName()) ||
                             !MODULE_NAME_LANG_TABLE.equals(functionSymbol.getModule().get().id().moduleName())) {
@@ -88,7 +89,7 @@ public class BallerinaTableTypeSymbol extends AbstractStructuredTypeSymbol imple
 
                     return !isKeyedLangLibFunction(functionSymbol, types) || !isNeverTypeKeyConstraint(types);
                 })
-                .toList());
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
@@ -79,7 +79,7 @@ public class BallerinaTableTypeSymbol extends AbstractStructuredTypeSymbol imple
         Types types = Types.getInstance(this.context);
 
         // Skip key-ed langlib functions if the table's type-constraint is never-typed
-        return super.filterLangLibMethods(functions, internalType).stream()
+        return new ArrayList<>(super.filterLangLibMethods(functions, internalType).stream()
                 .filter(functionSymbol -> {
                     if (!ORG_NAME_BALLERINA.equals(functionSymbol.getModule().get().id().orgName()) ||
                             !MODULE_NAME_LANG_TABLE.equals(functionSymbol.getModule().get().id().moduleName())) {
@@ -88,7 +88,7 @@ public class BallerinaTableTypeSymbol extends AbstractStructuredTypeSymbol imple
 
                     return !isKeyedLangLibFunction(functionSymbol, types) || !isNeverTypeKeyConstraint(types);
                 })
-                .toList();
+                .toList());
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilerPluginManager.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilerPluginManager.java
@@ -26,7 +26,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Responsible for loading and maintaining engaged compiler plugins.
@@ -171,7 +170,7 @@ class CompilerPluginManager {
         List<Path> jarLibraryPaths = pluginDescriptor.getCompilerPluginDependencies()
                 .stream()
                 .map(Paths::get)
-                .collect(Collectors.toList());
+                .toList();
 
         CompilerPlugin compilerPlugin;
         try {
@@ -192,7 +191,7 @@ class CompilerPluginManager {
         return dependencyGraph.getDirectDependencies(rootPkgNode)
                 .stream()
                 .map(ResolvedPackageDependency::packageInstance)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static List<CompilerPluginContextIml> initializePlugins(List<CompilerPluginInfo> compilerPlugins,

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompletionManager.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompletionManager.java
@@ -41,7 +41,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Manages interaction with completion providers via compiler plugins.
@@ -159,7 +158,7 @@ public class CompletionManager {
                     }
                     return Optional.of(listenerType);
                 }).filter(listenerType -> listenerType.isPresent() && listenerType.get().getModule().isPresent())
-                .map(listenerType -> listenerType.get().getModule().get()).collect(Collectors.toList());
+                .map(listenerType -> listenerType.get().getModule().get()).toList();
     }
 
     private TypeSymbol getRawType(TypeSymbol typeDescriptor) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ConfigReader.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ConfigReader.java
@@ -23,6 +23,7 @@ import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.IdentifierToken;
 import io.ballerina.compiler.syntax.tree.MappingFieldNode;
 import io.ballerina.compiler.syntax.tree.MetadataNode;
+import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
@@ -50,7 +51,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Util class to read configurable variables defined in a package.
@@ -303,11 +303,11 @@ public final class ConfigReader {
         for (Map.Entry<Document, SyntaxTree> syntaxTreeEntry : syntaxTreeMap.entrySet()) {
             if (syntaxTreeEntry.getValue().containsModulePart()) {
                 ModulePartNode modulePartNode = syntaxTreeMap.get(syntaxTreeEntry.getKey()).rootNode();
-                List<Node> filteredVarNodes = modulePartNode.members().stream()
+                List<ModuleMemberDeclarationNode> filteredVarNodes = modulePartNode.members().stream()
                         .filter(node -> node.kind() == SyntaxKind.MODULE_VAR_DECL &&
                                 node instanceof ModuleVariableDeclarationNode)
-                        .collect(Collectors.toList());
-                for (Node node : filteredVarNodes) {
+                        .toList();
+                for (ModuleMemberDeclarationNode node : filteredVarNodes) {
                     if (node.location().lineRange().startLine().line() <= position &&
                             node.location().lineRange().endLine().line() >= position) {
                         return node;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ConfigReader.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ConfigReader.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.IdentifierToken;
 import io.ballerina.compiler.syntax.tree.MappingFieldNode;
 import io.ballerina.compiler.syntax.tree.MetadataNode;
-import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
@@ -303,16 +302,13 @@ public final class ConfigReader {
         for (Map.Entry<Document, SyntaxTree> syntaxTreeEntry : syntaxTreeMap.entrySet()) {
             if (syntaxTreeEntry.getValue().containsModulePart()) {
                 ModulePartNode modulePartNode = syntaxTreeMap.get(syntaxTreeEntry.getKey()).rootNode();
-                List<ModuleMemberDeclarationNode> filteredVarNodes = modulePartNode.members().stream()
-                        .filter(node -> node.kind() == SyntaxKind.MODULE_VAR_DECL &&
-                                node instanceof ModuleVariableDeclarationNode)
-                        .toList();
-                for (ModuleMemberDeclarationNode node : filteredVarNodes) {
-                    if (node.location().lineRange().startLine().line() <= position &&
-                            node.location().lineRange().endLine().line() >= position) {
-                        return node;
-                    }
-                }
+                return modulePartNode.members().stream()
+                    .filter(node -> node.kind() == SyntaxKind.MODULE_VAR_DECL &&
+                        node instanceof ModuleVariableDeclarationNode &&
+                        node.location().lineRange().startLine().line() <= position &&
+                        node.location().lineRange().endLine().line() >= position)
+                    .findFirst()
+                    .orElse(null);
             }
         }
         return null;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Diagnostics.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Diagnostics.java
@@ -22,7 +22,6 @@ import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
 import java.util.Collection;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * This class contains various static methods that operate on {@code Diagnostic} instances.
@@ -72,7 +71,7 @@ public final class Diagnostics {
                                                             Predicate<Diagnostic> predicate) {
         return diagnostics.stream()
                 .filter(predicate)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static boolean hasDiagnosticsWithSeverity(Collection<Diagnostic> diagnostics,

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -72,7 +72,6 @@ import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
-import java.util.stream.Collectors;
 
 import static io.ballerina.projects.util.FileUtils.getFileNameWithoutExtension;
 import static io.ballerina.projects.util.ProjectConstants.BIN_DIR_NAME;
@@ -290,7 +289,7 @@ public class JBallerinaBackend extends CompilerBackend {
         return getPlatformLibraries(packageId)
                 .stream()
                 .filter(platformLibrary -> platformLibrary.scope() == scope)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private List<PlatformLibrary> getPlatformLibraries(PackageId packageId) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -401,7 +401,7 @@ class ModuleContext {
             packageCache.putSymbol(pkgNode.packageID, pkgNode.symbol);
             compilerPhaseRunner.performTypeCheckPhases(pkgNode);
         } catch (Throwable t) {
-            assert false : "Compilation failed due to " + ((Supplier<String>)() -> {
+            assert false : "Compilation failed due to " + ((Supplier<String>) () -> {
                 StringWriter errors = new StringWriter();
                 t.printStackTrace(new PrintWriter(errors));
                 return errors.toString();
@@ -424,7 +424,7 @@ class ModuleContext {
             try {
                 compilerPhaseRunner.performBirGenPhases(moduleContext.bLangPackage);
             } catch (Throwable t) {
-                assert false : "Compilation failed due to " + ((Supplier<String>)() -> {
+                assert false : "Compilation failed due to " + ((Supplier<String>) () -> {
                     StringWriter errors = new StringWriter();
                     t.printStackTrace(new PrintWriter(errors));
                     return errors.toString();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -45,6 +45,8 @@ import org.wso2.ballerinalang.programfile.PackageFileWriter;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -54,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.ballerinalang.model.tree.SourceKind.REGULAR_SOURCE;
 import static org.ballerinalang.model.tree.SourceKind.TEST_SOURCE;
@@ -398,8 +401,12 @@ class ModuleContext {
             packageCache.putSymbol(pkgNode.packageID, pkgNode.symbol);
             compilerPhaseRunner.performTypeCheckPhases(pkgNode);
         } catch (Throwable t) {
-            assert false : "Compilation failed due to" +
-                    (t.getMessage() != null ? ": " + t.getMessage() : " an unhandled exception");
+            assert false : "Compilation failed due to " + ((Supplier<String>)() -> {
+                StringWriter errors = new StringWriter();
+                t.printStackTrace(new PrintWriter(errors));
+                return errors.toString();
+            }).get();
+
             compilerPhaseRunner.addDiagnosticForUnhandledException(pkgNode, t);
         }
         moduleContext.bLangPackage = pkgNode;
@@ -417,8 +424,11 @@ class ModuleContext {
             try {
                 compilerPhaseRunner.performBirGenPhases(moduleContext.bLangPackage);
             } catch (Throwable t) {
-                assert false : "Compilation failed due to" +
-                        (t.getMessage() != null ? ": " + t.getMessage() : " an unhandled exception");
+                assert false : "Compilation failed due to " + ((Supplier<String>)() -> {
+                    StringWriter errors = new StringWriter();
+                    t.printStackTrace(new PrintWriter(errors));
+                    return errors.toString();
+                }).get();
                 compilerPhaseRunner.addDiagnosticForUnhandledException(moduleContext.bLangPackage, t);
                 return;
             }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -246,7 +246,7 @@ public class PackageResolution {
                 .stream()
                 // Remove root package from this list.
                 .filter(resolvedPkg -> resolvedPkg.packageId() != rootPackageContext.packageId())
-                .collect(Collectors.toList());
+                .toList();
         return dependenciesWithTransitives;
     }
 
@@ -410,7 +410,7 @@ public class PackageResolution {
                 .filter(depNode -> !depNode.equals(rootNode) // Remove root node from the requests
                         && !depNode.errorNode()) // Remove error nodes from the requests
                 .map(this::createFromDepNode)
-                .collect(Collectors.toList());
+                .toList();
         Collection<ResolutionResponse> resolutionResponses =
                 packageResolver.resolvePackages(resolutionRequests, resolutionOptions);
 
@@ -447,7 +447,7 @@ public class PackageResolution {
                                 .map(directDepNode -> resolvedPkgContainer.get(
                                         directDepNode.pkgDesc().org(), directDepNode.pkgDesc().name()))
                                 .flatMap(Optional::stream)
-                                .collect(Collectors.toList());
+                                .toList();
                 depGraphBuilder.addDependencies(resolvedPkg, directPkgDependencies);
             }
         }
@@ -552,7 +552,7 @@ public class PackageResolution {
         List<ModuleName> moduleNames = rootPackageContext.moduleIds().stream()
                 .map(rootPackageContext::moduleContext)
                 .map(ModuleContext::moduleName)
-                .collect(Collectors.toList());
+                .toList();
         return new ModuleResolver(rootPackageContext.descriptor(), moduleNames, blendedManifest,
                 projectEnvContext.getService(PackageResolver.class), resolutionOptions);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/BalaFiles.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/BalaFiles.java
@@ -205,7 +205,7 @@ public final class BalaFiles {
                     .filter(Files::isDirectory)
                     .map(modulePath -> modulePath.getFileName().toString())
                     .map(fullModuleName -> loadModule(pkgName, fullModuleName, packagePath))
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (IOException e) {
             throw new ProjectException("Failed to read modules from directory: " + modulesDirPath, e);
         }
@@ -654,7 +654,7 @@ public final class BalaFiles {
     private static List<ModuleDescriptor> createModDescriptorList(List<ModuleDependency> modDepEntries) {
         return modDepEntries.stream()
                 .map(BalaFiles::getModuleDescriptorFromDependencyEntry)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static DependencyGraphJson readDependencyGraphJson(Path dependencyGraphJsonPath) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/BlendedManifest.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/BlendedManifest.java
@@ -38,7 +38,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static io.ballerina.projects.PackageVersion.BUILTIN_PACKAGE_VERSION;
 
@@ -187,7 +186,7 @@ public class BlendedManifest {
         return dependency.modules()
                 .stream()
                 .map(DependencyManifest.Module::moduleName)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static Collection<String> moduleNames(PackageManifest.Dependency dependency,
@@ -196,7 +195,7 @@ public class BlendedManifest {
                 dependency.org(), dependency.name(), dependency.version());
         return moduleDescriptors.stream()
                 .map(moduleDesc -> moduleDesc.name().toString())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public Optional<Dependency> lockedDependency(PackageOrg org, PackageName name) {
@@ -235,7 +234,7 @@ public class BlendedManifest {
     private Collection<Dependency> dependencies(DependencyOrigin origin) {
         return depContainer.getAll().stream()
                 .filter(dep -> dep.origin == origin)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public DiagnosticResult diagnosticResult() {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageConfigCreator.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageConfigCreator.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Creates a {@code PackageConfig} instance from the given {@code PackageData} instance.
@@ -145,14 +146,12 @@ public final class PackageConfigCreator {
         PackageName packageName = packageManifest.name();
         PackageId packageId = PackageId.create(packageName.value());
 
-        List<ModuleConfig> moduleConfigs = packageData.otherModules()
-                .stream()
-                .map(moduleData -> createModuleConfig(packageManifest.descriptor(), moduleData,
-                        packageId, moduleDependencyGraph))
-                .toList();
+        List<ModuleConfig> moduleConfigs = Stream.concat(packageData.otherModules().stream()
+                        .map(moduleData -> createModuleConfig(packageManifest.descriptor(), moduleData,
+                                packageId, moduleDependencyGraph)),
+                Stream.of(createDefaultModuleConfig(packageManifest.descriptor(),
+                        packageData.defaultModule(), packageId, moduleDependencyGraph))).toList();
 
-        moduleConfigs.add(createDefaultModuleConfig(packageManifest.descriptor(),
-                packageData.defaultModule(), packageId, moduleDependencyGraph));
 
         DocumentConfig ballerinaToml = packageData.ballerinaToml()
                 .map(data -> createDocumentConfig(data, null)).orElse(null);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageConfigCreator.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageConfigCreator.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Creates a {@code PackageConfig} instance from the given {@code PackageData} instance.
@@ -150,7 +149,7 @@ public final class PackageConfigCreator {
                 .stream()
                 .map(moduleData -> createModuleConfig(packageManifest.descriptor(), moduleData,
                         packageId, moduleDependencyGraph))
-                .collect(Collectors.toList());
+                .toList();
 
         moduleConfigs.add(createDefaultModuleConfig(packageManifest.descriptor(),
                 packageData.defaultModule(), packageId, moduleDependencyGraph));
@@ -240,7 +239,7 @@ public final class PackageConfigCreator {
         // TODO: no need Remove duplicate paths before processing
         Set<Path> distinctResources = new HashSet<>(resources);
         return distinctResources.stream().map(
-                distinctResource -> createResourceConfig(distinctResource, packagePath)).collect(Collectors.toList());
+                distinctResource -> createResourceConfig(distinctResource, packagePath)).toList();
     }
 
     private static ResourceConfig createResourceConfig(Path path, Path packagePath) {
@@ -253,7 +252,7 @@ public final class PackageConfigCreator {
                 .stream()
                 .sorted(Comparator.comparing(DocumentData::name))
                 .map(srcDoc -> createDocumentConfig(srcDoc, moduleId))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     static DocumentConfig createDocumentConfig(DocumentData documentData, ModuleId moduleId) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageContainer.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageContainer.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * A container for various package representation that provides efficient access to packages.
@@ -81,6 +80,6 @@ public class PackageContainer<T> {
                 .stream()
                 .map(Map::values)
                 .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageDependencyGraphBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageDependencyGraphBuilder.java
@@ -43,7 +43,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * This class is responsible for creating the Package dependency graph with no version conflicts.
@@ -145,7 +144,7 @@ public class PackageDependencyGraphBuilder {
     public Collection<DependencyNode> getAllDependencies() {
         return vertices.values().stream()
                 .filter(vertex -> !vertex.equals(rootDepNode))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public DependencyGraph<DependencyNode> buildGraph() {
@@ -176,7 +175,7 @@ public class PackageDependencyGraphBuilder {
     public Collection<DependencyNode> getUnresolvedNodes() {
         Collection<DependencyNode> unresolvedNodes = unresolvedVertices.stream()
                 .map(vertices::get)
-                .collect(Collectors.toList());
+                .toList();
         this.unresolvedVertices = new HashSet<>();
         return unresolvedNodes;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageVersionContainer.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageVersionContainer.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * A container for various package representation that provides efficient access to packages.
@@ -82,6 +81,6 @@ public class PackageVersionContainer<T> {
                 .flatMap(Collection::stream)
                 .map(Map::values)
                 .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectFiles.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectFiles.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.projects.util.ProjectConstants.DOT;
@@ -146,7 +147,7 @@ public final class ProjectFiles {
         }
 
         try (Stream<Path> pathStream = Files.walk(modulesDirPath, 1)) {
-            return new ArrayList<>(pathStream
+            return pathStream
                     .filter(path -> !path.equals(modulesDirPath))
                     .filter(Files::isDirectory)
                     .filter(path -> {
@@ -162,7 +163,7 @@ public final class ProjectFiles {
                         return true;
                     })
                     .map(ProjectFiles::loadModule)
-                    .toList());
+                    .collect(Collectors.toList());
         } catch (IOException e) {
             throw new ProjectException(e);
         }
@@ -182,13 +183,13 @@ public final class ProjectFiles {
             if (Files.isDirectory(generatedSourcesRoot)) {
                 List<DocumentData> generatedDocs = loadDocuments(generatedSourcesRoot);
                 verifyDuplicateNames(srcDocs, generatedDocs, moduleDirPath.toFile().getName(), moduleDirPath, false);
-                srcDocs = Stream.concat(srcDocs.stream(), generatedDocs.stream()).toList();
+                srcDocs.addAll(generatedDocs);
                 if (Files.isDirectory(generatedSourcesRoot.resolve(TEST_DIR_NAME))) {
                     List<DocumentData> generatedTestDocs =
                             loadTestDocuments(generatedSourcesRoot.resolve(TEST_DIR_NAME));
                     verifyDuplicateNames(testSrcDocs, generatedTestDocs, moduleDirPath.toFile().getName(),
                             moduleDirPath, true);
-                    testSrcDocs = Stream.concat(testSrcDocs.stream(), generatedTestDocs.stream()).toList();
+                    testSrcDocs.addAll(generatedTestDocs);
                 }
             }
         }
@@ -274,7 +275,7 @@ public final class ProjectFiles {
                     .filter(BAL_EXTENSION_MATCHER::matches)
                     .filter(Files::isRegularFile)
                     .map(ProjectFiles::loadDocument)
-                    .toList();
+                    .collect(Collectors.toList());
         } catch (IOException e) {
             throw new ProjectException(e);
         }
@@ -290,7 +291,7 @@ public final class ProjectFiles {
             return pathStream
                     .filter(BAL_EXTENSION_MATCHER::matches)
                     .map(ProjectFiles::loadTestDocument)
-                    .toList();
+                    .collect(Collectors.toList());
         } catch (IOException e) {
             throw new ProjectException(e);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectFiles.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectFiles.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.projects.util.ProjectConstants.DOT;
@@ -126,7 +125,7 @@ public final class ProjectFiles {
                             return true;
                         })
                         .map(ProjectFiles::loadModule)
-                        .collect(Collectors.toList());
+                        .toList();
             } catch (IOException e) {
                 throw new ProjectException(e);
             }
@@ -166,7 +165,7 @@ public final class ProjectFiles {
                         return true;
                     })
                     .map(ProjectFiles::loadModule)
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (IOException e) {
             throw new ProjectException(e);
         }
@@ -261,7 +260,7 @@ public final class ProjectFiles {
         try (Stream<Path> pathStream = Files.walk(resourcesPath, 10)) {
             return pathStream
                     .filter(Files::isRegularFile)
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (IOException e) {
             throw new ProjectException(e);
         }
@@ -278,7 +277,7 @@ public final class ProjectFiles {
                     .filter(BAL_EXTENSION_MATCHER::matches)
                     .filter(Files::isRegularFile)
                     .map(ProjectFiles::loadDocument)
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (IOException e) {
             throw new ProjectException(e);
         }
@@ -294,7 +293,7 @@ public final class ProjectFiles {
             return pathStream
                     .filter(BAL_EXTENSION_MATCHER::matches)
                     .map(ProjectFiles::loadTestDocument)
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (IOException e) {
             throw new ProjectException(e);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectFiles.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectFiles.java
@@ -76,11 +76,8 @@ public final class ProjectFiles {
         ModuleData defaultModule = loadModule(packageDirPath);
         List<ModuleData> otherModules = loadOtherModules(packageDirPath);
         List<ModuleData> newModules = loadNewGeneratedModules(packageDirPath);
-        if (otherModules.isEmpty()) {
-            otherModules = newModules;
-        } else {
-            otherModules.addAll(newModules);
-        }
+        otherModules = Stream.concat(otherModules.stream(), newModules.stream()).toList();
+
         DocumentData ballerinaToml = loadDocument(packageDirPath.resolve(ProjectConstants.BALLERINA_TOML));
         DocumentData dependenciesToml = loadDocument(packageDirPath.resolve(ProjectConstants.DEPENDENCIES_TOML));
         DocumentData cloudToml = loadDocument(packageDirPath.resolve(ProjectConstants.CLOUD_TOML));
@@ -149,7 +146,7 @@ public final class ProjectFiles {
         }
 
         try (Stream<Path> pathStream = Files.walk(modulesDirPath, 1)) {
-            return pathStream
+            return new ArrayList<>(pathStream
                     .filter(path -> !path.equals(modulesDirPath))
                     .filter(Files::isDirectory)
                     .filter(path -> {
@@ -165,7 +162,7 @@ public final class ProjectFiles {
                         return true;
                     })
                     .map(ProjectFiles::loadModule)
-                    .toList();
+                    .toList());
         } catch (IOException e) {
             throw new ProjectException(e);
         }
@@ -173,9 +170,9 @@ public final class ProjectFiles {
 
     private static ModuleData loadModule(Path moduleDirPath) {
         List<DocumentData> srcDocs = loadDocuments(moduleDirPath);
-        List<DocumentData> testSrcDocs;
         Path testDirPath = moduleDirPath.resolve("tests");
-        testSrcDocs = Files.isDirectory(testDirPath) ? loadTestDocuments(testDirPath) : new ArrayList<>();
+        List<DocumentData> testSrcDocs = Files.isDirectory(testDirPath) ? loadTestDocuments(testDirPath) :
+                new ArrayList<>();
 
         // If the module is not a newly generated module, explicitly load generated sources
         if (!ProjectConstants.GENERATED_MODULES_ROOT.equals(Optional.of(
@@ -185,13 +182,13 @@ public final class ProjectFiles {
             if (Files.isDirectory(generatedSourcesRoot)) {
                 List<DocumentData> generatedDocs = loadDocuments(generatedSourcesRoot);
                 verifyDuplicateNames(srcDocs, generatedDocs, moduleDirPath.toFile().getName(), moduleDirPath, false);
-                srcDocs.addAll(generatedDocs);
+                srcDocs = Stream.concat(srcDocs.stream(), generatedDocs.stream()).toList();
                 if (Files.isDirectory(generatedSourcesRoot.resolve(TEST_DIR_NAME))) {
                     List<DocumentData> generatedTestDocs =
                             loadTestDocuments(generatedSourcesRoot.resolve(TEST_DIR_NAME));
                     verifyDuplicateNames(testSrcDocs, generatedTestDocs, moduleDirPath.toFile().getName(),
                             moduleDirPath, true);
-                    testSrcDocs.addAll(generatedTestDocs);
+                    testSrcDocs = Stream.concat(testSrcDocs.stream(), generatedTestDocs.stream()).toList();
                 }
             }
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/DefaultPackageResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/DefaultPackageResolver.java
@@ -165,7 +165,7 @@ public class DefaultPackageResolver implements PackageResolver {
         // Send non built in packages to central
         Collection<ResolutionRequest> centralLoadRequests = requests.stream()
                 .filter(r -> !r.packageDescriptor().isBuiltInPackage())
-                .collect(Collectors.toList());
+                .toList();
         Collection<PackageMetadataResponse> latestVersionsInCentral =
                 centralRepo.getPackageMetadata(centralLoadRequests, options);
 
@@ -207,7 +207,7 @@ public class DefaultPackageResolver implements PackageResolver {
 
         return requests.stream()
                 .map(request -> resolvePackage(request, options))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private ResolutionResponse resolvePackage(ResolutionRequest resolutionReq, ResolutionOptions options) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/BalToolDescriptor.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/BalToolDescriptor.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -201,7 +200,7 @@ public class BalToolDescriptor {
 
         return getToolJarsMatchingPattern(pattern, parentPath.get()).stream()
                 .map(path1 -> new BalToolDescriptor.Dependency(path1.toString()))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static List<Path> getToolJarsMatchingPattern(String pattern, Path parentPath) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
@@ -36,6 +36,7 @@ import io.ballerina.projects.util.ProjectUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static io.ballerina.projects.util.ProjectUtils.CompatibleRange;
 import static io.ballerina.projects.util.ProjectUtils.getLatest;
@@ -108,7 +109,7 @@ public abstract class AbstractPackageRepository implements PackageRepository {
         CompatibleRange compatibilityRange = ProjectUtils.getCompatibleRange(minSemVer, packageLockingMode);
         List<SemanticVersion> compatibleVersions = ProjectUtils.getVersionsInCompatibleRange(
                 minSemVer, semVers, compatibilityRange);
-        return compatibleVersions.stream().map(PackageVersion::from).toList();
+        return compatibleVersions.stream().map(PackageVersion::from).collect(Collectors.toList());
     }
 
     private ImportModuleResponse getImportModuleLoadResponse(ImportModuleRequest importModuleRequest) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
@@ -35,7 +35,6 @@ import io.ballerina.projects.util.ProjectUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 
 import static io.ballerina.projects.util.ProjectUtils.CompatibleRange;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
@@ -147,7 +147,7 @@ public abstract class AbstractPackageRepository implements PackageRepository {
     private ImportModuleResponse getImportModuleResponse(ImportModuleRequest importModuleRequest,
                                                          PackageName packageName,
                                                          List<PackageVersion> packageVersions) {
-        packageVersions = packageVersions.stream().sorted((v1, v2) -> {
+        packageVersions.sort((v1, v2) -> {
             if (v1.equals(v2)) {
                 return 0;
             }
@@ -156,7 +156,7 @@ public abstract class AbstractPackageRepository implements PackageRepository {
                 return -1;
             }
             return 1;
-        }).toList();
+        });
 
         for (PackageVersion packageVersion : packageVersions) {
             Collection<ModuleDescriptor> moduleDescriptors = getModules(

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static io.ballerina.projects.util.ProjectUtils.CompatibleRange;
 import static io.ballerina.projects.util.ProjectUtils.getLatest;
@@ -110,7 +109,7 @@ public abstract class AbstractPackageRepository implements PackageRepository {
         CompatibleRange compatibilityRange = ProjectUtils.getCompatibleRange(minSemVer, packageLockingMode);
         List<SemanticVersion> compatibleVersions = ProjectUtils.getVersionsInCompatibleRange(
                 minSemVer, semVers, compatibilityRange);
-        return compatibleVersions.stream().map(PackageVersion::from).collect(Collectors.toList());
+        return compatibleVersions.stream().map(PackageVersion::from).toList();
     }
 
     private ImportModuleResponse getImportModuleLoadResponse(ImportModuleRequest importModuleRequest) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
@@ -148,15 +148,16 @@ public abstract class AbstractPackageRepository implements PackageRepository {
     private ImportModuleResponse getImportModuleResponse(ImportModuleRequest importModuleRequest,
                                                          PackageName packageName,
                                                          List<PackageVersion> packageVersions) {
-        Comparator<PackageVersion> comparator = (v1, v2) -> {
-
+        packageVersions = packageVersions.stream().sorted((v1, v2) -> {
+            if (v1.equals(v2)) {
+                return 0;
+            }
             PackageVersion latest = getLatest(v1, v2);
             if (v1 == latest) {
                 return -1;
             }
             return 1;
-        };
-        packageVersions.sort(comparator);
+        }).toList();
 
         for (PackageVersion packageVersion : packageVersions) {
             Collection<ModuleDescriptor> moduleDescriptors = getModules(

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectUtils.java
@@ -93,7 +93,6 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -1251,7 +1250,7 @@ public final class ProjectUtils {
     private static List<Path> filterPathStream(Stream<Path> pathStream, String combinedPattern) {
         return pathStream.filter(
                         FileSystems.getDefault().getPathMatcher("glob:" + combinedPattern)::matches)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static String getGlobFormatPattern(String pattern) {

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/PackageID.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/PackageID.java
@@ -166,7 +166,7 @@ public class PackageID {
         if (name == Names.DEFAULT_PACKAGE) {
             return Lists.of(Names.DEFAULT_PACKAGE);
         }
-        return Arrays.stream(name.value.split("\\.")).map(Name::new).collect(Collectors.toList());
+        return Arrays.stream(name.value.split("\\.")).map(Name::new).toList();
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/PackageSource.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/PackageSource.java
@@ -49,6 +49,6 @@ public interface PackageSource extends PackageEntity {
      * 
      * @return the package source entries iterator
      */
-    List<CompilerInput> getPackageSourceEntries();
+    List<? extends CompilerInput> getPackageSourceEntries();
     
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/GeneralFSPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/GeneralFSPackageRepository.java
@@ -39,7 +39,6 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -258,8 +257,8 @@ public class GeneralFSPackageRepository implements PackageRepository {
         }
 
         @Override
-        public List<CompilerInput> getPackageSourceEntries() {
-            return this.getEntryNames().stream().map(e -> new FSCompilerInput(e)).collect(Collectors.toList());
+        public List<FSCompilerInput> getPackageSourceEntries() {
+            return this.getEntryNames().stream().map(e -> new FSCompilerInput(e)).toList();
         }
 
         /**

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/model/Manifest.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/model/Manifest.java
@@ -59,7 +59,7 @@ public class Manifest {
                     dependency.setMetadata(convertObjectToDependencyMetadata(entry.getValue()));
                     return dependency;
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private DependencyMetadata convertObjectToDependencyMetadata(Object obj) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProgramDirectory.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProgramDirectory.java
@@ -44,7 +44,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.wso2.ballerinalang.util.LambdaExceptionUtils.rethrow;
@@ -83,7 +82,7 @@ public class FileSystemProgramDirectory implements SourceDirectory {
                 fileNames = stream.map(ProjectDirs::getLastComp)
                         .filter(ProjectDirs::isSourceFile)
                         .map(Path::toString)
-                        .collect(Collectors.toList());
+                        .toList();
             }
             return fileNames;
         } catch (SecurityException | AccessDeniedException e) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProjectDirectory.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProjectDirectory.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.ballerinalang.repository.CompilerOutputEntry.Kind;
@@ -94,7 +93,7 @@ public class FileSystemProjectDirectory extends FileSystemProgramDirectory {
                         .filter(ProjectDirs::containsSourceFiles)
                         .map(ProjectDirs::getLastComp)
                         .map(Path::toString)
-                        .collect(Collectors.toList());
+                        .toList();
             }
         } catch (SecurityException | AccessDeniedException e) {
             throw new BLangCompilerException("permission denied: " + projectDirPath.toString());

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIROptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIROptimizer.java
@@ -277,9 +277,8 @@ public class BIROptimizer {
             birFunction.errorTable.forEach(ee -> this.optimizeNode(ee, funcOpEnv));
 
             // Remove unused temp vars
-            birFunction.localVars = birFunction.localVars.stream()
-                    .filter(l -> l.kind != VarKind.TEMP || !funcOpEnv.tempVars
-                            .containsKey(l)).toList();
+            birFunction.localVars = new ArrayList<>(birFunction.localVars.stream()
+                    .filter(l -> l.kind != VarKind.TEMP || !funcOpEnv.tempVars.containsKey(l)).toList());
             // Reuse lhs temp vars
             Set<BIRVariableDcl> replaceableVarSet = new HashSet<>();
             reuseTempVariables(birFunction.localVars, funcOpEnv.tempVarsList, replaceableVarSet);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIROptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIROptimizer.java
@@ -50,7 +50,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Optimize BIR.
@@ -280,7 +279,7 @@ public class BIROptimizer {
             // Remove unused temp vars
             birFunction.localVars = birFunction.localVars.stream()
                     .filter(l -> l.kind != VarKind.TEMP || !funcOpEnv.tempVars
-                            .containsKey(l)).collect(Collectors.toList());
+                            .containsKey(l)).toList();
             // Reuse lhs temp vars
             Set<BIRVariableDcl> replaceableVarSet = new HashSet<>();
             reuseTempVariables(birFunction.localVars, funcOpEnv.tempVarsList, replaceableVarSet);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
@@ -115,7 +115,6 @@ import org.wso2.ballerinalang.util.Lists;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 
@@ -904,7 +903,7 @@ public final class ASTBuilderUtil {
 
         dupFuncSymbol.params = invokableSymbol.params.stream()
                 .map(param -> duplicateParamSymbol(param, dupFuncSymbol))
-                .collect(Collectors.toList());
+                .toList();
         if (dupFuncSymbol.restParam != null) {
             dupFuncSymbol.restParam = duplicateParamSymbol(invokableSymbol.restParam, dupFuncSymbol);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
@@ -98,7 +98,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.UNDERSCORE;
 import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
@@ -570,7 +569,7 @@ public class AnnotationDesugar {
     private List<BLangAnnotationAttachment> getAnnotationList(AnnotatableNode node) {
         return node.getAnnotationAttachments().stream()
                 .map(annotAttachment -> (BLangAnnotationAttachment) annotAttachment)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private BLangLambdaFunction defineAnnotations(List<BLangAnnotationAttachment> annAttachments,
@@ -910,7 +909,7 @@ public class AnnotationDesugar {
         functionSymbol.retType = function.returnTypeNode.getBType();
         functionSymbol.params = function.requiredParams.stream()
                 .map(param -> param.symbol)
-                .collect(Collectors.toList());
+                .toList();
         functionSymbol.scope = new Scope(functionSymbol);
         functionSymbol.restParam = function.restParam != null ? function.restParam.symbol : null;
         functionSymbol.type = new BInvokableType(Collections.emptyList(),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1841,7 +1841,7 @@ public class Desugar extends BLangNodeVisitor {
 
             List<String> keysToRemove = parentRecordVariable.variableList.stream()
                     .map(var -> var.getKey().getValue())
-                    .collect(Collectors.toList());
+                    .toList();
 
             BLangSimpleVariable filteredDetail = generateRestFilter(variableReference, pos,
                     keysToRemove, restParamType, parentBlockStmt);
@@ -1948,7 +1948,7 @@ public class Desugar extends BLangNodeVisitor {
                     pos, detailTempVarDef.var.symbol);
             List<String> keysToRemove = parentErrorVariable.detail.stream()
                     .map(detail -> detail.key.getValue())
-                    .collect(Collectors.toList());
+                    .toList();
 
             BLangSimpleVariable filteredDetail = generateRestFilter(detailVarRef, parentErrorVariable.pos, keysToRemove,
                                                                     parentErrorVariable.restDetail.getBType(),
@@ -2120,7 +2120,7 @@ public class Desugar extends BLangNodeVisitor {
         functionSymbol.retType = function.returnTypeNode.getBType();
         functionSymbol.params = function.requiredParams.stream()
                 .map(param -> param.symbol)
-                .collect(Collectors.toList());
+                .toList();
         functionSymbol.scope = env.scope;
         functionSymbol.type = new BInvokableType(Collections.singletonList(getStringAnyTupleType()), constraint, null);
         function.symbol = functionSymbol;
@@ -2350,7 +2350,7 @@ public class Desugar extends BLangNodeVisitor {
                                                                Location location) {
         List<String> fieldNamesToRemove = recordVariable.variableList.stream()
                 .map(var -> var.getKey().getValue())
-                .collect(Collectors.toList());
+                .toList();
         return createFuncToFilterOutRestParam(fieldNamesToRemove, location);
     }
 
@@ -2406,7 +2406,7 @@ public class Desugar extends BLangNodeVisitor {
         functionSymbol.retType = function.returnTypeNode.getBType();
         functionSymbol.params = function.requiredParams.stream()
                 .map(param -> param.symbol)
-                .collect(Collectors.toList());
+                .toList();
         functionSymbol.scope = env.scope;
         functionSymbol.type = new BInvokableType(Collections.singletonList(getStringAnyTupleType()),
                                                  getRestType(functionSymbol), symTable.booleanType, null);
@@ -2900,7 +2900,7 @@ public class Desugar extends BLangNodeVisitor {
 
             List<String> keysToRemove = parentRecordVarRef.recordRefFields.stream()
                     .map(field -> field.variableName.value)
-                    .collect(Collectors.toList());
+                    .toList();
 
             BLangSimpleVariable filteredDetail = generateRestFilter(variableReference, pos,
                     keysToRemove, restParamType, parentBlockStmt);
@@ -8149,13 +8149,13 @@ public class Desugar extends BLangNodeVisitor {
             varNode.symbol.kind = SymbolKind.FUNCTION;
             varNode.symbol.owner = invokableEnv.scope.owner;
             enclScope.define(varNode.symbol.name, varNode.symbol);
-        }).map(varNode -> varNode.symbol).collect(Collectors.toList());
+        }).map(varNode -> varNode.symbol).toList();
 
         funcSymbol.params = paramSymbols;
         funcSymbol.restParam = getRestSymbol(funcNode);
         funcSymbol.retType = funcNode.returnTypeNode.getBType();
         // Create function type.
-        List<BType> paramTypes = paramSymbols.stream().map(paramSym -> paramSym.type).collect(Collectors.toList());
+        List<BType> paramTypes = paramSymbols.stream().map(paramSym -> paramSym.type).toList();
         funcNode.setBType(new BInvokableType(paramTypes, getRestType(funcSymbol), funcNode.returnTypeNode.getBType(),
                           funcSymbol.type.tsymbol));
 
@@ -8458,7 +8458,7 @@ public class Desugar extends BLangNodeVisitor {
     @Override
     public void visit(BLangWorkerFlushExpr workerFlushExpr) {
         workerFlushExpr.workerIdentifierList = workerFlushExpr.cachedWorkerSendStmts
-                .stream().map(send -> send.workerIdentifier).distinct().collect(Collectors.toList());
+                .stream().map(send -> send.workerIdentifier).distinct().toList();
         result = workerFlushExpr;
     }
 
@@ -8840,7 +8840,7 @@ public class Desugar extends BLangNodeVisitor {
         return nameBXMLNSSymbolMap.keySet().stream()
                 .map(key -> this.stmtsToBePropagatedToQuery.get(key))
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -8155,7 +8155,7 @@ public class Desugar extends BLangNodeVisitor {
         funcSymbol.restParam = getRestSymbol(funcNode);
         funcSymbol.retType = funcNode.returnTypeNode.getBType();
         // Create function type.
-        List<BType> paramTypes = paramSymbols.stream().map(paramSym -> paramSym.type).toList();
+        List<BType> paramTypes = new ArrayList<>(paramSymbols.stream().map(paramSym -> paramSym.type).toList());
         funcNode.setBType(new BInvokableType(paramTypes, getRestType(funcSymbol), funcNode.returnTypeNode.getBType(),
                           funcSymbol.type.tsymbol));
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
@@ -56,7 +56,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.UNDERSCORE;
 
@@ -288,8 +287,7 @@ public class ServiceDesugar {
     }
 
     void engageCustomServiceDesugar(BLangService service, SymbolEnv env) {
-        List<BType> expressionTypes = service.attachedExprs.stream().map(expression -> expression.getBType())
-                .collect(Collectors.toList());
+        List<BType> expressionTypes = service.attachedExprs.stream().map(expression -> expression.getBType()).toList();
         service.serviceClass.functions.stream()
                 .filter(fun -> Symbols.isResource(fun.symbol) || Symbols.isRemote(fun.symbol))
                 .forEach(func -> engageCustomResourceDesugar(func, env, expressionTypes));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBalaRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBalaRepo.java
@@ -48,14 +48,14 @@ import static org.wso2.ballerinalang.programfile.ProgramFileConstants.SUPPORTED_
 public class HomeBalaRepo implements Repo<Path> {
     private Path repoLocation;
     private ZipConverter zipConverter;
-    private List<String> supportedPlatforms = Arrays.stream(SUPPORTED_PLATFORMS).toList();
+    private List<String> supportedPlatforms = Stream.concat(
+            Arrays.stream(SUPPORTED_PLATFORMS), Stream.of("any")).toList();
     private Map<PackageID, Manifest> dependencyManifests;
     
     public HomeBalaRepo(Map<PackageID, Manifest> dependencyManifests) {
         this.repoLocation = RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.BALA_CACHE_DIR_NAME);
         this.dependencyManifests = dependencyManifests;
         this.zipConverter = new ZipConverter(this.repoLocation);
-        supportedPlatforms.add("any");
     }
     
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBalaRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBalaRepo.java
@@ -37,7 +37,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.wso2.ballerinalang.compiler.packaging.Patten.path;
@@ -49,7 +48,7 @@ import static org.wso2.ballerinalang.programfile.ProgramFileConstants.SUPPORTED_
 public class HomeBalaRepo implements Repo<Path> {
     private Path repoLocation;
     private ZipConverter zipConverter;
-    private List<String> supportedPlatforms = Arrays.stream(SUPPORTED_PLATFORMS).collect(Collectors.toList());
+    private List<String> supportedPlatforms = Arrays.stream(SUPPORTED_PLATFORMS).toList();
     private Map<PackageID, Manifest> dependencyManifests;
     
     public HomeBalaRepo(Map<PackageID, Manifest> dependencyManifests) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -266,6 +266,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import static org.ballerinalang.model.tree.NodeKind.LITERAL;
 import static org.ballerinalang.util.BLangCompilerConstants.RETRY_MANAGER_OBJECT_SHOULD_RETRY_FUNC;
@@ -1889,12 +1890,9 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
     }
 
     private List<BLangExpression> getVarRefs(BLangRecordVarRef varRef) {
-        List<BLangExpression> varRefs = varRef.recordRefFields.stream()
-                .map(e -> e.variableReference).toList();
-        if (varRef.restParam != null) {
-            varRefs.add(varRef.restParam);
-        }
-        return varRefs;
+        return Stream.concat(
+                varRef.recordRefFields.stream().map(e -> e.variableReference),
+                Stream.ofNullable(varRef.restParam)).toList();
     }
 
     private List<BLangExpression> getVarRefs(BLangErrorVarRef varRef) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -266,7 +266,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.model.tree.NodeKind.LITERAL;
 import static org.ballerinalang.util.BLangCompilerConstants.RETRY_MANAGER_OBJECT_SHOULD_RETRY_FUNC;
@@ -1891,7 +1890,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
 
     private List<BLangExpression> getVarRefs(BLangRecordVarRef varRef) {
         List<BLangExpression> varRefs = varRef.recordRefFields.stream()
-                .map(e -> e.variableReference).collect(Collectors.toList());
+                .map(e -> e.variableReference).toList();
         if (varRef.restParam != null) {
             varRefs.add(varRef.restParam);
         }
@@ -2904,7 +2903,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
             List<BLangWorkerAsyncSendExpr> sendsToGivenWrkr = sendStmts.stream()
                                                               .filter(bLangNode -> bLangNode.workerIdentifier.equals
                                                                       (flushWrkIdentifier))
-                                                              .collect(Collectors.toList());
+                                                              .toList();
             if (sendsToGivenWrkr.isEmpty()) {
                 this.dlog.error(workerFlushExpr.pos, DiagnosticErrorCode.INVALID_WORKER_FLUSH_FOR_WORKER,
                                 workerFlushExpr.workerSymbol, currentWrkerAction.currentWorkerId());
@@ -2928,7 +2927,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
         return actions.stream()
                       .filter(CodeAnalyzer::isWorkerSend)
                       .map(bLangNode -> (BLangWorkerAsyncSendExpr) bLangNode)
-                      .collect(Collectors.toList());
+                      .toList();
     }
     @Override
     public void visit(BLangTrapExpr trapExpr, AnalyzerData data) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
@@ -71,7 +71,6 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 /**
  * Invoke {@link CompilerPlugin} plugins.
@@ -400,7 +399,7 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
         }
 
         List<DefinitionID> definitions = Arrays.stream(supportedTypes)
-                .map(type -> new DefinitionID(type.packageName(), type.name())).collect(Collectors.toList());
+                .map(type -> new DefinitionID(type.packageName(), type.name())).toList();
         resourceTypeProcessorMap.put(plugin, definitions);
         serviceListenerMap.put(plugin, listenerType);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -1562,7 +1562,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
                 fieldMap.put(recordVarNameField.getVariableName().value, recordVarNameField);
             }
         }
-        return fieldNames.stream().map(fieldMap::get).collect(Collectors.toList());
+        return fieldNames.stream().map(fieldMap::get).toList();
     }
 
     private List<String> getFieldNames(BLangTableConstructorExpr constructorExpr) {
@@ -1577,7 +1577,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
                 !constructorExpr.tableKeySpecifier.fieldNameIdentifierList.isEmpty()) {
             BLangTableKeySpecifier tableKeySpecifier = constructorExpr.tableKeySpecifier;
             return tableKeySpecifier.fieldNameIdentifierList.stream().map(identifier ->
-                    ((BLangIdentifier) identifier).value).collect(Collectors.toList());
+                    ((BLangIdentifier) identifier).value).toList();
         } else {
             return new ArrayList<>();
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/QueryTypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/QueryTypeChecker.java
@@ -97,7 +97,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 import static org.ballerinalang.util.diagnostic.DiagnosticErrorCode.INVALID_QUERY_CONSTRUCT_INFERRED_MAP;
@@ -283,7 +282,7 @@ public class QueryTypeChecker extends TypeChecker {
         List<BType> safeResultTypes = types.getAllTypes(targetType, true).stream()
                 .filter(t -> !types.isAssignable(t, symTable.errorType))
                 .filter(t -> !types.isAssignable(t, symTable.nilType))
-                .collect(Collectors.toList());
+                .toList();
         // resultTypes will be empty if the targetType is `error?`
         if (safeResultTypes.isEmpty()) {
             safeResultTypes.add(symTable.noType);
@@ -497,7 +496,7 @@ public class QueryTypeChecker extends TypeChecker {
             validateKeySpecifier(queryExpr.fieldNameIdentifierList, constraintType);
             markReadOnlyForConstraintType(constraintType);
             tableType.fieldNameList = queryExpr.fieldNameIdentifierList.stream()
-                    .map(identifier -> ((BLangIdentifier) identifier).value).collect(Collectors.toList());
+                    .map(identifier -> ((BLangIdentifier) identifier).value).toList();
         }
         if (Symbols.isFlagOn(resolvedType.flags, Flags.READONLY)) {
             return ImmutableTypeCloner.getImmutableIntersectionType(null, types,
@@ -643,7 +642,7 @@ public class QueryTypeChecker extends TypeChecker {
         return clauses.stream()
                 .filter(clause -> (clause.getKind() == NodeKind.FROM || clause.getKind() == NodeKind.JOIN))
                 .map(clause -> ((BLangInputClause) clause).collection.getBType())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private BType getResolvedType(BType initType, BType expType, boolean isReadonly, SymbolEnv env) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/QueryTypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/QueryTypeChecker.java
@@ -285,7 +285,7 @@ public class QueryTypeChecker extends TypeChecker {
                 .toList();
         // resultTypes will be empty if the targetType is `error?`
         if (safeResultTypes.isEmpty()) {
-            safeResultTypes.add(symTable.noType);
+            safeResultTypes = List.of(symTable.noType);
         }
         BType actualType = symTable.semanticError;
         List<BType> selectTypes = new ArrayList<>();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
@@ -106,7 +106,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.wso2.ballerinalang.compiler.util.Constants.WORKER_LAMBDA_VAR_PREFIX;
 
@@ -963,7 +962,7 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
 
     private List<BLangExpression> getVarRefs(BLangRecordVarRef varRef) {
         List<BLangExpression> varRefs = varRef.recordRefFields.stream()
-                .map(e -> e.variableReference).collect(Collectors.toList());
+                .map(e -> e.variableReference).toList();
         varRefs.add(varRef.restParam);
         return varRefs;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
@@ -106,6 +106,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.wso2.ballerinalang.compiler.util.Constants.WORKER_LAMBDA_VAR_PREFIX;
 
@@ -961,10 +962,9 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
     }
 
     private List<BLangExpression> getVarRefs(BLangRecordVarRef varRef) {
-        List<BLangExpression> varRefs = varRef.recordRefFields.stream()
-                .map(e -> e.variableReference).toList();
-        varRefs.add(varRef.restParam);
-        return varRefs;
+        return Stream.concat(
+                varRef.recordRefFields.stream().map(e -> e.variableReference),
+                Stream.of(varRef.restParam)).toList();
     }
 
     private List<BLangExpression> getVarRefs(BLangErrorVarRef varRef) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -2713,7 +2713,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 Set<BType> bTypes = types.expandAndGetMemberTypesRecursive(unionType);
                 List<BType> possibleTypes = bTypes.stream()
                         .filter(rec -> doesRecordContainKeys(rec, recordVar.variableList, recordVar.restParam != null))
-                        .collect(Collectors.toList());
+                        .toList();
 
                 if (possibleTypes.isEmpty()) {
                     dlog.error(recordVar.pos, DiagnosticErrorCode.INVALID_RECORD_BINDING_PATTERN, recordType);
@@ -2764,7 +2764,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         BRecordType recordVarType = (BRecordType) symTable.recordType;
 
         List<String> mappedFields = recordVar.variableList.stream().map(varKeyValue -> varKeyValue.getKey().value)
-                .collect(Collectors.toList());
+                .toList();
         LinkedHashMap<String, BField> fields = populateAndGetPossibleFieldsForRecVar(recordVar.pos, possibleTypes,
                 mappedFields, recordSymbol, env);
 
@@ -2993,7 +2993,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         if (recordVar.restParam != null) {
             BType restType = getRestParamType(recordVarType);
             List<String> varList = recordVar.variableList.stream().map(t -> t.getKey().value)
-                    .collect(Collectors.toList());
+                    .toList();
             BRecordType restConstraint = createRecordTypeForRestField(recordVar.restParam.getPosition(), env,
                     recordVarType, varList, restType);
             defineMemberNode(recordVar.restParam, env, restConstraint);
@@ -4606,7 +4606,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         // Create function type
         List<BType> paramTypes = paramSymbols.stream()
                 .map(paramSym -> paramSym.type)
-                .collect(Collectors.toList());
+                .toList();
 
         BInvokableTypeSymbol functionTypeSymbol = Symbols.createInvokableTypeSymbol(SymTag.FUNCTION_TYPE,
                                                                                     invokableSymbol.flags,
@@ -4865,7 +4865,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                     p.symbol.kind = SymbolKind.PATH_PARAMETER;
                     return p.symbol;
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         BVarSymbol restPathParamSym = null;
         if (resourceFunction.restPathParam != null) {
@@ -5155,7 +5155,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 var.flagSet = field.symbol.getFlags();
                 return var;
             });
-        }).collect(Collectors.toList());
+        }).toList();
         structureTypeNode.typeRefs.removeAll(invalidTypeRefs);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -4604,9 +4604,9 @@ public class SymbolEnter extends BLangNodeVisitor {
         symResolver.validateInferTypedescParams(invokableNode.pos, invokableNode.getParameters(), retType);
 
         // Create function type
-        List<BType> paramTypes = paramSymbols.stream()
+        List<BType> paramTypes = new ArrayList<>(paramSymbols.stream()
                 .map(paramSym -> paramSym.type)
-                .toList();
+                .toList());
 
         BInvokableTypeSymbol functionTypeSymbol = Symbols.createInvokableTypeSymbol(SymTag.FUNCTION_TYPE,
                                                                                     invokableSymbol.flags,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1682,9 +1682,9 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     break;
                 case TypeTags.RECORD:
                     Map<String, BField> fieldList = ((BRecordType) referredKeyTypeConstraint).getFields();
-                    memberTypes = fieldList.entrySet().stream()
+                    memberTypes = new ArrayList<>(fieldList.entrySet().stream()
                             .filter(e -> fieldNameList.contains(e.getKey())).map(entry -> entry.getValue().type)
-                            .toList();
+                            .toList());
                     if (memberTypes.isEmpty()) {
                         memberTypes.add(keyTypeConstraint);
                     }
@@ -4805,17 +4805,17 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             }
         }
 
-        List<BVarSymbol> requiredParams = function.symbol.params.stream()
+        List<BVarSymbol> requiredParams = new ArrayList<>(function.symbol.params.stream()
                 .filter(param -> !param.isDefaultable)
-                .toList();
+                .toList());
         // Given named and positional arguments are less than required parameters.
         if (requiredParams.size() > invocationArguments.size()) {
             return false;
         }
 
-        List<BVarSymbol> defaultableParams = function.symbol.params.stream()
+        List<BVarSymbol> defaultableParams = new ArrayList<>(function.symbol.params.stream()
                 .filter(param -> param.isDefaultable)
-                .toList();
+                .toList());
 
         int givenRequiredParamCount = 0;
         for (int i = 0; i < positionalArgs.size(); i++) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1684,7 +1684,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     Map<String, BField> fieldList = ((BRecordType) referredKeyTypeConstraint).getFields();
                     memberTypes = fieldList.entrySet().stream()
                             .filter(e -> fieldNameList.contains(e.getKey())).map(entry -> entry.getValue().type)
-                            .collect(Collectors.toList());
+                            .toList();
                     if (memberTypes.isEmpty()) {
                         memberTypes.add(keyTypeConstraint);
                     }
@@ -4807,7 +4807,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
         List<BVarSymbol> requiredParams = function.symbol.params.stream()
                 .filter(param -> !param.isDefaultable)
-                .collect(Collectors.toList());
+                .toList();
         // Given named and positional arguments are less than required parameters.
         if (requiredParams.size() > invocationArguments.size()) {
             return false;
@@ -4815,7 +4815,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
         List<BVarSymbol> defaultableParams = function.symbol.params.stream()
                 .filter(param -> param.isDefaultable)
-                .collect(Collectors.toList());
+                .toList();
 
         int givenRequiredParamCount = 0;
         for (int i = 0; i < positionalArgs.size(); i++) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1676,13 +1676,11 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
             switch (referredKeyTypeConstraint.tag) {
                 case TypeTags.TUPLE:
-                    for (BType type : ((BTupleType) referredKeyTypeConstraint).getTupleTypes()) {
-                        memberTypes.add(type);
-                    }
+                    memberTypes.addAll(((BTupleType) referredKeyTypeConstraint).getTupleTypes());
                     break;
                 case TypeTags.RECORD:
                     Map<String, BField> fieldList = ((BRecordType) referredKeyTypeConstraint).getFields();
-                    memberTypes = new ArrayList<>(fieldList.entrySet().stream()
+                    memberTypes.addAll(fieldList.entrySet().stream()
                             .filter(e -> fieldNameList.contains(e.getKey())).map(entry -> entry.getValue().type)
                             .toList());
                     if (memberTypes.isEmpty()) {
@@ -4805,17 +4803,17 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             }
         }
 
-        List<BVarSymbol> requiredParams = new ArrayList<>(function.symbol.params.stream()
+        List<BVarSymbol> requiredParams = function.symbol.params.stream()
                 .filter(param -> !param.isDefaultable)
-                .toList());
+                .collect(Collectors.toList());
         // Given named and positional arguments are less than required parameters.
         if (requiredParams.size() > invocationArguments.size()) {
             return false;
         }
 
-        List<BVarSymbol> defaultableParams = new ArrayList<>(function.symbol.params.stream()
+        List<BVarSymbol> defaultableParams = function.symbol.params.stream()
                 .filter(param -> param.isDefaultable)
-                .toList());
+                .collect(Collectors.toList());
 
         int givenRequiredParamCount = 0;
         for (int i = 0; i < positionalArgs.size(); i++) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -125,7 +125,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.model.symbols.SymbolOrigin.BUILTIN;
 import static org.ballerinalang.model.symbols.SymbolOrigin.SOURCE;
@@ -1936,7 +1935,7 @@ public class TypeResolver {
         if (resolvingConstants.contains(constant)) { // To identify cycles.
             dlog.error(constant.pos, DiagnosticErrorCode.CONSTANT_CYCLIC_REFERENCE,
                     (this.resolvingConstants).stream().map(constNode -> constNode.symbol)
-                            .collect(Collectors.toList()));
+                            .toList());
             constant.setBType(symTable.semanticError);
             return;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
@@ -291,7 +291,7 @@ public class GlobalVariableRefAnalyzer {
         if (!dependencyOrder.isEmpty()) {
             List<BSymbol> symbolsProvidersOrdered = this.dependencyOrder.stream()
                     .map(nodeInfo -> nodeInfo.symbol)
-                    .collect(Collectors.toList());
+                    .toList();
             this.dependencyOrder.clear();
             return symbolsProvidersOrdered;
         }
@@ -382,7 +382,7 @@ public class GlobalVariableRefAnalyzer {
         List<BLangVariable> sortedGlobalVars = sorted.stream()
                 .filter(varMap::containsKey)
                 .map(varMap::get)
-                .collect(Collectors.toList());
+                .toList();
 
         if (sortedGlobalVars.size() != this.pkgNode.globalVars.size()) {
             List<BLangVariable> symbolLessGlobalVars = this.pkgNode.globalVars.stream()
@@ -401,7 +401,7 @@ public class GlobalVariableRefAnalyzer {
         List<BLangConstant> sortedConstants = sorted.stream()
                 .filter(varMap::containsKey)
                 .map(varMap::get)
-                .collect(Collectors.toList());
+                .toList();
 
         if (sortedConstants.size() != this.pkgNode.constants.size()) {
             List<BLangConstant> symbolLessGlobalVars = this.pkgNode.constants.stream()
@@ -487,7 +487,7 @@ public class GlobalVariableRefAnalyzer {
             Collections.reverse(cycle);
             List<BSymbol> symbolsOfCycle = cycle.stream()
                     .map(n -> n.symbol)
-                    .collect(Collectors.toList());
+                    .toList();
 
             if (doesContainAGlobalVar(symbolsOfCycle)) {
                 emitErrorMessage(symbolsOfCycle);
@@ -520,7 +520,7 @@ public class GlobalVariableRefAnalyzer {
         secondSubList.addAll(firstSubList);
 
         List<BLangIdentifier> names = secondSubList.stream()
-                .map(this::getNodeName).filter(Objects::nonNull).collect(Collectors.toList());
+                .map(this::getNodeName).filter(Objects::nonNull).toList();
         dlog.error(firstNode.get().getPosition(), DiagnosticErrorCode.GLOBAL_VARIABLE_CYCLIC_DEFINITION, names);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangImportPackage.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangImportPackage.java
@@ -24,7 +24,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * @since 0.94
@@ -136,7 +135,7 @@ public class BLangImportPackage extends BLangNode implements ImportPackageNode {
         String orgName = this.orgName.toString();
         String pkgName = String.join(".", pkgNameComps.stream()
                 .map(id -> id.value)
-                .collect(Collectors.toList()));
+                .toList());
 
         String versionStr = (this.version.value != null) ? this.version.value : "";
         if (!versionStr.isEmpty()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/NodeUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/NodeUtils.java
@@ -21,7 +21,6 @@ import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * @since 0.94
@@ -53,7 +52,7 @@ public final class NodeUtils {
 
     public static PackageID getPackageID(Names names, BLangIdentifier orgNameNode,
                                          List<BLangIdentifier> pkgNameComps, BLangIdentifier versionNode) {
-        List<Name> nameList = pkgNameComps.stream().map(names::fromIdNode).collect(Collectors.toList());
+        List<Name> nameList = pkgNameComps.stream().map(names::fromIdNode).toList();
         Name orgName = null;
         if (orgNameNode != null) {
             orgName = names.fromIdNode(orgNameNode);

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/DefaultPackageRepository.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/DefaultPackageRepository.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Test implementation of the package repository.
@@ -65,7 +66,7 @@ public class  DefaultPackageRepository extends AbstractPackageRepository {
                 .stream()
                 .map(PackageDescWrapper::pkgDesc)
                 .map(PackageDescriptor::version)
-                .toList();
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/DefaultPackageRepository.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/DefaultPackageRepository.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Test implementation of the package repository.
@@ -66,7 +65,7 @@ public class  DefaultPackageRepository extends AbstractPackageRepository {
                 .stream()
                 .map(PackageDescWrapper::pkgDesc)
                 .map(PackageDescriptor::version)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override
@@ -89,7 +88,7 @@ public class  DefaultPackageRepository extends AbstractPackageRepository {
         return pkgDescWrapper.modules().stream()
                 .map(modNameStr -> Utils.getModuleName(name, modNameStr))
                 .map(moduleName -> ModuleDescriptor.from(moduleName, pkgDesc))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/GraphUtils.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/GraphUtils.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Contains a list of utility methods to work with Ballerina dependency graphs.
@@ -84,7 +83,7 @@ public final class GraphUtils {
     }
 
     private static List<DependencyNode> getSortedCollection(Collection<DependencyNode> nodes) {
-        return nodes.stream().sorted(pkgDescComparator).collect(Collectors.toList());
+        return nodes.stream().sorted(pkgDescComparator).toList();
     }
 
     private static GraphComparisonResult reportGraphsWithDifferentNumberOfNodes(

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/LocalPackageRepository.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/LocalPackageRepository.java
@@ -27,6 +27,7 @@ import io.ballerina.projects.internal.PackageVersionContainer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Test implementation of the package repository.
@@ -49,6 +50,6 @@ public class LocalPackageRepository extends DefaultPackageRepository {
                 .stream()
                 .map(PackageDescWrapper::pkgDesc)
                 .map(PackageDescriptor::version)
-                .toList();
+                .collect(Collectors.toList());
     }
 }

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/LocalPackageRepository.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/LocalPackageRepository.java
@@ -27,7 +27,6 @@ import io.ballerina.projects.internal.PackageVersionContainer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Test implementation of the package repository.
@@ -50,6 +49,6 @@ public class LocalPackageRepository extends DefaultPackageRepository {
                 .stream()
                 .map(PackageDescWrapper::pkgDesc)
                 .map(PackageDescriptor::version)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/PackageRepositoryBuilder.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/PackageRepositoryBuilder.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -90,7 +89,7 @@ public class PackageRepositoryBuilder {
         }
 
         try (Stream<Path> paths = Files.list(localRepoDirPath)) {
-            return buildLocalRepo(paths.collect(Collectors.toList()));
+            return buildLocalRepo(paths.toList());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -211,7 +210,7 @@ public class PackageRepositoryBuilder {
             return marker.entrySet().stream()
                     .filter(entry -> entry.getValue() == Boolean.FALSE)
                     .map(Map.Entry::getKey)
-                    .collect(Collectors.toList());
+                    .toList();
         }
     }
 }

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/PackageResolutionTestCaseBuilder.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/PackageResolutionTestCaseBuilder.java
@@ -48,7 +48,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Builds package resolution test cases.
@@ -101,7 +100,7 @@ public final class PackageResolutionTestCaseBuilder {
                                                             PackageDescriptor rootPkgDes) {
         return rootPkgDescWrapper.modules().stream()
                 .map(modNameStr -> Utils.getModuleName(rootPkgDes.name(), modNameStr))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static DependencyGraph<DependencyNode> getPkgDescGraph(Path dotFilePath) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/AbstractNodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/AbstractNodeFactory.java
@@ -26,7 +26,6 @@ import io.ballerina.compiler.internal.syntax.NodeListUtils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * A factory for creating nodes in the syntax tree.
@@ -159,7 +158,7 @@ public abstract class AbstractNodeFactory {
                 minutiaeNodes.stream()
                         .map(minutiae -> Objects.requireNonNull(minutiae, "minutiae should not be null"))
                         .map(Minutiae::internalNode)
-                        .collect(Collectors.toList())), 0);
+                        .toList()), 0);
     }
 
     public static Minutiae createCommentMinutiae(String text) {
@@ -204,7 +203,7 @@ public abstract class AbstractNodeFactory {
                 nodes.stream()
                         .map(node -> Objects.requireNonNull(node, "node should not be null"))
                         .map(Node::internalNode)
-                        .collect(Collectors.toList())).createUnlinkedFacade());
+                        .toList()).createUnlinkedFacade());
     }
 
     public static <T extends Node> SeparatedNodeList<T> createSeparatedNodeList(Node... nodes) {
@@ -217,12 +216,12 @@ public abstract class AbstractNodeFactory {
         return new SeparatedNodeList<>(STNodeFactory.createNodeList(internalNodes).createUnlinkedFacade());
     }
 
-    public static <T extends Node> SeparatedNodeList<T> createSeparatedNodeList(Collection<Node> nodes) {
+    public static <T extends Node> SeparatedNodeList<T> createSeparatedNodeList(Collection<? extends Node> nodes) {
         return new SeparatedNodeList<>(STNodeFactory.createNodeList(
                 nodes.stream()
                         .map(node -> Objects.requireNonNull(node, "node should not be null"))
                         .map(Node::internalNode)
-                        .collect(Collectors.toList())).createUnlinkedFacade());
+                        .toList()).createUnlinkedFacade());
     }
 
     protected static STNode getOptionalSTNode(Node node) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/MinutiaeList.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/MinutiaeList.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.internal.syntax.NodeListUtils.rangeCheck;
 import static io.ballerina.compiler.internal.syntax.NodeListUtils.rangeCheckForAdd;
@@ -87,7 +86,7 @@ public final class MinutiaeList implements Iterable<Minutiae> {
         List<STNode> stNodesToBeAdded = c.stream()
                 .map(minutiae -> Objects.requireNonNull(minutiae, "minutiae should not be null"))
                 .map(Minutiae::internalNode)
-                .collect(Collectors.toList());
+                .toList();
         return new MinutiaeList(token,
                 internalListNode.addAll(stNodesToBeAdded),
                 position);

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeList.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeList.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -85,7 +84,7 @@ public class NodeList<T extends Node> implements Iterable<T> {
         List<STNode> stNodesToBeAdded = c.stream()
                 .map(node -> Objects.requireNonNull(node, "node should not be null"))
                 .map(Node::internalNode)
-                .collect(Collectors.toList());
+                .toList();
         return new NodeList<>(internalListNode.addAll(stNodesToBeAdded).createUnlinkedFacade());
     }
 

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NonTerminalNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NonTerminalNode.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static io.ballerina.compiler.internal.syntax.SyntaxUtils.isSTNodePresent;
@@ -71,7 +70,7 @@ public abstract class NonTerminalNode extends Node {
                 IntStream.range(0, bucketCount())
                         .filter(bucket -> childInBucket(bucket) != null)
                         .mapToObj(bucket -> new ChildNodeEntry(childNames[bucket], childInBucket(bucket)))
-                        .collect(Collectors.toList()));
+                        .toList());
     }
 
     @Override

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/SyntaxInfo.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/SyntaxInfo.java
@@ -22,7 +22,6 @@ import io.ballerina.tools.text.CharReader;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * A class that provides syntax related information.
@@ -34,7 +33,7 @@ public final class SyntaxInfo {
     private static final List<String> BALLERINA_KEYWORDS = Arrays.stream(SyntaxKind.values())
             .filter(syntaxKind -> SyntaxKind.RE_KEYWORD.compareTo(syntaxKind) > 0)
             .map(SyntaxKind::stringValue)
-            .collect(Collectors.toList());
+            .toList();
 
     private SyntaxInfo() {
     }

--- a/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/targets/node/AbstractNodeTarget.java
+++ b/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/targets/node/AbstractNodeTarget.java
@@ -27,7 +27,6 @@ import io.ballerinalang.compiler.internal.treegen.targets.Target;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * The class {@code AbstractNodeTarget} represent a generic entity that converts a
@@ -57,7 +56,7 @@ public abstract class AbstractNodeTarget extends Target {
                 .stream()
                 .map(syntaxNode -> generateNodeClass(syntaxNode, nodeMetadataMap))
                 .map(treeNodeClass -> getSourceText(treeNodeClass, getOutputDir(), getClassName(treeNodeClass)))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private TreeNodeClass generateNodeClass(SyntaxNode syntaxNode, HashMap<String,

--- a/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/targets/nodevisitor/AbstractNodeVisitorTarget.java
+++ b/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/targets/nodevisitor/AbstractNodeVisitorTarget.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * The class {@code AbstractNodeVisitorTarget} represent a generic entity that converts a
@@ -73,7 +72,7 @@ public abstract class AbstractNodeVisitorTarget extends Target {
                 .stream()
                 .map(syntaxNode -> convertToTreeNodeClass(syntaxNode,
                         getPackageName(), new ArrayList<>(), nodeMetadataMap))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     protected abstract String getPackageName();

--- a/compiler/linter-plugin/src/test/java/io/ballerina/compiler/linter/codeactions/test/CodeActionUtils.java
+++ b/compiler/linter-plugin/src/test/java/io/ballerina/compiler/linter/codeactions/test/CodeActionUtils.java
@@ -38,7 +38,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Helper methods for writing code action tests.
@@ -85,7 +84,7 @@ public final class CodeActionUtils {
                     // Get codeactions for the diagnostic
                     return codeActionManager.codeActions(context).getCodeActions().stream();
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**
@@ -108,7 +107,7 @@ public final class CodeActionUtils {
         Gson gson = new Gson();
         List<CodeActionArgument> codeActionArguments = codeAction.getArguments().stream()
                 .map(arg -> CodeActionArgument.from(gson.toJsonTree(arg)))
-                .collect(Collectors.toList());
+                .toList();
 
         CodeActionExecutionContext executionContext = CodeActionExecutionContextImpl.from(
                 filePath.toUri().toString(),

--- a/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
+++ b/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
@@ -50,7 +50,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -87,7 +86,7 @@ final class BIRTestUtils {
             return paths.filter(file -> Files.isRegularFile(file))
                     .map(file -> file.toAbsolutePath().normalize().toString())
                     .filter(file -> file.endsWith(".bal") && !file.contains("negative") && !file.contains("subtype"))
-                    .collect(Collectors.toList());
+                    .toList();
         }
     }
 

--- a/docs/language-server/CompilerPluginCodeActions.md
+++ b/docs/language-server/CompilerPluginCodeActions.md
@@ -321,7 +321,7 @@ public class CodeActionUtils {
                     // Get codeactions for the diagnostic
                     return codeActionManager.codeActions(context).getCodeActions().stream();
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 }
 ```
@@ -387,7 +387,7 @@ public class CodeActionUtils {
         // JsonElements to objects via deserialization.
         List<CodeActionArgument> codeActionArguments = codeAction.getArguments().stream()
                 .map(arg -> CodeActionArgument.from(GSON.toJsonTree(arg)))
-                .collect(Collectors.toList());
+                .toList();
 
         CodeActionExecutionContext executionContext = CodeActionExecutionContextImpl.from(
                 filePath.toUri().toString(),

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -114,7 +114,6 @@ import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.formatter.core.FormatterUtils.buildFormattingOptions;
 
@@ -345,7 +344,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
                         cancelChecker);
                 return LangExtensionDelegator.instance().codeActions(params, context, this.serverContext).stream()
                         .map((Function<CodeAction, Either<Command, CodeAction>>) Either::forRight)
-                        .collect(Collectors.toList());
+                        .toList();
             } catch (UserErrorException e) {
                 this.clientLogger.notifyUser("Code Action", e);
             } catch (CancellationException ignore) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
@@ -41,7 +41,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 /**
  * Workspace service implementation for Ballerina.
@@ -110,7 +109,7 @@ public class BallerinaWorkspaceService implements WorkspaceService {
         return CompletableFuture.supplyAsync(() -> {
             List<CommandArgument> commandArguments = params.getArguments().stream()
                     .map(CommandArgument::from)
-                    .collect(Collectors.toList());
+                    .toList();
             ExecuteCommandContext context = ContextBuilder.buildExecuteCommandContext(this.workspaceManagerProxy.get(),
                     this.serverContext,
                     commandArguments,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionProvidersHolder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionProvidersHolder.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.stream.Collectors;
 
 /**
  * Represents the Code Action provider factory.
@@ -96,7 +95,7 @@ public class CodeActionProvidersHolder {
             return CodeActionProvidersHolder.rangeBasedProviders.get(nodeType).stream()
                     .filter(provider -> provider.isEnabled(ctx.languageServercontext()))
                     .sorted(Comparator.comparingInt(LSCodeActionProvider::priority))
-                    .collect(Collectors.toList());
+                    .toList();
         }
         return Collections.emptyList();
     }
@@ -110,7 +109,7 @@ public class CodeActionProvidersHolder {
         return CodeActionProvidersHolder.diagnosticsBasedProviders.stream()
                 .filter(provider -> provider.isEnabled(ctx.languageServercontext()))
                 .sorted(Comparator.comparingInt(LSCodeActionProvider::priority))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -87,7 +87,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.langserver.common.utils.CommonUtil.LINE_SEPARATOR;
 
@@ -558,7 +557,7 @@ public final class CodeActionUtil {
         List<TypeSymbol> errorTypeSymbolsClone = new ArrayList<>(errorTypeSymbols);
         return errorTypeSymbolsClone.stream().filter(typeSymbol ->
                 errorTypeSymbols.stream().filter(other -> !other.signature().equals(typeSymbol.signature()))
-                        .noneMatch(typeSymbol::subtypeOf)).collect(Collectors.toList());
+                        .noneMatch(typeSymbol::subtypeOf)).toList();
     }
 
     private static Pair<List<TypeSymbol>, List<TypeSymbol>> getErrorAndNonErrorTypedSymbols(

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CompilerPluginCodeActionExtension.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CompilerPluginCodeActionExtension.java
@@ -61,7 +61,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Compiler plugin code action extension implementation for ballerina.
@@ -129,7 +128,7 @@ public class CompilerPluginCodeActionExtension implements CodeActionExtension {
                     return CodeActionUtil.createResolvableCodeAction(codeActionInfo.getTitle(),
                             CodeActionKind.QuickFix, codeActionData);
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override
@@ -155,7 +154,7 @@ public class CompilerPluginCodeActionExtension implements CodeActionExtension {
         List<CodeActionArgument> arguments = actionData.stream()
                 .map(gson::toJsonTree)
                 .map(CodeActionArgument::from)
-                .collect(Collectors.toList());
+                .toList();
         // Build the execution context and execute code action
         CodeActionExecutionContext codeActionContext = CodeActionExecutionContextImpl.from(
                 codeActionData.getFileUri(),

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddCheckCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddCheckCodeAction.java
@@ -46,7 +46,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Code Action for error type handle.
@@ -137,7 +136,7 @@ public class AddCheckCodeAction extends TypeCastCodeAction {
 
         List<TypeSymbol> errorTypeSymbols = ((UnionTypeSymbol) foundType.get()).memberTypeDescriptors().stream()
                 .filter(typeSymbol -> CommonUtil.getRawType(typeSymbol).typeKind() == TypeDescKind.ERROR)
-                .collect(Collectors.toList());
+                .toList();
 
         ImportsAcceptor acceptor = new ImportsAcceptor(context);
         List<TextEdit> edits = new ArrayList<>(CodeActionUtil.getAddCheckTextEdits(

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToFunctionCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToFunctionCodeAction.java
@@ -341,7 +341,7 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
         return Optional.of(argsSymbolsForExtractFunction.stream()
                 // getLocation() is present for each symbol
                 .sorted(Comparator.comparingInt(symbol -> symbol.getLocation().get().textRange().startOffset()))
-                .collect(Collectors.toList()));
+                .toList());
     }
 
     /**
@@ -550,7 +550,7 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
                 .filter(symbol -> !PositionUtil.isWithinLineRange(symbol.getLocation().get().lineRange(),
                         matchedLineRange))
                 .sorted(Comparator.comparingInt(symbol -> symbol.getLocation().get().textRange().startOffset()))
-                .collect(Collectors.toList()));
+                .toList());
     }
 
     private Optional<ArgListsHolder> getArgLists(CodeActionContext context, List<Symbol> symbolsList,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/FillRecordFieldsCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/FillRecordFieldsCodeAction.java
@@ -50,7 +50,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Code Action to autofill record fields.
@@ -135,7 +134,7 @@ public class FillRecordFieldsCodeAction implements RangeBasedCodeActionProvider 
                 .filter(field -> !field.isMissing() && field.kind() == SyntaxKind.SPECIFIC_FIELD
                         && ((SpecificFieldNode) field).fieldName().kind() == SyntaxKind.IDENTIFIER_TOKEN)
                 .map(field -> ((IdentifierToken) ((SpecificFieldNode) field).fieldName()).text())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static Optional<MappingConstructorExpressionNode> getMappingConstructorNode(Node node) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ImplementAllCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ImplementAllCodeAction.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.langserver.codeaction.CodeActionUtil.computePositionDetails;
 
@@ -90,7 +89,7 @@ public class ImplementAllCodeAction extends AbstractImplementMethodCodeAction im
                         .isRangeWithinRange(context.range(), PositionUtil.toRange(diag.location().lineRange()))
                 )
                 .filter(diagnostic -> DIAGNOSTIC_CODES.contains(diagnostic.diagnosticInfo().code()))
-                .collect(Collectors.toList());
+                .toList();
 
         if (diags.isEmpty() || diags.size() == 1) {
             return Collections.emptyList();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableWithTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableWithTypeCodeAction.java
@@ -225,11 +225,7 @@ public class CreateVariableWithTypeCodeAction extends CreateVariableCodeAction {
             typeStream = typeStream.map(type -> type + "|" + errorTypeStr);
         }
 
-        List<String> typesList = typeStream.toList();
-        if (unionType != null) {
-            typesList.add(0, unionType);
-        }
-        return typesList;
+        return Stream.concat(Stream.ofNullable(unionType), typeStream).toList();
     }
 
     private boolean isInRemoteMethodCallOrResourceAccess(CodeActionContext context) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableWithTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableWithTypeCodeAction.java
@@ -225,7 +225,7 @@ public class CreateVariableWithTypeCodeAction extends CreateVariableCodeAction {
             typeStream = typeStream.map(type -> type + "|" + errorTypeStr);
         }
 
-        List<String> typesList = typeStream.collect(Collectors.toList());
+        List<String> typesList = typeStream.toList();
         if (unionType != null) {
             typesList.add(0, unionType);
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/OptimizeImportsCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/OptimizeImportsCodeAction.java
@@ -73,10 +73,10 @@ public class OptimizeImportsCodeAction implements RangeBasedCodeActionProvider {
         List<ImportDeclarationNode> fileImports = new ArrayList<>();
         ((ModulePartNode) syntaxTree.rootNode()).imports().stream().forEach(fileImports::add);
 
-        List<LineRange> toBeRemovedImportsLocations = context.diagnostics(context.filePath()).stream()
+        List<LineRange> toBeRemovedImportsLocations = new ArrayList<>(context.diagnostics(context.filePath()).stream()
                 .filter(diag -> UNUSED_IMPORT_DIAGNOSTIC_CODE.equals(diag.diagnosticInfo().code()))
                 .map(diag -> diag.location().lineRange())
-                .toList();
+                .toList());
 
         // Skip, when nothing to remove and only single import pending
         if (fileImports.isEmpty() || (fileImports.size() <= 1 && toBeRemovedImportsLocations.isEmpty())) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/OptimizeImportsCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/OptimizeImportsCodeAction.java
@@ -73,10 +73,10 @@ public class OptimizeImportsCodeAction implements RangeBasedCodeActionProvider {
         List<ImportDeclarationNode> fileImports = new ArrayList<>();
         ((ModulePartNode) syntaxTree.rootNode()).imports().stream().forEach(fileImports::add);
 
-        List<LineRange> toBeRemovedImportsLocations = new ArrayList<>(context.diagnostics(context.filePath()).stream()
+        List<LineRange> toBeRemovedImportsLocations = context.diagnostics(context.filePath()).stream()
                 .filter(diag -> UNUSED_IMPORT_DIAGNOSTIC_CODE.equals(diag.diagnosticInfo().code()))
                 .map(diag -> diag.location().lineRange())
-                .toList());
+                .collect(Collectors.toList());
 
         // Skip, when nothing to remove and only single import pending
         if (fileImports.isEmpty() || (fileImports.size() <= 1 && toBeRemovedImportsLocations.isEmpty())) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/OptimizeImportsCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/OptimizeImportsCodeAction.java
@@ -76,7 +76,7 @@ public class OptimizeImportsCodeAction implements RangeBasedCodeActionProvider {
         List<LineRange> toBeRemovedImportsLocations = context.diagnostics(context.filePath()).stream()
                 .filter(diag -> UNUSED_IMPORT_DIAGNOSTIC_CODE.equals(diag.diagnosticInfo().code()))
                 .map(diag -> diag.location().lineRange())
-                .collect(Collectors.toList());
+                .toList();
 
         // Skip, when nothing to remove and only single import pending
         if (fileImports.isEmpty() || (fileImports.size() <= 1 && toBeRemovedImportsLocations.isEmpty())) {
@@ -180,7 +180,7 @@ public class OptimizeImportsCodeAction implements RangeBasedCodeActionProvider {
                         .thenComparing(
                                 o -> o.moduleName().stream().map(Token::text).collect(Collectors.joining(".")))
                         .thenComparing(o -> o.prefix().isPresent() ? o.prefix().get().prefix().text() : ""))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     protected static void buildEditText(StringBuilder editText, ImportDeclarationNode importNode) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -51,7 +51,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 /**
  * Command executor for pulling a package from central.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -139,7 +139,7 @@ public class PullModuleExecutor implements LSCommandExecutor {
                                     .map(PullModuleCodeAction::getMissingModuleNameFromDiagnostic)
                                     .filter(Optional::isPresent)
                                     .map(Optional::get)
-                                    .collect(Collectors.toList())
+                                    .toList()
                             );
                     if (missingModules.isEmpty()) {
                         throw new UserErrorException("Failed to pull modules!");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -654,8 +654,7 @@ public final class CommonUtil {
      */
     public static List<String> getFuncArguments(FunctionSymbol symbol, BallerinaCompletionContext ctx) {
         List<ParameterSymbol> params = CommonUtil.getFunctionParameters(symbol, ctx);
-        return params.stream().map(param -> getFunctionParamaterSyntax(param, ctx).orElse(""))
-                .toList();
+        return params.stream().map(param -> getFunctionParamaterSyntax(param, ctx).orElse("")).toList();
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -655,7 +655,7 @@ public final class CommonUtil {
     public static List<String> getFuncArguments(FunctionSymbol symbol, BallerinaCompletionContext ctx) {
         List<ParameterSymbol> params = CommonUtil.getFunctionParameters(symbol, ctx);
         return params.stream().map(param -> getFunctionParamaterSyntax(param, ctx).orElse(""))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/NameUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/NameUtil.java
@@ -311,7 +311,7 @@ public final class NameUtil {
             // Remove '_' underscores
             while (newName.contains("_")) {
                 String[] parts = newName.split("_");
-                List<String> restParts = Arrays.stream(parts, 1, parts.length).collect(Collectors.toList());
+                List<String> restParts = Arrays.stream(parts, 1, parts.length).toList();
                 newName = parts[0] + StringUtils.capitalize(String.join("", restParts));
             }
             // If empty, revert to original name

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/RecordUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/RecordUtil.java
@@ -201,7 +201,7 @@ public final class RecordUtil {
     public static List<RecordFieldSymbol> getMandatoryRecordFields(RecordTypeSymbol recordType) {
         return recordType.fieldDescriptors().values().stream()
                 .filter(field -> !field.hasDefaultValue() && !field.isOptional())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**
@@ -239,7 +239,7 @@ public final class RecordUtil {
                     .map(tSymbol -> {
                         RecordTypeSymbol recordTypeSymbol = (RecordTypeSymbol) CommonUtil.getRawType(tSymbol);
                         return RawTypeSymbolWrapper.from(tSymbol, recordTypeSymbol);
-                    }).collect(Collectors.toList());
+                    }).toList();
         }
 
         return Collections.emptyList();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
@@ -452,7 +452,7 @@ public final class SymbolUtil {
         if (!completionSearchProvider.checkModuleIndexed(moduleId)) {
             completionSearchProvider.indexModuleAndModuleSymbolNames(moduleId, symbolList.stream()
                     .map(symbol -> symbol.getName().get())
-                    .collect(Collectors.toList()), new ArrayList<>(symbolMapWithPrefix.keySet()));
+                    .toList(), new ArrayList<>(symbolMapWithPrefix.keySet()));
         }
 
         List<String> stringList = completionSearchProvider.getSuggestions(prefix);
@@ -468,6 +468,6 @@ public final class SymbolUtil {
     private static List<Symbol> getFilteredList(Map<String, Symbol> symbolMap, List<String> stringList) {
         return symbolMap.entrySet().stream().filter(stringSymbolEntry ->
                         stringList.contains(stringSymbolEntry.getKey().toLowerCase())).map(Map.Entry::getValue)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompilerPluginCompletionExtension.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompilerPluginCompletionExtension.java
@@ -49,7 +49,6 @@ import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Completion extension implementation for ballerina compiler plugins.
@@ -117,10 +116,10 @@ public class CompilerPluginCompletionExtension implements CompletionExtension {
                             lsp4jTextEdit.setNewText(textEdit.text());
                             lsp4jTextEdit.setRange(range);
                             return lsp4jTextEdit;
-                        }).collect(Collectors.toList()));
+                        }).toList());
             }
             return item;
-        }).collect(Collectors.toList());
+        }).toList();
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ResourcePathCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ResourcePathCompletionItemBuilder.java
@@ -84,7 +84,7 @@ public final class ResourcePathCompletionItemBuilder {
             item.setFilterText(ResourcePathCompletionUtil
                     .getFilterTextForClientResourceAccessAction(resourceMethodSymbol, segments));
             return item;
-        }).collect(Collectors.toList());
+        }).toList();
     }
 
     private static CompletionItem buildCompletionItem(ResourceMethodSymbol resourceMethodSymbol, 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ResourcePathCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ResourcePathCompletionItemBuilder.java
@@ -35,7 +35,6 @@ import org.eclipse.lsp4j.TextEdit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * This class is being used to build resource access completion item.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -381,7 +381,7 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
                 List<String> pkgNameComps = Arrays.stream(name.split("\\."))
                         .map(ModuleUtil::escapeModuleName)
                         .map(CommonUtil::escapeReservedKeyword)
-                        .collect(Collectors.toList());
+                        .toList();
                 String label = pkg.packageOrg().value().isEmpty() ? String.join(".", pkgNameComps)
                         : CommonUtil.getPackageLabel(pkg);
                 String aliasComponent = pkgNameComps.get(pkgNameComps.size() - 1);
@@ -545,7 +545,7 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
         List<Symbol> filteredList = visibleSymbols.stream()
                 .filter(symbolFilter)
                 .sorted(Comparator.comparing(symbol -> symbol.getName().get()))
-                .collect(Collectors.toList());
+                .toList();
         completionItems.addAll(this.getCompletionItemList(filteredList, context));
         completionItems.addAll(this.getBasicAndOtherTypeCompletions(context));
         this.getAnonFunctionDefSnippet(context).ifPresent(completionItems::add);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationAccessExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationAccessExpressionNodeContext.java
@@ -48,7 +48,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.ANNOTATION;
 
@@ -179,12 +178,12 @@ public class AnnotationAccessExpressionNodeContext extends AbstractCompletionPro
                     QNameRefCompletionUtil.getModuleContent(ctx, (QualifiedNameReferenceNode) nodeAtCursor, predicate)
                             .stream()
                             .map(symbol -> (AnnotationSymbol) symbol)
-                            .collect(Collectors.toList());
+                            .toList();
         } else {
             annotationSymbols = ctx.visibleSymbols(ctx.getCursorPosition()).stream()
                     .filter(predicate)
                     .map(symbol -> (AnnotationSymbol) symbol)
-                    .collect(Collectors.toList());
+                    .toList();
         }
 
         return annotationSymbols;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationDeclarationNodeContext.java
@@ -43,7 +43,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link AnnotationDeclarationNode} context.
@@ -72,7 +71,7 @@ public class AnnotationDeclarationNodeContext extends AbstractCompletionProvider
             } else {
                 List<Symbol> filteredSymbols = context.visibleSymbols(context.getCursorPosition()).stream()
                         .filter(predicate)
-                        .collect(Collectors.toList());
+                        .toList();
                 completionItemList.addAll(this.getCompletionItemList(filteredSymbols, context));
                 completionItemList.addAll(this.getModuleCompletionItems(context));
                 completionItemList.add(new SnippetCompletionItem(context, Snippet.DEF_RECORD_TYPE_DESC.get()));
@@ -135,7 +134,7 @@ public class AnnotationDeclarationNodeContext extends AbstractCompletionProvider
         return rawType.typeKind() == TypeDescKind.MAP || rawType.typeKind() == TypeDescKind.RECORD;
     }
 
-    private List<LSCompletionItem> getAnnotationAttachmentPoints(BallerinaCompletionContext context,
+    private List<SnippetCompletionItem> getAnnotationAttachmentPoints(BallerinaCompletionContext context,
                                                                  AnnotationDeclarationNode node) {
         AttachmentPointContext attachmentPointContext = getAttachmentPointContext(context, node);
         List<Snippet> itemSnippets = new ArrayList<>();
@@ -166,7 +165,7 @@ public class AnnotationDeclarationNodeContext extends AbstractCompletionProvider
 
         return itemSnippets.stream()
                 .map(snippet -> new SnippetCompletionItem(context, snippet.get()))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private List<Snippet> anyAttachmentPoints() {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationNodeContext.java
@@ -42,7 +42,6 @@ import org.ballerinalang.langserver.completions.util.SortingUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link AnnotationNode} context.
@@ -95,7 +94,7 @@ public class AnnotationNodeContext extends AbstractCompletionProvider<Annotation
                 .filter(symbol -> symbol.kind() == SymbolKind.ANNOTATION
                         && this.matchingAnnotation((AnnotationSymbol) symbol, annotationNode, attachedNode, ctx))
                 .map(symbol -> AnnotationUtil.getAnnotationItem((AnnotationSymbol) symbol, ctx))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private List<LSCompletionItem> getAnnotationsInModule(BallerinaCompletionContext context, String alias,
@@ -118,7 +117,7 @@ public class AnnotationNodeContext extends AbstractCompletionProvider<Annotation
                 .filter(symbol -> symbol.kind() == SymbolKind.ANNOTATION
                         && this.matchingAnnotation((AnnotationSymbol) symbol, annotationNode, attachedNode, context))
                 .map(symbol -> AnnotationUtil.getAnnotationItem((AnnotationSymbol) symbol, context))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private Node getAttached(AnnotationNode node) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ArrayTypeDescriptorNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ArrayTypeDescriptorNodeContext.java
@@ -33,7 +33,6 @@ import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link ArrayTypeDescriptorNode} context.
@@ -65,7 +64,7 @@ public class ArrayTypeDescriptorNodeContext extends AbstractCompletionProvider<A
         } else {
             List<Symbol> constants = visibleSymbols.stream()
                     .filter(constantFilter())
-                    .collect(Collectors.toList());
+                    .toList();
             completionItems.addAll(this.getModuleCompletionItems(context));
             completionItems.addAll(this.getCompletionItemList(constants, context));
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
@@ -46,7 +46,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Generic completion resolver for the Block Nodes.
@@ -222,7 +221,7 @@ public class BlockNodeContextProvider<T extends Node> extends AbstractCompletion
         symbolFilter = symbolFilter.or(symbol -> symbol.kind() == SymbolKind.FUNCTION);
         List<Symbol> filteredList = visibleSymbols.stream()
                 .filter(symbolFilter)
-                .collect(Collectors.toList());
+                .toList();
         
         return this.getCompletionItemList(filteredList, context);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ClientResourceAccessActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ClientResourceAccessActionNodeContext.java
@@ -59,7 +59,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 /**
@@ -120,14 +119,13 @@ public class ClientResourceAccessActionNodeContext
                 completionItems.addAll(this.getNamedArgExpressionCompletionItems(context, node));
             }
         } else {
-            List<Symbol> clientActions = this.getClientActions(expressionType.get());
+            List<MethodSymbol> clientActions = this.getClientActions(expressionType.get());
             List<ResourceMethodSymbol> resourceMethodSymbols = clientActions.stream()
                     .filter(symbol -> symbol.kind() == SymbolKind.RESOURCE_METHOD)
-                    .map(symbol -> (ResourceMethodSymbol) symbol).collect(Collectors.toList());
+                    .map(symbol -> (ResourceMethodSymbol) symbol).toList();
             List<MethodSymbol> remoteMethods = clientActions.stream()
                     .filter(symbol -> symbol.kind() == SymbolKind.METHOD
-                            && ((MethodSymbol) symbol).qualifiers().contains(Qualifier.REMOTE))
-                    .map(symbol -> (MethodSymbol) symbol).collect(Collectors.toList());
+                            && symbol.qualifiers().contains(Qualifier.REMOTE)).toList();
 
             if (node.slashToken().isMissing()) {
                 completionItems.addAll(this.getCompletionItemList(remoteMethods, context));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/CollectClauseNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/CollectClauseNodeContext.java
@@ -30,7 +30,6 @@ import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link CollectClauseNode} context.
@@ -62,7 +61,7 @@ public class CollectClauseNodeContext extends AbstractCompletionProvider<Collect
                     .filter(symbol -> symbol.getName().isPresent() && !symbol.getName().get().contains("$"))
                     .filter(symbol -> completionItems
                             .addAll(populateBallerinaFunctionCompletionItems(symbol, context)))
-                    .collect(Collectors.toList());
+                    .toList();
         }
         this.sort(context, node, completionItems);
         return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ConstantDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ConstantDeclarationNodeContext.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link ModulePartNode} context.
@@ -119,7 +118,7 @@ public class ConstantDeclarationNodeContext extends NodeWithRHSInitializerProvid
         } else {
             constants = context.visibleSymbols(context.getCursorPosition()).stream()
                     .filter(predicate)
-                    .collect(Collectors.toList());
+                    .toList();
             completionItems.addAll(this.getModuleCompletionItems(context));
             completionItems.add(new SnippetCompletionItem(context, Snippet.KW_TRUE.get()));
             completionItems.add(new SnippetCompletionItem(context, Snippet.KW_FALSE.get()));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/DistinctTypeDescriptorNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/DistinctTypeDescriptorNodeContext.java
@@ -36,7 +36,6 @@ import org.ballerinalang.langserver.completions.util.SortingUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link DistinctTypeDescriptorNode} context.
@@ -78,7 +77,7 @@ public class DistinctTypeDescriptorNodeContext extends AbstractCompletionProvide
             completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_OBJECT_TYPE_DESC_SNIPPET.get()));
             List<Symbol> filteredSymbols = context.visibleSymbols(context.getCursorPosition()).stream()
                     .filter(predicate)
-                    .collect(Collectors.toList());
+                    .toList();
             completionItems.addAll(this.getCompletionItemList(filteredSymbols, context));
         }
         this.sort(context, node, completionItems);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ErrorConstructorExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ErrorConstructorExpressionNodeContext.java
@@ -51,7 +51,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link ErrorConstructorExpressionNode} context.
@@ -134,7 +133,7 @@ public class ErrorConstructorExpressionNodeContext extends
         List<Symbol> errorTypes = ctx.visibleSymbols(ctx.getCursorPosition()).stream()
                 .filter(SymbolUtil.isOfType(TypeDescKind.ERROR)
                         .and(symbol -> !symbol.getName().orElse("").equals(Names.ERROR.getValue())))
-                .collect(Collectors.toList());
+                .toList();
         List<LSCompletionItem> completionItems = this.getCompletionItemList(errorTypes, ctx);
         completionItems.addAll(this.getModuleCompletionItems(ctx));
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ErrorMatchPatternNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ErrorMatchPatternNodeContext.java
@@ -32,7 +32,6 @@ import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link ErrorMatchPatternNode} context.
@@ -67,7 +66,7 @@ public class ErrorMatchPatternNodeContext extends MatchStatementContext<ErrorMat
             List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
             errorTypes = visibleSymbols.stream()
                     .filter(this.errorTypeFilter())
-                    .collect(Collectors.toList());
+                    .toList();
             completionItems.addAll(this.getModuleCompletionItems(context));
         }
         completionItems.addAll(this.getCompletionItemList(errorTypes, context));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ExplicitNewExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ExplicitNewExpressionNodeContext.java
@@ -43,7 +43,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link ExplicitNewExpressionNode} context.
@@ -143,7 +142,7 @@ public class ExplicitNewExpressionNodeContext extends InvocationNodeContextProvi
         }
         List<LSCompletionItem> completionItems = new ArrayList<>();
         if (isNotInNamedArgOnlyContext(ctx, 
-                node.parenthesizedArgList().arguments().stream().collect(Collectors.toList()))) {
+                node.parenthesizedArgList().arguments().stream().toList())) {
             completionItems.addAll(this.expressionCompletions(ctx));
         }
         completionItems.addAll(getNamedArgExpressionCompletionItems(ctx, node));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
@@ -47,7 +47,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Generic Completion provider for field access providers.
@@ -154,7 +153,7 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
          */
         List<Symbol> xmlNamespaces = context.visibleSymbols(context.getCursorPosition()).stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.XMLNS)
-                .collect(Collectors.toList());
+                .toList();
         completionItems.addAll(this.getCompletionItemList(xmlNamespaces, context));
         completionItems.addAll(this.getModuleCompletionItems(context));
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FlushActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FlushActionNodeContext.java
@@ -28,7 +28,6 @@ import org.ballerinalang.langserver.completions.util.Snippet;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Completion Provider for {@link FlushActionNode} context.
@@ -48,7 +47,7 @@ public class FlushActionNodeContext extends AbstractCompletionProvider<FlushActi
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         List<Symbol> filteredWorkers = visibleSymbols.stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.WORKER)
-                .collect(Collectors.toList());
+                .toList();
 
         List<LSCompletionItem> completionItems = new ArrayList<>(this.getCompletionItemList(filteredWorkers, context));
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_FUNCTION.get()));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FunctionCallExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FunctionCallExpressionNodeContext.java
@@ -31,7 +31,6 @@ import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Completion Provider for {@link FunctionCallExpressionNode} context.
@@ -54,7 +53,7 @@ public class FunctionCallExpressionNodeContext extends InvocationNodeContextProv
             completionItems.addAll(this.getCompletionItemList(QNameRefCompletionUtil
                     .getExpressionContextEntries(ctx, qNameRef), ctx));
         } else {
-            if (this.isNotInNamedArgOnlyContext(ctx, node.arguments().stream().collect(Collectors.toList()))) {
+            if (this.isNotInNamedArgOnlyContext(ctx, node.arguments().stream().toList())) {
                 completionItems.addAll(this.actionKWCompletions(ctx));
                 completionItems.addAll(this.expressionCompletions(ctx));
             }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImplicitNewExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImplicitNewExpressionNodeContext.java
@@ -24,6 +24,7 @@ import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
 import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
@@ -43,7 +44,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link ImplicitNewExpressionNode} context.
@@ -114,8 +114,8 @@ public class ImplicitNewExpressionNodeContext extends InvocationNodeContextProvi
             return this.getCompletionItemList(QNameRefCompletionUtil.getExpressionContextEntries(ctx, qNameRef), ctx);
         }
         List<LSCompletionItem> completionItems = new ArrayList<>();
-        List<Node> arguments = node.parenthesizedArgList().isPresent() ?
-                node.parenthesizedArgList().get().arguments().stream().collect(Collectors.toList())
+        List<FunctionArgumentNode> arguments = node.parenthesizedArgList().isPresent() ?
+                node.parenthesizedArgList().get().arguments().stream().toList()
                 : Collections.emptyList();
         if (isNotInNamedArgOnlyContext(ctx, arguments)) {
             completionItems.addAll(this.expressionCompletions(ctx));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
@@ -90,7 +90,7 @@ public class ImportDeclarationNodeContext extends AbstractCompletionProvider<Imp
          */
         List<IdentifierToken> moduleName = node.moduleName().stream()
                 .filter(token -> !token.isMissing())
-                .collect(Collectors.toList());
+                .toList();
 
         ArrayList<LSCompletionItem> completionItems = new ArrayList<>();
         ContextScope contextScope;
@@ -230,7 +230,7 @@ public class ImportDeclarationNodeContext extends AbstractCompletionProvider<Imp
             List<String> pkgNameComps = Arrays.stream(pkgName.split("\\."))
                     .map(ModuleUtil::escapeModuleName)
                     .map(CommonUtil::escapeReservedKeyword)
-                    .collect(Collectors.toList());
+                    .toList();
             String label = pkg.packageOrg().value().isEmpty() ? String.join(".", pkgNameComps)
                     : CommonUtil.getPackageLabel(pkg);
             String insertText = orgName.isEmpty() ? "" : orgName + Names.ORG_NAME_SEPARATOR.getValue();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/IncludedRecordParameterNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/IncludedRecordParameterNodeContext.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link IncludedRecordParameterNode} context.
@@ -68,7 +67,7 @@ public class IncludedRecordParameterNodeContext extends AbstractCompletionProvid
                     .filter(symbol -> symbol.kind() == SymbolKind.TYPE_DEFINITION
                             && CommonUtil.getRawType(((TypeDefinitionSymbol) symbol).typeDescriptor())
                             .typeKind() == TypeDescKind.RECORD)
-                    .collect(Collectors.toList());
+                    .toList();
             // Add the keywords and snippets related to record type descriptor
             completionItems.addAll(Arrays.asList(
                     new SnippetCompletionItem(ctx, Snippet.KW_RECORD.get()),

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/InvocationNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/InvocationNodeContextProvider.java
@@ -209,7 +209,8 @@ public class InvocationNodeContextProvider<T extends Node> extends AbstractCompl
         return true;
     }
     
-    protected boolean isNotInNamedArgOnlyContext(BallerinaCompletionContext context, List<Node> arguments) {
+    protected boolean isNotInNamedArgOnlyContext(BallerinaCompletionContext context,
+                                                 List<? extends Node> arguments) {
         int cursorPosition = context.getCursorPositionInTree();
         for (Node child : arguments) {
             TextRange textRange = child.textRange();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/KeySpecifierNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/KeySpecifierNodeContext.java
@@ -113,7 +113,7 @@ public class KeySpecifierNodeContext extends AbstractCompletionProvider<KeySpeci
                 .map(Map.Entry::getValue)
                 .filter(recordFieldSymbol -> recordFieldSymbol.getName().isPresent())
                 .filter(recordFieldSymbol -> SyntaxInfo.isIdentifier(recordFieldSymbol.getName().get()))
-                .collect(Collectors.toList());
+                .toList();
 
         completionItems.addAll(this.getCompletionItemList(commonFields, context));
         return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListConstructorExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListConstructorExpressionNodeContext.java
@@ -45,7 +45,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link ListConstructorExpressionNode} context.
@@ -79,7 +78,7 @@ public class ListConstructorExpressionNodeContext extends AbstractCompletionProv
         return completionItems;
     }
 
-    private List<LSCompletionItem> spreadOperatorCompletions(BallerinaCompletionContext context) {
+    private List<SpreadCompletionItem> spreadOperatorCompletions(BallerinaCompletionContext context) {
         Optional<SemanticModel> semanticModel = context.currentSemanticModel();
         Optional<Document> document = context.currentDocument();
         if (semanticModel.isEmpty() || document.isEmpty()) {
@@ -124,7 +123,7 @@ public class ListConstructorExpressionNodeContext extends AbstractCompletionProv
                     CompletionItem completionItem =
                             SpreadCompletionItemBuilder.build(symbol, typeName, context);
                     return new SpreadCompletionItem(context, completionItem, symbol);
-                }).collect(Collectors.toList());
+                }).toList();
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListenerDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListenerDeclarationNodeContext.java
@@ -52,7 +52,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
@@ -199,7 +198,7 @@ public class ListenerDeclarationNodeContext extends AbstractCompletionProvider<L
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         List<Symbol> listeners = visibleSymbols.stream()
                 .filter(SymbolUtil::isListener)
-                .collect(Collectors.toList());
+                .toList();
         completionItems.addAll(this.getCompletionItemList(listeners, context));
 
         return completionItems;
@@ -221,7 +220,7 @@ public class ListenerDeclarationNodeContext extends AbstractCompletionProvider<L
         Stream<Symbol> classesAndTypeDefs = Stream.concat(module.classes().stream(), module.typeDefinitions().stream());
         List<Symbol> listeners = classesAndTypeDefs
                 .filter(SymbolUtil::isListener)
-                .collect(Collectors.toList());
+                .toList();
         completionItems.addAll(this.getCompletionItemList(listeners, context));
 
         return completionItems;
@@ -330,7 +329,7 @@ public class ListenerDeclarationNodeContext extends AbstractCompletionProvider<L
         Optional<ClassSymbol> objectTypeDesc = getListenerTypeDesc(context, listenerNode);
         List<Symbol> filteredList = visibleSymbols.stream()
                 .filter(symbol -> symbol.kind() == VARIABLE || symbol.kind() == FUNCTION)
-                .collect(Collectors.toList());
+                .toList();
         completionItems.addAll(this.getCompletionItemList(filteredList, context));
         completionItems.addAll(this.getModuleCompletionItems(context));
         objectTypeDesc.ifPresent(tDesc -> completionItems.add(this.getImplicitNewCItemForClass(tDesc, context)));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
@@ -42,7 +42,6 @@ import org.ballerinalang.langserver.completions.util.SortingUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link MappingConstructorExpressionNode} context.
@@ -153,7 +152,7 @@ public class MappingConstructorExpressionNodeContext extends
 
         List<Symbol> filteredList = visibleSymbols.stream()
                 .filter(symbol -> symbol instanceof VariableSymbol || symbol.kind() == SymbolKind.FUNCTION)
-                .collect(Collectors.toList());
+                .toList();
         List<LSCompletionItem> completionItems = this.getCompletionItemList(filteredList, context);
         completionItems.addAll(this.getModuleCompletionItems(context));
 
@@ -166,7 +165,7 @@ public class MappingConstructorExpressionNodeContext extends
                 .filter(field -> !field.isMissing() && field.kind() == SyntaxKind.SPECIFIC_FIELD
                         && ((SpecificFieldNode) field).fieldName().kind() == SyntaxKind.IDENTIFIER_TOKEN)
                 .map(field -> ((IdentifierToken) ((SpecificFieldNode) field).fieldName()).text())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private enum Scope {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingContextProvider.java
@@ -56,7 +56,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
 
@@ -129,7 +128,7 @@ public abstract class MappingContextProvider<T extends Node> extends AbstractCom
                             && recFields.get(symbolName.get()).typeDescriptor().typeKind()
                             == typeDescriptor.get().typeKind();
                 }))
-                .collect(Collectors.toList());
+                .toList();
 
         return this.getCompletionItemList(visibleSymbols, ctx);
     }
@@ -204,7 +203,7 @@ public abstract class MappingContextProvider<T extends Node> extends AbstractCom
                     .filter(this.getVariableFilter())
                     .filter(varSymbol -> varSymbol.getName().isPresent())
                     .filter(varSymbol -> !existingFields.contains(varSymbol.getName().get()))
-                    .collect(Collectors.toList());
+                    .toList();
             completionItems.addAll(this.getCompletionItemList(variables, context));
             //Spread field can only be used with in a mapping constructor and the fields should be empty
             if (existingFields.isEmpty() && evalNode.kind() == SyntaxKind.MAPPING_CONSTRUCTOR) {
@@ -251,7 +250,7 @@ public abstract class MappingContextProvider<T extends Node> extends AbstractCom
                     // For nested maps, we have to treat specially
                     return resolvedType.get().typeKind() == TypeDescKind.MAP
                             && mapTypeSymbol.subtypeOf(resolvedType.get());
-                })).collect(Collectors.toList());
+                })).toList();
 
         return getSpreadFieldCompletionItemList(visibleSymbols, context);
     }
@@ -268,7 +267,7 @@ public abstract class MappingContextProvider<T extends Node> extends AbstractCom
         Predicate<Symbol> symbolFilter = this.getVariableFilter().or(symbol -> (symbol.kind() == FUNCTION));
         List<Symbol> filteredSymbols = context.visibleSymbols(context.getCursorPosition()).stream()
                 .filter(symbolFilter.and(symbol -> isSpreadable(symbol, validFields)))
-                .collect(Collectors.toList());
+                .toList();
         return this.getSpreadFieldCompletionItemList(filteredSymbols, context);
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingMatchPatternNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingMatchPatternNodeContext.java
@@ -29,7 +29,6 @@ import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link MappingMatchPatternNode} context.
@@ -67,7 +66,7 @@ public class MappingMatchPatternNodeContext extends MappingContextProvider<Mappi
                 .filter(field -> !field.isMissing() && field.kind() == SyntaxKind.FIELD_MATCH_PATTERN
                         && ((FieldMatchPatternNode) field).fieldNameNode().kind() == SyntaxKind.IDENTIFIER_TOKEN)
                 .map(field -> ((FieldMatchPatternNode) field).fieldNameNode().text())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MatchStatementContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MatchStatementContext.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Generic Completion provider for match statement related contexts such as match node and pattern clauses.
@@ -51,7 +50,7 @@ public abstract class MatchStatementContext<T extends Node> extends AbstractComp
         snippets.forEach(snippet -> completionItems.add(new SnippetCompletionItem(context, snippet.get())));
         List<Symbol> filteredConstants = visibleSymbols.stream()
                 .filter(this.constantFilter())
-                .collect(Collectors.toList());
+                .toList();
 
         completionItems.addAll(this.getCompletionItemList(filteredConstants, context));
         completionItems.addAll(this.getModuleCompletionItems(context));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ModuleXMLNamespaceDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ModuleXMLNamespaceDeclarationNodeContext.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link ModuleXMLNamespaceDeclarationNode} context.
@@ -68,7 +67,7 @@ public class ModuleXMLNamespaceDeclarationNodeContext extends
             } else {
                 List<Symbol> constants = context.visibleSymbols(context.getCursorPosition()).stream()
                         .filter(predicate)
-                        .collect(Collectors.toList());
+                        .toList();
                 completionItems.addAll(this.getCompletionItemList(constants, context));
                 completionItems.addAll(this.getModuleCompletionItems(context));
             }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ObjectConstructorExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ObjectConstructorExpressionNodeContext.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link ObjectConstructorExpressionNode} context.
@@ -110,7 +109,7 @@ public class ObjectConstructorExpressionNodeContext
         List<Symbol> visibleSymbols = ctx.visibleSymbols(ctx.getCursorPosition());
         List<Symbol> objectEntries = visibleSymbols.stream()
                 .filter(predicate)
-                .collect(Collectors.toList());
+                .toList();
 
         List<LSCompletionItem> completionItems = this.getCompletionItemList(objectEntries, ctx);
         completionItems.addAll(this.getModuleCompletionItems(ctx));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ObjectFieldNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ObjectFieldNodeContext.java
@@ -37,7 +37,6 @@ import org.ballerinalang.langserver.completions.util.SortingUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link ObjectFieldNode} context.
@@ -88,7 +87,7 @@ public class ObjectFieldNodeContext extends AbstractCompletionProvider<ObjectFie
         // Specifically add the class fields as the completion items
         List<Symbol> classFields = ctx.visibleSymbols(ctx.getCursorPosition()).stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.CLASS_FIELD)
-                .collect(Collectors.toList());
+                .toList();
         completionItems.addAll(this.getCompletionItemList(classFields, ctx));
         
         Optional<TypeSymbol> contextType = ctx.getContextType();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/OnFailClauseNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/OnFailClauseNodeContext.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link OnFailClauseNode} context.
@@ -69,7 +68,7 @@ public class OnFailClauseNodeContext extends AbstractCompletionProvider<OnFailCl
                 List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
                 List<Symbol> errEntries = visibleSymbols.stream()
                         .filter(errorPredicate)
-                        .collect(Collectors.toList());
+                        .toList();
                 completionItems.addAll(this.getCompletionItemList(errEntries, context));
 
                 // Add 'var' completion item

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/PanicStatementNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/PanicStatementNodeContext.java
@@ -30,7 +30,6 @@ import org.ballerinalang.langserver.completions.util.SortingUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link PanicStatementNode} context.
@@ -51,7 +50,7 @@ public class PanicStatementNodeContext extends AbstractCompletionProvider<PanicS
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         List<Symbol> filteredList = visibleSymbols.stream()
                 .filter(SymbolUtil::isError)
-                .collect(Collectors.toList());
+                .toList();
         completionItems.addAll(this.getCompletionItemList(filteredList, context));
         completionItems.addAll(this.expressionCompletions(context));
         this.sort(context, node, completionItems);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ReceiveActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ReceiveActionNodeContext.java
@@ -47,7 +47,7 @@ public class ReceiveActionNodeContext extends AbstractCompletionProvider<Receive
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         List<Symbol> filteredWorkers = visibleSymbols.stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.WORKER)
-                .collect(Collectors.toList());
+                .toList();
         List<LSCompletionItem> completionItems = this.getCompletionItemList(filteredWorkers, context);
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_FUNCTION.get()));
         this.sort(context, node, completionItems);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ReceiveActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ReceiveActionNodeContext.java
@@ -27,7 +27,6 @@ import org.ballerinalang.langserver.completions.providers.AbstractCompletionProv
 import org.ballerinalang.langserver.completions.util.Snippet;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link ReceiveActionNode}.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RemoteMethodCallActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RemoteMethodCallActionNodeContext.java
@@ -17,6 +17,7 @@ package org.ballerinalang.langserver.completions.providers.context;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -77,7 +78,7 @@ public class RemoteMethodCallActionNodeContext extends RightArrowActionNodeConte
             Covers the following case where a is a client object and we suggest the remote actions
             (1) a -> g<cursor>
              */
-            List<Symbol> clientActions = this.getClientActions(expressionType.get());
+            List<MethodSymbol> clientActions = this.getClientActions(expressionType.get());
             completionItems.addAll(this.getCompletionItemList(clientActions, context));
         } else if (TypeResolverUtil.isInMethodCallParameterContext(node, context.getCursorPositionInTree())) {
             /*
@@ -91,7 +92,7 @@ public class RemoteMethodCallActionNodeContext extends RightArrowActionNodeConte
                 List<LSCompletionItem> items = this.getCompletionItemList(exprEntries, context);
                 completionItems.addAll(items);
             } else {
-                if (isNotInNamedArgOnlyContext(context, node.arguments().stream().collect(Collectors.toList()))) {
+                if (isNotInNamedArgOnlyContext(context, node.arguments().stream().toList())) {
                     completionItems.addAll(this.actionKWCompletions(context));
                     completionItems.addAll(this.expressionCompletions(context));
                 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RemoteMethodCallActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RemoteMethodCallActionNodeContext.java
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Handles the completions for the {@link RemoteMethodCallActionNode}.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RightArrowActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RightArrowActionNodeContext.java
@@ -34,7 +34,6 @@ import org.ballerinalang.langserver.completions.util.Snippet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Parent completion provider for Right arrow action nodes.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RightArrowActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RightArrowActionNodeContext.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.langserver.completions.providers.context;
 
+import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -63,7 +64,7 @@ public abstract class RightArrowActionNodeContext<T extends ActionNode> extends 
             Covers the following case where a is a client object and we suggest the remote actions
             (1) a -> g<cursor>
              */
-            List<Symbol> clientActions = this.getClientActions(expressionType.get());
+            List<MethodSymbol> clientActions = this.getClientActions(expressionType.get());
             completionItems.addAll(this.getCompletionItemList(clientActions, context));
         } else {
             /*
@@ -73,7 +74,7 @@ public abstract class RightArrowActionNodeContext<T extends ActionNode> extends 
              */
             List<Symbol> filteredWorkers = visibleSymbols.stream()
                     .filter(symbol -> symbol.kind() == SymbolKind.WORKER)
-                    .collect(Collectors.toList());
+                    .toList();
             completionItems.addAll(this.getCompletionItemList(filteredWorkers, context));
             completionItems.add(new SnippetCompletionItem(context, Snippet.KW_FUNCTION.get()));
         }
@@ -87,7 +88,7 @@ public abstract class RightArrowActionNodeContext<T extends ActionNode> extends 
      * @param symbol Endpoint variable symbol to evaluate
      * @return {@link List} List of extracted actions as Symbol Info
      */
-    public List<Symbol> getClientActions(Symbol symbol) {
+    public List<MethodSymbol> getClientActions(Symbol symbol) {
         if (!SymbolUtil.isObject(symbol)) {
             return new ArrayList<>();
         }
@@ -95,6 +96,6 @@ public abstract class RightArrowActionNodeContext<T extends ActionNode> extends 
         return ((ObjectTypeSymbol) typeDescriptor).methods().values().stream()
                 .filter(method -> method.qualifiers().contains(Qualifier.REMOTE) 
                         || method.qualifiers().contains(Qualifier.RESOURCE))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SelectClauseNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SelectClauseNodeContext.java
@@ -70,9 +70,8 @@ public class SelectClauseNodeContext extends AbstractCompletionProvider<SelectCl
                 functionSymbols.stream()
                         .filter(symbol -> symbol.typeDescriptor().restParam().isPresent())
                         .filter(symbol -> symbol.getName().isPresent() && !symbol.getName().get().contains("$"))
-                        .filter(symbol -> completionItems
-                                .addAll(populateBallerinaFunctionCompletionItems(symbol, context)))
-                        .toList();
+                        .forEach(symbol -> completionItems
+                                .addAll(populateBallerinaFunctionCompletionItems(symbol, context)));
             }
         }
         this.sort(context, node, completionItems);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SelectClauseNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SelectClauseNodeContext.java
@@ -36,7 +36,6 @@ import org.ballerinalang.langserver.completions.util.SortingUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link SelectClauseNode} context.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SelectClauseNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SelectClauseNodeContext.java
@@ -73,7 +73,7 @@ public class SelectClauseNodeContext extends AbstractCompletionProvider<SelectCl
                         .filter(symbol -> symbol.getName().isPresent() && !symbol.getName().get().contains("$"))
                         .filter(symbol -> completionItems
                                 .addAll(populateBallerinaFunctionCompletionItems(symbol, context)))
-                        .collect(Collectors.toList());
+                        .toList();
             }
         }
         this.sort(context, node, completionItems);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ServiceDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ServiceDeclarationNodeContext.java
@@ -120,7 +120,7 @@ public class ServiceDeclarationNodeContext extends ObjectBodiedNodeContextProvid
                 List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
                 List<Symbol> listeners = visibleSymbols.stream()
                         .filter(predicate)
-                        .collect(Collectors.toList());
+                        .toList();
                 completionItems.addAll(this.getCompletionItemList(listeners, context));
                 completionItems.addAll(this.getModuleCompletionItems(context));
                 completionItems.add(new SnippetCompletionItem(context, Snippet.KW_NEW.get()));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ServiceDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ServiceDeclarationNodeContext.java
@@ -44,7 +44,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.langserver.completions.util.SortingUtil.genSortText;
 import static org.ballerinalang.langserver.completions.util.SortingUtil.genSortTextForModule;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/StartActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/StartActionNodeContext.java
@@ -37,7 +37,6 @@ import org.ballerinalang.langserver.completions.util.SortingUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/StartActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/StartActionNodeContext.java
@@ -90,7 +90,7 @@ public class StartActionNodeContext extends AbstractCompletionProvider<StartActi
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         List<Symbol> filteredList = visibleSymbols.stream()
                 .filter(symbol -> (symbol instanceof VariableSymbol || symbol.kind() == FUNCTION))
-                .collect(Collectors.toList());
+                .toList();
         completionItems.addAll(this.getCompletionItemList(filteredList, context));
         return completionItems;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SyncSendActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SyncSendActionNodeContext.java
@@ -47,7 +47,7 @@ public class SyncSendActionNodeContext extends AbstractCompletionProvider<SyncSe
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         List<Symbol> filteredWorkers = visibleSymbols.stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.WORKER)
-                .collect(Collectors.toList());
+                .toList();
 
         List<LSCompletionItem> completionItems = new ArrayList<>(this.getCompletionItemList(filteredWorkers, context));
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_FUNCTION.get()));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SyncSendActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SyncSendActionNodeContext.java
@@ -28,7 +28,6 @@ import org.ballerinalang.langserver.completions.util.Snippet;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link SyncSendActionNode} context.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeParameterContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeParameterContextProvider.java
@@ -130,7 +130,7 @@ public class TypeParameterContextProvider<T extends Node> extends AbstractComple
              */
             List<Symbol> filtered = context.visibleSymbols(context.getCursorPosition()).stream()
                     .filter(predicate)
-                    .collect(Collectors.toList());
+                    .toList();
             List<LSCompletionItem> completionItems = new ArrayList<>();
             completionItems.addAll(this.getModuleCompletionItems(context));
             completionItems.addAll(this.getCompletionItemList(filtered, context));
@@ -172,7 +172,7 @@ public class TypeParameterContextProvider<T extends Node> extends AbstractComple
                     Arrays.asList(new SnippetCompletionItem(context, Snippet.DEF_RECORD_TYPE_DESC.get()),
                             new SnippetCompletionItem(context, Snippet.DEF_CLOSED_RECORD_TYPE_DESC.get())));
             List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
-            mappingTypes = visibleSymbols.stream().filter(predicate).collect(Collectors.toList());
+            mappingTypes = visibleSymbols.stream().filter(predicate).toList();
             completionItems.addAll(this.getCompletionItemList(mappingTypes, context));
             completionItems.addAll(this.getModuleCompletionItems(context));
         }
@@ -213,7 +213,7 @@ public class TypeParameterContextProvider<T extends Node> extends AbstractComple
             // modules and the xml sub types are suggested
             List<Symbol> filtered = visibleSymbols.stream()
                     .filter(predicate)
-                    .collect(Collectors.toList());
+                    .toList();
             completionItems.addAll(this.getCompletionItemList(filtered, context));
             completionItems.addAll(this.getModuleCompletionItems(context));
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeReferenceNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeReferenceNodeContext.java
@@ -65,7 +65,7 @@ public class TypeReferenceNodeContext extends AbstractCompletionProvider<TypeRef
             completionItems.addAll(this.getCompletionItemList(moduleContent, context));
         } else {
             List<Symbol> symbols = context.visibleSymbols(context.getCursorPosition()).stream()
-                    .filter(predicate.get()).collect(Collectors.toList());
+                    .filter(predicate.get()).toList();
             completionItems.addAll(this.getCompletionItemList(symbols, context));
             completionItems.addAll(this.getModuleCompletionItems(context));
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeReferenceNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeReferenceNodeContext.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link TypeReferenceNode} context.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeTestExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeTestExpressionNodeContext.java
@@ -104,7 +104,7 @@ public class TypeTestExpressionNodeContext extends AbstractCompletionProvider<Ty
         if (typeSymbol.get().typeKind() == TypeDescKind.UNION) {
             typeReferences = ((UnionTypeSymbol) typeSymbol.get()).memberTypeDescriptors().stream()
                     .filter(type -> type.typeKind() == TypeDescKind.TYPE_REFERENCE)
-                    .map(type -> (TypeReferenceTypeSymbol) type).collect(Collectors.toList());
+                    .map(type -> (TypeReferenceTypeSymbol) type).toList();
         } else if (typeSymbol.get().typeKind() == TypeDescKind.TYPE_REFERENCE) {
             typeReferences = List.of((TypeReferenceTypeSymbol) typeSymbol.get());
         } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeTestExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeTestExpressionNodeContext.java
@@ -48,7 +48,6 @@ import org.ballerinalang.langserver.completions.util.SortingUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link TypeTestExpressionNode} context.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitActionNodeContext.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.PARAMETER;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitActionNodeContext.java
@@ -119,7 +119,7 @@ public class WaitActionNodeContext extends AbstractCompletionProvider<WaitAction
                 .filter(symbol -> (symbol instanceof VariableSymbol || symbol.kind() == PARAMETER ||
                         symbol.kind() == FUNCTION || symbol.kind() == WORKER)
                         && !symbol.getName().orElse("").equals(Names.ERROR.getValue()))
-                .collect(Collectors.toList());
+                .toList();
         completionItems.addAll(this.getCompletionItemList(filteredList, context));
         this.getAnonFunctionDefSnippet(context).ifPresent(completionItems::add);
         return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitFieldsListNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitFieldsListNodeContext.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.WORKER;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitFieldsListNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitFieldsListNodeContext.java
@@ -79,7 +79,7 @@ public class WaitFieldsListNodeContext extends AbstractCompletionProvider<WaitFi
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         List<Symbol> filteredList = visibleSymbols.stream() 
                 .filter(CommonUtil.getVariableFilterPredicate().or(symbol -> symbol.kind() == WORKER))
-                .collect(Collectors.toList());
+                .toList();
         return this.getCompletionItemList(filteredList, context);
     }
     

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLNSDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLNSDeclarationNodeContext.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link XMLNamespaceDeclarationNode} context.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLNSDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLNSDeclarationNodeContext.java
@@ -67,7 +67,7 @@ public class XMLNSDeclarationNodeContext extends AbstractCompletionProvider<XMLN
             } else {
                 List<Symbol> constants = context.visibleSymbols(context.getCursorPosition()).stream()
                         .filter(predicate)
-                        .collect(Collectors.toList());
+                        .toList();
                 completionItems.addAll(this.getCompletionItemList(constants, context));
                 completionItems.addAll(this.getModuleCompletionItems(context));
             }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLNamePatternChainingNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLNamePatternChainingNodeContext.java
@@ -42,7 +42,7 @@ public class XMLNamePatternChainingNodeContext extends AbstractCompletionProvide
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, XMLNamePatternChainingNode node) {
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         List<Symbol> xmlNs = visibleSymbols.stream().filter(symbol -> symbol.kind() == SymbolKind.XMLNS)
-                .collect(Collectors.toList());
+                .toList();
         List<LSCompletionItem> completionItems = this.getCompletionItemList(xmlNs, context);
         this.sort(context, node, completionItems);
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLNamePatternChainingNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLNamePatternChainingNodeContext.java
@@ -24,7 +24,6 @@ import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link XMLNamePatternChainingNode} context.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLNamePatternChainingNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLNamePatternChainingNodeContext.java
@@ -41,8 +41,7 @@ public class XMLNamePatternChainingNodeContext extends AbstractCompletionProvide
     @Override
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, XMLNamePatternChainingNode node) {
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
-        List<Symbol> xmlNs = visibleSymbols.stream().filter(symbol -> symbol.kind() == SymbolKind.XMLNS)
-                .toList();
+        List<Symbol> xmlNs = visibleSymbols.stream().filter(symbol -> symbol.kind() == SymbolKind.XMLNS).toList();
         List<LSCompletionItem> completionItems = this.getCompletionItemList(xmlNs, context);
         this.sort(context, node, completionItems);
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLSimpleNameNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLSimpleNameNodeContext.java
@@ -44,7 +44,7 @@ public class XMLSimpleNameNodeContext extends AbstractCompletionProvider<XMLSimp
 
         List<Symbol> xmlNamespaces = visibleSymbols.stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.XMLNS)
-                .collect(Collectors.toList());
+                .toList();
 
         List<LSCompletionItem> completionItems = this.getCompletionItemList(xmlNamespaces, context);
         this.sort(context, node, completionItems);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLSimpleNameNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/XMLSimpleNameNodeContext.java
@@ -24,7 +24,6 @@ import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link XMLSimpleNameNode} context.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ModulePartNodeContextUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ModulePartNodeContextUtil.java
@@ -46,7 +46,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.langserver.completions.util.SortingUtil.genSortText;
 
@@ -207,7 +206,7 @@ public final class ModulePartNodeContextUtil {
      */
     public static List<Symbol> serviceTypeDescContextSymbols(BallerinaCompletionContext context) {
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
-        return visibleSymbols.stream().filter(serviceTypeDescPredicate()).collect(Collectors.toList());
+        return visibleSymbols.stream().filter(serviceTypeDescPredicate()).toList();
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/QueryExpressionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/QueryExpressionUtil.java
@@ -24,7 +24,6 @@ import org.ballerinalang.langserver.completions.util.Snippet;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * A utility to provide completions related to query expressions.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/QueryExpressionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/QueryExpressionUtil.java
@@ -78,6 +78,6 @@ public final class QueryExpressionUtil {
         langLibMethods.addAll(types.TYPEDESC.langLibMethods());
         langLibMethods.addAll(types.XML.langLibMethods());
 
-        return langLibMethods.stream().distinct().collect(Collectors.toList());
+        return langLibMethods.stream().distinct().toList();
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/CompletionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/CompletionUtil.java
@@ -41,7 +41,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Common utility methods for the completion operation.
@@ -86,7 +85,7 @@ public final class CompletionUtil {
 
         return items.stream()
                 .map(LSCompletionItem::getCompletionItem)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
@@ -62,7 +62,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Symbol resolver for the field access expressions.
@@ -157,7 +156,7 @@ public class FieldAccessCompletionResolver extends NodeTransformer<Optional<Type
             functionName = ((SimpleNameReferenceNode) nameRef).name().text();
             visibleEntries = context.visibleSymbols(context.getCursorPosition()).stream()
                     .filter(fSymbolPredicate.or(fPointerPredicate))
-                    .collect(Collectors.toList());
+                    .toList();
         } else {
             return Optional.empty();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/QNameRefCompletionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/QNameRefCompletionUtil.java
@@ -27,7 +27,7 @@ import org.ballerinalang.langserver.common.utils.ModuleUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.PositionedOperationContext;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -70,7 +70,7 @@ public final class QNameRefCompletionUtil {
                         || symbol.kind() == SymbolKind.TYPE_DEFINITION
                         || symbol.kind() == SymbolKind.CLASS
                         || symbol instanceof VariableSymbol)
-                .toList()).orElseGet(ArrayList::new);
+                .toList()).orElseGet(Collections::emptyList);
     }
 
     /**
@@ -110,7 +110,7 @@ public final class QNameRefCompletionUtil {
         return module.map(moduleSymbol -> moduleSymbol.allSymbols().stream()
                 .filter(predicate)
                 .toList())
-                .orElseGet(ArrayList::new);
+                .orElseGet(Collections::emptyList);
     }
 
     /**
@@ -127,7 +127,7 @@ public final class QNameRefCompletionUtil {
         return module.map(symbol -> symbol.allSymbols().stream()
                 .filter(CommonUtil.typesFilter())
                 .toList())
-                .orElseGet(ArrayList::new);
+                .orElseGet(Collections::emptyList);
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/QNameRefCompletionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/QNameRefCompletionUtil.java
@@ -71,7 +71,7 @@ public final class QNameRefCompletionUtil {
                         || symbol.kind() == SymbolKind.TYPE_DEFINITION
                         || symbol.kind() == SymbolKind.CLASS
                         || symbol instanceof VariableSymbol)
-                .collect(Collectors.toList())).orElseGet(ArrayList::new);
+                .toList()).orElseGet(ArrayList::new);
     }
 
     /**
@@ -110,7 +110,7 @@ public final class QNameRefCompletionUtil {
                 QNameRefCompletionUtil.getAlias(qNameRef));
         return module.map(moduleSymbol -> moduleSymbol.allSymbols().stream()
                 .filter(predicate)
-                .collect(Collectors.toList()))
+                .toList())
                 .orElseGet(ArrayList::new);
     }
 
@@ -127,7 +127,7 @@ public final class QNameRefCompletionUtil {
                 QNameRefCompletionUtil.getAlias(qNameRef));
         return module.map(symbol -> symbol.allSymbols().stream()
                 .filter(CommonUtil.typesFilter())
-                .collect(Collectors.toList()))
+                .toList())
                 .orElseGet(ArrayList::new);
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/QNameRefCompletionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/QNameRefCompletionUtil.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Holds the set of utilities to get the qualified name reference associated Completion Items.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractDocumentServiceContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractDocumentServiceContext.java
@@ -42,7 +42,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -161,7 +160,7 @@ public class AbstractDocumentServiceContext implements DocumentServiceContext {
             throw new RuntimeException("Cannot find a valid document");
         }
         return ((ModulePartNode) document.get().syntaxTree().rootNode()).imports().stream()
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/CodeActionContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/CodeActionContextImpl.java
@@ -41,7 +41,6 @@ import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Language server context implementation.
@@ -107,7 +106,7 @@ public class CodeActionContextImpl extends AbstractDocumentServiceContext implem
                 project.sourceRoot();
         this.diagnostics = compilation.diagnosticResult().diagnostics().stream()
                 .filter(diag -> projectRoot.resolve(diag.location().lineRange().fileName()).equals(filePath))
-                .collect(Collectors.toList());
+                .toList();
         return this.diagnostics;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentService.java
@@ -66,7 +66,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 /**
  * Implementation of Ballerina Document extension for Language Server.
@@ -432,7 +431,7 @@ public class BallerinaDocumentService implements ExtendedLanguageServerService {
                 return diagnosticsHelper.getLatestDiagnostics(context).entrySet().stream()
                         .filter(entry -> fileUri.equals(entry.getKey()))
                         .map((entry) -> new PublishDiagnosticsParams(entry.getKey(), entry.getValue()))
-                        .collect(Collectors.toList());
+                        .toList();
             } catch (Throwable e) {
                 String msg = "Operation 'ballerinaDocument/diagnostics' failed!";
                 this.clientLogger.logError(DocumentContext.DC_DIAGNOSTICS, msg, e, params.getDocumentIdentifier(),

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/inlayhint/InlayHintProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/inlayhint/InlayHintProvider.java
@@ -62,7 +62,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Represents the Inlay Hint Provider.
@@ -158,7 +157,7 @@ public final class InlayHintProvider {
                 return Pair.of(Collections.emptyList(), Optional.empty());
             }
             // Since the method is a lang-lib function, skip the first parameter
-            return Pair.of(libFunction.get().params().get().stream().skip(1).collect(Collectors.toList()),
+            return Pair.of(libFunction.get().params().get().stream().skip(1).toList(),
                     libFunction.get().restParam());
         } else if (invokableNode.kind() == SyntaxKind.CLIENT_RESOURCE_ACCESS_ACTION) {
             return context.currentSemanticModel().get()
@@ -233,7 +232,7 @@ public final class InlayHintProvider {
         } else if (node.functionName().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             functionSymbols = visibleSymbols.stream()
                     .filter(symbol -> symbol.kind() == SymbolKind.FUNCTION)
-                    .map(symbol -> (FunctionSymbol) symbol).collect(Collectors.toList());
+                    .map(symbol -> (FunctionSymbol) symbol).toList();
             functionName = ((SimpleNameReferenceNode) node.functionName()).name().text();
         } else {
             return Pair.of(Collections.emptyList(), Optional.empty());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/DocumentationReferenceFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/DocumentationReferenceFinder.java
@@ -21,25 +21,24 @@ import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.MarkdownDocumentationNode;
 import io.ballerina.compiler.syntax.tree.MarkdownParameterDocumentationLineNode;
 import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeLocation;
 import io.ballerina.compiler.syntax.tree.NodeTransformer;
 import io.ballerina.compiler.syntax.tree.RecordFieldNode;
 import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
-import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Finds references for the given symbol within documentation (parameters).
  *
  * @since 2201.6.0
  */
-public class DocumentationReferenceFinder extends NodeTransformer<List<Location>> {
+public class DocumentationReferenceFinder extends NodeTransformer<List<NodeLocation>> {
 
     private Symbol symbol;
 
@@ -48,7 +47,7 @@ public class DocumentationReferenceFinder extends NodeTransformer<List<Location>
     }
 
     @Override
-    public List<Location> transform(RequiredParameterNode node) {
+    public List<NodeLocation> transform(RequiredParameterNode node) {
         Optional<FunctionDefinitionNode> fnDefNode = CodeActionUtil.getEnclosedFunction(node);
         if (fnDefNode.isEmpty()) {
             return Collections.emptyList();
@@ -64,7 +63,7 @@ public class DocumentationReferenceFinder extends NodeTransformer<List<Location>
     }
 
     @Override
-    public List<Location> transform(RecordFieldNode node) {
+    public List<NodeLocation> transform(RecordFieldNode node) {
         if (node.parent().parent().kind() != SyntaxKind.TYPE_DEFINITION) {
             return Collections.emptyList();
         }
@@ -84,18 +83,18 @@ public class DocumentationReferenceFinder extends NodeTransformer<List<Location>
      * @param mdNode Markdown documentation node
      * @return List of locations of the parameters within the documentation
      */
-    private List<Location> getParameterLocations(MarkdownDocumentationNode mdNode) {
+    private List<NodeLocation> getParameterLocations(MarkdownDocumentationNode mdNode) {
         return mdNode.documentationLines().stream()
                 .filter(line -> line.kind() == SyntaxKind.MARKDOWN_PARAMETER_DOCUMENTATION_LINE)
                 .map(line -> (MarkdownParameterDocumentationLineNode) line)
                 .map(line -> line.parameterName())
                 .filter(token -> token.text().equals(symbol.getName().get()))
                 .map(paramToken -> paramToken.location())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override
-    protected List<Location> transformSyntaxNode(Node node) {
+    protected List<NodeLocation> transformSyntaxNode(Node node) {
         return Collections.emptyList();
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/ReferencesUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/ReferencesUtil.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver.references;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.NodeLocation;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.Document;
@@ -61,7 +62,7 @@ public final class ReferencesUtil {
             List<Location> docReferences = new LinkedList<>();
             // Find references in documentation
             locations.forEach(location -> {
-                List<Location> refs = findReferencesInDocumentation(location, module, context, symbol.get());
+                List<NodeLocation> refs = findReferencesInDocumentation(location, module, context, symbol.get());
                 if (refs != null && !refs.isEmpty()) {
                     docReferences.addAll(refs);
                 }
@@ -93,10 +94,10 @@ public final class ReferencesUtil {
         return moduleLocationMap;
     }
     
-    private static List<Location> findReferencesInDocumentation(Location location, 
-                                                                Module module, 
-                                                                PositionedOperationContext context,
-                                                                Symbol symbol) {
+    private static List<NodeLocation> findReferencesInDocumentation(Location location,
+                                                                    Module module,
+                                                                    PositionedOperationContext context,
+                                                                    Symbol symbol) {
         Path filePath = PathUtil.getPathFromLocation(module, location);
         Range range = PositionUtil.getRangeFromLineRange(location.lineRange());
         Optional<NonTerminalNode> node = context.workspace().syntaxTree(filePath)

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/semantictokens/SemanticTokensUtils.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/semantictokens/SemanticTokensUtils.java
@@ -73,7 +73,7 @@ public final class SemanticTokensUtils {
     public static List<String> getTokenTypes() {
         return Arrays.stream(SemanticTokensContext.TokenTypes.values())
                 .map(SemanticTokensContext.TokenTypes::getValue)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**
@@ -84,7 +84,7 @@ public final class SemanticTokensUtils {
     public static List<String> getTokenTypeModifiers() {
         return Arrays.stream(SemanticTokensContext.TokenTypeModifiers.values())
                 .map(SemanticTokensContext.TokenTypeModifiers::getValue)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/semantictokens/SemanticTokensUtils.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/semantictokens/SemanticTokensUtils.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Semantic tokens util class.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -281,7 +281,7 @@ public final class SignatureHelpUtil {
             filteredContent = visibleSymbols.stream()
                     .filter(symbolPredicate.and(symbol -> symbol.getName().isPresent()
                             && symbol.getName().get().equals(funcName)))
-                    .collect(Collectors.toList());
+                    .toList();
         }
 
         return filteredContent.stream().findAny();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -74,7 +74,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureInfoModelBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureInfoModelBuilder.java
@@ -182,15 +182,13 @@ public class SignatureInfoModelBuilder {
             return;
         }
 
-        List<Parameter> parameters = new ArrayList<>(parameterSymbols
-                .subList(skipFirstParam() ? 1 : 0, parameterSymbols.size())
-                .stream()
-                .map(param -> new Parameter(param, false, false, context))
-                .toList());
-
         Optional<ParameterSymbol> restParam = functionTypeSymbol.flatMap(FunctionTypeSymbol::restParam);
-        parameters = Stream.concat(parameters.stream(),
-                restParam.stream().map(param -> new Parameter(param, true, false, context))).toList();
+        List<Parameter> parameters = Stream.concat(
+                parameterSymbols.subList(skipFirstParam() ? 1 : 0, parameterSymbols.size())
+                    .stream()
+                    .map(param -> new Parameter(param, false, false, context)),
+                restParam.stream().map(parameter -> new Parameter(parameter, false, true, context))
+        ).toList();
 
         // Create a list of param info models
         for (Parameter param : parameters) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureInfoModelBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureInfoModelBuilder.java
@@ -49,7 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A utility for building a SignatureInformation.
@@ -182,14 +182,15 @@ public class SignatureInfoModelBuilder {
             return;
         }
 
-        List<Parameter> parameters = parameterSymbols
+        List<Parameter> parameters = new ArrayList<>(parameterSymbols
                 .subList(skipFirstParam() ? 1 : 0, parameterSymbols.size())
                 .stream()
                 .map(param -> new Parameter(param, false, false, context))
-                .toList();
+                .toList());
 
         Optional<ParameterSymbol> restParam = functionTypeSymbol.flatMap(FunctionTypeSymbol::restParam);
-        restParam.ifPresent(parameter -> parameters.add(new Parameter(parameter, false, true, context)));
+        parameters = Stream.concat(parameters.stream(),
+                restParam.stream().map(param -> new Parameter(param, true, false, context))).toList();
 
         // Create a list of param info models
         for (Parameter param : parameters) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureInfoModelBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureInfoModelBuilder.java
@@ -186,7 +186,7 @@ public class SignatureInfoModelBuilder {
                 .subList(skipFirstParam() ? 1 : 0, parameterSymbols.size())
                 .stream()
                 .map(param -> new Parameter(param, false, false, context))
-                .collect(Collectors.toList());
+                .toList();
 
         Optional<ParameterSymbol> restParam = functionTypeSymbol.flatMap(FunctionTypeSymbol::restParam);
         restParam.ifPresent(parameter -> parameters.add(new Parameter(parameter, false, true, context)));
@@ -200,7 +200,7 @@ public class SignatureInfoModelBuilder {
 
         includedRecordParams = this.parameterModels.stream()
                 .filter(ParameterInfoModel::isIncludedRecordParam)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionContext.java
@@ -44,7 +44,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Ballerina toml completion context.
@@ -102,7 +101,7 @@ public class BallerinaTomlCompletionContext implements TomlCompletionContext {
         }
 
         return ((ModulePartNode) document.get().syntaxTree().rootNode()).imports().stream()
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionContext.java
@@ -100,8 +100,7 @@ public class BallerinaTomlCompletionContext implements TomlCompletionContext {
             throw new RuntimeException("Cannot find a valid document");
         }
 
-        return ((ModulePartNode) document.get().syntaxTree().rootNode()).imports().stream()
-                .toList();
+        return ((ModulePartNode) document.get().syntaxTree().rootNode()).imports().stream().toList();
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -61,7 +61,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Abstract test for code action related tests.
@@ -98,7 +97,7 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
         Range finalRange = range;
         diags = diags.stream()
                 .filter(diag -> PositionUtil.isRangeWithinRange(finalRange, diag.getRange()))
-                .collect(Collectors.toList());
+                .toList();
         CodeActionContext codeActionContext = new CodeActionContext(diags);
 
         String res = getResponse(sourcePath, finalRange, codeActionContext);
@@ -298,7 +297,7 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
         Range finalRange = range;
         diags = diags.stream()
                 .filter(diag -> PositionUtil.isRangeWithinRange(finalRange, diag.getRange()))
-                .collect(Collectors.toList());
+                .toList();
         CodeActionContext codeActionContext = new CodeActionContext(diags);
 
         String res = TestUtil.getCodeActionResponse(endpoint, sourcePath.toString(), finalRange, codeActionContext);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddModuleToBallerinaTomlCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddModuleToBallerinaTomlCodeActionTest.java
@@ -36,7 +36,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Test class to test module addition to Ballerina.toml.
@@ -63,7 +62,7 @@ public class AddModuleToBallerinaTomlCodeActionTest extends AbstractCodeActionTe
                     "x.y", "main.bal");
             List<LSPackageLoader.ModuleInfo> localPackages = getLocalPackages(localProjects,
                     languageServer.getWorkspaceManager(), context).stream().map(LSPackageLoader.ModuleInfo::new)
-                    .collect(Collectors.toList());
+                    .toList();
             Mockito.when(getLSPackageLoader().getLocalRepoModules()).thenReturn(localPackages);
         } catch (Exception e) {
             //ignore

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/AbstractSignatureHelpTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/AbstractSignatureHelpTest.java
@@ -80,7 +80,8 @@ public abstract class AbstractSignatureHelpTest {
 //            java.nio.file.Files.write(org.ballerinalang.langserver.util.FileUtils.RES_DIR.resolve(configJsonPath),
 //                                      obj.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8));
 
-            Assert.fail("Failed Test for: " + configJsonPath);
+            Assert.fail("Failed Test for: " + configJsonPath + "\n Expected: " +
+                    expected + "\n Found: " + responseJson);
         }
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/TestDidChangeWatchedFiles.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/TestDidChangeWatchedFiles.java
@@ -129,7 +129,7 @@ public class TestDidChangeWatchedFiles {
     private void sendMultipleFileChanges(Map<Path, FileChangeType> changesMap) {
         List<FileEvent> fileEvents = changesMap.entrySet().stream()
                 .map(entry -> new FileEvent(entry.getKey().toUri().toString(), entry.getValue()))
-                .collect(Collectors.toList());
+                .toList();
 
         DidChangeWatchedFilesParams params = new DidChangeWatchedFilesParams();
         params.setChanges(fileEvents);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/TestDidChangeWatchedFiles.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/TestDidChangeWatchedFiles.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Test the watched file changes.

--- a/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/DataMapperTestUtils.java
+++ b/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/DataMapperTestUtils.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Common utils that are reused within data-mapper test suits.
@@ -89,7 +88,7 @@ public final class DataMapperTestUtils {
                 configJsonObject.get("character").getAsInt());
         diags = diags.stream().
                 filter(diag -> PositionUtil.isWithinRange(pos, diag.getRange()))
-                .collect(Collectors.toList());
+                .toList();
         CodeActionContext codeActionContext = new CodeActionContext(diags);
         Range range = new Range(pos, pos);
         String response = TestUtil.getCodeActionResponse(serviceEndpoint, sourcePath.toString(), range,

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/context/AsyncSendActionNodeContext.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/context/AsyncSendActionNodeContext.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.debugadapter.completion.context;
 
+import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -27,7 +28,6 @@ import org.eclipse.lsp4j.debug.CompletionItem;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.debugadapter.completion.util.CommonUtil.getClientActions;
 import static org.ballerinalang.debugadapter.completion.util.CompletionUtil.getCompletionItemList;
@@ -61,7 +61,7 @@ public class AsyncSendActionNodeContext {
             Covers the following case where a is a client object and we suggest the remote actions
             (1) a -> g<cursor>
              */
-            List<Symbol> clientActions = getClientActions(expressionType.get());
+            List<MethodSymbol> clientActions = getClientActions(expressionType.get());
             completionItems.addAll(getCompletionItemList(clientActions, context));
         } else {
             /*
@@ -71,7 +71,7 @@ public class AsyncSendActionNodeContext {
              */
             List<Symbol> filteredWorkers = visibleSymbols.stream()
                     .filter(symbol -> symbol.kind() == SymbolKind.WORKER)
-                    .collect(Collectors.toList());
+                    .toList();
             completionItems.addAll(getCompletionItemList(filteredWorkers, context));
         }
 

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/context/RemoteMethodCallActionNodeContext.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/context/RemoteMethodCallActionNodeContext.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.debugadapter.completion.context;
 
+import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
@@ -61,7 +62,7 @@ public class RemoteMethodCallActionNodeContext {
             Covers the following case where a is a client object and we suggest the remote actions
             (1) a -> g<cursor>
              */
-            List<Symbol> clientActions = getClientActions(expressionType.get());
+            List<MethodSymbol> clientActions = getClientActions(expressionType.get());
             completionItems.addAll(getCompletionItemList(clientActions, context));
         } else if (CommonUtil.isInMethodCallParameterContext(context, node)) {
             /*

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/util/CommonUtil.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/util/CommonUtil.java
@@ -19,6 +19,7 @@ import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
@@ -425,13 +426,13 @@ public final class CommonUtil {
      * @param symbol Endpoint variable symbol to evaluate
      * @return {@link List} List of extracted actions as Symbol Info
      */
-    public static List<Symbol> getClientActions(Symbol symbol) {
+    public static List<MethodSymbol> getClientActions(Symbol symbol) {
         if (!SymbolUtil.isObject(symbol)) {
             return new ArrayList<>();
         }
         TypeSymbol typeDescriptor = CommonUtil.getRawType(SymbolUtil.getTypeDescriptor(symbol).orElseThrow());
         return ((ObjectTypeSymbol) typeDescriptor).methods().values().stream()
                 .filter(method -> method.qualifiers().contains(Qualifier.REMOTE))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/util/QNameReferenceUtil.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/util/QNameReferenceUtil.java
@@ -76,7 +76,7 @@ public final class QNameReferenceUtil {
         Optional<ModuleSymbol> module = CommonUtil.searchModuleForAlias(context, QNameReferenceUtil.getAlias(qNameRef));
         return module.map(moduleSymbol -> moduleSymbol.allSymbols().stream()
                 .filter(predicate)
-                .collect(Collectors.toList()))
+                .toList())
                 .orElseGet(ArrayList::new);
     }
 
@@ -127,6 +127,6 @@ public final class QNameReferenceUtil {
                         || symbol.kind() == SymbolKind.TYPE_DEFINITION
                         || symbol.kind() == SymbolKind.CLASS
                         || symbol instanceof VariableSymbol)
-                .collect(Collectors.toList())).orElseGet(ArrayList::new);
+                .toList()).orElseGet(ArrayList::new);
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/util/QNameReferenceUtil.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/util/QNameReferenceUtil.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Holds the set of utilities to get the qualified name reference associated Completion Items.

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/ExpressionAsProgramEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/ExpressionAsProgramEvaluator.java
@@ -68,6 +68,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 import static org.ballerinalang.debugadapter.evaluation.EvaluationException.createEvaluationException;
 import static org.ballerinalang.debugadapter.evaluation.EvaluationExceptionKind.INTERNAL_ERROR;
@@ -497,7 +498,7 @@ public class ExpressionAsProgramEvaluator extends Evaluator {
             }
 
             // Replaces original package name with the evaluation package name.
-            List<IdentifierToken> moduleParts = new ArrayList<>(importDeclarationNode.moduleName().stream().toList());
+            List<Node> moduleParts = importDeclarationNode.moduleName().stream().collect(Collectors.toList());
             IdentifierToken packageToken = NodeFactory.createIdentifierToken(EVALUATION_PACKAGE_NAME);
             moduleParts.remove(0);
             moduleParts.add(0, packageToken);

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/ExpressionAsProgramEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/ExpressionAsProgramEvaluator.java
@@ -497,7 +497,7 @@ public class ExpressionAsProgramEvaluator extends Evaluator {
             }
 
             // Replaces original package name with the evaluation package name.
-            List<IdentifierToken> moduleParts = importDeclarationNode.moduleName().stream().toList();
+            List<IdentifierToken> moduleParts = new ArrayList<>(importDeclarationNode.moduleName().stream().toList());
             IdentifierToken packageToken = NodeFactory.createIdentifierToken(EVALUATION_PACKAGE_NAME);
             moduleParts.remove(0);
             moduleParts.add(0, packageToken);

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/ExpressionAsProgramEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/ExpressionAsProgramEvaluator.java
@@ -68,7 +68,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.debugadapter.evaluation.EvaluationException.createEvaluationException;
 import static org.ballerinalang.debugadapter.evaluation.EvaluationExceptionKind.INTERNAL_ERROR;
@@ -498,7 +497,7 @@ public class ExpressionAsProgramEvaluator extends Evaluator {
             }
 
             // Replaces original package name with the evaluation package name.
-            List<Node> moduleParts = importDeclarationNode.moduleName().stream().collect(Collectors.toList());
+            List<IdentifierToken> moduleParts = importDeclarationNode.moduleName().stream().toList();
             IdentifierToken packageToken = NodeFactory.createIdentifierToken(EVALUATION_PACKAGE_NAME);
             moduleParts.remove(0);
             moduleParts.add(0, packageToken);
@@ -510,7 +509,7 @@ public class ExpressionAsProgramEvaluator extends Evaluator {
             modifier = modifier.withModuleName(newModuleName);
 
             return modifier.apply();
-        }).collect(Collectors.toList());
+        }).toList();
     }
 
     private void processSnippetFunctionParameters() throws EvaluationException {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/FunctionInvocationExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/FunctionInvocationExpressionEvaluator.java
@@ -35,7 +35,6 @@ import org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
 import static org.ballerinalang.debugadapter.evaluation.EvaluationException.createEvaluationException;
@@ -102,7 +101,7 @@ public class FunctionInvocationExpressionEvaluator extends Evaluator {
             functionMatches = resolvedImports.get(modulePrefix.get()).getResolvedSymbol().functions().stream()
                     .filter(symbol -> symbol.getName().isPresent() &&
                             modifyName(symbol.getName().get()).equals(functionName))
-                    .collect(Collectors.toList());
+                    .toList();
 
             if (functionMatches.size() == 1 && !isPublicSymbol(functionMatches.get(0))) {
                 throw createEvaluationException(NON_PUBLIC_OR_UNDEFINED_ACCESS, functionName);
@@ -115,7 +114,7 @@ public class FunctionInvocationExpressionEvaluator extends Evaluator {
                     .filter(symbol -> symbol.kind() == FUNCTION && symbol.getName().isPresent()
                             && modifyName(symbol.getName().get()).equals(functionName))
                     .map(symbol -> (FunctionSymbol) symbol)
-                    .collect(Collectors.toList());
+                    .toList();
         }
 
         if (functionMatches.isEmpty()) {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/jdi/ObjectReferenceProxyImpl.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/jdi/ObjectReferenceProxyImpl.java
@@ -28,7 +28,6 @@ import com.sun.jdi.Value;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Proxy implementation for JDI object reference.
@@ -109,7 +108,7 @@ public class ObjectReferenceProxyImpl extends JdiProxy {
      */
     public List<ThreadReferenceProxyImpl> waitingThreads() throws IncompatibleThreadStateException {
         return getObjectReference().waitingThreads().stream().map(getVirtualMachineProxy()::getThreadReferenceProxy)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public ThreadReferenceProxyImpl owningThread() throws IncompatibleThreadStateException {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/jdi/ThreadGroupReferenceProxyImpl.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/jdi/ThreadGroupReferenceProxyImpl.java
@@ -77,12 +77,12 @@ public class ThreadGroupReferenceProxyImpl extends ObjectReferenceProxyImpl impl
 
     public List<ThreadReferenceProxyImpl> threads() {
         return getThreadGroupReference().threads().stream().map(getVirtualMachineProxy()::getThreadReferenceProxy)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<ThreadGroupReferenceProxyImpl> threadGroups() {
         return getThreadGroupReference().threadGroups().stream().map(getVirtualMachineProxy()
-                ::getThreadGroupReferenceProxy).collect(Collectors.toList());
+                ::getThreadGroupReferenceProxy).toList();
     }
 
     @Override

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/jdi/ThreadGroupReferenceProxyImpl.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/jdi/ThreadGroupReferenceProxyImpl.java
@@ -21,7 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Proxy implementation for JDI thread group.

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -95,6 +95,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
+import java.util.stream.Stream;
 
 /**
  * Generates the Page bClasses for bal packages.
@@ -574,13 +575,11 @@ public final class Generator {
         }
 
         // Get functions that are not overridden
-        List<Function> functions = includedFunctions.stream().filter(includedFunction ->
+        List<Function> functions = Stream.concat(includedFunctions.stream().filter(includedFunction ->
                 classFunctions
                         .stream()
-                        .noneMatch(objFunction -> objFunction.name.equals(includedFunction.name)))
-                .toList();
-
-        functions.addAll(classFunctions);
+                        .noneMatch(objFunction -> objFunction.name.equals(includedFunction.name))),
+                classFunctions.stream()).toList();
 
         if (containsToken(classDefinitionNode.classTypeQualifiers(), SyntaxKind.CLIENT_KEYWORD)) {
             return new Client(name, description, descriptionSections, isDeprecated, fields, functions, isReadOnly,
@@ -691,13 +690,10 @@ public final class Generator {
         }
 
         // Get functions that are not overridden
-        List<Function> functions = includedFunctions.stream().filter(includedFunction ->
-                objectFunctions
-                        .stream()
-                        .noneMatch(objFunction -> objFunction.name.equals(includedFunction.name)))
-                .toList();
-
-        functions.addAll(objectFunctions);
+        List<Function> functions = Stream.concat(
+                includedFunctions.stream().filter(includedFunction -> objectFunctions.stream()
+                        .noneMatch(objFunction -> objFunction.name.equals(includedFunction.name))),
+                objectFunctions.stream()).toList();
 
         return new BObjectType(objectName, description, descriptionSections, isDeprecated, fields, functions);
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -95,7 +95,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 /**
  * Generates the Page bClasses for bal packages.
@@ -579,7 +578,7 @@ public final class Generator {
                 classFunctions
                         .stream()
                         .noneMatch(objFunction -> objFunction.name.equals(includedFunction.name)))
-                .collect(Collectors.toList());
+                .toList();
 
         functions.addAll(classFunctions);
 
@@ -696,7 +695,7 @@ public final class Generator {
                 objectFunctions
                         .stream()
                         .noneMatch(objFunction -> objFunction.name.equals(includedFunction.name)))
-                .collect(Collectors.toList());
+                .toList();
 
         functions.addAll(objectFunctions);
 
@@ -708,7 +707,7 @@ public final class Generator {
         for (FunctionType functionType : functionTypes) {
             List<DefaultableVariable> parameters = new ArrayList<>(functionType.paramTypes.stream()
                     .map(type -> new DefaultableVariable(type.name, type.description, false,
-                            type.elementType, "")).collect(Collectors.toList()));
+                            type.elementType, "")).toList());
 
             List<Variable> returnParameters = new ArrayList<>();
             if (functionType.returnType != null) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BClass.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BClass.java
@@ -19,7 +19,6 @@ import com.google.gson.annotations.Expose;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Represent documentation for an BClass.
@@ -64,7 +63,7 @@ public class BClass extends Construct {
     public List<Function> getOtherMethods(List<Function> methods) {
         return methods.stream()
                 .filter(function -> !function.name.equals("init"))
-                .collect(Collectors.toList());
+                .toList();
     }
 
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
@@ -18,7 +18,6 @@ package org.ballerinalang.docgen.generator.model;
 import com.google.gson.annotations.Expose;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Represent documentation for a Client.
@@ -43,18 +42,18 @@ public class Client extends BClass {
     public List<Function> getOtherMethods(List<Function> methods) {
         return super.getOtherMethods(methods).stream()
                 .filter(function -> !function.isRemote && !function.isResource)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private List<Function> getRemoteMethods() {
         return this.methods.stream()
                 .filter(function -> function.isRemote)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private List<Function> getResourceMethods() {
         return this.methods.stream()
                 .filter(function -> function.isResource)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Listener.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Listener.java
@@ -18,7 +18,6 @@ package org.ballerinalang.docgen.generator.model;
 import com.google.gson.annotations.Expose;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Represent documentation for a Listener.
@@ -41,7 +40,7 @@ public class Listener extends BClass {
                 .filter(function -> function.name.equals("attach")
                     || function.name.equals("start")
                     || function.name.equals("stop"))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override
@@ -50,6 +49,6 @@ public class Listener extends BClass {
                 .filter(function -> !(function.name.equals("attach")
                         || function.name.equals("start")
                         || function.name.equals("stop")))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/JsonToRecordMapper.java
+++ b/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/JsonToRecordMapper.java
@@ -181,7 +181,7 @@ public final class JsonToRecordMapper {
                     Token semicolon = AbstractNodeFactory.createToken(SyntaxKind.SEMICOLON_TOKEN);
                     return NodeFactory.createTypeDefinitionNode(null, null, typeKeyWord, typeName,
                             entry.getValue(), semicolon);
-                }).collect(Collectors.toList());
+                }).toList();
 
         NodeList<ModuleMemberDeclarationNode> moduleMembers;
         if (isRecordTypeDesc) {

--- a/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/util/ConverterUtils.java
+++ b/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/util/ConverterUtils.java
@@ -218,12 +218,10 @@ public final class ConverterUtils {
      * @return {@link List<TypeDescriptorNode>} The sorted TypeDescriptorNode list.
      */
     public static List<TypeDescriptorNode> sortTypeDescriptorNodes(List<TypeDescriptorNode> typeDescriptorNodes) {
-        List<TypeDescriptorNode> nonArrayNodes = typeDescriptorNodes.stream()
-                .filter(node -> !(node instanceof ArrayTypeDescriptorNode)).toList();
-        List<TypeDescriptorNode> arrayNodes = typeDescriptorNodes.stream()
-                .filter(node -> (node instanceof ArrayTypeDescriptorNode)).toList();
-        nonArrayNodes.sort(Comparator.comparing(TypeDescriptorNode::toSourceCode));
-        arrayNodes.sort((node1, node2) -> {
+        Stream<TypeDescriptorNode> nonArrayNodes = typeDescriptorNodes.stream()
+                .filter(node -> !(node instanceof ArrayTypeDescriptorNode)).sorted(Comparator.comparing(TypeDescriptorNode::toSourceCode));
+        Stream<TypeDescriptorNode> arrayNodes = typeDescriptorNodes.stream()
+                .filter(node -> (node instanceof ArrayTypeDescriptorNode)).sorted((node1, node2) -> {
             ArrayTypeDescriptorNode arrayNode1 = (ArrayTypeDescriptorNode) node1;
             ArrayTypeDescriptorNode arrayNode2 = (ArrayTypeDescriptorNode) node2;
             return getNumberOfDimensions(arrayNode1).equals(getNumberOfDimensions(arrayNode2)) ?
@@ -231,7 +229,7 @@ public final class ConverterUtils {
                             .compareTo((arrayNode2).memberTypeDesc().toSourceCode()) :
                     getNumberOfDimensions(arrayNode1) - getNumberOfDimensions(arrayNode2);
         });
-        return Stream.concat(nonArrayNodes.stream(), arrayNodes.stream()).toList();
+        return Stream.concat(nonArrayNodes, arrayNodes).toList();
     }
 
     /**

--- a/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/util/ConverterUtils.java
+++ b/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/util/ConverterUtils.java
@@ -219,7 +219,8 @@ public final class ConverterUtils {
      */
     public static List<TypeDescriptorNode> sortTypeDescriptorNodes(List<TypeDescriptorNode> typeDescriptorNodes) {
         Stream<TypeDescriptorNode> nonArrayNodes = typeDescriptorNodes.stream()
-                .filter(node -> !(node instanceof ArrayTypeDescriptorNode)).sorted(Comparator.comparing(TypeDescriptorNode::toSourceCode));
+                .filter(node -> !(node instanceof ArrayTypeDescriptorNode))
+                .sorted(Comparator.comparing(TypeDescriptorNode::toSourceCode));
         Stream<TypeDescriptorNode> arrayNodes = typeDescriptorNodes.stream()
                 .filter(node -> (node instanceof ArrayTypeDescriptorNode)).sorted((node1, node2) -> {
             ArrayTypeDescriptorNode arrayNode1 = (ArrayTypeDescriptorNode) node1;

--- a/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/util/ConverterUtils.java
+++ b/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/util/ConverterUtils.java
@@ -45,7 +45,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.identifier.Utils.escapeSpecialCharacters;
@@ -220,9 +219,9 @@ public final class ConverterUtils {
      */
     public static List<TypeDescriptorNode> sortTypeDescriptorNodes(List<TypeDescriptorNode> typeDescriptorNodes) {
         List<TypeDescriptorNode> nonArrayNodes = typeDescriptorNodes.stream()
-                .filter(node -> !(node instanceof ArrayTypeDescriptorNode)).collect(Collectors.toList());
+                .filter(node -> !(node instanceof ArrayTypeDescriptorNode)).toList();
         List<TypeDescriptorNode> arrayNodes = typeDescriptorNodes.stream()
-                .filter(node -> (node instanceof ArrayTypeDescriptorNode)).collect(Collectors.toList());
+                .filter(node -> (node instanceof ArrayTypeDescriptorNode)).toList();
         nonArrayNodes.sort(Comparator.comparing(TypeDescriptorNode::toSourceCode));
         arrayNodes.sort((node1, node2) -> {
             ArrayTypeDescriptorNode arrayNode1 = (ArrayTypeDescriptorNode) node1;
@@ -232,7 +231,7 @@ public final class ConverterUtils {
                             .compareTo((arrayNode2).memberTypeDesc().toSourceCode()) :
                     getNumberOfDimensions(arrayNode1) - getNumberOfDimensions(arrayNode2);
         });
-        return Stream.concat(nonArrayNodes.stream(), arrayNodes.stream()).collect(Collectors.toList());
+        return Stream.concat(nonArrayNodes.stream(), arrayNodes.stream()).toList();
     }
 
     /**

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/java/io/ballerina/converters/JsonToRecordConverterTests.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/java/io/ballerina/converters/JsonToRecordConverterTests.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 
 /**
  * Tests for JsonToRecordConverter.
@@ -400,7 +399,7 @@ public class JsonToRecordConverterTests {
         io.ballerina.jsonmapper.JsonToRecordResponse response =
                 (io.ballerina.jsonmapper.JsonToRecordResponse) result.get();
         List<String> generatedDiagnosticMessages = response.getDiagnostics().stream()
-                .map(JsonToRecordMapperDiagnostic::toString).collect(Collectors.toList());
+                .map(JsonToRecordMapperDiagnostic::toString).toList();
         List<String> expectedCDiagnosticMessages = List.of("[ERROR] Provided JSON is invalid : " +
                 "Unterminated object at line 5 column 4 path $.position");
         Assert.assertEquals(generatedDiagnosticMessages, expectedCDiagnosticMessages);
@@ -417,7 +416,7 @@ public class JsonToRecordConverterTests {
         io.ballerina.jsonmapper.JsonToRecordResponse response =
                 (io.ballerina.jsonmapper.JsonToRecordResponse) result.get();
         List<String> generatedDiagnosticMessages = response.getDiagnostics().stream()
-                .map(JsonToRecordMapperDiagnostic::toString).collect(Collectors.toList());
+                .map(JsonToRecordMapperDiagnostic::toString).toList();
         List<String> expectedCDiagnosticMessages =
                 List.of("[ERROR] Provided JSON is unsupported. It may be null or have missing types.");
         Assert.assertEquals(generatedDiagnosticMessages, expectedCDiagnosticMessages);

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/BallerinaPackageResolver.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/BallerinaPackageResolver.java
@@ -101,7 +101,7 @@ class BallerinaPackageResolver {
                         "Ballerina central under the org '%s' with name '%s'", orgName, pkgName));
             }
             List<SemanticVersion> availableVersions = publishedVersions.stream().map(SemanticVersion::from)
-                    .collect(Collectors.toList());
+                    .toList();
 
             Optional<SemanticVersion> compatibleVersion = selectCompatibleVersion(availableVersions, localVersion);
             if (compatibleVersion.isEmpty()) {

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/DumbNodeListComparator.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/DumbNodeListComparator.java
@@ -59,8 +59,8 @@ public class DumbNodeListComparator<T extends Node> implements Comparator {
     }
 
     DumbNodeListComparator(NodeList<T> newNodes, NodeList<T> oldNodes, DiffKind nodeKind) {
-        this.newNodes = newNodes != null ? newNodes.stream().collect(Collectors.toList()) : null;
-        this.oldNodes = oldNodes != null ? oldNodes.stream().collect(Collectors.toList()) : null;
+        this.newNodes = newNodes != null ? newNodes.stream().toList() : null;
+        this.oldNodes = oldNodes != null ? oldNodes.stream().toList() : null;
         this.nodeKind = nodeKind;
     }
 

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/FunctionComparator.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/FunctionComparator.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.ISOLATED_KEYWORD;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.PUBLIC_KEYWORD;
@@ -164,8 +163,8 @@ public class FunctionComparator extends NodeComparator<FunctionDefinitionNode> {
 
     private List<Diff> compareFunctionParams() {
         List<Diff> paramDiffs = new ArrayList<>();
-        List<ParameterNode> newParams = newNode.functionSignature().parameters().stream().collect(Collectors.toList());
-        List<ParameterNode> oldParams = oldNode.functionSignature().parameters().stream().collect(Collectors.toList());
+        List<ParameterNode> newParams = newNode.functionSignature().parameters().stream().toList();
+        List<ParameterNode> oldParams = oldNode.functionSignature().parameters().stream().toList();
 
         ParamListComparator paramComparator = new ParamListComparator(newParams, oldParams);
         paramComparator.computeDiff().ifPresent(diff ->

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/ServiceComparator.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/ServiceComparator.java
@@ -145,8 +145,8 @@ public class ServiceComparator extends NodeComparator<ServiceDeclarationNode> {
     private List<Diff> compareAttachPoints() {
         // TODO: implement attach point comparator
         Optional<? extends Diff> diff = new DumbNodeListComparator<>(
-                newNode.absoluteResourcePath().stream().collect(Collectors.toList()),
-                oldNode.absoluteResourcePath().stream().collect(Collectors.toList()))
+                newNode.absoluteResourcePath().stream().toList(),
+                oldNode.absoluteResourcePath().stream().toList())
                 .computeDiff();
         return diff.<List<Diff>>map(Collections::singletonList).orElseGet(ArrayList::new);
     }
@@ -160,8 +160,8 @@ public class ServiceComparator extends NodeComparator<ServiceDeclarationNode> {
             new DumbNodeComparator<>(newListener, oldListener, DiffKind.SERVICE_LISTENER_EXPR).computeDiff()
                     .ifPresent(listenerDiffs::add);
         } else {
-            new DumbNodeListComparator<>(newNode.expressions().stream().collect(Collectors.toList()),
-                    oldNode.expressions().stream().collect(Collectors.toList())).computeDiff()
+            new DumbNodeListComparator<>(newNode.expressions().stream().toList(),
+                    oldNode.expressions().stream().toList()).computeDiff()
                     .ifPresent(listenerDiffs::add);
         }
 

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/ServiceComparator.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/ServiceComparator.java
@@ -43,7 +43,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.ISOLATED_KEYWORD;
 import static io.ballerina.semver.checker.util.SyntaxTreeUtils.getFunctionIdentifier;

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/MockAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/MockAnnotationProcessor.java
@@ -54,7 +54,6 @@ import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.FILE_NAME_PERIOD_SEPARATOR;
 
@@ -108,7 +107,7 @@ public class MockAnnotationProcessor extends AbstractCompilerPlugin {
         BLangPackage parent = (BLangPackage) ((BLangSimpleVariable) simpleVariableNode).parent;
         String packageName = getPackageName(parent);
 
-        annotations = annotations.stream().distinct().collect(Collectors.toList());
+        annotations = annotations.stream().distinct().toList();
         // Iterate through all the annotations
         for (AnnotationAttachmentNode attachmentNode : annotations) {
             // Check if the package belongs to a single file project
@@ -173,7 +172,7 @@ public class MockAnnotationProcessor extends AbstractCompilerPlugin {
     public void process(FunctionNode functionNode, List<AnnotationAttachmentNode> annotations) {
         BLangPackage parent = (BLangPackage) ((BLangFunction) functionNode).parent;
         String packageName = getPackageName(parent);
-        annotations = annotations.stream().distinct().collect(Collectors.toList());
+        annotations = annotations.stream().distinct().toList();
 
         // Iterate through all the annotations
         for (AnnotationAttachmentNode attachmentNode : annotations) {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -58,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static io.ballerina.identifier.Utils.decodeIdentifier;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.BIN_DIR;
@@ -618,17 +619,14 @@ public class CoverageReport {
     }
 
     private List<Path> getPlatformLibsList(JBallerinaBackend jBallerinaBackend, Package pkg) {
-        List<Path> platformLibsList = new ArrayList<>();
-        Collection<PlatformLibrary> otherJarDependencies = jBallerinaBackend.platformLibraryDependencies(
-                pkg.packageId(), PlatformLibraryScope.DEFAULT);
-        otherJarDependencies.addAll(jBallerinaBackend.platformLibraryDependencies(
-                pkg.packageId(), PlatformLibraryScope.PROVIDED));
-        for (PlatformLibrary otherJarDependency : otherJarDependencies) {
-            if (!platformLibsList.contains(otherJarDependency.path())) {
-                platformLibsList.add(otherJarDependency.path());
-            }
-        }
-        return platformLibsList;
+        return Stream.concat(
+                jBallerinaBackend.platformLibraryDependencies(
+                        pkg.packageId(), PlatformLibraryScope.DEFAULT).stream(),
+                jBallerinaBackend.platformLibraryDependencies(
+                        pkg.packageId(), PlatformLibraryScope.PROVIDED).stream())
+                .map(PlatformLibrary::path)
+                .distinct()
+                .toList();
     }
 
     private List<Path> getDependencyJarList(JBallerinaBackend jBallerinaBackend) {
@@ -645,10 +643,12 @@ public class CoverageReport {
                             dependencyPathList.add(generatedJarLibrary.path());
                         }
                     }
-                    Collection<PlatformLibrary> otherJarDependencies = jBallerinaBackend.platformLibraryDependencies(
-                            pkg.packageId(), PlatformLibraryScope.DEFAULT);
-                    otherJarDependencies.addAll(jBallerinaBackend.platformLibraryDependencies(
-                            pkg.packageId(), PlatformLibraryScope.PROVIDED));
+                    Collection<PlatformLibrary> otherJarDependencies = Stream.concat(
+                            jBallerinaBackend.platformLibraryDependencies(
+                                    pkg.packageId(), PlatformLibraryScope.DEFAULT).stream(),
+                            jBallerinaBackend.platformLibraryDependencies(
+                                    pkg.packageId(), PlatformLibraryScope.PROVIDED).stream()).toList();
+
                     for (PlatformLibrary otherJarDependency : otherJarDependencies) {
                         if (!dependencyPathList.contains(otherJarDependency.path())) {
                             dependencyPathList.add(otherJarDependency.path());

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestReport.java
@@ -139,11 +139,11 @@ public class TestReport {
         // sort the module list to be in the alphabetical order
         moduleStatus = moduleStatus.stream()
                 .sorted(Comparator.comparing(ModuleStatus::getName))
-                .collect(Collectors.toList());
+                .toList();
 
         moduleCoverage = moduleCoverage.stream()
                 .sorted(Comparator.comparing(ModuleCoverage::getName))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public float getCoveragePercentage() {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestReport.java
@@ -22,7 +22,6 @@ import org.ballerinalang.test.runtime.util.TesterinaConstants;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Final test report with coverage (if enabled).

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/syntax/tree/AbstractNodeFactory.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/syntax/tree/AbstractNodeFactory.java
@@ -27,7 +27,6 @@ import io.ballerina.toml.internal.syntax.NodeListUtils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * A factory for creating nodes in the syntax tree.
@@ -143,7 +142,7 @@ public abstract class AbstractNodeFactory {
                 minutiaeNodes.stream()
                         .map(minutiae -> Objects.requireNonNull(minutiae, "minutiae should not be null"))
                         .map(Minutiae::internalNode)
-                        .collect(Collectors.toList())), 0);
+                        .toList()), 0);
     }
 
     public static Minutiae createCommentMinutiae(String text) {
@@ -188,7 +187,7 @@ public abstract class AbstractNodeFactory {
                 nodes.stream()
                         .map(node -> Objects.requireNonNull(node, "node should not be null"))
                         .map(Node::internalNode)
-                        .collect(Collectors.toList())).createUnlinkedFacade());
+                        .toList()).createUnlinkedFacade());
     }
 
     public static <T extends Node> SeparatedNodeList<T> createSeparatedNodeList(Node... nodes) {
@@ -206,7 +205,7 @@ public abstract class AbstractNodeFactory {
                 nodes.stream()
                         .map(node -> Objects.requireNonNull(node, "node should not be null"))
                         .map(Node::internalNode)
-                        .collect(Collectors.toList())).createUnlinkedFacade());
+                        .toList()).createUnlinkedFacade());
     }
 
     protected static STNode getOptionalSTNode(Node node) {

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/syntax/tree/MinutiaeList.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/syntax/tree/MinutiaeList.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static io.ballerina.toml.internal.syntax.NodeListUtils.rangeCheck;
 import static io.ballerina.toml.internal.syntax.NodeListUtils.rangeCheckForAdd;
@@ -87,7 +86,7 @@ public final class MinutiaeList implements Iterable<Minutiae> {
         List<STNode> stNodesToBeAdded = c.stream()
                 .map(minutiae -> Objects.requireNonNull(minutiae, "minutiae should not be null"))
                 .map(Minutiae::internalNode)
-                .collect(Collectors.toList());
+                .toList();
         return new MinutiaeList(token,
                 internalListNode.addAll(stNodesToBeAdded),
                 position);

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/syntax/tree/NodeList.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/syntax/tree/NodeList.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -85,7 +84,7 @@ public class NodeList<T extends Node> implements Iterable<T> {
         List<STNode> stNodesToBeAdded = c.stream()
                 .map(node -> Objects.requireNonNull(node, "node should not be null"))
                 .map(Node::internalNode)
-                .collect(Collectors.toList());
+                .toList();
         return new NodeList<>(internalListNode.addAll(stNodesToBeAdded).createUnlinkedFacade());
     }
 

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/syntax/tree/NonTerminalNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/syntax/tree/NonTerminalNode.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static io.ballerina.toml.internal.syntax.SyntaxUtils.isSTNodePresent;
@@ -70,7 +69,7 @@ public abstract class NonTerminalNode extends Node {
                 IntStream.range(0, bucketCount())
                         .filter(bucket -> childInBucket(bucket) != null)
                         .mapToObj(bucket -> new ChildNodeEntry(childNames[bucket], childInBucket(bucket)))
-                        .collect(Collectors.toList()));
+                        .toList());
     }
 
     @Override

--- a/misc/xml-to-record-converter/src/main/java/io/ballerina/xmltorecordconverter/util/ConverterUtils.java
+++ b/misc/xml-to-record-converter/src/main/java/io/ballerina/xmltorecordconverter/util/ConverterUtils.java
@@ -117,24 +117,24 @@ public final class ConverterUtils {
      * @return {@link List<TypeDescriptorNode>} The sorted TypeDescriptorNode list.
      */
     public static List<TypeDescriptorNode> sortTypeDescriptorNodes(List<TypeDescriptorNode> typeDescriptorNodes) {
-        List<TypeDescriptorNode> nonArrayNodes = typeDescriptorNodes.stream()
-                .filter(node -> !(node instanceof ArrayTypeDescriptorNode)).toList();
+        List<TypeDescriptorNode> nonArrayNodes = new ArrayList<>(typeDescriptorNodes.stream()
+                .filter(node -> !(node instanceof ArrayTypeDescriptorNode)).toList());
         List<TypeDescriptorNode> arrayNodes = typeDescriptorNodes.stream()
                 .filter(node -> (node instanceof ArrayTypeDescriptorNode)).toList();
         List<TypeDescriptorNode> membersOfArrayNodes = arrayNodes.stream()
                 .map(node -> extractArrayTypeDescNode((ArrayTypeDescriptorNode) node)).toList();
         nonArrayNodes.removeIf(node ->
                 membersOfArrayNodes.stream().map(Node::toSourceCode).toList().contains(node.toSourceCode()));
-        nonArrayNodes.sort(Comparator.comparing(TypeDescriptorNode::toSourceCode));
-        arrayNodes.sort((node1, node2) -> {
-            ArrayTypeDescriptorNode arrayNode1 = (ArrayTypeDescriptorNode) node1;
-            ArrayTypeDescriptorNode arrayNode2 = (ArrayTypeDescriptorNode) node2;
-            return getNumberOfDimensions(arrayNode1).equals(getNumberOfDimensions(arrayNode2)) ?
-                    (arrayNode1).memberTypeDesc().toSourceCode()
-                            .compareTo((arrayNode2).memberTypeDesc().toSourceCode()) :
-                    getNumberOfDimensions(arrayNode1) - getNumberOfDimensions(arrayNode2);
-        });
-        return Stream.concat(nonArrayNodes.stream(), arrayNodes.stream()).toList();
+        return Stream.concat(
+                nonArrayNodes.stream().sorted(Comparator.comparing(TypeDescriptorNode::toSourceCode)),
+                arrayNodes.stream().sorted((node1, node2) -> {
+                            ArrayTypeDescriptorNode arrayNode1 = (ArrayTypeDescriptorNode) node1;
+                            ArrayTypeDescriptorNode arrayNode2 = (ArrayTypeDescriptorNode) node2;
+                            return getNumberOfDimensions(arrayNode1).equals(getNumberOfDimensions(arrayNode2)) ?
+                                    (arrayNode1).memberTypeDesc().toSourceCode()
+                                            .compareTo((arrayNode2).memberTypeDesc().toSourceCode()) :
+                                    getNumberOfDimensions(arrayNode1) - getNumberOfDimensions(arrayNode2);
+                })).toList();
     }
 
     /**

--- a/misc/xml-to-record-converter/src/main/java/io/ballerina/xmltorecordconverter/util/ConverterUtils.java
+++ b/misc/xml-to-record-converter/src/main/java/io/ballerina/xmltorecordconverter/util/ConverterUtils.java
@@ -31,6 +31,7 @@ import io.ballerina.compiler.syntax.tree.UnionTypeDescriptorNode;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.identifier.Utils.escapeSpecialCharacters;
@@ -117,24 +118,24 @@ public final class ConverterUtils {
      * @return {@link List<TypeDescriptorNode>} The sorted TypeDescriptorNode list.
      */
     public static List<TypeDescriptorNode> sortTypeDescriptorNodes(List<TypeDescriptorNode> typeDescriptorNodes) {
-        List<TypeDescriptorNode> nonArrayNodes = new ArrayList<>(typeDescriptorNodes.stream()
-                .filter(node -> !(node instanceof ArrayTypeDescriptorNode)).toList());
+        List<TypeDescriptorNode> nonArrayNodes = typeDescriptorNodes.stream()
+                .filter(node -> !(node instanceof ArrayTypeDescriptorNode)).collect(Collectors.toList());
         List<TypeDescriptorNode> arrayNodes = typeDescriptorNodes.stream()
-                .filter(node -> (node instanceof ArrayTypeDescriptorNode)).toList();
+                .filter(node -> (node instanceof ArrayTypeDescriptorNode)).collect(Collectors.toList());
         List<TypeDescriptorNode> membersOfArrayNodes = arrayNodes.stream()
                 .map(node -> extractArrayTypeDescNode((ArrayTypeDescriptorNode) node)).toList();
         nonArrayNodes.removeIf(node ->
                 membersOfArrayNodes.stream().map(Node::toSourceCode).toList().contains(node.toSourceCode()));
-        return Stream.concat(
-                nonArrayNodes.stream().sorted(Comparator.comparing(TypeDescriptorNode::toSourceCode)),
-                arrayNodes.stream().sorted((node1, node2) -> {
-                            ArrayTypeDescriptorNode arrayNode1 = (ArrayTypeDescriptorNode) node1;
-                            ArrayTypeDescriptorNode arrayNode2 = (ArrayTypeDescriptorNode) node2;
-                            return getNumberOfDimensions(arrayNode1).equals(getNumberOfDimensions(arrayNode2)) ?
-                                    (arrayNode1).memberTypeDesc().toSourceCode()
-                                            .compareTo((arrayNode2).memberTypeDesc().toSourceCode()) :
-                                    getNumberOfDimensions(arrayNode1) - getNumberOfDimensions(arrayNode2);
-                })).toList();
+        nonArrayNodes.sort(Comparator.comparing(TypeDescriptorNode::toSourceCode));
+        arrayNodes.sort((node1, node2) -> {
+            ArrayTypeDescriptorNode arrayNode1 = (ArrayTypeDescriptorNode) node1;
+            ArrayTypeDescriptorNode arrayNode2 = (ArrayTypeDescriptorNode) node2;
+            return getNumberOfDimensions(arrayNode1).equals(getNumberOfDimensions(arrayNode2)) ?
+                    (arrayNode1).memberTypeDesc().toSourceCode()
+                            .compareTo((arrayNode2).memberTypeDesc().toSourceCode()) :
+                    getNumberOfDimensions(arrayNode1) - getNumberOfDimensions(arrayNode2);
+        });
+        return Stream.concat(nonArrayNodes.stream(), arrayNodes.stream()).toList();
     }
 
     /**

--- a/misc/xml-to-record-converter/src/main/java/io/ballerina/xmltorecordconverter/util/ConverterUtils.java
+++ b/misc/xml-to-record-converter/src/main/java/io/ballerina/xmltorecordconverter/util/ConverterUtils.java
@@ -31,7 +31,6 @@ import io.ballerina.compiler.syntax.tree.UnionTypeDescriptorNode;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.identifier.Utils.escapeSpecialCharacters;
@@ -119,9 +118,9 @@ public final class ConverterUtils {
      */
     public static List<TypeDescriptorNode> sortTypeDescriptorNodes(List<TypeDescriptorNode> typeDescriptorNodes) {
         List<TypeDescriptorNode> nonArrayNodes = typeDescriptorNodes.stream()
-                .filter(node -> !(node instanceof ArrayTypeDescriptorNode)).collect(Collectors.toList());
+                .filter(node -> !(node instanceof ArrayTypeDescriptorNode)).toList();
         List<TypeDescriptorNode> arrayNodes = typeDescriptorNodes.stream()
-                .filter(node -> (node instanceof ArrayTypeDescriptorNode)).collect(Collectors.toList());
+                .filter(node -> (node instanceof ArrayTypeDescriptorNode)).toList();
         List<TypeDescriptorNode> membersOfArrayNodes = arrayNodes.stream()
                 .map(node -> extractArrayTypeDescNode((ArrayTypeDescriptorNode) node)).toList();
         nonArrayNodes.removeIf(node ->
@@ -135,7 +134,7 @@ public final class ConverterUtils {
                             .compareTo((arrayNode2).memberTypeDesc().toSourceCode()) :
                     getNumberOfDimensions(arrayNode1) - getNumberOfDimensions(arrayNode2);
         });
-        return Stream.concat(nonArrayNodes.stream(), arrayNodes.stream()).collect(Collectors.toList());
+        return Stream.concat(nonArrayNodes.stream(), arrayNodes.stream()).toList();
     }
 
     /**

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -302,7 +302,7 @@ public class TestBuildProject extends BaseTest {
 
         // Verify paths in packageCompilation diagnostics
         List<String> diagnosticFilePaths = compilation.diagnosticResult().diagnostics().stream().map(diagnostic ->
-                diagnostic.location().lineRange().fileName()).distinct().collect(Collectors.toList());
+                diagnostic.location().lineRange().fileName()).distinct().toList();
 
         for (String path : expectedPaths) {
             Assert.assertTrue(diagnosticFilePaths.contains(path), diagnosticFilePaths.toString());
@@ -2255,7 +2255,7 @@ public class TestBuildProject extends BaseTest {
         PackageCompilation compilation = currentPackage.getCompilation();
 
         List<String> actualDiagnosticPaths = compilation.diagnosticResult().diagnostics().stream().map(diagnostic ->
-                diagnostic.location().lineRange().fileName()).distinct().collect(Collectors.toList());
+                diagnostic.location().lineRange().fileName()).distinct().toList();
 
         List<String> expectedDiagnosticPaths = Arrays.asList(
                 "main.bal", Paths.get("tests").resolve("main_test.bal").toString(),

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProjectWithGeneratedSources.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProjectWithGeneratedSources.java
@@ -30,6 +30,8 @@ import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
@@ -189,7 +191,9 @@ public class TestBuildProjectWithGeneratedSources extends BaseTest {
                 buildProject = TestUtils.loadBuildProject(projectPath, buildOptions);
             }
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            StringWriter errors = new StringWriter();
+            e.printStackTrace(new PrintWriter(errors));
+            Assert.fail(errors.toString());
         }
         return buildProject;
     }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/LanguageServerExtensionTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/LanguageServerExtensionTests.java
@@ -67,7 +67,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Tests for language server's extensions.
@@ -125,7 +124,7 @@ public class LanguageServerExtensionTests {
         List<CodeActionArgument> arguments = info.get().getArguments();
         arguments = arguments.stream()
                 .map(codeActionArgument -> CodeActionArgument.from(gson.toJsonTree(codeActionArgument)))
-                .collect(Collectors.toList());
+                .toList();
 
         Assert.assertFalse(arguments.isEmpty());
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -255,11 +255,11 @@ public class LangLibFunctionTest {
         return new Object[][]{
                 {68, 8, XML, expFunctions},
                 {69, 17, TYPE_REFERENCE, Stream.concat(expFunctions.stream(), elementFuncs.stream())
-                        .collect(Collectors.toList())},
+                        .toList()},
                 {79, 31, TYPE_REFERENCE, Stream.concat(expFunctions.stream(), piFuncs.stream())
-                        .collect(Collectors.toList())},
+                        .toList()},
                 {80, 17, TYPE_REFERENCE, Stream.concat(expFunctions.stream(), commentFuncs.stream())
-                        .collect(Collectors.toList())},
+                        .toList()},
                 {81, 14, TYPE_REFERENCE, expFunctions},
         };
     }
@@ -384,7 +384,7 @@ public class LangLibFunctionTest {
 
         return new Object[][]{
                 {64, 22, expFunctions},
-                {65, 32, Stream.concat(expFunctions.stream(), additionalFuncs.stream()).collect(Collectors.toList())},
+                {65, 32, Stream.concat(expFunctions.stream(), additionalFuncs.stream()).toList()},
                 {66, 37, expFunctions},
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
@@ -325,10 +325,10 @@ public class ServiceSemanticAPITest {
         return symbols.stream()
                 .filter(s -> s.getModule().isPresent() &&
                         !"ballerina".equals(s.getModule().get().getModule().get().id().orgName()))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private List<String> concatSymbols(List<String> moduleSymbols, String... symbols) {
-        return Stream.concat(moduleSymbols.stream(), Arrays.stream(symbols)).collect(Collectors.toList());
+        return Stream.concat(moduleSymbols.stream(), Arrays.stream(symbols)).toList();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
@@ -49,7 +49,6 @@ import org.testng.internal.collections.Pair;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.compiler.api.symbols.Qualifier.FINAL;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
@@ -72,7 +72,7 @@ public class SymbolEquivalenceTest {
     public void testSymbols(List<LinePosition> positions) {
         List<Symbol> symbols = positions.stream()
                 .map(pos -> model.symbol(srcFile, pos).get())
-                .collect(Collectors.toList());
+                .toList();
         assertSymbols(symbols);
     }
 
@@ -113,7 +113,7 @@ public class SymbolEquivalenceTest {
         SemanticModel typeRefModel = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/typedesc_test.bal");
         List<Symbol> symbols = positions.stream()
                 .map(pos -> typeRefModel.symbol(typesSrcFile, pos).get())
-                .collect(Collectors.toList());
+                .toList();
 
         assertSymbols(symbols);
     }
@@ -128,7 +128,7 @@ public class SymbolEquivalenceTest {
                     case VARIABLE -> ((VariableSymbol) s).typeDescriptor();
                     default -> throw new AssertionError("Unexpected symbol kind: " + s.kind());
                 })
-                .collect(Collectors.toList());
+                .toList();
         assertTypeSymbols(types);
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
@@ -34,7 +34,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.RECORD_FIELD;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
@@ -418,6 +418,6 @@ public class SymbolLookupTest {
     }
 
     private List<String> concatSymbols(List<String> moduleSymbols, String... symbols) {
-        return Stream.concat(moduleSymbols.stream(), Arrays.stream(symbols)).collect(Collectors.toList());
+        return Stream.concat(moduleSymbols.stream(), Arrays.stream(symbols)).toList();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.compiler.api.symbols.DiagnosticState.REDECLARED;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
@@ -37,7 +37,6 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
@@ -99,7 +99,7 @@ public class TestSourcesTest {
                     String moduleName = sym.getModule().get().id().moduleName();
                     return moduleName.equals("semapi.baz") || !moduleName.startsWith("lang.");
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         assertEquals(symbols.size(), expSymbols.size());
         assertList(symbols, expSymbols);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ClassSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ClassSymbolTest.java
@@ -42,7 +42,6 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.CLASS;
 import static io.ballerina.compiler.api.symbols.SymbolKind.CLASS_FIELD;
@@ -88,7 +87,7 @@ public class ClassSymbolTest {
         assertEquals(initMethod.getName().get(), "init");
         assertEquals(initMethod.typeDescriptor().params().get().stream()
                              .map(p -> p.getName().get())
-                             .collect(Collectors.toList()), fieldNames);
+                             .toList(), fieldNames);
     }
 
     @Test

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/UnionTypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/UnionTypeSymbolTest.java
@@ -69,7 +69,7 @@ public class UnionTypeSymbolTest {
         List<TypeDescKind> memberTypeDescKindList = memberTypeDescriptors
                                                             .stream()
                                                             .map(TypeSymbol::typeKind)
-                                                            .collect(Collectors.toList());
+                                                            .toList();
 
         assertList(memberTypeDescKindList, expTypeList);
     }
@@ -112,7 +112,7 @@ public class UnionTypeSymbolTest {
                                                     .stream()
                                                     .filter(member -> member.typeKind() == TypeDescKind.SINGLETON)
                                                     .map(TypeSymbol::signature)
-                                                    .collect(Collectors.toList());
+                                                    .toList();
         assertList(signatures, List.of("\"int\"", "\"string\"", "100", "\"200\"", "true"));
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/UnionTypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/UnionTypeSymbolTest.java
@@ -32,7 +32,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.assertBasicsAndGetSymbol;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
@@ -154,12 +154,12 @@ public final class SemanticAPITestUtils {
     }
 
     public static List<String> getSymbolNames(List<String> mainList, String... args) {
-        return Stream.concat(mainList.stream(), Stream.of(args)).collect(Collectors.toList());
+        return Stream.concat(mainList.stream(), Stream.of(args)).toList();
     }
 
     @SafeVarargs
     public static <T> List<T> getSymbolNames(List<T>... lists) {
-        return Arrays.stream(lists).flatMap(Collection::stream).collect(Collectors.toList());
+        return Arrays.stream(lists).flatMap(Collection::stream).toList();
     }
 
     public static List<String> getSymbolNames(BPackageSymbol pkgSymbol, int symTag) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/visiblesymbols/BaseVisibleSymbolsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/visiblesymbols/BaseVisibleSymbolsTest.java
@@ -37,7 +37,6 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
@@ -91,7 +90,7 @@ public abstract class BaseVisibleSymbolsTest {
     }
 
     List<ExpectedSymbolInfo> concat(List<ExpectedSymbolInfo> list, ExpectedSymbolInfo... symbols) {
-        return Stream.concat(list.stream(), Stream.of(symbols)).collect(Collectors.toList());
+        return Stream.concat(list.stream(), Stream.of(symbols)).toList();
     }
 
     static class ExpectedSymbolInfo {

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/BreakpointVerificationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/BreakpointVerificationTest.java
@@ -35,7 +35,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Test implementation for debug breakpoint verification scenarios.
@@ -107,7 +106,7 @@ public class BreakpointVerificationTest extends BaseTestCase {
         List<BallerinaTestDebugPoint> breakPoints = Arrays.stream(breakpointResponse.get().getBreakpoints())
                 .map(breakpoint -> new BallerinaTestDebugPoint(Path.of(breakpoint.getSource().getPath()),
                         breakpoint.getLine(), breakpoint.isVerified()))
-                .collect(Collectors.toList());
+                .toList();
 
         assertBreakpointChanges(breakPoints);
     }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/troubleshoot/StrandDumpTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/troubleshoot/StrandDumpTest.java
@@ -175,7 +175,7 @@ public class StrandDumpTest extends BaseTest {
 
     private static List<String> readFileNonEmptyLines(Path filePath) throws BallerinaTestException {
         try (Stream<String> fileLines = Files.lines(filePath)) {
-            return fileLines.filter(s -> !s.isBlank()).collect(Collectors.toList());
+            return fileLines.filter(s -> !s.isBlank()).toList();
         } catch (IOException e) {
             throw new BallerinaTestException("Failure to read from the file: " + filePath);
         }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/troubleshoot/StrandDumpTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/troubleshoot/StrandDumpTest.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentTest.java
@@ -61,7 +61,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Class to test annotation attachments.
@@ -459,7 +458,7 @@ public class AnnotationAttachmentTest {
                         .get().getAnnotationAttachments()
                         .stream()
                         .filter(ann -> !isServiceIntropAnnot((BLangAnnotationAttachment) ann))
-                        .collect(Collectors.toList());
+                        .toList();
         validateEmptyMapConstructorExprInAnnot(attachments, "v20", "A", 1);
     }
 
@@ -628,7 +627,7 @@ public class AnnotationAttachmentTest {
                 getServiceClassForServiceDecl(name).getAnnotationAttachments()
                         .stream()
                         .filter(ann -> !isServiceIntropAnnot((BLangAnnotationAttachment) ann))
-                        .collect(Collectors.toList());
+                        .toList();
     }
 
     private ClassDefinition getServiceClassForServiceDecl(String name) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/PattenTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/PattenTest.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.wso2.ballerinalang.compiler.packaging.Patten.path;
@@ -67,7 +66,7 @@ public class PattenTest {
                                               null, null);
         Patten subject = new Patten(path("hello", "world"));
 
-        List<String> strings = subject.convert(mock, null).collect(Collectors.toList());
+        List<String> strings = subject.convert(mock, null).toList();
 
         Assert.assertEquals(strings, Collections.singletonList("root-dir > hello > world"));
     }
@@ -82,7 +81,7 @@ public class PattenTest {
                                               null, null);
         Patten subject = new Patten(Patten.LATEST_VERSION_DIR);
 
-        List<String> strings = subject.convert(mock, null).collect(Collectors.toList());
+        List<String> strings = subject.convert(mock, null).toList();
 
         Assert.assertEquals(strings, Arrays.asList("root-dir > cache1",
                                                    "root-dir > cache2",
@@ -117,7 +116,7 @@ public class PattenTest {
                                                              s + " > dir2 > dir3 > f.bal"), null);
         Patten subject = new Patten(Patten.WILDCARD_SOURCE);
 
-        List<String> strings = subject.convert(mock, null).collect(Collectors.toList());
+        List<String> strings = subject.convert(mock, null).toList();
 
         Assert.assertEquals(strings, Arrays.asList("project-dir > dir1 > x.bal",
                                                    "project-dir > y.bal",
@@ -157,7 +156,7 @@ public class PattenTest {
                                                              q + " > dir2 > dir3 > f.bal"), null);
         Patten subject = new Patten(path("hello"), Patten.LATEST_VERSION_DIR, path("world"), Patten.WILDCARD_SOURCE);
 
-        List<String> strings = subject.convert(mock, null).collect(Collectors.toList());
+        List<String> strings = subject.convert(mock, null).toList();
 
         Assert.assertEquals(strings, Arrays.asList("my-dir > hello > cache1 > world > dir1 > x.bal",
                                                    "my-dir > hello > cache1 > world > y.bal",

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/URIConverterTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/URIConverterTest.java
@@ -43,7 +43,7 @@ public class URIConverterTest {
         URIConverter subject = new URIConverter(baseURI, new HashMap<>());
 
         List<URI> urls = patten.convert(subject, null)
-                               .collect(Collectors.toList());
+                               .toList();
 
         URI expected = URI.create("http://staging.central.ballerina.io:9090/modules/natasha/foo.bar/1.0.5/");
         Assert.assertEquals(urls, Collections.singletonList(expected));

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/URIConverterTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/packaging/URIConverterTest.java
@@ -27,7 +27,6 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.wso2.ballerinalang.compiler.packaging.Patten.path;
 


### PR DESCRIPTION
## Purpose
This is a continuation of PR #42894. Somehow I missed a lot of places where `collect(Collectors.toList())` is still used.
I also had to fix some typing issues since the resulting types of the Lists are not 100% the same:
- `collect(Collectors.toList())` can return `List<? super T>`
- `toList()` returns `List<T>`

Which means `collect(Collectors.toList())` can convert from `List<String>` to `List<Object>` but `toList()` can't.
I fixed the type signatures so they respect the more explicit type.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
