### PR TITLE
Fix workspace manger proxy to update cloned workspace manager

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManagerProxyImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManagerProxyImpl.java
@@ -84,6 +84,7 @@ public class BallerinaWorkspaceManagerProxyImpl implements BallerinaWorkspaceMan
             return;
         }
         this.baseWorkspaceManager.didChange(path.get(), params);
+        this.clonedWorkspaceManager.didChange(path.get(), params);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManagerProxyImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManagerProxyImpl.java
@@ -79,11 +79,9 @@ public class BallerinaWorkspaceManagerProxyImpl implements BallerinaWorkspaceMan
         if (path.isEmpty()) {
             return;
         }
-        if (this.isExprScheme(uri)) {
-            this.clonedWorkspaceManager.didChange(path.get(), params);
-            return;
+        if (!this.isExprScheme(uri)) {
+            this.baseWorkspaceManager.didChange(path.get(), params);
         }
-        this.baseWorkspaceManager.didChange(path.get(), params);
         this.clonedWorkspaceManager.didChange(path.get(), params);
     }
 


### PR DESCRIPTION
## Purpose
We have `BallerinaWorkspaceManager` which includes a set of methods to manage projects. It maintains two managers, `BaseWorkspaceManager` for file scheme based documents and `ClonedWorkspaceManager` for expr file scheme based documents. Currently, changes made in the editor do not update the ClonedWorkspaceManager. With this change, the ClonedWorkspaceManager will be updated whenever the BaseWorkspaceManager is updated.

Fixes #42910

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
