### PR TITLE
Don't access static members via instance reference

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -285,7 +285,7 @@ public class BIRPackageSymbolEnter {
                             continue;
                         }
                         String referencedFuncName = function.funcName.value;
-                        Name funcName = names.fromString(
+                        Name funcName = Names.fromString(
                                 Symbols.getAttachedFuncSymbolName(structureTypeSymbol.name.value, referencedFuncName));
                         Scope.ScopeEntry matchingObjFuncSym = objectType.tsymbol.scope.lookup(funcName);
                         if (matchingObjFuncSym == NOT_FOUND_ENTRY) {
@@ -403,7 +403,7 @@ public class BIRPackageSymbolEnter {
 
         BInvokableType funcType = (BInvokableType) readBType(dataInStream);
         BInvokableSymbol invokableSymbol =
-                Symbols.createFunctionSymbol(flags, names.fromString(funcName), names.fromString(funcOrigName),
+                Symbols.createFunctionSymbol(flags, Names.fromString(funcName), Names.fromString(funcOrigName),
                                              this.env.pkgSymbol.pkgID, funcType, this.env.pkgSymbol,
                                              Symbols.isFlagOn(flags, Flags.NATIVE), pos, toOrigin(origin));
         invokableSymbol.source = pos.lineRange().fileName();
@@ -419,14 +419,14 @@ public class BIRPackageSymbolEnter {
             // Update the symbol
             invokableSymbol.owner = attachedType.tsymbol;
             invokableSymbol.name =
-                    names.fromString(Symbols.getAttachedFuncSymbolName(attachedType.tsymbol.name.value, funcName));
+                    Names.fromString(Symbols.getAttachedFuncSymbolName(attachedType.tsymbol.name.value, funcName));
             if (attachedType.tag == TypeTags.OBJECT || attachedType.tag == TypeTags.RECORD) {
                 scopeToDefine = attachedType.tsymbol.scope;
                 if (isResourceFunction) {
                     int pathParamCount = dataInStream.readInt();
                     List<BVarSymbol> pathParams = new ArrayList<>(pathParamCount);
                     for (int i = 0; i < pathParamCount; i++) {
-                        Name pathParamName = names.fromString(getStringCPEntryValue(dataInStream));
+                        Name pathParamName = Names.fromString(getStringCPEntryValue(dataInStream));
                         BType paramType = readBType(dataInStream);
                         BVarSymbol varSymbol = new BVarSymbol(0, pathParamName, this.env.pkgSymbol.pkgID,
                                 paramType, null, symTable.builtinPos, COMPILED_SOURCE);
@@ -436,7 +436,7 @@ public class BIRPackageSymbolEnter {
                     boolean restPathParamExist = dataInStream.readBoolean();
                     BVarSymbol restPathParam = null;
                     if (restPathParamExist) {
-                        Name pathParamName = names.fromString(getStringCPEntryValue(dataInStream));
+                        Name pathParamName = Names.fromString(getStringCPEntryValue(dataInStream));
                         BType paramType = readBType(dataInStream);
                         restPathParam = new BVarSymbol(0, pathParamName, this.env.pkgSymbol.pkgID, paramType,
                                 null, symTable.builtinPos, COMPILED_SOURCE);
@@ -447,14 +447,14 @@ public class BIRPackageSymbolEnter {
                     List<Location> resourcePathSegmentPosList = new ArrayList<>(resourcePathCount);
                     List<BType> pathSegmentTypeList = new ArrayList<>(resourcePathCount);
                     for (int i = 0; i < resourcePathCount; i++) {
-                        resourcePath.add(names.fromString(getStringCPEntryValue(dataInStream)));
+                        resourcePath.add(Names.fromString(getStringCPEntryValue(dataInStream)));
                         resourcePathSegmentPosList.add(readPosition(dataInStream));
                         pathSegmentTypeList.add(readBType(dataInStream));
                     }
 
-                    Name accessor = names.fromString(getStringCPEntryValue(dataInStream));
+                    Name accessor = Names.fromString(getStringCPEntryValue(dataInStream));
 
-                    BResourceFunction resourceFunction = new BResourceFunction(names.fromString(funcName),
+                    BResourceFunction resourceFunction = new BResourceFunction(Names.fromString(funcName),
                             invokableSymbol, funcType, accessor, pathParams, restPathParam, symTable.builtinPos);
 
                     // If it is a resource function, attached type should be an object
@@ -478,7 +478,7 @@ public class BIRPackageSymbolEnter {
                     objectTypeSymbol.attachedFuncs.add(resourceFunction);
                 } else {
                     BAttachedFunction attachedFunc =
-                            new BAttachedFunction(names.fromString(funcName), invokableSymbol, funcType,
+                            new BAttachedFunction(Names.fromString(funcName), invokableSymbol, funcType,
                                     symTable.builtinPos);
                     BStructureTypeSymbol structureTypeSymbol = (BStructureTypeSymbol) attachedType.tsymbol;
                     if (Names.USER_DEFINED_INIT_SUFFIX.value.equals(funcName) ||
@@ -549,7 +549,7 @@ public class BIRPackageSymbolEnter {
                 referenceType = (BTypeReferenceType) type;
                 referenceType.tsymbol.pos = pos;
             } else {
-                BTypeSymbol typeSymbol = new BTypeSymbol(SymTag.TYPE_REF, flags, names.fromString(typeDefName),
+                BTypeSymbol typeSymbol = new BTypeSymbol(SymTag.TYPE_REF, flags, Names.fromString(typeDefName),
                         this.env.pkgSymbol.pkgID, type, this.env.pkgSymbol, pos, COMPILED_SOURCE);
                 referenceType = new BTypeReferenceType(type, typeSymbol, flags);
             }
@@ -572,11 +572,11 @@ public class BIRPackageSymbolEnter {
             symbol = type.tsymbol;
             symbol.pos = pos;
         } else {
-            symbol = Symbols.createTypeDefinitionSymbol(flags, names.fromString(typeDefName),
+            symbol = Symbols.createTypeDefinitionSymbol(flags, Names.fromString(typeDefName),
                     this.env.pkgSymbol.pkgID, type, this.env.pkgSymbol, pos, COMPILED_SOURCE);
             ((BTypeDefinitionSymbol) symbol).referenceType = referenceType;
         }
-        symbol.originalName = names.fromString(typeDefOrigName);
+        symbol.originalName = Names.fromString(typeDefOrigName);
         symbol.origin = toOrigin(origin);
         symbol.flags = flags;
 
@@ -710,8 +710,8 @@ public class BIRPackageSymbolEnter {
 
         BPackageSymbol pkgSymbol = pkgId.equals(env.pkgSymbol.pkgID) ? this.env.pkgSymbol :
                 packageCache.getSymbol(pkgId);
-        BAnnotationSymbol annotationSymbol = Symbols.createAnnotationSymbol(flags, attachPoints, names.fromString(name),
-                                                                            names.fromString(originalName),
+        BAnnotationSymbol annotationSymbol = Symbols.createAnnotationSymbol(flags, attachPoints, Names.fromString(name),
+                                                                            Names.fromString(originalName),
                                                                             pkgId, null, pkgSymbol, pos,
                                                                             toOrigin(origin));
         annotationSymbol.type = new BAnnotationType(annotationSymbol);
@@ -762,7 +762,7 @@ public class BIRPackageSymbolEnter {
         Scope enclScope = this.env.pkgSymbol.scope;
 
         // Create the constant symbol.
-        BConstantSymbol constantSymbol = new BConstantSymbol(flags, names.fromString(constantName),
+        BConstantSymbol constantSymbol = new BConstantSymbol(flags, Names.fromString(constantName),
                                                              this.env.pkgSymbol.pkgID, null, type, enclScope.owner,
                                                              pos, toOrigin(origin));
 
@@ -851,9 +851,9 @@ public class BIRPackageSymbolEnter {
             attachPointLiteral = getStringCPEntryValue(inputStream);
         }
 
-        BSymbol classSymbol = this.env.pkgSymbol.scope.lookup(names.fromString(associatedClassName)).symbol;
+        BSymbol classSymbol = this.env.pkgSymbol.scope.lookup(Names.fromString(associatedClassName)).symbol;
         BServiceSymbol serviceDecl = new BServiceSymbol((BClassSymbol) classSymbol, flags,
-                                                        names.fromString(serviceName), this.env.pkgSymbol.pkgID, type,
+                                                        Names.fromString(serviceName), this.env.pkgSymbol.pkgID, type,
                                                         this.env.pkgSymbol, pos, SymbolOrigin.toOrigin(origin));
 
         int nListeners = inputStream.readInt();
@@ -863,7 +863,7 @@ public class BIRPackageSymbolEnter {
         
         serviceDecl.setAttachPointStringLiteral(attachPointLiteral);
         serviceDecl.setAbsResourcePath(attachPoint);
-        this.env.pkgSymbol.scope.define(names.fromString(serviceName), serviceDecl);
+        this.env.pkgSymbol.scope.define(Names.fromString(serviceName), serviceDecl);
     }
 
     private void definePackageLevelVariables(DataInputStream dataInStream) throws IOException {
@@ -882,7 +882,7 @@ public class BIRPackageSymbolEnter {
         BVarSymbol varSymbol;
         if (referredVarType.tag == TypeTags.INVOKABLE) {
             BInvokableTypeSymbol bInvokableTypeSymbol = (BInvokableTypeSymbol) referredVarType.tsymbol;
-            BInvokableSymbol invokableSymbol = new BInvokableSymbol(SymTag.VARIABLE, flags, names.fromString(varName),
+            BInvokableSymbol invokableSymbol = new BInvokableSymbol(SymTag.VARIABLE, flags, Names.fromString(varName),
                     this.env.pkgSymbol.pkgID, referredVarType, enclScope.owner, symTable.builtinPos, toOrigin(origin));
 
             invokableSymbol.kind = SymbolKind.FUNCTION;
@@ -893,7 +893,7 @@ public class BIRPackageSymbolEnter {
             invokableSymbol.retType = ((BInvokableType) invokableSymbol.type).retType;
             varSymbol = invokableSymbol;
         } else {
-            varSymbol = new BVarSymbol(flags, names.fromString(varName), this.env.pkgSymbol.pkgID, varType,
+            varSymbol = new BVarSymbol(flags, Names.fromString(varName), this.env.pkgSymbol.pkgID, varType,
                                        enclScope.owner, symTable.builtinPos, toOrigin(origin));
             if (varType.tsymbol != null && Symbols.isFlagOn(varType.tsymbol.flags, Flags.CLIENT)) {
                 varSymbol.tag = SymTag.ENDPOINT;
@@ -918,7 +918,7 @@ public class BIRPackageSymbolEnter {
         for (int i = 0; i < requiredParamCount; i++) {
             String paramName = getStringCPEntryValue(dataInStream);
             var flags = dataInStream.readLong();
-            BVarSymbol varSymbol = new BVarSymbol(flags, names.fromString(paramName), this.env.pkgSymbol.pkgID,
+            BVarSymbol varSymbol = new BVarSymbol(flags, Names.fromString(paramName), this.env.pkgSymbol.pkgID,
                                                   invokableType.paramTypes.get(i), invokableSymbol,
                                                   symTable.builtinPos, COMPILED_SOURCE);
             varSymbol.isDefaultable = ((flags & Flags.OPTIONAL) == Flags.OPTIONAL);
@@ -928,7 +928,7 @@ public class BIRPackageSymbolEnter {
 
         if (dataInStream.readBoolean()) { //if rest param exist
             String paramName = getStringCPEntryValue(dataInStream);
-            BVarSymbol restParam = new BVarSymbol(0, names.fromString(paramName), this.env.pkgSymbol.pkgID,
+            BVarSymbol restParam = new BVarSymbol(0, Names.fromString(paramName), this.env.pkgSymbol.pkgID,
                                                   invokableType.restType, invokableSymbol, symTable.builtinPos,
                                                   COMPILED_SOURCE);
             invokableSymbol.restParam = restParam;
@@ -1100,10 +1100,10 @@ public class BIRPackageSymbolEnter {
             throw new BLangCompilerException("invalid module name '" + moduleName + "' in compiled package file");
         }
 
-        return new PackageID(names.fromString(orgName),
-                names.fromString(pkgName),
-                names.fromString(moduleName),
-                names.fromString(pkgVersion), null);
+        return new PackageID(Names.fromString(orgName),
+                Names.fromString(pkgName),
+                Names.fromString(moduleName),
+                Names.fromString(pkgVersion), null);
     }
 
     /**
@@ -1159,7 +1159,7 @@ public class BIRPackageSymbolEnter {
                 byte[] docBytes = readDocBytes(inputStream);
                 BType fieldType = readTypeFromCp();
 
-                BVarSymbol varSymbol = new BVarSymbol(paramFlags, names.fromString(paramName), tSymbol.pkgID,
+                BVarSymbol varSymbol = new BVarSymbol(paramFlags, Names.fromString(paramName), tSymbol.pkgID,
                                                       fieldType, tSymbol, symTable.builtinPos,
                                                       COMPILED_SOURCE);
 
@@ -1175,7 +1175,7 @@ public class BIRPackageSymbolEnter {
                 byte[] docBytes = readDocBytes(inputStream);
                 BType fieldType = readTypeFromCp();
 
-                BVarSymbol varSymbol = new BVarSymbol(fieldFlags, names.fromString(fieldName), tSymbol.pkgID, fieldType,
+                BVarSymbol varSymbol = new BVarSymbol(fieldFlags, Names.fromString(fieldName), tSymbol.pkgID, fieldType,
                                                       tSymbol, symTable.builtinPos, COMPILED_SOURCE);
                 defineMarkDownDocAttachment(varSymbol, docBytes);
                 tSymbol.restParam = varSymbol;
@@ -1220,7 +1220,7 @@ public class BIRPackageSymbolEnter {
 
         public BType readType(int cpI) throws IOException {
             byte tag = inputStream.readByte();
-            Name name = names.fromString(getStringCPEntryValue(inputStream));
+            Name name = Names.fromString(getStringCPEntryValue(inputStream));
             var flags = inputStream.readLong();
 
             // Read the type flags to identify if type reference types are nullable.
@@ -1267,7 +1267,7 @@ public class BIRPackageSymbolEnter {
 
                     String recordName = getStringCPEntryValue(inputStream);
                     BRecordTypeSymbol recordSymbol = Symbols.createRecordSymbol(Flags.asMask(EnumSet.of(Flag.PUBLIC)),
-                                                                                names.fromString(recordName),
+                                                                                Names.fromString(recordName),
                                                                                 env.pkgSymbol.pkgID, null,
                                                                                 env.pkgSymbol, symTable.builtinPos,
                                                                                 COMPILED_SOURCE);
@@ -1291,7 +1291,7 @@ public class BIRPackageSymbolEnter {
 
                         BType fieldType = readTypeFromCp();
 
-                        BVarSymbol varSymbol = new BVarSymbol(fieldFlags, names.fromString(fieldName),
+                        BVarSymbol varSymbol = new BVarSymbol(fieldFlags, Names.fromString(fieldName),
                                                               recordSymbol.pkgID, fieldType,
                                                               recordSymbol.scope.owner, symTable.builtinPos,
                                                               COMPILED_SOURCE);
@@ -1322,7 +1322,7 @@ public class BIRPackageSymbolEnter {
                     }
 
                     SymbolEnv pkgEnv = symTable.pkgEnvMap.get(packageCache.getSymbol(pkgId));
-                    return getType(recordType, pkgEnv, names.fromString(recordName));
+                    return getType(recordType, pkgEnv, Names.fromString(recordName));
                 case TypeTags.TYPEDESC:
                     BTypedescType typedescType = new BTypedescType(null, symTable.typeDesc.tsymbol);
                     typedescType.constraint = readTypeFromCp();
@@ -1337,7 +1337,7 @@ public class BIRPackageSymbolEnter {
                     String typeDefName = getStringCPEntryValue(inputStream);
                     BTypeSymbol typeSymbol = Symbols.createTypeSymbol(SymTag.TYPE_REF,
                             Flags.asMask(EnumSet.of(Flag.PUBLIC)),
-                            names.fromString(typeDefName), pkg, null, pkgSymbol,
+                            Names.fromString(typeDefName), pkg, null, pkgSymbol,
                             symTable.builtinPos, COMPILED_SOURCE);
 
                     boolean nullable = (typeFlags & TypeFlags.NILABLE) == TypeFlags.NILABLE;
@@ -1449,7 +1449,7 @@ public class BIRPackageSymbolEnter {
                         pkgCpIndex = inputStream.readInt();
                         unionsPkgId = getPackageId(pkgCpIndex);
                         String unionNameStr = getStringCPEntryValue(inputStream);
-                        unionName = names.fromString(unionNameStr);
+                        unionName = Names.fromString(unionNameStr);
                     }
                     BTypeSymbol unionTypeSymbol = Symbols.createTypeSymbol(SymTag.UNION_TYPE,
                             Flags.asMask(EnumSet.of(Flag.PUBLIC)), unionName, unionsPkgId,
@@ -1550,7 +1550,7 @@ public class BIRPackageSymbolEnter {
                     errorType.flags = flags;
                     errorSymbol.type = errorType;
                     errorSymbol.pkgID = pkgId;
-                    errorSymbol.originalName = errorSymbol.name = names.fromString(errorName);
+                    errorSymbol.originalName = errorSymbol.name = Names.fromString(errorName);
                     Object poppedErrorType = compositeStack.pop();
                     assert poppedErrorType == errorType;
                     if (!env.pkgSymbol.pkgID.equals(PackageID.ANNOTATIONS)
@@ -1579,7 +1579,7 @@ public class BIRPackageSymbolEnter {
                         long fieldFlags = inputStream.readLong();
 
                         BType memberType = readTypeFromCp();
-                        BVarSymbol varSymbol = new BVarSymbol(fieldFlags, names.fromString(index), tuplePkg,
+                        BVarSymbol varSymbol = new BVarSymbol(fieldFlags, Names.fromString(index), tuplePkg,
                                 memberType, tupleOwner, symTable.builtinPos, COMPILED_SOURCE);
 
                         defineAnnotAttachmentSymbols(inputStream, varSymbol);
@@ -1603,7 +1603,7 @@ public class BIRPackageSymbolEnter {
                     String finiteTypeName = getStringCPEntryValue(inputStream);
                     var finiteTypeFlags = inputStream.readLong();
                     BTypeSymbol symbol = Symbols.createTypeSymbol(SymTag.FINITE_TYPE, finiteTypeFlags,
-                                                                  names.fromString(finiteTypeName), env.pkgSymbol.pkgID,
+                                                                  Names.fromString(finiteTypeName), env.pkgSymbol.pkgID,
                                                                   null, env.pkgSymbol, symTable.builtinPos,
                                                                   COMPILED_SOURCE);
                     symbol.scope = new Scope(symbol);
@@ -1624,11 +1624,11 @@ public class BIRPackageSymbolEnter {
                     BObjectTypeSymbol objectSymbol;
 
                     if (Symbols.isFlagOn(objSymFlags, Flags.CLASS)) {
-                        objectSymbol = Symbols.createClassSymbol(objSymFlags, names.fromString(objName),
+                        objectSymbol = Symbols.createClassSymbol(objSymFlags, Names.fromString(objName),
                                 env.pkgSymbol.pkgID, null, env.pkgSymbol,
                                 symTable.builtinPos, COMPILED_SOURCE, false);
                     } else {
-                        objectSymbol = Symbols.createObjectSymbol(objSymFlags, names.fromString(objName),
+                        objectSymbol = Symbols.createObjectSymbol(objSymFlags, Names.fromString(objName),
                                 env.pkgSymbol.pkgID, null, env.pkgSymbol,
                                 symTable.builtinPos, COMPILED_SOURCE);
                     }
@@ -1649,7 +1649,7 @@ public class BIRPackageSymbolEnter {
                         byte[] docBytes = readDocBytes(inputStream);
 
                         BType fieldType = readTypeFromCp();
-                        BVarSymbol objectVarSymbol = new BVarSymbol(fieldFlags, names.fromString(fieldName),
+                        BVarSymbol objectVarSymbol = new BVarSymbol(fieldFlags, Names.fromString(fieldName),
                                                                     objectSymbol.pkgID, fieldType,
                                                                     objectSymbol.scope.owner, symTable.builtinPos,
                                                                     COMPILED_SOURCE);
@@ -1690,7 +1690,7 @@ public class BIRPackageSymbolEnter {
                     }
 
                     pkgEnv = symTable.pkgEnvMap.get(packageCache.getSymbol(pkgId));
-                    return getType(objectType, pkgEnv, names.fromString(objName));
+                    return getType(objectType, pkgEnv, Names.fromString(objName));
                 case TypeTags.BYTE_ARRAY:
                     // TODO fix
                     break;
@@ -1792,11 +1792,11 @@ public class BIRPackageSymbolEnter {
             List<BConstantSymbol> members = new ArrayList<>();
             for (int i = 0; i < memberCount; i++) {
                 String memName = getStringCPEntryValue(inputStream);
-                BSymbol sym = symbolResolver.lookupSymbolInMainSpace(enumPkgEnv, names.fromString(memName));
+                BSymbol sym = symbolResolver.lookupSymbolInMainSpace(enumPkgEnv, Names.fromString(memName));
                 members.add((BConstantSymbol) sym);
             }
 
-            unionType.tsymbol = new BEnumSymbol(members, flags, names.fromString(enumName), pkgSymbol.pkgID, unionType,
+            unionType.tsymbol = new BEnumSymbol(members, flags, Names.fromString(enumName), pkgSymbol.pkgID, unionType,
                                                 pkgSymbol, symTable.builtinPos, COMPILED_SOURCE);
         }
 
@@ -1887,8 +1887,8 @@ public class BIRPackageSymbolEnter {
         String pkgName = ((StringCPEntry) env.constantPool[pkgCpEntry.pkgNameCPIndex]).value;
         String moduleName = ((StringCPEntry) env.constantPool[pkgCpEntry.moduleNameCPIndex]).value;
         String version = ((StringCPEntry) env.constantPool[pkgCpEntry.versionCPIndex]).value;
-        return new PackageID(names.fromString(orgName), names.fromString(pkgName),
-                names.fromString(moduleName), names.fromString(version), null);
+        return new PackageID(Names.fromString(orgName), Names.fromString(pkgName),
+                Names.fromString(moduleName), Names.fromString(version), null);
     }
 
     private void defineValueSpace(DataInputStream dataInStream, BFiniteType finiteType, BIRTypeReader typeReader)

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectoryManager.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectoryManager.java
@@ -118,7 +118,7 @@ public class SourceDirectoryManager implements Project {
 
         //Check for built-in packages
         if (orgName.equals(Names.BUILTIN_ORG)) {
-            return new PackageID(orgName, names.fromString(sourcePackage), version);
+            return new PackageID(orgName, Names.fromString(sourcePackage), version);
         }
 
         //Check for source files
@@ -129,7 +129,7 @@ public class SourceDirectoryManager implements Project {
         //Check for packages
         List<String> packageNames = this.sourceDirectory.getSourcePackageNames();
         if (packageNames.contains(sourcePackage)) {
-            return new PackageID(orgName, names.fromString(sourcePackage), version);
+            return new PackageID(orgName, Names.fromString(sourcePackage), version);
         }
 
         return null;
@@ -216,7 +216,7 @@ public class SourceDirectoryManager implements Project {
 
     private Name getOrgName(Manifest manifest) {
         return manifest.getProject().getOrgName() == null || manifest.getProject().getOrgName().isEmpty() ?
-                Names.ANON_ORG : names.fromString(manifest.getProject().getOrgName());
+                Names.ANON_ORG : Names.fromString(manifest.getProject().getOrgName());
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -433,7 +433,7 @@ public class BIRGen extends BLangNodeVisitor {
 
             BInvokableSymbol funcSymbol = func.symbol;
             BIRFunction birFunc = new BIRFunction(astTypeDefinition.pos, func.funcName, funcSymbol.flags, func.type,
-                                                  names.fromString(DEFAULT_WORKER_NAME), 0,
+                                                  Names.fromString(DEFAULT_WORKER_NAME), 0,
                                                   funcSymbol.origin.toBIROrigin());
 
             if (funcSymbol.receiverSymbol != null) {
@@ -496,7 +496,7 @@ public class BIRGen extends BLangNodeVisitor {
             BInvokableSymbol funcSymbol = func.symbol;
 
             BIRFunction birFunc = new BIRFunction(classDefinition.pos, func.funcName, funcSymbol.flags, func.type,
-                    names.fromString(DEFAULT_WORKER_NAME), 0, funcSymbol.origin.toBIROrigin());
+                    Names.fromString(DEFAULT_WORKER_NAME), 0, funcSymbol.origin.toBIROrigin());
 
             if (funcSymbol.receiverSymbol != null) {
                 birFunc.receiver = getSelf(funcSymbol.receiverSymbol);
@@ -582,12 +582,12 @@ public class BIRGen extends BLangNodeVisitor {
         this.env.unlockVars.push(new BIRLockDetailsHolder());
         Name funcName;
         if (isTypeAttachedFunction) {
-            funcName = names.fromString(astFunc.symbol.name.value);
+            funcName = Names.fromString(astFunc.symbol.name.value);
         } else {
             funcName = getFuncName(astFunc.symbol);
         }
         BIRFunction birFunc = new BIRFunction(astFunc.pos, funcName,
-                names.fromString(astFunc.symbol.getOriginalName().value), astFunc.symbol.flags, type, workerName,
+                Names.fromString(astFunc.symbol.getOriginalName().value), astFunc.symbol.flags, type, workerName,
                 astFunc.sendsToThis.size(), astFunc.symbol.origin.toBIROrigin());
         this.currentScope = new BirScope(0, null);
         if (astFunc.receiver != null) {
@@ -892,12 +892,12 @@ public class BIRGen extends BLangNodeVisitor {
 
     private Name getFuncName(BInvokableSymbol symbol) {
         if (symbol.receiverSymbol == null) {
-            return names.fromString(symbol.name.value);
+            return Names.fromString(symbol.name.value);
         }
 
         int offset = symbol.receiverSymbol.type.tsymbol.name.value.length() + 1;
         String attachedFuncName = symbol.name.value;
-        return names.fromString(attachedFuncName.substring(offset));
+        return Names.fromString(attachedFuncName.substring(offset));
     }
 
     private void addParam(BIRFunction birFunc, BLangVariable functionParam) {
@@ -1109,8 +1109,8 @@ public class BIRGen extends BLangNodeVisitor {
                                                                     ANNOTATION_DATA : varNode.name.originalValue;
         BIRGlobalVariableDcl birVarDcl = new BIRGlobalVariableDcl(varNode.pos, varNode.symbol.flags,
                                                                   varNode.symbol.type, varNode.symbol.pkgID,
-                                                                  names.fromString(name),
-                                                                  names.fromString(originalName), VarScope.GLOBAL,
+                                                                  Names.fromString(name),
+                                                                  Names.fromString(originalName), VarScope.GLOBAL,
                                                                   VarKind.GLOBAL, varNode.name.value,
                                                                   varNode.symbol.origin.toBIROrigin());
         birVarDcl.setMarkdownDocAttachment(varNode.symbol.markdownDocumentation);
@@ -1243,7 +1243,7 @@ public class BIRGen extends BLangNodeVisitor {
         boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.value);
 
         this.env.enclBB.terminator = new BIRTerminator.WorkerReceive(workerReceive.pos,
-                names.fromString(workerReceive.getChannel().channelId()), lhsOp, isOnSameStrand, thenBB,
+                Names.fromString(workerReceive.getChannel().channelId()), lhsOp, isOnSameStrand, thenBB,
                 this.currentScope);
 
         this.env.enclBasicBlocks.add(thenBB);
@@ -1265,7 +1265,7 @@ public class BIRGen extends BLangNodeVisitor {
         boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.value);
 
         this.env.enclBB.terminator = new BIRTerminator.WorkerSend(
-                asyncSendExpr.pos, names.fromString(asyncSendExpr.getChannel().channelId()), dataOp, isOnSameStrand,
+                asyncSendExpr.pos, Names.fromString(asyncSendExpr.getChannel().channelId()), dataOp, isOnSameStrand,
                 false, lhsOp, thenBB, this.currentScope);
 
         this.env.enclBasicBlocks.add(thenBB);
@@ -1288,7 +1288,7 @@ public class BIRGen extends BLangNodeVisitor {
         boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.value);
 
         this.env.enclBB.terminator = new BIRTerminator.WorkerSend(
-                syncSend.pos, names.fromString(syncSend.getChannel().channelId()), dataOp, isOnSameStrand, true, lhsOp,
+                syncSend.pos, Names.fromString(syncSend.getChannel().channelId()), dataOp, isOnSameStrand, true, lhsOp,
                 thenBB, this.currentScope);
 
         this.env.enclBasicBlocks.add(thenBB);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGenEnv.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGenEnv.java
@@ -86,12 +86,12 @@ class BIRGenEnv {
 
     Name nextLocalVarId(Names names) {
         currentLocalVarId++;
-        return names.merge(Names.BIR_LOCAL_VAR_PREFIX, names.fromString(Integer.toString(currentLocalVarId)));
+        return names.merge(Names.BIR_LOCAL_VAR_PREFIX, Names.fromString(Integer.toString(currentLocalVarId)));
     }
 
     Name nextLambdaVarId(Names names) {
         currentLambdaVarId++;
-        return names.merge(Names.BIR_LOCAL_VAR_PREFIX, names.fromString(Integer.toString(currentLambdaVarId)));
+        return names.merge(Names.BIR_LOCAL_VAR_PREFIX, Names.fromString(Integer.toString(currentLambdaVarId)));
     }
 
     void clear() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
@@ -633,7 +633,7 @@ public class ASTBuilderUtil {
         assignableExpr.lhsExpr = lhsExpr;
         assignableExpr.targetType = targetType;
         assignableExpr.setBType(type);
-        assignableExpr.opSymbol = new BOperatorSymbol(names.fromString(assignableExpr.opKind.value()),
+        assignableExpr.opSymbol = new BOperatorSymbol(Names.fromString(assignableExpr.opKind.value()),
                                                       null, targetType, null, opSymPos, VIRTUAL);
         return assignableExpr;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
@@ -258,7 +258,7 @@ public class AnnotationDesugar {
         target.pos = pos;
 
         String lamdaName = "$anon" + classDef.name.value + "_lambda_" + lambdaFunction.function.name.value;
-        BVarSymbol symbolVar = new BVarSymbol(0, names.fromString(lamdaName), pkgID,
+        BVarSymbol symbolVar = new BVarSymbol(0, Names.fromString(lamdaName), pkgID,
                 lambdaFunction.getBType(), owner, pos, VIRTUAL);
 
         // function () returns (map) $anon$anonType$_1_lambda = LambdaRef:$annot_func$_0
@@ -308,7 +308,7 @@ public class AnnotationDesugar {
         BLangAnnotationAttachment annoAttachment = (BLangAnnotationAttachment) TreeBuilder.createAnnotAttachmentNode();
         final SymbolEnv pkgEnv = symTable.pkgEnvMap.get(serviceClass.symbol.getEnclosingSymbol());
         BSymbol annSymbol = symResolver.lookupSymbolInAnnotationSpace(symTable.pkgEnvMap.get(symTable.rootPkgSymbol),
-                names.fromString(SERVICE_INTROSPECTION_INFO_ANN));
+                Names.fromString(SERVICE_INTROSPECTION_INFO_ANN));
         annSymbol.origin = SymbolOrigin.BUILTIN;
         if (annSymbol instanceof BAnnotationSymbol) {
             annoAttachment.annotationSymbol = (BAnnotationSymbol) annSymbol;
@@ -329,7 +329,7 @@ public class AnnotationDesugar {
         annoAttachment.attachPoints.add(AttachPoint.Point.SERVICE);
         literalNode.pos = position;
         BSymbol annTypeSymbol = symResolver.lookupSymbolInMainSpace(
-                pkgEnv, names.fromString(SERVICE_INTROSPECTION_INFO_REC));
+                pkgEnv, Names.fromString(SERVICE_INTROSPECTION_INFO_REC));
         BStructureTypeSymbol bStructSymbol = (BStructureTypeSymbol) annTypeSymbol.type.tsymbol;
         literalNode.setBType(bStructSymbol.type);
         literalNode.typeChecked = true;
@@ -354,7 +354,7 @@ public class AnnotationDesugar {
 
         descriptorKeyValue.key = new BLangRecordLiteral.BLangRecordKey(keyLiteral);
         BSymbol fieldSymbol = symResolver.resolveStructField(position, pkgEnv,
-                names.fromString(SERVICE_NAME), bStructSymbol);
+                Names.fromString(SERVICE_NAME), bStructSymbol);
 
         if (fieldSymbol instanceof BVarSymbol) {
             descriptorKeyValue.key.fieldSymbol = (BVarSymbol) fieldSymbol;
@@ -730,7 +730,7 @@ public class AnnotationDesugar {
         BLangAnnotationAttachment annoAttachment = (BLangAnnotationAttachment) TreeBuilder.createAnnotAttachmentNode();
         mainFunc.addAnnotationAttachment(annoAttachment);
         final SymbolEnv pkgEnv = symTable.pkgEnvMap.get(mainFunc.symbol.getEnclosingSymbol());
-        BSymbol annSymbol = symResolver.lookupSymbolInAnnotationSpace(pkgEnv, names.fromString(DEFAULTABLE_ANN));
+        BSymbol annSymbol = symResolver.lookupSymbolInAnnotationSpace(pkgEnv, Names.fromString(DEFAULTABLE_ANN));
         if (annSymbol instanceof BAnnotationSymbol) {
             annoAttachment.annotationSymbol = (BAnnotationSymbol) annSymbol;
         }
@@ -747,7 +747,7 @@ public class AnnotationDesugar {
         annoAttachment.pkgAlias = pkgAlias;
         annoAttachment.attachPoints.add(AttachPoint.Point.FUNCTION);
         literalNode.pos = pos;
-        BSymbol annTypeSymbol = symResolver.lookupSymbolInMainSpace(pkgEnv, names.fromString(DEFAULTABLE_REC));
+        BSymbol annTypeSymbol = symResolver.lookupSymbolInMainSpace(pkgEnv, Names.fromString(DEFAULTABLE_REC));
         BStructureTypeSymbol bStructSymbol = (BStructureTypeSymbol) annTypeSymbol.type.tsymbol;
         literalNode.setBType(annTypeSymbol.type);
         literalNode.typeChecked = true;
@@ -785,7 +785,7 @@ public class AnnotationDesugar {
         }
         descriptorKeyValue.key = new BLangRecordLiteral.BLangRecordKey(keyLiteral);
         BSymbol fieldSymbol = symResolver.resolveStructField(mainFunc.pos, pkgEnv,
-                names.fromString(ARG_NAMES), bStructSymbol);
+                Names.fromString(ARG_NAMES), bStructSymbol);
         if (fieldSymbol instanceof BVarSymbol) {
             descriptorKeyValue.key.fieldSymbol = (BVarSymbol) fieldSymbol;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClassClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClassClosureDesugar.java
@@ -199,7 +199,7 @@ public class ClassClosureDesugar extends BLangNodeVisitor {
         this.desugar = Desugar.getInstance(context);
         this.names = Names.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
-        this.CLOSURE_MAP_NOT_FOUND.pos = this.symTable.builtinPos;
+        CLOSURE_MAP_NOT_FOUND.pos = this.symTable.builtinPos;
     }
 
     private void reset() {
@@ -975,7 +975,7 @@ public class ClassClosureDesugar extends BLangNodeVisitor {
      * @return map symbol created
      */
     private BVarSymbol createMapSymbol(String mapName, SymbolEnv symbolEnv) {
-        return new BVarSymbol(0, names.fromString(mapName), symbolEnv.scope.owner.pkgID,
+        return new BVarSymbol(0, Names.fromString(mapName), symbolEnv.scope.owner.pkgID,
                               symTable.mapAllType, symbolEnv.scope.owner, symTable.builtinPos, VIRTUAL);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -236,7 +236,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
         this.names = Names.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
         this.classClosureDesugar = ClassClosureDesugar.getInstance(context);
-        this.CLOSURE_MAP_NOT_FOUND.pos = this.symTable.builtinPos;
+        CLOSURE_MAP_NOT_FOUND.pos = this.symTable.builtinPos;
         this.symResolver = SymbolResolver.getInstance(context);
     }
 
@@ -1307,7 +1307,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
     }
 
     public BLangSimpleVariableDef createVarDef(String name, BType type, BLangExpression expr, Location location) {
-        BVarSymbol symbol = new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID, type,
+        BVarSymbol symbol = new BVarSymbol(0, Names.fromString(name), this.env.scope.owner.pkgID, type,
                 ((BLangFunction) this.env.enclInvokable).originalFuncSymbol, location, VIRTUAL);
         BLangSimpleVariable simpleVariable = ASTBuilderUtil.createVariable(location, name, type, expr, symbol);
         BLangSimpleVariableDef simpleVariableDef = ASTBuilderUtil.createVariableDef(location);
@@ -1666,7 +1666,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
      * @return map symbol created
      */
     private BVarSymbol createMapSymbol(String mapName, SymbolEnv symbolEnv) {
-        return new BVarSymbol(0, names.fromString(mapName), symbolEnv.scope.owner.pkgID,
+        return new BVarSymbol(0, Names.fromString(mapName), symbolEnv.scope.owner.pkgID,
                               symTable.mapAllType, symbolEnv.scope.owner, symTable.builtinPos, VIRTUAL);
     }
 
@@ -1798,7 +1798,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
                         SymbolEnv env = parentData.capturedClosureEnv;
 
                         BVarSymbol parentBlockSymbol = new BVarSymbol(0,
-                                names.fromString("$passThroughMap"),
+                                Names.fromString("$passThroughMap"),
                                 env.scope.owner.pkgID, parentBlockMap.getType(), env.scope.owner, body.pos, VIRTUAL);
 
                         BLangSimpleVariable blockMapVar = ASTBuilderUtil.createVariable(body.pos,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/DeclarativeAuthDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/DeclarativeAuthDesugar.java
@@ -143,7 +143,7 @@ public class DeclarativeAuthDesugar {
         // `function authenticateResource(service object {} serviceRef)`
         // The function is expected to panic with a distinct error when fail to authenticate.
         // Relevant listener will handle this error.
-        BSymbol methodSym = symResolver.lookupMethodInModule(packageSymbol, names.fromString(AUTHENTICATE_RESOURCE),
+        BSymbol methodSym = symResolver.lookupMethodInModule(packageSymbol, Names.fromString(AUTHENTICATE_RESOURCE),
                                                              env);
         if (methodSym == symTable.notFoundSymbol || !(methodSym instanceof BInvokableSymbol)) {
             return;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -592,7 +592,7 @@ public class Desugar extends BLangNodeVisitor {
                                                   requiredParameter.name.getValue(), requiredParameter.getBType(),
                                                   createRequiredParamExpr(requiredParameter.expr),
                                                   new BVarSymbol(Flags.asMask(requiredParameter.flagSet),
-                                                                 names.fromString(requiredParameter.name.getValue()),
+                                                                 Names.fromString(requiredParameter.name.getValue()),
                                                                  requiredParameter.symbol.pkgID,
                                                                  requiredParameter.getBType(),
                                                                  requiredParameter.symbol.owner, initFunction.pos,
@@ -631,7 +631,7 @@ public class Desugar extends BLangNodeVisitor {
         generatedInitFunc.restParam =
                 ASTBuilderUtil.createVariable(initFunction.pos,
                                               restParam.name.getValue(), restParam.getBType(), null,
-                                              new BVarSymbol(0, names.fromString(restParam.name.getValue()),
+                                              new BVarSymbol(0, Names.fromString(restParam.name.getValue()),
                                                              restParam.symbol.pkgID, restParam.getBType(),
                                                              restParam.symbol.owner, restParam.pos, VIRTUAL));
         generatedInitializerFunc.symbol.restParam = generatedInitFunc.restParam.symbol;
@@ -1496,7 +1496,7 @@ public class Desugar extends BLangNodeVisitor {
         String name = anonModelHelper.getNextTupleVarKey(env.enclPkg.packageID);
         final BLangSimpleVariable tuple =
                 ASTBuilderUtil.createVariable(varNode.pos, name, symTable.arrayAllType, null,
-                                              new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID,
+                                              new BVarSymbol(0, Names.fromString(name), this.env.scope.owner.pkgID,
                                                              symTable.arrayAllType, this.env.scope.owner, varNode.pos,
                                                              VIRTUAL));
         tuple.expr = varNode.expr;
@@ -1518,7 +1518,7 @@ public class Desugar extends BLangNodeVisitor {
         String name = anonModelHelper.getNextRecordVarKey(env.enclPkg.packageID);
         final BLangSimpleVariable mapVariable =
                 ASTBuilderUtil.createVariable(varNode.pos, name, symTable.mapAllType, null,
-                                              new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID,
+                                              new BVarSymbol(0, Names.fromString(name), this.env.scope.owner.pkgID,
                                                              symTable.mapAllType, this.env.scope.owner, varNode.pos,
                                                              VIRTUAL));
         mapVariable.expr = varNode.expr;
@@ -1538,7 +1538,7 @@ public class Desugar extends BLangNodeVisitor {
         BType errorType = varNode.getBType() == null ? symTable.errorType : varNode.getBType();
         // Create a simple var for the error 'error x = ($error$)'.
         String name = anonModelHelper.getNextErrorVarKey(env.enclPkg.packageID);
-        BVarSymbol errorVarSymbol = new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID,
+        BVarSymbol errorVarSymbol = new BVarSymbol(0, Names.fromString(name), this.env.scope.owner.pkgID,
                                                    errorType, this.env.scope.owner, varNode.pos, VIRTUAL);
         final BLangSimpleVariable error = ASTBuilderUtil.createVariable(varNode.pos, name, errorType, null,
                 errorVarSymbol);
@@ -1820,7 +1820,7 @@ public class Desugar extends BLangNodeVisitor {
                 BLangSimpleVariable mapVariable =
                         ASTBuilderUtil.createVariable(pos, "$map$_1",
                                                       parentIndexAccessExpr.getBType(), null,
-                                                      new BVarSymbol(0, names.fromString("$map$_1"),
+                                                      new BVarSymbol(0, Names.fromString("$map$_1"),
                                                                      this.env.scope.owner.pkgID,
                                                                      parentIndexAccessExpr.getBType(),
                                                                      this.env.scope.owner, pos, VIRTUAL));
@@ -1960,7 +1960,7 @@ public class Desugar extends BLangNodeVisitor {
 
     private BLangSimpleVariableDef forceCastIfApplicable(BVarSymbol errorVarySymbol, Location pos,
                                                          BType targetType) {
-        BVarSymbol errorVarSym = new BVarSymbol(Flags.PUBLIC, names.fromString("$cast$temp$"),
+        BVarSymbol errorVarSym = new BVarSymbol(Flags.PUBLIC, Names.fromString("$cast$temp$"),
                                                 this.env.enclPkg.packageID, targetType, this.env.scope.owner, pos,
                                                 VIRTUAL);
         BLangSimpleVarRef variableRef = ASTBuilderUtil.createVariableRef(pos, errorVarySymbol);
@@ -2053,7 +2053,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangInvocation invocationNode = createInvocationNode("entries", new ArrayList<>(), type);
 
         invocationNode.expr = expr;
-        invocationNode.symbol = symResolver.lookupLangLibMethod(type, names.fromString("entries"), env);
+        invocationNode.symbol = symResolver.lookupLangLibMethod(type, Names.fromString("entries"), env);
         invocationNode.requiredArgs = Lists.of(expr);
         invocationNode.setBType(invocationNode.symbol.type.getReturnType());
         invocationNode.langLibInvocation = true;
@@ -2065,7 +2065,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangInvocation invocationNode = createInvocationNode("map", new ArrayList<>(), filteredVar.getBType());
 
         invocationNode.expr = ASTBuilderUtil.createVariableRef(pos, filteredVar.symbol);
-        invocationNode.symbol = symResolver.lookupLangLibMethod(filteredVar.getBType(), names.fromString("map"), env);
+        invocationNode.symbol = symResolver.lookupLangLibMethod(filteredVar.getBType(), Names.fromString("map"), env);
         invocationNode.requiredArgs = Lists.of(ASTBuilderUtil.createVariableRef(pos, filteredVar.symbol));
         invocationNode.setBType(invocationNode.symbol.type.getReturnType());
         invocationNode.requiredArgs.add(backToMapLambda);
@@ -2078,7 +2078,7 @@ public class Desugar extends BLangNodeVisitor {
         String anonfuncName = "$anonGetValFunc$" + UNDERSCORE + lambdaFunctionCount++;
         BLangFunction function = ASTBuilderUtil.createFunction(pos, anonfuncName);
 
-        BVarSymbol keyValSymbol = new BVarSymbol(0, names.fromString("$lambdaArg$_0"), this.env.scope.owner.pkgID,
+        BVarSymbol keyValSymbol = new BVarSymbol(0, Names.fromString("$lambdaArg$_0"), this.env.scope.owner.pkgID,
                                                  getStringAnyTupleType(), this.env.scope.owner, pos, VIRTUAL);
 
         BLangSimpleVariable inputParameter = ASTBuilderUtil.createVariable(pos, null, getStringAnyTupleType(),
@@ -2134,7 +2134,7 @@ public class Desugar extends BLangNodeVisitor {
 
         invocationNode.expr = ASTBuilderUtil.createVariableRef(pos, entriesInvocationVar.symbol);
         invocationNode.symbol = symResolver.lookupLangLibMethod(entriesInvocationVar.getBType(),
-                names.fromString("filter"), env);
+                Names.fromString("filter"), env);
         invocationNode.requiredArgs = Lists.of(ASTBuilderUtil.createVariableRef(pos, entriesInvocationVar.symbol));
         invocationNode.setBType(invocationNode.symbol.type.getReturnType());
         invocationNode.requiredArgs.add(filter);
@@ -2144,7 +2144,7 @@ public class Desugar extends BLangNodeVisitor {
 
     private BLangSimpleVariable defVariable(Location pos, BType varType, BLangBlockStmt parentBlockStmt,
                                             BLangExpression expression, String name) {
-        Name varName = names.fromString(name);
+        Name varName = Names.fromString(name);
         BLangSimpleVariable detailMap = ASTBuilderUtil.createVariable(pos, name, varType, expression,
                                                                       new BVarSymbol(Flags.PUBLIC, varName,
                                                                                      env.enclPkg.packageID, varType,
@@ -2222,7 +2222,7 @@ public class Desugar extends BLangNodeVisitor {
 
     private BLangInvocation getToStringInvocationOnExpr(BLangExpression expression) {
         BInvokableSymbol symbol = (BInvokableSymbol) symTable.langValueModuleSymbol.scope
-                .lookup(names.fromString(TO_STRING_FUNCTION_NAME)).symbol;
+                .lookup(Names.fromString(TO_STRING_FUNCTION_NAME)).symbol;
 
         List<BLangExpression> requiredArgs = new ArrayList<BLangExpression>() {{
             add(types.addConversionExprIfRequired(expression, symbol.params.get(0).type));
@@ -2277,7 +2277,7 @@ public class Desugar extends BLangNodeVisitor {
 
         invocationNode.expr = typedescExpr;
         invocationNode.symbol = symResolver.lookupLangLibMethod(typedescType,
-                names.fromString(CREATE_RECORD_VALUE), env);
+                Names.fromString(CREATE_RECORD_VALUE), env);
         invocationNode.requiredArgs = Lists.of(ASTBuilderUtil.createVariableRef(pos, source), typedescExpr);
         invocationNode.setBType(BUnionType.create(null, targetType, symTable.errorType));
         return invocationNode;
@@ -2294,7 +2294,7 @@ public class Desugar extends BLangNodeVisitor {
         typedescExpr.setBType(typedescType);
 
         invocationNode.expr = typedescExpr;
-        invocationNode.symbol = symResolver.lookupLangLibMethod(typedescType, names.fromString(CLONE_WITH_TYPE), env);
+        invocationNode.symbol = symResolver.lookupLangLibMethod(typedescType, Names.fromString(CLONE_WITH_TYPE), env);
         invocationNode.requiredArgs = Lists.of(ASTBuilderUtil.createVariableRef(pos, source), typedescExpr);
         invocationNode.setBType(BUnionType.create(null, targetType, symTable.errorType));
         return invocationNode;
@@ -2318,7 +2318,7 @@ public class Desugar extends BLangNodeVisitor {
         String anonfuncName = "$anonRestParamFilterFunc$" + UNDERSCORE + lambdaFunctionCount++;
         BLangFunction function = ASTBuilderUtil.createFunction(pos, anonfuncName);
 
-        BVarSymbol keyValSymbol = new BVarSymbol(0, names.fromString("$lambdaArg$_0"), this.env.scope.owner.pkgID,
+        BVarSymbol keyValSymbol = new BVarSymbol(0, Names.fromString("$lambdaArg$_0"), this.env.scope.owner.pkgID,
                                                  getStringAnyTupleType(), this.env.scope.owner, pos, VIRTUAL);
         BLangBlockFunctionBody functionBlock = createAnonymousFunctionBlock(pos, function, keyValSymbol);
 
@@ -2530,7 +2530,7 @@ public class Desugar extends BLangNodeVisitor {
         String name = "tuple";
         final BLangSimpleVariable tuple =
                 ASTBuilderUtil.createVariable(tupleDestructure.pos, name, runTimeType, null,
-                                              new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID,
+                                              new BVarSymbol(0, Names.fromString(name), this.env.scope.owner.pkgID,
                                                              runTimeType, this.env.scope.owner, tupleDestructure.pos,
                                                              VIRTUAL));
         tuple.expr = tupleDestructure.expr;
@@ -2632,7 +2632,7 @@ public class Desugar extends BLangNodeVisitor {
 
     private BLangInvocation createLengthInvocation(Location pos, BLangExpression collection) {
         BInvokableSymbol lengthInvokableSymbol = (BInvokableSymbol) symResolver
-                .lookupLangLibMethod(collection.getBType(), names.fromString(LENGTH_FUNCTION_NAME), env);
+                .lookupLangLibMethod(collection.getBType(), Names.fromString(LENGTH_FUNCTION_NAME), env);
         BLangInvocation lengthInvocation = ASTBuilderUtil.createInvocationExprForMethod(pos, lengthInvokableSymbol,
                 Lists.of(collection), symResolver);
         lengthInvocation.argExprs = lengthInvocation.requiredArgs;
@@ -2784,7 +2784,7 @@ public class Desugar extends BLangNodeVisitor {
         String name = "$map$_0";
         final BLangSimpleVariable mapVariable =
                 ASTBuilderUtil.createVariable(recordDestructure.pos, name, runTimeType, null,
-                                              new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID,
+                                              new BVarSymbol(0, Names.fromString(name), this.env.scope.owner.pkgID,
                                                              runTimeType, this.env.scope.owner, recordDestructure.pos,
                                                              VIRTUAL));
         mapVariable.expr = recordDestructure.expr;
@@ -2804,7 +2804,7 @@ public class Desugar extends BLangNodeVisitor {
         final BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(errorDestructure.pos);
         final BLangSimpleVariable errorVar =
                 ASTBuilderUtil.createVariable(errorDestructure.pos, GENERATED_ERROR_VAR, symTable.errorType, null,
-                        new BVarSymbol(0, names.fromString(GENERATED_ERROR_VAR), this.env.scope.owner.pkgID,
+                        new BVarSymbol(0, Names.fromString(GENERATED_ERROR_VAR), this.env.scope.owner.pkgID,
                                 symTable.errorType, this.env.scope.owner,
                                 errorDestructure.pos, VIRTUAL));
         errorVar.expr = errorDestructure.expr;
@@ -2878,7 +2878,7 @@ public class Desugar extends BLangNodeVisitor {
             if (parentIndexAccessExpr != null) {
                 BLangSimpleVariable mapVariable =
                         ASTBuilderUtil.createVariable(pos, "$map$_1", restParamType, null,
-                                                      new BVarSymbol(0, names.fromString("$map$_1"),
+                                                      new BVarSymbol(0, Names.fromString("$map$_1"),
                                                                      this.env.scope.owner.pkgID, restParamType,
                                                                      this.env.scope.owner, pos, VIRTUAL));
                 mapVariable.expr = parentIndexAccessExpr;
@@ -3017,7 +3017,7 @@ public class Desugar extends BLangNodeVisitor {
             BLangSimpleVariableDef retryManagerVarDef = createRetryManagerDef(retryNode.retrySpec, retryNode.pos);
             retryBlockStmt.stmts.add(retryManagerVarDef);
             BLangSimpleVarRef retryManagerVarRef = ASTBuilderUtil.createVariableRef(pos, retryManagerVarDef.var.symbol);
-            BVarSymbol retryMangerRefVarSymbol = new BVarSymbol(0, names.fromString("$retryManagerRef$"),
+            BVarSymbol retryMangerRefVarSymbol = new BVarSymbol(0, Names.fromString("$retryManagerRef$"),
                     env.scope.owner.pkgID, retryManagerVarDef.var.symbol.type, this.env.scope.owner, pos,
                     VIRTUAL);
             retryMangerRefVarSymbol.closure = true;
@@ -3030,7 +3030,7 @@ public class Desugar extends BLangNodeVisitor {
 
             // error? $retryResult$ = ();
             BLangLiteral nillLiteral =  ASTBuilderUtil.createLiteral(pos, symTable.nilType, null);
-            BVarSymbol retryResultVarSymbol = new BVarSymbol(0, names.fromString("$retryResult$"),
+            BVarSymbol retryResultVarSymbol = new BVarSymbol(0, Names.fromString("$retryResult$"),
                     env.scope.owner.pkgID, symTable.errorOrNilType, this.env.scope.owner, pos, VIRTUAL);
             retryResultVarSymbol.closure = true;
             BLangSimpleVariable retryResultVariable = ASTBuilderUtil.createVariable(pos, "$retryResult$",
@@ -3042,7 +3042,7 @@ public class Desugar extends BLangNodeVisitor {
 
             // boolean $shouldRetry$ = false;
             BLangLiteral falseLiteral =  ASTBuilderUtil.createLiteral(pos, symTable.booleanType, false);
-            BVarSymbol shouldRetryVarSymbol = new BVarSymbol(0, names.fromString("$shouldRetry$"),
+            BVarSymbol shouldRetryVarSymbol = new BVarSymbol(0, Names.fromString("$shouldRetry$"),
                     env.scope.owner.pkgID, symTable.booleanType, this.env.scope.owner, pos, VIRTUAL);
             shouldRetryVarSymbol.closure = true;
             BLangSimpleVariable shouldRetryVariable = ASTBuilderUtil.createVariable(pos, "$shouldRetry$",
@@ -3130,7 +3130,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangLiteral falseLiteral =  createLiteral(pos, symTable.booleanType, false);
 
         // boolean $returnErrorResult$ = false;
-        BVarSymbol returnResultSymbol = new BVarSymbol(0, names.fromString("$returnErrorResult$"),
+        BVarSymbol returnResultSymbol = new BVarSymbol(0, Names.fromString("$returnErrorResult$"),
                 env.scope.owner.pkgID, symTable.booleanType, this.env.scope.owner, pos, VIRTUAL);
         returnResultSymbol.closure = true;
         BLangSimpleVariable returnResultVariable = createVariable(pos, "$returnErrorResult$",
@@ -3141,7 +3141,7 @@ public class Desugar extends BLangNodeVisitor {
         whileBody.stmts.add(returnResultDef);
 
         // boolean continueLoop = false;
-        BVarSymbol continueLoopVarSymbol = new BVarSymbol(0, names.fromString("$continueLoop$"),
+        BVarSymbol continueLoopVarSymbol = new BVarSymbol(0, Names.fromString("$continueLoop$"),
                 env.scope.owner.pkgID, symTable.booleanType, this.env.scope.owner, pos, VIRTUAL);
         continueLoopVarSymbol.closure = true;
         BLangSimpleVariable continueLoopVariable = createVariable(pos, "$continueLoop$",
@@ -3265,14 +3265,14 @@ public class Desugar extends BLangNodeVisitor {
 
     protected BLangSimpleVariableDef createRetryManagerDef(BLangRetrySpec retrySpec, Location pos) {
         BSymbol retryManagerTypeSymbol = symTable.langErrorModuleSymbol.scope
-                .lookup(names.fromString("DefaultRetryManager")).symbol;
+                .lookup(Names.fromString("DefaultRetryManager")).symbol;
         BType retryManagerType = retryManagerTypeSymbol.type;
         if (retrySpec.retryManagerType != null) {
             retryManagerType = retrySpec.retryManagerType.getBType();
         }
 
         //<RetryManagerType> $retryManager$ = new;
-        BVarSymbol retryMangerSymbol = new BVarSymbol(0, names.fromString("$retryManager$"),
+        BVarSymbol retryMangerSymbol = new BVarSymbol(0, Names.fromString("$retryManager$"),
                                                       env.scope.owner.pkgID, retryManagerType, this.env.scope.owner,
                                                       pos, VIRTUAL);
         BLangTypeInit managerInit = ASTBuilderUtil.createEmptyTypeInit(pos, retryManagerType);
@@ -3601,7 +3601,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangExpression matchExpr = matchStatement.expr;
         BLangSimpleVariable matchExprVar =
                 ASTBuilderUtil.createVariable(matchExpr.pos, matchExprVarName, matchExpr.getBType(), matchExpr,
-                                              new BVarSymbol(0, names.fromString(matchExprVarName),
+                                              new BVarSymbol(0, Names.fromString(matchExprVarName),
                                                              this.env.scope.owner.pkgID, matchExpr.getBType(),
                                                              this.env.scope.owner, matchExpr.pos, VIRTUAL));
 
@@ -5112,7 +5112,7 @@ public class Desugar extends BLangNodeVisitor {
         } else {
             // We need to create a new variable for the expression as well. This is needed because integer ranges can be
             // added as the expression so we cannot get the symbol in such cases.
-            BVarSymbol dataSymbol = new BVarSymbol(0, names.fromString("$data$"),
+            BVarSymbol dataSymbol = new BVarSymbol(0, Names.fromString("$data$"),
                                                    this.env.scope.owner.pkgID, foreach.collection.getBType(),
                                                    this.env.scope.owner, foreach.pos, VIRTUAL);
             BLangSimpleVariable dataVariable = ASTBuilderUtil.createVariable(foreach.pos, "$data$",
@@ -5439,7 +5439,7 @@ public class Desugar extends BLangNodeVisitor {
 
     BInvokableSymbol getLangLibIteratorInvokableSymbol(BVarSymbol collectionSymbol) {
         return (BInvokableSymbol) symResolver.lookupLangLibMethod(collectionSymbol.type,
-                names.fromString(BLangCompilerConstants.ITERABLE_COLLECTION_ITERATOR_FUNC), env);
+                Names.fromString(BLangCompilerConstants.ITERABLE_COLLECTION_ITERATOR_FUNC), env);
     }
 
     private BLangBlockStmt desugarForeachToWhileWithIterator(BLangForeach foreach, BLangSimpleVariableDef varDef) {
@@ -5474,7 +5474,7 @@ public class Desugar extends BLangNodeVisitor {
         BVarSymbol iteratorSymbol = varDef.var.symbol;
 
         // Create a new symbol for the $result$.
-        BVarSymbol resultSymbol = new BVarSymbol(0, names.fromString("$result$"), this.env.scope.owner.pkgID,
+        BVarSymbol resultSymbol = new BVarSymbol(0, Names.fromString("$result$"), this.env.scope.owner.pkgID,
                                                  foreach.nillableResultType, this.env.scope.owner, foreach.pos,
                                                  VIRTUAL);
 
@@ -5596,7 +5596,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangTrapExpr trapExpr = (BLangTrapExpr) TreeBuilder.createTrapExpressionNode();
         trapExpr.setBType(nillableError);
         trapExpr.expr = statementExpression;
-        BVarSymbol nillableErrorVarSymbol = new BVarSymbol(0, names.fromString("$errorResult"),
+        BVarSymbol nillableErrorVarSymbol = new BVarSymbol(0, Names.fromString("$errorResult"),
                                                            this.env.scope.owner.pkgID, nillableError,
                                                            this.env.scope.owner, lockNode.pos, VIRTUAL);
         BLangSimpleVariable simpleVariable = ASTBuilderUtil.createVariable(lockNode.pos, "$errorResult",
@@ -5648,7 +5648,7 @@ public class Desugar extends BLangNodeVisitor {
 
         // on fail error $trxError$ {
         // }
-        BVarSymbol trxOnFailErrorSym = new BVarSymbol(0, names.fromString("$trxError$"),
+        BVarSymbol trxOnFailErrorSym = new BVarSymbol(0, Names.fromString("$trxError$"),
                 env.scope.owner.pkgID, symTable.errorType, env.scope.owner, pos, VIRTUAL);
         BLangSimpleVariable trxOnFailError = ASTBuilderUtil.createVariable(pos,
                 "$trxError$", symTable.errorType, null, trxOnFailErrorSym);
@@ -5732,7 +5732,7 @@ public class Desugar extends BLangNodeVisitor {
 
             // boolean $shouldPanic$ = false;
             BLangLiteral falseLiteral = ASTBuilderUtil.createLiteral(transactionNode.pos, symTable.booleanType, false);
-            BVarSymbol shouldPanicVarSymbol = new BVarSymbol(0, names.fromString("$shouldPanic$"),
+            BVarSymbol shouldPanicVarSymbol = new BVarSymbol(0, Names.fromString("$shouldPanic$"),
                     env.scope.owner.pkgID, symTable.booleanType, this.env.scope.owner, transactionNode.pos, VIRTUAL);
             shouldPanicVarSymbol.closure = true;
             BLangSimpleVariable shouldPanicVariable = ASTBuilderUtil.createVariable(transactionNode.pos,
@@ -5826,7 +5826,7 @@ public class Desugar extends BLangNodeVisitor {
         internalOnFail.body = ASTBuilderUtil.createBlockStmt(pos);
         internalOnFail.body.scope = new Scope(env.scope.owner);
 
-        BVarSymbol caughtErrorSym = new BVarSymbol(0, names.fromString("$caughtError$"),
+        BVarSymbol caughtErrorSym = new BVarSymbol(0, Names.fromString("$caughtError$"),
                 env.scope.owner.pkgID, symTable.errorType, env.scope.owner, pos, VIRTUAL);
         BLangSimpleVariable caughtError = ASTBuilderUtil.createVariable(pos,
                 "$caughtError$", symTable.errorType, null, caughtErrorSym);
@@ -5900,7 +5900,7 @@ public class Desugar extends BLangNodeVisitor {
         BInvokableType type = new BInvokableType(paramTypes, symTable.booleanType,
                 null);
         BOperatorSymbol notOperatorSymbol = new BOperatorSymbol(
-                names.fromString(OperatorKind.NOT.value()), symTable.rootPkgSymbol.pkgID, type, symTable.rootPkgSymbol,
+                Names.fromString(OperatorKind.NOT.value()), symTable.rootPkgSymbol.pkgID, type, symTable.rootPkgSymbol,
                 symTable.builtinPos, VIRTUAL);
         return ASTBuilderUtil.createUnaryExpr(pos, expression, symTable.booleanType,
                 OperatorKind.NOT, notOperatorSymbol);
@@ -6566,7 +6566,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangErrorConstructorExpr errorConstructorExpr =
                 (BLangErrorConstructorExpr) TreeBuilder.createErrorConstructorExpressionNode();
         BSymbol symbol = symResolver.lookupMainSpaceSymbolInPackage(errorConstructorExpr.pos, env,
-                names.fromString(""), names.fromString("error"));
+                Names.fromString(""), Names.fromString("error"));
         errorConstructorExpr.setBType(symbol.type);
 
         List<BLangExpression> positionalArgs = new ArrayList<>();
@@ -7301,10 +7301,10 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangSimpleVariableDef createVarDef(String name, BType type, BLangExpression expr, Location location) {
-        BSymbol objSym = symResolver.lookupSymbolInMainSpace(env, names.fromString(name));
+        BSymbol objSym = symResolver.lookupSymbolInMainSpace(env, Names.fromString(name));
         // todo: check and remove this bit here
         if (objSym == null || objSym == symTable.notFoundSymbol) {
-            objSym = new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID, type,
+            objSym = new BVarSymbol(0, Names.fromString(name), this.env.scope.owner.pkgID, type,
                                     this.env.scope.owner, location, VIRTUAL);
         }
         BLangSimpleVariable objVar = ASTBuilderUtil.createVariable(location, name, type, expr, (BVarSymbol) objSym);
@@ -7878,7 +7878,7 @@ public class Desugar extends BLangNodeVisitor {
         BType resultType = elvisExpr.getBType();
         BLangSimpleVariable resultVar =
                 ASTBuilderUtil.createVariable(pos, resultVarName, resultType, null,
-                        new BVarSymbol(0, names.fromString(resultVarName),
+                        new BVarSymbol(0, Names.fromString(resultVarName),
                                 this.env.scope.owner.pkgID, resultType,
                                 this.env.scope.owner, pos, VIRTUAL));
         BLangSimpleVariableDef resultVarDef = ASTBuilderUtil.createVariableDef(pos, resultVar);
@@ -7888,7 +7888,7 @@ public class Desugar extends BLangNodeVisitor {
         String lhsResultVarName = GEN_VAR_PREFIX.value;
         BLangSimpleVariable lhsResultVar =
                 ASTBuilderUtil.createVariable(pos, lhsResultVarName, elvisExpr.lhsExpr.getBType(), elvisExpr.lhsExpr,
-                        new BVarSymbol(0, names.fromString(lhsResultVarName),
+                        new BVarSymbol(0, Names.fromString(lhsResultVarName),
                                 this.env.scope.owner.pkgID, elvisExpr.lhsExpr.getBType(),
                                 this.env.scope.owner, elvisExpr.pos, VIRTUAL));
         BLangSimpleVariableDef lhsResultVarDef = ASTBuilderUtil.createVariableDef(pos, lhsResultVar);
@@ -8311,7 +8311,7 @@ public class Desugar extends BLangNodeVisitor {
                                                                     Location pos) {
         // TODO: Use the anon model helper to generate the object name?
         BObjectTypeSymbol tSymbol = (BObjectTypeSymbol) objectType.tsymbol;
-        Name objectClassName = names.fromString(
+        Name objectClassName = Names.fromString(
                 anonModelHelper.getNextRawTemplateTypeKey(env.enclPkg.packageID, tSymbol.name));
 
         BObjectTypeSymbol classTSymbol = Symbols.createClassSymbol(tSymbol.flags, objectClassName,
@@ -8583,7 +8583,7 @@ public class Desugar extends BLangNodeVisitor {
 
         invocationNode.expr = invokeOnExpr;
 
-        invocationNode.symbol = symResolver.lookupLangLibMethod(symTable.xmlType, names.fromString(functionName), env);
+        invocationNode.symbol = symResolver.lookupLangLibMethod(symTable.xmlType, Names.fromString(functionName), env);
 
         ArrayList<BLangExpression> requiredArgs = new ArrayList<>();
         requiredArgs.add(invokeOnExpr);
@@ -8690,7 +8690,7 @@ public class Desugar extends BLangNodeVisitor {
         BType resultType = checkedExpr.getBType();
         BLangSimpleVariable resultVar =
                 ASTBuilderUtil.createVariable(pos, resultVarName, resultType, null,
-                                              new BVarSymbol(0, names.fromString(resultVarName),
+                                              new BVarSymbol(0, Names.fromString(resultVarName),
                                                              this.env.scope.owner.pkgID, resultType,
                                                              this.env.scope.owner, pos, VIRTUAL));
         BLangSimpleVariableDef resultVarDef = ASTBuilderUtil.createVariableDef(pos, resultVar);
@@ -8701,7 +8701,7 @@ public class Desugar extends BLangNodeVisitor {
         BType checkedExprType = checkedExpr.expr.getBType();
         BLangSimpleVariable checkedExprVar =
                 ASTBuilderUtil.createVariable(pos, checkedExprVarName, checkedExprType,
-                        checkedExpr.expr, new BVarSymbol(0, names.fromString(checkedExprVarName),
+                        checkedExpr.expr, new BVarSymbol(0, Names.fromString(checkedExprVarName),
                                 this.env.scope.owner.pkgID, checkedExprType,
                                 this.env.scope.owner, pos, VIRTUAL));
         BLangSimpleVariableDef checkedExprVarDef = ASTBuilderUtil.createVariableDef(pos, checkedExprVar);
@@ -8756,7 +8756,7 @@ public class Desugar extends BLangNodeVisitor {
         binaryExpr.rhsExpr = ASTBuilderUtil.createLiteral(annotAccessExpr.pkgAlias.pos, symTable.stringType,
                 annotAccessExpr.annotationSymbol.bvmAlias());
         binaryExpr.setBType(annotAccessExpr.getBType());
-        binaryExpr.opSymbol = new BOperatorSymbol(names.fromString(OperatorKind.ANNOT_ACCESS.value()), null,
+        binaryExpr.opSymbol = new BOperatorSymbol(Names.fromString(OperatorKind.ANNOT_ACCESS.value()), null,
                 new BInvokableType(Lists.of(binaryExpr.lhsExpr.getBType(),
                         binaryExpr.rhsExpr.getBType()),
                         annotAccessExpr.getBType(), null), null,
@@ -9018,7 +9018,7 @@ public class Desugar extends BLangNodeVisitor {
         iteratorInvocation.argExprs = Lists.of(dataReference);
         iteratorInvocation.requiredArgs = iteratorInvocation.argExprs;
         iteratorInvocation.langLibInvocation = isIteratorFuncFromLangLib;
-        BVarSymbol iteratorSymbol = new BVarSymbol(0, names.fromString("$iterator$"), this.env.scope.owner.pkgID,
+        BVarSymbol iteratorSymbol = new BVarSymbol(0, Names.fromString("$iterator$"), this.env.scope.owner.pkgID,
                                                    iteratorInvokableSymbol.retType, this.env.scope.owner, pos, VIRTUAL);
 
         // Note - any $iterator$ = $data$.iterator();
@@ -9121,7 +9121,7 @@ public class Desugar extends BLangNodeVisitor {
         invocationNode.pkgAlias = (BLangIdentifier) TreeBuilder.createIdentifierNode();
 
         invocationNode.expr = onExpr;
-        invocationNode.symbol = symResolver.lookupLangLibMethod(onExpr.getBType(), names.fromString(functionName), env);
+        invocationNode.symbol = symResolver.lookupLangLibMethod(onExpr.getBType(), Names.fromString(functionName), env);
 
         ArrayList<BLangExpression> requiredArgs = new ArrayList<>();
         requiredArgs.add(onExpr);
@@ -9155,7 +9155,7 @@ public class Desugar extends BLangNodeVisitor {
         invocationNode.pkgAlias = (BLangIdentifier) TreeBuilder.createIdentifierNode();
 
         invocationNode.symbol = symResolver.lookupMethodInModule(symTable.langInternalModuleSymbol,
-                names.fromString(functionName), env);
+                Names.fromString(functionName), env);
 
         invocationNode.requiredArgs = new ArrayList<>(requiredArgs);
         invocationNode.restArgs = new ArrayList<>(restArgs);
@@ -9398,7 +9398,7 @@ public class Desugar extends BLangNodeVisitor {
             varargVarType = expr.getBType();
             String varargVarName = DESUGARED_VARARG_KEY + UNDERSCORE + this.varargCount++;
 
-            BVarSymbol varargVarSymbol = new BVarSymbol(0, names.fromString(varargVarName), this.env.scope.owner.pkgID,
+            BVarSymbol varargVarSymbol = new BVarSymbol(0, Names.fromString(varargVarName), this.env.scope.owner.pkgID,
                                                         varargVarType, this.env.scope.owner, varargExpPos, VIRTUAL);
             varargRef = ASTBuilderUtil.createVariableRef(varargExpPos, varargVarSymbol);
 
@@ -9487,7 +9487,7 @@ public class Desugar extends BLangNodeVisitor {
             newArrayLiteral.setBType(restParamType);
 
             String name = DESUGARED_VARARG_KEY + UNDERSCORE + this.varargCount++;
-            BVarSymbol varSymbol = new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID,
+            BVarSymbol varSymbol = new BVarSymbol(0, Names.fromString(name), this.env.scope.owner.pkgID,
                                                   restParamType, this.env.scope.owner, pos, VIRTUAL);
             BLangSimpleVarRef arrayVarRef = ASTBuilderUtil.createVariableRef(pos, varSymbol);
 
@@ -9574,7 +9574,7 @@ public class Desugar extends BLangNodeVisitor {
         pushRestArgsExpr.expr = restArgs.remove(restArgCount - 1);
 
         String name = DESUGARED_VARARG_KEY + UNDERSCORE + this.varargCount++;
-        BVarSymbol varSymbol = new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID, restParamType,
+        BVarSymbol varSymbol = new BVarSymbol(0, Names.fromString(name), this.env.scope.owner.pkgID, restParamType,
                                               this.env.scope.owner, pos, VIRTUAL);
         BLangSimpleVarRef arrayVarRef = ASTBuilderUtil.createVariableRef(pos, varSymbol);
 
@@ -9746,7 +9746,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangSimpleVariable errorVar =
                 ASTBuilderUtil.createVariable(location, patternFailureCaseVarName, symTable.errorType,
                                                 createTypeCastExpr(ref, symTable.errorType),
-                                              new BVarSymbol(0, names.fromString(patternFailureCaseVarName),
+                                              new BVarSymbol(0, Names.fromString(patternFailureCaseVarName),
                                                              this.env.scope.owner.pkgID, symTable.errorType,
                                                              this.env.scope.owner, location, VIRTUAL));
 
@@ -9798,7 +9798,7 @@ public class Desugar extends BLangNodeVisitor {
             BLangRecordVariable recordVariable = (BLangRecordVariable) bindingPatternVariable;
 
             BRecordTypeSymbol recordSymbol =
-                    Symbols.createRecordSymbol(0, names.fromString("$anonRecordType$" + UNDERSCORE + recordCount++),
+                    Symbols.createRecordSymbol(0, Names.fromString("$anonRecordType$" + UNDERSCORE + recordCount++),
                                                env.enclPkg.symbol.pkgID, null, env.scope.owner, recordVariable.pos,
                                                VIRTUAL);
             recordSymbol.scope = new Scope(recordSymbol);
@@ -9808,7 +9808,7 @@ public class Desugar extends BLangNodeVisitor {
 
             for (int i = 0; i < recordVariable.variableList.size(); i++) {
                 String fieldNameStr = recordVariable.variableList.get(i).key.value;
-                Name fieldName = names.fromString(fieldNameStr);
+                Name fieldName = Names.fromString(fieldNameStr);
                 BType fieldType = getStructuredBindingPatternType(
                         recordVariable.variableList.get(i).valueBindingPattern);
                 BVarSymbol fieldSymbol = new BVarSymbol(Flags.REQUIRED, fieldName, env.enclPkg.symbol.pkgID, fieldType,
@@ -9843,7 +9843,7 @@ public class Desugar extends BLangNodeVisitor {
             BErrorTypeSymbol errorTypeSymbol = new BErrorTypeSymbol(
                     SymTag.ERROR,
                     Flags.PUBLIC,
-                    names.fromString("$anonErrorType$" + UNDERSCORE + errorCount++),
+                    Names.fromString("$anonErrorType$" + UNDERSCORE + errorCount++),
                     env.enclPkg.symbol.pkgID,
                     null, null, errorVariable.pos, VIRTUAL);
             BType detailType;
@@ -9873,7 +9873,7 @@ public class Desugar extends BLangNodeVisitor {
         for (BLangErrorVariable.BLangErrorDetailEntry field : errorVariable.detail) {
             BVarSymbol symbol = field.valueBindingPattern.symbol;
             if (symbol == null) {
-                symbol = new BVarSymbol(Flags.PUBLIC, names.fromString(field.key.value + "$"),
+                symbol = new BVarSymbol(Flags.PUBLIC, Names.fromString(field.key.value + "$"),
                                         this.env.enclPkg.packageID, symTable.pureType, null,
                                         field.valueBindingPattern.pos, VIRTUAL);
             }
@@ -9912,7 +9912,7 @@ public class Desugar extends BLangNodeVisitor {
         BRecordTypeSymbol detailRecordTypeSymbol = new BRecordTypeSymbol(
                 SymTag.RECORD,
                 Flags.PUBLIC,
-                names.fromString(anonModelHelper.getNextRecordVarKey(env.enclPkg.packageID)),
+                Names.fromString(anonModelHelper.getNextRecordVarKey(env.enclPkg.packageID)),
                 env.enclPkg.symbol.pkgID, null, null, pos, VIRTUAL);
         detailRecordTypeSymbol.scope = new Scope(detailRecordTypeSymbol);
 
@@ -10034,7 +10034,7 @@ public class Desugar extends BLangNodeVisitor {
         String matchTempResultVarName = GEN_VAR_PREFIX.value + "temp_result";
         BLangSimpleVariable tempResultVar =
                 ASTBuilderUtil.createVariable(accessExpr.pos, matchTempResultVarName, accessExpr.getBType(), null,
-                                              new BVarSymbol(0, names.fromString(matchTempResultVarName),
+                                              new BVarSymbol(0, Names.fromString(matchTempResultVarName),
                                                              this.env.scope.owner.pkgID, accessExpr.getBType(),
                                                              this.env.scope.owner, accessExpr.pos, VIRTUAL));
         BLangSimpleVariableDef tempResultVarDef = ASTBuilderUtil.createVariableDef(accessExpr.pos, tempResultVar);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
@@ -128,7 +128,7 @@ public class ServiceDesugar {
         // Find correct symbol.
         BTypeSymbol listenerTypeSymbol = Types.getImpliedType(
                 getListenerType(variable.getBType())).tsymbol;
-        final Name functionName = names
+        final Name functionName = Names
                 .fromString(Symbols.getAttachedFuncSymbolName(listenerTypeSymbol.name.value, method));
         BInvokableSymbol methodInvocationSymbol = (BInvokableSymbol) symResolver
                 .lookupMemberSymbol(pos, listenerTypeSymbol.scope, env, functionName,
@@ -194,7 +194,7 @@ public class ServiceDesugar {
             //      (.<init>)              ->      y.__attach(x, {});
             // Find correct symbol.
             BTypeSymbol listenerTypeSymbol = getListenerType(listenerVarRef.getBType()).tsymbol;
-            final Name functionName = names
+            final Name functionName = Names
                     .fromString(Symbols.getAttachedFuncSymbolName(listenerTypeSymbol.name.value, ATTACH_METHOD));
             BInvokableSymbol methodRef = (BInvokableSymbol) symResolver
                     .lookupMemberSymbol(pos, listenerTypeSymbol.scope, env, functionName, SymTag.INVOKABLE);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/TransactionDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/TransactionDesugar.java
@@ -214,7 +214,7 @@ public class TransactionDesugar extends BLangNodeVisitor {
         trapExpr.expr = statementExpression;
 
         //error? $trapResult = trap <Transaction Body>
-        BVarSymbol nillableErrorVarSymbol = new BVarSymbol(0, names.fromString("$trapResult"),
+        BVarSymbol nillableErrorVarSymbol = new BVarSymbol(0, Names.fromString("$trapResult"),
                 this.env.scope.owner.pkgID, transactionReturnType,
                 this.env.scope.owner, pos, VIRTUAL);
         BLangSimpleVariable trapResultVariable = ASTBuilderUtil.createVariable(pos, "$trapResult",
@@ -416,7 +416,7 @@ public class TransactionDesugar extends BLangNodeVisitor {
         onFailBodyBlock.stmts.add(stmtIndex, rollbackCheck);
 
         BSymbol transactionErrorSymbol = symTable.langTransactionModuleSymbol
-                .scope.lookup(names.fromString("Error")).symbol;
+                .scope.lookup(Names.fromString("Error")).symbol;
         BType errorType = transactionErrorSymbol.type;
 
         BLangErrorType trxErrorTypeNode = (BLangErrorType) TreeBuilder.createErrorTypeNode();
@@ -613,7 +613,7 @@ public class TransactionDesugar extends BLangNodeVisitor {
         BInvokableType type = new BInvokableType(paramTypes, symTable.booleanType,
                                                  null);
         BOperatorSymbol notOperatorSymbol = new BOperatorSymbol(
-                names.fromString(OperatorKind.NOT.value()), symTable.rootPkgSymbol.pkgID, type, symTable.rootPkgSymbol,
+                Names.fromString(OperatorKind.NOT.value()), symTable.rootPkgSymbol.pkgID, type, symTable.rootPkgSymbol,
                 symTable.builtinPos, VIRTUAL);
         failureValidationGroupExpr.expression = ASTBuilderUtil.createUnaryExpr(pos, failureValidationExprVarRef,
                 symTable.booleanType, OperatorKind.NOT, notOperatorSymbol);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -674,7 +674,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
     public void visit(BLangRetrySpec retrySpec, AnalyzerData data) {
         if (retrySpec.retryManagerType != null) {
             BSymbol retryManagerTypeSymbol = symTable.langErrorModuleSymbol.scope
-                    .lookup(names.fromString("RetryManager")).symbol;
+                    .lookup(Names.fromString("RetryManager")).symbol;
             BType abstractRetryManagerType = retryManagerTypeSymbol.type;
             if (!types.isAssignable(retrySpec.retryManagerType.getBType(), abstractRetryManagerType)) {
                 dlog.error(retrySpec.pos, DiagnosticErrorCode.INVALID_INTERFACE_ON_NON_ABSTRACT_OBJECT,
@@ -2055,7 +2055,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
 
         String workerName = asyncSendExpr.workerIdentifier.getValue();
         if (!this.workerExists(asyncSendExpr.workerType, workerName, data.env)
-                || (!isWorkerFromFunction(data.env, names.fromString(workerName)) && !workerName.equals("function"))) {
+                || (!isWorkerFromFunction(data.env, Names.fromString(workerName)) && !workerName.equals("function"))) {
             this.dlog.error(asyncSendExpr.pos, DiagnosticErrorCode.UNDEFINED_WORKER, workerName);
             was.hasErrors = true;
         }
@@ -2211,7 +2211,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
 
         Set<Flag> flagSet = funcNode.flagSet;
         // Analyze worker interactions inside workers
-        Name workerDerivedName = names.fromString("0" + otherWorker.name.value);
+        Name workerDerivedName = Names.fromString("0" + otherWorker.name.value);
         if (flagSet.contains(Flag.WORKER)) {
             // Interacting with default worker from a worker within a fork.
             if (otherWorkerName.equals(DEFAULT_WORKER_NAME)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
@@ -374,7 +374,7 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
         BType listenerType = null;
         if (!resParamTypes.expectedListenerType().name().isEmpty() && !resParamTypes.expectedListenerType()
                 .packageName().isEmpty()) {
-            Name listenerName = names.fromString(resParamTypes.expectedListenerType().name());
+            Name listenerName = Names.fromString(resParamTypes.expectedListenerType().name());
             String packageQName =
                     resParamTypes.expectedListenerType().orgName() + "/" + resParamTypes.expectedListenerType()
                             .packageName();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
@@ -782,7 +782,7 @@ public class ConstantValueResolver extends BLangNodeVisitor {
         BTypeDefinitionSymbol typeDefinitionSymbol = Symbols.createTypeDefinitionSymbol(type.tsymbol.flags,
                 type.tsymbol.name, pkgID, null, env.scope.owner, pos, VIRTUAL);
         typeDefinitionSymbol.scope = new Scope(typeDefinitionSymbol);
-        typeDefinitionSymbol.scope.define(names.fromString(typeDefinitionSymbol.name.value), typeDefinitionSymbol);
+        typeDefinitionSymbol.scope.define(Names.fromString(typeDefinitionSymbol.name.value), typeDefinitionSymbol);
 
         type.tsymbol.scope = new Scope(type.tsymbol);
         for (BField field : ((HashMap<String, BField>) type.fields).values()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -1043,8 +1043,8 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         analyzeStmtWithOnFail(transactionNode.transactionBody, transactionNode.onFailClause);
 
         // marks the injected import as used
-        Name transactionPkgName = names.fromString(Names.DOT.value + Names.TRANSACTION_PACKAGE.value);
-        Name compUnitName = names.fromString(transactionNode.pos.lineRange().fileName());
+        Name transactionPkgName = Names.fromString(Names.DOT.value + Names.TRANSACTION_PACKAGE.value);
+        Name compUnitName = Names.fromString(transactionNode.pos.lineRange().fileName());
         this.symResolver.resolvePrefixSymbol(env, transactionPkgName, compUnitName);
     }
 
@@ -2729,7 +2729,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
             }
 
             BObjectTypeSymbol objTypeSymbol = (BObjectTypeSymbol) type.tsymbol;
-            Name funcName = names.fromString(Symbols.getAttachedFuncSymbolName(objTypeSymbol.name.value, fieldName));
+            Name funcName = Names.fromString(Symbols.getAttachedFuncSymbolName(objTypeSymbol.name.value, fieldName));
             BSymbol funcSymbol = symResolver.resolveObjectMethod(pos, env, funcName, objTypeSymbol);
 
             // Object member functions are inherently final

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DocumentationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DocumentationAnalyzer.java
@@ -381,14 +381,14 @@ public class DocumentationAnalyzer extends SimpleBLangNodeAnalyzer<Documentation
 
     private BSymbol resolveFullyQualifiedSymbol(Location location, SymbolEnv env, String packageId,
                                                 String type, String identifier, long tag) {
-        Name identifierName = names.fromString(identifier);
-        Name pkgName = names.fromString(packageId);
-        Name typeName = names.fromString(type);
+        Name identifierName = Names.fromString(identifier);
+        Name pkgName = Names.fromString(packageId);
+        Name typeName = Names.fromString(type);
         SymbolEnv pkgEnv = env;
 
         if (pkgName != Names.EMPTY) {
             BSymbol pkgSymbol = symResolver.resolvePrefixSymbol(env, pkgName,
-                    names.fromString(location.lineRange().fileName()));
+                    Names.fromString(location.lineRange().fileName()));
 
             if (pkgSymbol == symTable.notFoundSymbol) {
                 return symTable.notFoundSymbol;
@@ -422,7 +422,7 @@ public class DocumentationAnalyzer extends SimpleBLangNodeAnalyzer<Documentation
             // If the type is available at the global scope or package level then lets dive in to the scope of the type
             // `pkgEnv` is `env` if no package was identified or else it's the package's environment
             String functionID = typeName + "." + identifierName;
-            Name functionName = names.fromString(functionID);
+            Name functionName = Names.fromString(functionID);
             return symResolver.lookupMemberSymbol(location, objectTypeSymbol.scope, pkgEnv, functionName, tag);
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1075,8 +1075,8 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
     @Override
     public void visit(BLangAnnotationAttachment annAttachmentNode, AnalyzerData data) {
         BSymbol symbol = this.symResolver.resolveAnnotation(annAttachmentNode.pos, data.env,
-                names.fromString(annAttachmentNode.pkgAlias.getValue()),
-                names.fromString(annAttachmentNode.getAnnotationName().getValue()));
+                Names.fromString(annAttachmentNode.pkgAlias.getValue()),
+                Names.fromString(annAttachmentNode.getAnnotationName().getValue()));
         if (symbol == this.symTable.notFoundSymbol) {
             this.dlog.error(annAttachmentNode.pos, DiagnosticErrorCode.UNDEFINED_ANNOTATION,
                     annAttachmentNode.getAnnotationName().getValue());
@@ -1802,13 +1802,13 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
     }
 
     private void validateErrorDetailBindingPatterns(BLangErrorVariable errorVariable) {
-        BType rhsType = types.getImpliedType(errorVariable.expr.getBType());
+        BType rhsType = Types.getImpliedType(errorVariable.expr.getBType());
         if (rhsType.getKind() != TypeKind.ERROR) {
             return;
         }
 
         BErrorType errorType = (BErrorType) rhsType;
-        BType detailType = types.getImpliedType(errorType.detailType);
+        BType detailType = Types.getImpliedType(errorType.detailType);
 
         if (detailType.getKind() != TypeKind.RECORD) {
             for (BLangErrorVariable.BLangErrorDetailEntry errorDetailEntry : errorVariable.detail) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1290,7 +1290,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                     // Skip the type resolving in the first iteration (i == 0)
                     // as we want to define the type before trying to resolve it.
                     if (isTypeOrClassDefinition && i != 0) { // Do not skip the first iteration
-                        BSymbol bSymbol = symResolver.lookupSymbolInMainSpace(env, names.fromString(name));
+                        BSymbol bSymbol = symResolver.lookupSymbolInMainSpace(env, Names.fromString(name));
                         symbolNotFound = (bSymbol == symTable.notFoundSymbol);
                     }
 
@@ -1314,7 +1314,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         BErrorType intersectionErrorType = types.createErrorType(null, flags, env);
-        intersectionErrorType.tsymbol.name = names.fromString(typeDef.name.value);
+        intersectionErrorType.tsymbol.name = Names.fromString(typeDef.name.value);
         defineErrorType(typeDef.pos, intersectionErrorType, env);
 
         this.intersectionTypes.add(typeDef);
@@ -1824,7 +1824,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     }
 
     public BSymbol lookupTypeSymbol(SymbolEnv env, BLangIdentifier name) {
-        return symResolver.lookupSymbolInMainSpace(env, names.fromString(name.value));
+        return symResolver.lookupSymbolInMainSpace(env, Names.fromString(name.value));
     }
 
     private BEnumSymbol createEnumSymbol(BLangTypeDefinition typeDefinition, BType definedType) {
@@ -2073,7 +2073,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     public void visit(BLangService serviceNode) {
         defineNode(serviceNode.serviceVariable, env);
 
-        Name generatedServiceName = names.fromString("service$" + serviceNode.serviceClass.symbol.name.value);
+        Name generatedServiceName = Names.fromString("service$" + serviceNode.serviceClass.symbol.name.value);
         BType type = serviceNode.serviceClass.typeRefs.isEmpty() ? null : serviceNode.serviceClass.typeRefs.get(0)
                 .getBType();
         BServiceSymbol serviceSymbol = new BServiceSymbol((BClassSymbol) serviceNode.serviceClass.symbol,
@@ -2392,7 +2392,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         if (varNode.isDeclaredWithVar) {
             varNode.symbol =
                     defineVarSymbol(varNode.pos, varNode.flagSet, symTable.noType,
-                                    names.fromString(anonymousModelHelper.getNextTupleVarKey(env.enclPkg.packageID)),
+                                    Names.fromString(anonymousModelHelper.getNextTupleVarKey(env.enclPkg.packageID)),
                                     env, true);
             // Symbol enter with type other
             List<BLangVariable> memberVariables = new ArrayList<>(varNode.memberVariables);
@@ -2418,7 +2418,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
     boolean checkTypeAndVarCountConsistency(BLangTupleVariable var, SymbolEnv env) {
         if (var.symbol == null) {
-            Name varName = names.fromString(anonymousModelHelper.getNextTupleVarKey(env.enclPkg.packageID));
+            Name varName = Names.fromString(anonymousModelHelper.getNextTupleVarKey(env.enclPkg.packageID));
             var.symbol = defineVarSymbol(var.pos, var.flagSet, var.getBType(), varName, env, true);
         }
 
@@ -2652,7 +2652,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         if (recordVar.isDeclaredWithVar) {
             recordVar.symbol =
                     defineVarSymbol(recordVar.pos, recordVar.flagSet, symTable.noType,
-                                    names.fromString(anonymousModelHelper.getNextRecordVarKey(env.enclPkg.packageID)),
+                                    Names.fromString(anonymousModelHelper.getNextRecordVarKey(env.enclPkg.packageID)),
                                     env, true);
             // Symbol enter each member with type other.
             for (BLangRecordVariable.BLangRecordVariableKeyValue variable : recordVar.variableList) {
@@ -2681,7 +2681,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
     boolean symbolEnterAndValidateRecordVariable(BLangRecordVariable var, SymbolEnv env) {
         if (var.symbol == null) {
-            Name varName = names.fromString(anonymousModelHelper.getNextRecordVarKey(env.enclPkg.packageID));
+            Name varName = Names.fromString(anonymousModelHelper.getNextRecordVarKey(env.enclPkg.packageID));
             var.symbol = defineVarSymbol(var.pos, var.flagSet, var.getBType(), varName, env, true);
         }
 
@@ -2754,7 +2754,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     private BRecordType populatePossibleFields(BLangRecordVariable recordVar, List<BType> possibleTypes,
                                                SymbolEnv env) {
         BRecordTypeSymbol recordSymbol = Symbols.createRecordSymbol(Flags.ANONYMOUS,
-                names.fromString(ANONYMOUS_RECORD_NAME),
+                Names.fromString(ANONYMOUS_RECORD_NAME),
                 env.enclPkg.symbol.pkgID, null,
                 env.scope.owner, recordVar.pos, SOURCE);
         BRecordType recordVarType = (BRecordType) symTable.recordType;
@@ -2882,8 +2882,8 @@ public class SymbolEnter extends BLangNodeVisitor {
 
             BType fieldType = memberTypes.size() > 1 ?
                     BUnionType.create(null, memberTypes) : memberTypes.iterator().next();
-            BField field = new BField(names.fromString(fieldName), pos,
-                    new BVarSymbol(0, names.fromString(fieldName), env.enclPkg.symbol.pkgID,
+            BField field = new BField(Names.fromString(fieldName), pos,
+                    new BVarSymbol(0, Names.fromString(fieldName), env.enclPkg.symbol.pkgID,
                             fieldType, recordSymbol, pos, SOURCE));
             fields.put(field.name.value, field);
         }
@@ -2900,7 +2900,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         BRecordTypeSymbol recordSymbol = Symbols.createRecordSymbol(Flags.ANONYMOUS,
-                names.fromString(ANONYMOUS_RECORD_NAME),
+                Names.fromString(ANONYMOUS_RECORD_NAME),
                 env.enclPkg.symbol.pkgID, null, env.scope.owner,
                 recordVar.pos, SOURCE);
         //TODO check below field position
@@ -3028,7 +3028,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         EnumSet<Flag> flags = EnumSet.of(Flag.PUBLIC, Flag.ANONYMOUS);
         BRecordTypeSymbol recordSymbol = Symbols.createRecordSymbol(Flags.asMask(flags), Names.EMPTY,
                 env.enclPkg.packageID, null, env.scope.owner, pos, VIRTUAL);
-        recordSymbol.name = names.fromString(anonymousModelHelper.getNextAnonymousTypeKey(env.enclPkg.packageID));
+        recordSymbol.name = Names.fromString(anonymousModelHelper.getNextAnonymousTypeKey(env.enclPkg.packageID));
         recordSymbol.scope = new Scope(recordSymbol);
         return recordSymbol;
     }
@@ -3123,8 +3123,8 @@ public class SymbolEnter extends BLangNodeVisitor {
         //adds a never-typed optional field for the mapped bindings
         for (String fieldName : variableList) {
             unMappedFields.remove(fieldName);
-            BField newField = new BField(names.fromString(fieldName), pos,
-                    new BVarSymbol(Flags.OPTIONAL, names.fromString(fieldName), env.enclPkg.symbol.pkgID,
+            BField newField = new BField(Names.fromString(fieldName), pos,
+                    new BVarSymbol(Flags.OPTIONAL, Names.fromString(fieldName), env.enclPkg.symbol.pkgID,
                             symTable.neverType, targetRestRecType.tsymbol, pos, VIRTUAL));
             fields.put(fieldName, newField);
         }
@@ -3205,7 +3205,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         if (errorVar.isDeclaredWithVar) {
             errorVar.symbol =
                     defineVarSymbol(errorVar.pos, errorVar.flagSet, symTable.noType,
-                                    names.fromString(anonymousModelHelper.getNextErrorVarKey(env.enclPkg.packageID)),
+                                    Names.fromString(anonymousModelHelper.getNextErrorVarKey(env.enclPkg.packageID)),
                                     env, true);
 
             // Symbol enter each member with type other.
@@ -3249,7 +3249,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
     boolean symbolEnterAndValidateErrorVariable(BLangErrorVariable var, SymbolEnv env) {
         if (var.symbol == null) {
-            Name varName = names.fromString(anonymousModelHelper.getNextErrorVarKey(env.enclPkg.packageID));
+            Name varName = Names.fromString(anonymousModelHelper.getNextErrorVarKey(env.enclPkg.packageID));
             var.symbol = defineVarSymbol(var.pos, var.flagSet, var.getBType(), varName, env, true);
         }
 
@@ -3444,7 +3444,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 && isReasonSpecified(errorVariable)) {
 
             BSymbol reasonConst = symResolver.lookupSymbolInMainSpace(env.enclEnv,
-                    names.fromString(errorVariable.message.name.value));
+                    Names.fromString(errorVariable.message.name.value));
             if ((reasonConst.tag & SymTag.CONSTANT) != SymTag.CONSTANT) {
                 dlog.error(errorVariable.message.pos, DiagnosticErrorCode.INVALID_ERROR_REASON_BINDING_PATTERN,
                         errorVariable.message.name);
@@ -3530,7 +3530,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             symbolName = XMLConstants.DEFAULT_NS_PREFIX;
         }
 
-        Name prefix = names.fromString(symbolName);
+        Name prefix = Names.fromString(symbolName);
         BXMLNSSymbol xmlnsSymbol = new BXMLNSSymbol(prefix, nsURI, env.enclPkg.symbol.pkgID, env.scope.owner,
                                                     qname.localname.pos, getOrigin(prefix));
 
@@ -4989,7 +4989,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
     private Name getFuncSymbolName(BLangFunction funcNode) {
         if (funcNode.receiver != null) {
-            return names.fromString(Symbols.getAttachedFuncSymbolName(
+            return Names.fromString(Symbols.getAttachedFuncSymbolName(
                     funcNode.receiver.getBType().tsymbol.name.value, funcNode.name.value));
         }
         return names.fromIdNode(funcNode.name);
@@ -5000,7 +5000,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     }
 
     private Name getFieldSymbolName(BLangSimpleVariable receiver, BLangSimpleVariable variable) {
-        return names.fromString(Symbols.getAttachedFuncSymbolName(
+        return Names.fromString(Symbols.getAttachedFuncSymbolName(
                 receiver.getBType().tsymbol.name.value, variable.name.value));
     }
 
@@ -5165,7 +5165,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                                           List<BLangFunction> declaredFunctions, boolean isInternal) {
         typeDefSymbol = typeDefSymbol.tag == SymTag.TYPE_DEF ? typeDefSymbol.type.tsymbol : typeDefSymbol;
         String referencedFuncName = referencedFunc.funcName.value;
-        Name funcName = names.fromString(
+        Name funcName = Names.fromString(
                 Symbols.getAttachedFuncSymbolName(typeDefSymbol.name.value, referencedFuncName));
         BSymbol matchingObjFuncSym = symResolver.lookupSymbolInMainSpace(objEnv, funcName);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -216,7 +216,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
             int dotPosition = symbol.name.value.indexOf('.');
             if (dotPosition > 0 && dotPosition != symbol.name.value.length()) {
                 String funcName = symbol.name.value.substring(dotPosition + 1);
-                foundSym = lookupSymbolForDecl(env, names.fromString(funcName), SymTag.MAIN);
+                foundSym = lookupSymbolForDecl(env, Names.fromString(funcName), SymTag.MAIN);
             }
         }
 
@@ -410,19 +410,19 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
     public BSymbol resolveBinaryOperator(OperatorKind opKind,
                                          BType lhsType,
                                          BType rhsType) {
-        return resolveOperator(names.fromString(opKind.value()), Lists.of(lhsType, rhsType));
+        return resolveOperator(Names.fromString(opKind.value()), Lists.of(lhsType, rhsType));
     }
 
     private BSymbol createEqualityOperator(OperatorKind opKind, BType lhsType, BType rhsType) {
         List<BType> paramTypes = Lists.of(lhsType, rhsType);
         BType retType = symTable.booleanType;
         BInvokableType opType = new BInvokableType(paramTypes, retType, null);
-        return new BOperatorSymbol(names.fromString(opKind.value()), null, opType, null, symTable.builtinPos, VIRTUAL);
+        return new BOperatorSymbol(Names.fromString(opKind.value()), null, opType, null, symTable.builtinPos, VIRTUAL);
     }
 
     public BSymbol resolveUnaryOperator(OperatorKind opKind,
                                         BType type) {
-        return resolveOperator(names.fromString(opKind.value()), Lists.of(type));
+        return resolveOperator(Names.fromString(opKind.value()), Lists.of(type));
     }
 
     public BSymbol resolveOperator(Name name, List<BType> types) {
@@ -433,19 +433,19 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
     private BSymbol createBinaryComparisonOperator(OperatorKind opKind, BType lhsType, BType rhsType) {
         List<BType> paramTypes = Lists.of(lhsType, rhsType);
         BInvokableType opType = new BInvokableType(paramTypes, symTable.booleanType, null);
-        return new BOperatorSymbol(names.fromString(opKind.value()), null, opType, null, symTable.builtinPos, VIRTUAL);
+        return new BOperatorSymbol(Names.fromString(opKind.value()), null, opType, null, symTable.builtinPos, VIRTUAL);
     }
 
     private BSymbol createBinaryOperator(OperatorKind opKind, BType lhsType, BType rhsType, BType retType) {
         List<BType> paramTypes = Lists.of(lhsType, rhsType);
         BInvokableType opType = new BInvokableType(paramTypes, retType, null);
-        return new BOperatorSymbol(names.fromString(opKind.value()), null, opType, null, symTable.builtinPos, VIRTUAL);
+        return new BOperatorSymbol(Names.fromString(opKind.value()), null, opType, null, symTable.builtinPos, VIRTUAL);
     }
 
     BSymbol createUnaryOperator(OperatorKind kind, BType type, BType retType) {
         List<BType> paramTypes = Lists.of(type);
         BInvokableType opType = new BInvokableType(paramTypes, retType, null);
-        return new BOperatorSymbol(names.fromString(kind.value()), null, opType, null, symTable.builtinPos, VIRTUAL);
+        return new BOperatorSymbol(Names.fromString(kind.value()), null, opType, null, symTable.builtinPos, VIRTUAL);
     }
 
     public BSymbol resolvePkgSymbol(Location pos, SymbolEnv env, Name pkgAlias) {
@@ -857,7 +857,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
 
         // 2) Retrieve the package symbol first
         BSymbol pkgSymbol =
-                resolvePrefixSymbol(env, pkgAlias, names.fromString(pos.lineRange().fileName()));
+                resolvePrefixSymbol(env, pkgAlias, Names.fromString(pos.lineRange().fileName()));
         if (pkgSymbol == symTable.notFoundSymbol) {
             dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.value);
             return pkgSymbol;
@@ -882,7 +882,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
 
         // 2) Retrieve the package symbol first
         BSymbol pkgSymbol =
-                resolvePrefixSymbol(env, pkgAlias, names.fromString(pos.lineRange().fileName()));
+                resolvePrefixSymbol(env, pkgAlias, Names.fromString(pos.lineRange().fileName()));
         if (pkgSymbol == symTable.notFoundSymbol) {
             dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.value);
             return pkgSymbol;
@@ -903,7 +903,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
 
         // 2) Retrieve the package symbol first
         BSymbol pkgSymbol =
-                resolvePrefixSymbol(env, pkgAlias, names.fromString(pos.lineRange().fileName()));
+                resolvePrefixSymbol(env, pkgAlias, Names.fromString(pos.lineRange().fileName()));
         if (pkgSymbol == symTable.notFoundSymbol) {
             dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.value);
             return pkgSymbol;
@@ -924,7 +924,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
 
         // 2) Retrieve the package symbol first
         BSymbol pkgSymbol =
-                resolvePrefixSymbol(env, pkgAlias, names.fromString(pos.lineRange().fileName()));
+                resolvePrefixSymbol(env, pkgAlias, Names.fromString(pos.lineRange().fileName()));
         if (pkgSymbol == symTable.notFoundSymbol) {
             dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.value);
             return pkgSymbol;
@@ -1114,7 +1114,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 entry = entry.next;
                 continue;
             }
-            symTable.intRangeType = (BObjectType) types
+            symTable.intRangeType = (BObjectType) Types
                     .getImpliedType(((BInvokableType) entry.symbol.type).retType);
             symTable.defineIntRangeOperations();
             return;
@@ -1330,7 +1330,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
             recordTypeNode.symbol = recordSymbol;
 
             if (data.env.node.getKind() != NodeKind.PACKAGE) {
-                recordSymbol.name = names.fromString(
+                recordSymbol.name = Names.fromString(
                         anonymousModelHelper.getNextAnonymousTypeKey(data.env.enclPkg.packageID));
                 symbolEnter.defineSymbol(recordTypeNode.pos, recordTypeNode.symbol, data.env);
                 symbolEnter.defineNode(recordTypeNode, data.env);
@@ -1502,7 +1502,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
 
         PackageID packageID = data.env.enclPkg.packageID;
         if (data.env.node.getKind() != NodeKind.PACKAGE) {
-            errorTypeSymbol.name = names.fromString(
+            errorTypeSymbol.name = Names.fromString(
                     anonymousModelHelper.getNextAnonymousTypeKey(packageID));
             symbolEnter.defineSymbol(errorTypeNode.pos, errorTypeSymbol, data.env);
         }
@@ -2611,7 +2611,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
 
     public BAnnotationSymbol getStrandAnnotationSymbol() {
         return (BAnnotationSymbol) lookupSymbolInAnnotationSpace(
-                symTable.pkgEnvMap.get(symTable.rootPkgSymbol), names.fromString("strand"));
+                symTable.pkgEnvMap.get(symTable.rootPkgSymbol), Names.fromString("strand"));
     }
 
     public BPackageSymbol getModuleForPackageId(PackageID packageID) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2440,7 +2440,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             RecordLiteralNode.RecordField field = readOnlyEntry.getValue();
 
             String key = readOnlyEntry.getKey();
-            Name fieldName = names.fromString(key);
+            Name fieldName = Names.fromString(key);
 
             BType readOnlyFieldType;
             if (field.isKeyValueField()) {
@@ -2794,7 +2794,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
             List<BType> typeInclusions = mutableType.typeInclusions;
             for (BType typeInclusion : typeInclusions) {
-                determineDefaultValues(typesOfDefaultValues, (BRecordType) types.getImpliedType(typeInclusion),
+                determineDefaultValues(typesOfDefaultValues, (BRecordType) Types.getImpliedType(typeInclusion),
                                         data);
             }
             break;
@@ -2809,7 +2809,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         }
         List<BType> typeInclusions = mutableType.typeInclusions;
         for (BType typeInclusion : typeInclusions) {
-            determineDefaultValues(typesOfDefaultValues, (BRecordType) types.getImpliedType(typeInclusion), data);
+            determineDefaultValues(typesOfDefaultValues, (BRecordType) Types.getImpliedType(typeInclusion), data);
         }
     }
 
@@ -2879,7 +2879,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             if (!this.workerExists(data.env, workerName)) {
                 this.dlog.error(workerFlushExpr.pos, DiagnosticErrorCode.UNDEFINED_WORKER, workerName);
             } else {
-                BSymbol symbol = symResolver.lookupSymbolInMainSpace(data.env, names.fromString(workerName));
+                BSymbol symbol = symResolver.lookupSymbolInMainSpace(data.env, Names.fromString(workerName));
                 if (symbol != symTable.notFoundSymbol) {
                     workerFlushExpr.workerSymbol = symbol;
                 }
@@ -3167,7 +3167,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             // if no symbol, check same for object attached function
             BLangType enclType = data.env.enclType;
             if (symbol == symTable.notFoundSymbol && enclType != null && enclType.getBType().tsymbol.scope != null) {
-                Name objFuncName = names.fromString(Symbols
+                Name objFuncName = Names.fromString(Symbols
                         .getAttachedFuncSymbolName(enclType.getBType().tsymbol.name.value, varName.value));
                 symbol = symResolver.resolveStructField(varRefExpr.pos, data.env, objFuncName,
                         enclType.getBType().tsymbol);
@@ -3246,7 +3246,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         LinkedHashMap<String, BField> fields = new LinkedHashMap<>();
 
         String recordName = this.anonymousModelHelper.getNextAnonymousTypeKey(data.env.enclPkg.symbol.pkgID);
-        BRecordTypeSymbol recordSymbol = Symbols.createRecordSymbol(Flags.ANONYMOUS, names.fromString(recordName),
+        BRecordTypeSymbol recordSymbol = Symbols.createRecordSymbol(Flags.ANONYMOUS, Names.fromString(recordName),
                 data.env.enclPkg.symbol.pkgID, null, data.env.scope.owner,
                                                                          varRefExpr.pos, SOURCE);
         symbolEnter.defineSymbol(varRefExpr.pos, recordSymbol, data.env);
@@ -5505,7 +5505,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         LinkedHashSet<BType> basicNumericTypes = new LinkedHashSet<>(memberTypes.size());
 
         for (BType value : memberTypes) {
-            BType referredType = types.getImpliedType(value);
+            BType referredType = Types.getImpliedType(value);
             int typeTag = referredType.tag;
             if (TypeTags.isIntegerTypeTag(typeTag)) {
                 basicNumericTypes.add(symTable.intType);
@@ -5558,7 +5558,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
     public BType setExpectedTypeForSubtractionOperator(AnalyzerData data) {
         BType newExpectedType = data.expType;
-        BType referredType = types.getImpliedType(newExpectedType);
+        BType referredType = Types.getImpliedType(newExpectedType);
         int referredTypeTag = referredType.tag;
 
         if (TypeTags.isIntegerTypeTag(referredTypeTag)) {
@@ -5588,7 +5588,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
     public BType getActualTypeForOtherUnaryExpr(BLangUnaryExpr unaryExpr, AnalyzerData data) {
         BType actualType = symTable.semanticError;
         BType newExpectedType = data.expType;
-        BType referredType = types.getImpliedType(newExpectedType);
+        BType referredType = Types.getImpliedType(newExpectedType);
         int referredTypeTag = referredType.tag;
 
         //Allow subtraction and add (to resolve ex: byte x = +7) operators to get expected type
@@ -5669,7 +5669,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
     public LinkedHashSet getIntSubtypesInUnionType(BUnionType expectedType) {
         LinkedHashSet<BType> intTypesInUnion = new LinkedHashSet<>(expectedType.getMemberTypes().size());
         for (BType type : expectedType.getMemberTypes()) {
-            BType referredType = types.getImpliedType(type);
+            BType referredType = Types.getImpliedType(type);
             if (referredType.tag != TypeTags.INT && TypeTags.isIntegerTypeTag(referredType.tag)) {
                 intTypesInUnion.add(type);
             }
@@ -5687,7 +5687,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
         BType compatibleTypeOfUnaryExpression;
         for (BType type : expectedType.getMemberTypes()) {
-            compatibleTypeOfUnaryExpression = checkExpr(nodeCloner.cloneNode(unaryExpr), types.getImpliedType(type),
+            compatibleTypeOfUnaryExpression = checkExpr(nodeCloner.cloneNode(unaryExpr), Types.getImpliedType(type),
                     data);
             if (Types.getImpliedType(compatibleTypeOfUnaryExpression).tag == TypeTags.FINITE) {
                 unmuteDlog(data, prevNonErrorLoggingCheck, prevErrorCount);
@@ -5936,7 +5936,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                                                      BPackageSymbol pkgSymbol, Location pos, AnalyzerData data) {
         // Resolve a const from module scope.
         BSymbol constSymbol = symResolver.lookupMemberSymbol(pos, pkgSymbol.scope, data.env,
-                names.fromString(localname), SymTag.CONSTANT);
+                Names.fromString(localname), SymTag.CONSTANT);
         if (constSymbol == symTable.notFoundSymbol) {
             if (!missingNodesHelper.isMissingNode(prefix) && !missingNodesHelper.isMissingNode(localname)) {
                 dlog.error(pos, DiagnosticErrorCode.UNDEFINED_SYMBOL, prefix + ":" + localname);
@@ -5959,7 +5959,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             pkgSymbol.isUsed = true;
             String nsURI = constVal.substring(s + 1, e);
             String local = constVal.substring(e);
-            return new BXMLNSSymbol(names.fromString(local), nsURI, constantSymbol.pkgID, constantSymbol.owner, pos,
+            return new BXMLNSSymbol(Names.fromString(local), nsURI, constantSymbol.pkgID, constantSymbol.owner, pos,
                                     SOURCE);
         }
 
@@ -6019,7 +6019,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         });
 
         Map<Name, BXMLNSSymbol> namespaces = symResolver.resolveAllNamespaces(xmlElementEnv);
-        Name defaultNs = names.fromString(XMLConstants.DEFAULT_NS_PREFIX);
+        Name defaultNs = Names.fromString(XMLConstants.DEFAULT_NS_PREFIX);
         if (namespaces.containsKey(defaultNs)) {
             bLangXMLElementLiteral.defaultNsSymbol = namespaces.remove(defaultNs);
         }
@@ -6522,7 +6522,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         argExprs.add(typedescExpr);
         BLangInvocation invocation = ASTBuilderUtil.createLangLibInvocationNode(FUNCTION_NAME_ENSURE_TYPE,
                 argExprs, checkedExpr.expr, checkedExpr.pos);
-        invocation.symbol = symResolver.lookupLangLibMethod(type, names.fromString(invocation.name.value), data.env);
+        invocation.symbol = symResolver.lookupLangLibMethod(type, Names.fromString(invocation.name.value), data.env);
         invocation.pkgAlias = (BLangIdentifier) TreeBuilder.createIdentifierNode();
         checkedExpr.expr = invocation;
     }
@@ -6585,8 +6585,8 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         BType actualType = symTable.semanticError;
         BSymbol symbol =
                 this.symResolver.resolveAnnotation(annotAccessExpr.pos, data.env,
-                        names.fromString(annotAccessExpr.pkgAlias.getValue()),
-                        names.fromString(annotAccessExpr.annotationName.getValue()));
+                        Names.fromString(annotAccessExpr.pkgAlias.getValue()),
+                        Names.fromString(annotAccessExpr.annotationName.getValue()));
         if (symbol == this.symTable.notFoundSymbol) {
             this.dlog.error(annotAccessExpr.pos, DiagnosticErrorCode.UNDEFINED_ANNOTATION,
                     annotAccessExpr.annotationName.getValue());
@@ -6991,7 +6991,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         }
         // check for object attached function
         Name funcName =
-                names.fromString(Symbols.getAttachedFuncSymbolName(objectType.tsymbol.name.value, iExpr.name.value));
+                Names.fromString(Symbols.getAttachedFuncSymbolName(objectType.tsymbol.name.value, iExpr.name.value));
         BSymbol funcSymbol =
                 symResolver.resolveObjectMethod(iExpr.pos, data.env, funcName, (BObjectTypeSymbol) objectType.tsymbol);
 
@@ -7047,7 +7047,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             return;
         }
 
-        Name remoteMethodQName = names
+        Name remoteMethodQName = Names
                 .fromString(Symbols.getAttachedFuncSymbolName(expType.tsymbol.name.value, aInv.name.value));
         Name actionName = names.fromIdNode(aInv.name);
         BSymbol remoteFuncSymbol = symResolver.resolveObjectMethod(aInv.pos, data.env,
@@ -7097,7 +7097,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
     private BSymbol getLangLibMethod(BLangInvocation iExpr, BType bType, AnalyzerData data) {
 
-        Name funcName = names.fromString(iExpr.name.value);
+        Name funcName = Names.fromString(iExpr.name.value);
         BSymbol funcSymbol = symResolver.lookupLangLibMethod(bType, funcName, data.env);
 
         if (funcSymbol == symTable.notFoundSymbol) {
@@ -7967,7 +7967,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             BLangSimpleVarRef varRef = (BLangSimpleVarRef) keyExpr;
             fieldName = names.fromIdNode(varRef.variableName);
         } else if (keyExpr.getKind() == NodeKind.LITERAL && keyExpr.getBType().tag == TypeTags.STRING) {
-            fieldName = names.fromString((String) ((BLangLiteral) keyExpr).value);
+            fieldName = Names.fromString((String) ((BLangLiteral) keyExpr).value);
         } else {
             dlog.error(keyExpr.pos, DiagnosticErrorCode.INVALID_RECORD_LITERAL_KEY);
             return new TypeSymbolPair(null, symTable.semanticError);
@@ -8077,7 +8077,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         }
 
         // check if it is an attached function pointer call
-        Name objFuncName = names.fromString(Symbols.getAttachedFuncSymbolName(objectType.tsymbol.name.value,
+        Name objFuncName = Names.fromString(Symbols.getAttachedFuncSymbolName(objectType.tsymbol.name.value,
                 fieldName.value));
         fieldSymbol =
                 symResolver.resolveObjectField(bLangFieldBasedAccess.pos, data.env, objFuncName, objectType.tsymbol);
@@ -8588,7 +8588,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                                      AnalyzerData data) {
         BLangFieldBasedAccess.BLangNSPrefixedFieldBasedAccess nsPrefixedFieldAccess = fieldAccessExpr;
         String nsPrefix = nsPrefixedFieldAccess.nsPrefix.value;
-        BSymbol nsSymbol = symResolver.lookupSymbolInPrefixSpace(data.env, names.fromString(nsPrefix));
+        BSymbol nsSymbol = symResolver.lookupSymbolInPrefixSpace(data.env, Names.fromString(nsPrefix));
 
         if (nsSymbol == symTable.notFoundSymbol) {
             dlog.error(nsPrefixedFieldAccess.nsPrefix.pos, DiagnosticErrorCode.CANNOT_FIND_XML_NAMESPACE,
@@ -9141,14 +9141,14 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             case TypeTags.CHAR_STRING:
                 if (isConstExpr(indexExpr)) {
                     String fieldName = Utils.escapeSpecialCharacters(getConstFieldName(indexExpr));
-                    actualType = checkRecordRequiredFieldAccess(accessExpr, names.fromString(fieldName), record, data);
+                    actualType = checkRecordRequiredFieldAccess(accessExpr, Names.fromString(fieldName), record, data);
                     if (actualType != symTable.semanticError) {
                         return actualType;
                     }
 
-                    actualType = checkRecordOptionalFieldAccess(accessExpr, names.fromString(fieldName), record, data);
+                    actualType = checkRecordOptionalFieldAccess(accessExpr, Names.fromString(fieldName), record, data);
                     if (actualType == symTable.semanticError) {
-                        actualType = checkRecordRestFieldAccess(accessExpr, names.fromString(fieldName), record, data);
+                        actualType = checkRecordRestFieldAccess(accessExpr, Names.fromString(fieldName), record, data);
                         if (actualType == symTable.semanticError) {
                             return actualType;
                         }
@@ -9185,13 +9185,13 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 for (BLangExpression finiteMember : finiteIndexExpr.getValueSpace()) {
                     String fieldName = (String) ((BLangLiteral) finiteMember).value;
                     BType fieldType =
-                            checkRecordRequiredFieldAccess(accessExpr, names.fromString(fieldName), record, data);
+                            checkRecordRequiredFieldAccess(accessExpr, Names.fromString(fieldName), record, data);
                     if (fieldType == symTable.semanticError) {
                         fieldType =
-                                checkRecordOptionalFieldAccess(accessExpr, names.fromString(fieldName), record, data);
+                                checkRecordOptionalFieldAccess(accessExpr, Names.fromString(fieldName), record, data);
                         if (fieldType == symTable.semanticError) {
                             fieldType =
-                                    checkRecordRestFieldAccess(accessExpr, names.fromString(fieldName), record, data);
+                                    checkRecordRestFieldAccess(accessExpr, Names.fromString(fieldName), record, data);
                         }
 
                         if (fieldType != symTable.semanticError) {
@@ -9272,7 +9272,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
     }
 
     public Name getCurrentCompUnit(BLangNode node) {
-        return names.fromString(node.pos.lineRange().fileName());
+        return Names.fromString(node.pos.lineRange().fileName());
     }
 
 
@@ -9387,7 +9387,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             }
 
             String key = entry.getKey();
-            Name fieldName = names.fromString(key);
+            Name fieldName = Names.fromString(key);
             BType type = types.size() == 1 ? types.get(0) : BUnionType.create(null, types.toArray(new BType[0]));
 
             Set<Flag> flags = new HashSet<>();
@@ -9445,7 +9445,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         SymbolEnv env = data.env;
         BRecordTypeSymbol recordSymbol =
                 Symbols.createRecordSymbol(Flags.ANONYMOUS,
-                                           names.fromString(anonymousModelHelper.getNextAnonymousTypeKey(pkgID)),
+                                           Names.fromString(anonymousModelHelper.getNextAnonymousTypeKey(pkgID)),
                                            pkgID, null, env.scope.owner, location, origin);
         recordSymbol.scope = new Scope(recordSymbol);
         return recordSymbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -1100,7 +1100,7 @@ public class TypeParamAnalyzer {
             actObjectSymbol.attachedFuncs.add(duplicateAttachFunc(expFunc, matchType, invokableSymbol));
             String funcName = Symbols.getAttachedFuncSymbolName(actObjectSymbol.type.tsymbol.name.value,
                     expFunc.funcName.value);
-            actObjectSymbol.scope.define(names.fromString(funcName), invokableSymbol);
+            actObjectSymbol.scope.define(Names.fromString(funcName), invokableSymbol);
         }
 
         if (!hasDifferentType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -2012,7 +2012,7 @@ public class Types {
         }
 
         BInvokableSymbol iteratorSymbol = (BInvokableSymbol) symResolver.lookupLangLibMethod(collectionType,
-                names.fromString(BLangCompilerConstants.ITERABLE_COLLECTION_ITERATOR_FUNC), env);
+                Names.fromString(BLangCompilerConstants.ITERABLE_COLLECTION_ITERATOR_FUNC), env);
         BObjectType objectType = (BObjectType) getImpliedType(iteratorSymbol.retType);
         BUnionType nextMethodReturnType =
                 (BUnionType) getResultTypeOfNextInvocation(objectType);
@@ -2035,7 +2035,7 @@ public class Types {
         }
         
         BInvokableSymbol iteratorSymbol = (BInvokableSymbol) symResolver.lookupLangLibMethod(collectionType,
-                names.fromString(BLangCompilerConstants.ITERABLE_COLLECTION_ITERATOR_FUNC), env);
+                Names.fromString(BLangCompilerConstants.ITERABLE_COLLECTION_ITERATOR_FUNC), env);
         BUnionType nextMethodReturnType =
                 (BUnionType) getResultTypeOfNextInvocation((BObjectType) getImpliedType(iteratorSymbol.retType));
         bLangInputClause.resultType = getRecordType(nextMethodReturnType);
@@ -4229,7 +4229,7 @@ public class Types {
 
         // Create a new finite type representing the assignable values.
         BTypeSymbol finiteTypeSymbol = Symbols.createTypeSymbol(SymTag.FINITE_TYPE, finiteType.tsymbol.flags,
-                names.fromString("$anonType$" + UNDERSCORE + finiteTypeCount++),
+                Names.fromString("$anonType$" + UNDERSCORE + finiteTypeCount++),
                 finiteType.tsymbol.pkgID, null,
                 finiteType.tsymbol.owner, finiteType.tsymbol.pos,
                 VIRTUAL);
@@ -5662,7 +5662,7 @@ public class Types {
         BRecordTypeSymbol recordSymbol = Symbols.createRecordSymbol(Flags.asMask(flags), Names.EMPTY,
                                                                                 env.enclPkg.packageID, null,
                                                                                 env.scope.owner, null, VIRTUAL);
-        recordSymbol.name = names.fromString(
+        recordSymbol.name = Names.fromString(
                 anonymousModelHelper.getNextAnonymousTypeKey(env.enclPkg.packageID));
         BInvokableType bInvokableType = new BInvokableType(new ArrayList<>(), symTable.nilType, null);
         BInvokableSymbol initFuncSymbol = Symbols.createFunctionSymbol(
@@ -5699,7 +5699,7 @@ public class Types {
 
     public BErrorType createErrorType(BType detailType, long flags, SymbolEnv env) {
         String name = anonymousModelHelper.getNextAnonymousIntersectionErrorTypeName(env.enclPkg.packageID);
-        BErrorTypeSymbol errorTypeSymbol = Symbols.createErrorSymbol(flags | Flags.ANONYMOUS, names.fromString(name),
+        BErrorTypeSymbol errorTypeSymbol = Symbols.createErrorSymbol(flags | Flags.ANONYMOUS, Names.fromString(name),
                                                                      env.enclPkg.symbol.pkgID, null,
                                                                      env.scope.owner, symTable.builtinPos, VIRTUAL);
         errorTypeSymbol.scope = new Scope(errorTypeSymbol);
@@ -5894,7 +5894,7 @@ public class Types {
         }
 
         BTypeSymbol finiteTypeSymbol = Symbols.createTypeSymbol(SymTag.FINITE_TYPE, originalType.tsymbol.flags,
-                names.fromString("$anonType$" + UNDERSCORE + finiteTypeCount++),
+                Names.fromString("$anonType$" + UNDERSCORE + finiteTypeCount++),
                 originalType.tsymbol.pkgID, null,
                 originalType.tsymbol.owner, originalType.tsymbol.pos,
                 VIRTUAL);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -299,7 +299,7 @@ public class SymbolTable {
         defineCyclicUnionBasedInternalTypes();
 
         BTypeSymbol finiteTypeSymbol = Symbols.createTypeSymbol(SymTag.FINITE_TYPE, Flags.PUBLIC,
-                                                                names.fromString("$anonType$TRUE"),
+                                                                Names.fromString("$anonType$TRUE"),
                                                                 rootPkgNode.packageID, null, rootPkgNode.symbol.owner,
                                                                 this.builtinPos, VIRTUAL);
         this.trueType = new BFiniteType(finiteTypeSymbol, new HashSet<>() {{
@@ -307,7 +307,7 @@ public class SymbolTable {
         }});
 
         BTypeSymbol falseFiniteTypeSymbol = Symbols.createTypeSymbol(SymTag.FINITE_TYPE, Flags.PUBLIC,
-                names.fromString("$anonType$FALSE"), rootPkgNode.packageID, null, rootPkgNode.symbol.owner,
+                Names.fromString("$anonType$FALSE"), rootPkgNode.packageID, null, rootPkgNode.symbol.owner,
                 this.builtinPos, VIRTUAL);
         this.falseType = new BFiniteType(falseFiniteTypeSymbol, new HashSet<>() {{
             add(falseLiteral);
@@ -444,7 +444,7 @@ public class SymbolTable {
     }
 
     public void initializeType(BType type, String name, SymbolOrigin origin) {
-        initializeType(type, names.fromString(name), origin);
+        initializeType(type, Names.fromString(name), origin);
     }
 
     private void initializeType(BType type, Name name, SymbolOrigin origin) {
@@ -1129,14 +1129,14 @@ public class SymbolTable {
                                      BType retType) {
 
         List<BType> paramTypes = Lists.of(lhsType, rhsType);
-        defineOperator(names.fromString(kind.value()), paramTypes, retType);
+        defineOperator(Names.fromString(kind.value()), paramTypes, retType);
     }
 
     private void defineUnaryOperator(OperatorKind kind,
                                      BType type,
                                      BType retType) {
         List<BType> paramTypes = Lists.of(type);
-        defineOperator(names.fromString(kind.value()), paramTypes, retType);
+        defineOperator(Names.fromString(kind.value()), paramTypes, retType);
     }
 
     private void defineOperator(Name name,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
@@ -220,7 +220,7 @@ public class ImmutableTypeCloner {
                 // TODO: 4/28/20 Check tsymbol
                 BXMLSubType immutableXmlSubType =
                         new BXMLSubType(origXmlSubType.tag,
-                                        names.fromString(origXmlSubType.name.getValue().concat(AND_READONLY_SUFFIX)),
+                                        Names.fromString(origXmlSubType.name.getValue().concat(AND_READONLY_SUFFIX)),
                                         origXmlSubType.flags | Flags.READONLY);
 
                 BIntersectionType immutableXmlSubTypeIntersectionType =
@@ -680,7 +680,7 @@ public class ImmutableTypeCloner {
 
         List<BAttachedFunction> immutableFuncs = new ArrayList<>();
         for (BAttachedFunction origFunc : originalObjectAttachedFuncs) {
-            Name funcName = names.fromString(Symbols.getAttachedFuncSymbolName(immutableObjectSymbol.name.value,
+            Name funcName = Names.fromString(Symbols.getAttachedFuncSymbolName(immutableObjectSymbol.name.value,
                                                                                origFunc.funcName.value));
             BInvokableSymbol immutableFuncSymbol =
                     ASTBuilderUtil.duplicateFunctionDeclarationSymbol(origFunc.symbol, immutableObjectSymbol,
@@ -887,7 +887,7 @@ public class ImmutableTypeCloner {
             return Names.EMPTY;
         }
 
-        return names.fromString("(".concat(origName).concat(AND_READONLY_SUFFIX).concat(")"));
+        return Names.fromString("(".concat(origName).concat(AND_READONLY_SUFFIX).concat(")"));
     }
 
     private static BIntersectionType createImmutableIntersectionType(SymbolEnv env, BType nonReadOnlyType,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/NodeUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/NodeUtils.java
@@ -40,7 +40,7 @@ public class NodeUtils {
         String pkgName = String.join(".", pkgNameComps.stream()
                 .map(id -> id.value)
                 .toList());
-        return names.fromString(pkgName);
+        return Names.fromString(pkgName);
     }
 
     public static Name getName(String localname, String namespaceURI) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeDefBuilderHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeDefBuilderHelper.java
@@ -165,7 +165,7 @@ public class TypeDefBuilderHelper {
         initFunction.setBType(new BInvokableType(new ArrayList<>(), returnType, null));
 
         // Create the function symbol
-        Name funcSymbolName = names.fromString(Symbols.getAttachedFuncSymbolName(structTypeName, suffix.value));
+        Name funcSymbolName = Names.fromString(Symbols.getAttachedFuncSymbolName(structTypeName, suffix.value));
         initFunction.symbol = Symbols
                 .createFunctionSymbol(Flags.asMask(initFunction.flagSet), funcSymbolName, funcSymbolName,
                                       env.enclPkg.symbol.pkgID, initFunction.getBType(), symbol,

--- a/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/SourceDirectoryManagerTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/SourceDirectoryManagerTest.java
@@ -53,9 +53,9 @@ public class SourceDirectoryManagerTest {
     public void testListSourceFilesAndPackages() {
         Names names = Names.getInstance(context);
         List<PackageID> expectedPackageIds = new ArrayList<>();
-        expectedPackageIds.add(new PackageID(names.fromString("abc"),
-                                             names.fromString("fruits"),
-                                             names.fromString("0.0.1"))
+        expectedPackageIds.add(new PackageID(Names.fromString("abc"),
+                                             Names.fromString("fruits"),
+                                             Names.fromString("0.0.1"))
         );
 
         Stream<PackageID> packageIDStream = directoryManager.listSourceFilesAndPackages();
@@ -66,9 +66,9 @@ public class SourceDirectoryManagerTest {
     public void testGetPackageID() {
         PackageID fruits = directoryManager.getPackageID("fruits");
         Names names = Names.getInstance(context);
-        PackageID expectedPackageId = new PackageID(names.fromString("abc"),
-                                                    names.fromString("fruits"),
-                                                    names.fromString("0.0.1"));
+        PackageID expectedPackageId = new PackageID(Names.fromString("abc"),
+                                                    Names.fromString("fruits"),
+                                                    Names.fromString("0.0.1"));
         Assert.assertEquals(fruits, expectedPackageId);
     }
 
@@ -76,21 +76,21 @@ public class SourceDirectoryManagerTest {
     public void testIsModuleExists() {
         Project project = context.get(Project.PROJECT_KEY);
         Names names = Names.getInstance(context);
-        PackageID expectedPackageId = new PackageID(names.fromString("abc"),
-                names.fromString("fruits"),
-                names.fromString("0.0.1"));
+        PackageID expectedPackageId = new PackageID(Names.fromString("abc"),
+                Names.fromString("fruits"),
+                Names.fromString("0.0.1"));
         Assert.assertTrue(project.isModuleExists(expectedPackageId));
-        PackageID invalidName = new PackageID(names.fromString("abc"),
-                names.fromString("invalid"),
-                names.fromString("0.0.1"));
+        PackageID invalidName = new PackageID(Names.fromString("abc"),
+                Names.fromString("invalid"),
+                Names.fromString("0.0.1"));
         Assert.assertFalse(project.isModuleExists(invalidName));
-        PackageID invalidOrg = new PackageID(names.fromString("invalid"),
-                names.fromString("fruits"),
-                names.fromString("0.0.1"));
+        PackageID invalidOrg = new PackageID(Names.fromString("invalid"),
+                Names.fromString("fruits"),
+                Names.fromString("0.0.1"));
         Assert.assertFalse(project.isModuleExists(invalidOrg));
-        PackageID invalidVersion = new PackageID(names.fromString("abc"),
-                names.fromString("fruits"),
-                names.fromString("0.1.1"));
+        PackageID invalidVersion = new PackageID(Names.fromString("abc"),
+                Names.fromString("fruits"),
+                Names.fromString("0.1.1"));
         Assert.assertFalse(project.isModuleExists(invalidVersion));
     }
 
@@ -98,9 +98,9 @@ public class SourceDirectoryManagerTest {
     public void getBalaPath() throws InvalidModuleException {
         Project project = context.get(Project.PROJECT_KEY);
         Names names = Names.getInstance(context);
-        PackageID moduleId = new PackageID(names.fromString("abc"),
-                names.fromString("fruits"),
-                names.fromString("0.0.1"));
+        PackageID moduleId = new PackageID(Names.fromString("abc"),
+                Names.fromString("fruits"),
+                Names.fromString("0.0.1"));
         // valid module
         String balaName =  "fruits-abc-any-0.0.1.bala";
         Path balaPath = directoryManager.getSourceDirectory().getPath()
@@ -110,9 +110,9 @@ public class SourceDirectoryManagerTest {
 
         // invalid module
         try {
-            PackageID invalidModuleId = new PackageID(names.fromString("invalid"),
-                    names.fromString("fruits"),
-                    names.fromString("0.0.1"));
+            PackageID invalidModuleId = new PackageID(Names.fromString("invalid"),
+                    Names.fromString("fruits"),
+                    Names.fromString("0.0.1"));
             // invalid valid module
             project.getBalaPath(invalidModuleId);
             throw new AssertionError("Failed to identify invalid module");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/LSCodeLensesProviderHolder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/LSCodeLensesProviderHolder.java
@@ -88,7 +88,7 @@ public class LSCodeLensesProviderHolder {
      */
     public List<LSCodeLensesProvider> getProviders() {
         List<LSCodeLensesProvider> activeProviders = new ArrayList<>();
-        for (LSCodeLensesProvider provider : this.codeLenses) {
+        for (LSCodeLensesProvider provider : codeLenses) {
             if (provider != null && provider.isEnabled(this.serverContext)) {
                 activeProviders.add(provider);
             }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bir/BirVariableOptimizationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bir/BirVariableOptimizationTest.java
@@ -67,7 +67,7 @@ public class BirVariableOptimizationTest {
             Assert.fail("Failed when reading file", e);
         }
         if (!"".equals(expectedBir)) {
-            String funcBir = birEmitter.emitFunction(func, 0);
+            String funcBir = BIREmitter.emitFunction(func, 0);
             Assert.assertEquals(funcBir, expectedBir);
         }
     }


### PR DESCRIPTION
## Purpose
While it is _possible_ to access `static` members from a class instance, it’s bad form, and considered by most to be misleading because it implies to the readers of your code that there’s an instance of the member per class instance.

https://sonarcloud.io/organizations/ballerina-platform/rules?open=java%3AS2209&rule_key=java%3AS2209

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
