### PR TITLE
[Refactoring] Make inner classes static

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/env/EnvVarProvider.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/env/EnvVarProvider.java
@@ -333,7 +333,7 @@ public class EnvVarProvider implements ConfigProvider {
         return new EnvVar(key, value);
     }
 
-    public class EnvVar {
+    public static class EnvVar {
 
         public String key;
         public String value;

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/codegen/BallerinaAnnotationProcessor.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/codegen/BallerinaAnnotationProcessor.java
@@ -262,7 +262,7 @@ public class BallerinaAnnotationProcessor extends AbstractProcessor {
     /**
      * @since 0.94
      */
-    private class NativeFunctionCodeDef implements NativeElementCodeDef {
+    private static class NativeFunctionCodeDef implements NativeElementCodeDef {
 
         public String org;
 
@@ -298,7 +298,7 @@ public class BallerinaAnnotationProcessor extends AbstractProcessor {
     /**
      * @since 0.94
      */
-    private class NativeActionCodeDef extends NativeFunctionCodeDef {
+    private static class NativeActionCodeDef extends NativeFunctionCodeDef {
         
         public String connectorName;
         

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/GeneralFSPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/GeneralFSPackageRepository.java
@@ -315,7 +315,7 @@ public class GeneralFSPackageRepository implements PackageRepository {
      *
      * @since 0.94
      */
-    public class FSPackageEntityNotAvailableException extends Exception {
+    public static class FSPackageEntityNotAvailableException extends Exception {
 
         private static final long serialVersionUID = 1528033476455781589L;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
@@ -1172,7 +1172,7 @@ public class AnnotationDesugar {
         return annotAttachment;
     }
 
-    private class LocationData {
+    private static class LocationData {
         public PackageID pkgID;
         public BSymbol owner;
         public Location pos;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -2946,7 +2946,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         UN_INIT, PARTIAL_INIT
     }
 
-    private class BranchResult {
+    private static class BranchResult {
 
         Map<BSymbol, InitStatus> uninitializedVars;
         Map<BSymbol, InitStatus> possibleFailureUnInitVars;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -5465,7 +5465,7 @@ public class SymbolEnter extends BLangNodeVisitor {
      *
      * @since 0.985.0
      */
-    static class LocationData {
+    private static class LocationData {
 
         private String name;
         private int row;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -5465,7 +5465,7 @@ public class SymbolEnter extends BLangNodeVisitor {
      *
      * @since 0.985.0
      */
-    class LocationData {
+    static class LocationData {
 
         private String name;
         private int row;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -2159,7 +2159,7 @@ public class TypeResolver {
      *
      * @since 2201.7.0
      */
-    static class ResolverData {
+    private static class ResolverData {
         SymbolEnv env;
         Map<String, BLangNode> modTable;
         int depth;
@@ -2171,7 +2171,7 @@ public class TypeResolver {
      *
      * @since 2201.7.0
      */
-    static class LocationData {
+    private static class LocationData {
         private String name;
         private int row;
         private int column;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -2159,7 +2159,7 @@ public class TypeResolver {
      *
      * @since 2201.7.0
      */
-    class ResolverData {
+    static class ResolverData {
         SymbolEnv env;
         Map<String, BLangNode> modTable;
         int depth;
@@ -2171,7 +2171,7 @@ public class TypeResolver {
      *
      * @since 2201.7.0
      */
-    class LocationData {
+    static class LocationData {
         private String name;
         private int row;
         private int column;

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/FileSystemRepositoryTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/FileSystemRepositoryTests.java
@@ -39,7 +39,7 @@ import java.util.List;
  */
 public class FileSystemRepositoryTests {
 
-    static class MockFileSystemRepository extends FileSystemRepository {
+   private static class MockFileSystemRepository extends FileSystemRepository {
 
         public MockFileSystemRepository(Environment environment, Path cacheDirectory) {
             super(environment, cacheDirectory);

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/FileSystemRepositoryTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/FileSystemRepositoryTests.java
@@ -39,7 +39,7 @@ import java.util.List;
  */
 public class FileSystemRepositoryTests {
 
-    class MockFileSystemRepository extends FileSystemRepository {
+    static class MockFileSystemRepository extends FileSystemRepository {
 
         public MockFileSystemRepository(Environment environment, Path cacheDirectory) {
             super(environment, cacheDirectory);

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/MavenPackageRepositoryTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/MavenPackageRepositoryTests.java
@@ -47,7 +47,7 @@ import java.util.Optional;
 public class MavenPackageRepositoryTests {
 
 
-    static class MockMavenPackageRepository extends MavenPackageRepository {
+    private static class MockMavenPackageRepository extends MavenPackageRepository {
 
         public MockMavenPackageRepository(Environment environment, Path cacheDirectory, String distributionVersion) {
             super(environment, cacheDirectory, distributionVersion, null, null);

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/MavenPackageRepositoryTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/MavenPackageRepositoryTests.java
@@ -47,7 +47,7 @@ import java.util.Optional;
 public class MavenPackageRepositoryTests {
 
 
-    class MockMavenPackageRepository extends MavenPackageRepository {
+    static class MockMavenPackageRepository extends MavenPackageRepository {
 
         public MockMavenPackageRepository(Environment environment, Path cacheDirectory, String distributionVersion) {
             super(environment, cacheDirectory, distributionVersion, null, null);

--- a/misc/toml-parser/src/test/java/toml/parser/test/api/object/ToObjectTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/api/object/ToObjectTest.java
@@ -148,7 +148,7 @@ public class ToObjectTest {
         Assert.assertEquals(thirdTableStr1, "tableArr kv1 third");
     }
     
-    static class NewObject {
+    private static class NewObject {
         private String simplekv;
         private String simplekv1;
         private int simpleint;
@@ -191,7 +191,7 @@ public class ToObjectTest {
         }
     }
     
-    static class Table {
+    private static class Table {
         private String tableKv;
         private String tableKv1;
         private Child child;

--- a/misc/toml-parser/src/test/java/toml/parser/test/api/object/ToObjectTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/api/object/ToObjectTest.java
@@ -148,7 +148,7 @@ public class ToObjectTest {
         Assert.assertEquals(thirdTableStr1, "tableArr kv1 third");
     }
     
-    class NewObject { 
+    static class NewObject {
         private String simplekv;
         private String simplekv1;
         private int simpleint;
@@ -191,7 +191,7 @@ public class ToObjectTest {
         }
     }
     
-    class Table {
+    static class Table {
         private String tableKv;
         private String tableKv1;
         private Child child;
@@ -209,7 +209,7 @@ public class ToObjectTest {
         }
     }
 
-    class Child {
+    static class Child {
         private String tableKvChild;
         private String tableKv1Child;
         private GrandChild grandchild;
@@ -227,7 +227,7 @@ public class ToObjectTest {
         }
     }
 
-    class GrandChild {
+    static class GrandChild {
         private String tableKvGrandChild;
         private String tableKv1GrandChild;
 
@@ -240,7 +240,7 @@ public class ToObjectTest {
         }
     }
     
-    class TableArr {
+    static class TableArr {
         private String tableKv;
         private String tableKv1;
 


### PR DESCRIPTION
## Purpose
A non-static inner class has a reference to its outer class, and access to the outer class' fields and methods. That class reference makes the inner class larger and could cause the outer class instance to live in memory longer than necessary.

If the reference to the outer class isn’t used, it is more efficient to make the inner class static (also called nested). If the reference is used only in the class constructor, then explicitly pass a class reference to the constructor. If the inner class is anonymous, it will also be necessary to name it.

However, while a nested/static class would be more efficient, it’s worth noting that there are semantic differences between an inner class and a nested one:

- an inner class can only be instantiated within the context of an instance of the outer class.
- a nested (static) class can be instantiated independently of the outer class.

https://sonarcloud.io/organizations/ballerina-platform/rules?open=java%3AS2694&q=inner+class&tab=why

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
