### PR TITLE
Fix change var type code action not working for wild card bindings

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
@@ -260,9 +260,11 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
     private Optional<String> getVariableName(Node matchedNode) {
         switch (matchedNode.kind()) {
             case LOCAL_VAR_DECL:
-                return getLocalVarName((VariableDeclarationNode) matchedNode);
+                return getVarNameFromBindingPattern(((VariableDeclarationNode) matchedNode)
+                        .typedBindingPattern().bindingPattern());
             case MODULE_VAR_DECL:
-                return getModuleVarName((ModuleVariableDeclarationNode) matchedNode);
+                return getVarNameFromBindingPattern(((ModuleVariableDeclarationNode) matchedNode)
+                        .typedBindingPattern().bindingPattern());
             case ASSIGNMENT_STATEMENT:
                 AssignmentStatementNode assignmentStmtNode = (AssignmentStatementNode) matchedNode;
                 Node varRef = assignmentStmtNode.varRef();
@@ -283,9 +285,11 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
                 Node parent = matchedNode.parent();
                 switch (parent.kind()) {
                     case LOCAL_VAR_DECL:
-                        return getLocalVarName((VariableDeclarationNode) parent);
+                        return getVarNameFromBindingPattern(((VariableDeclarationNode) parent)
+                                .typedBindingPattern().bindingPattern());
                     case MODULE_VAR_DECL:
-                        return getModuleVarName((ModuleVariableDeclarationNode) parent);
+                        return getVarNameFromBindingPattern(((ModuleVariableDeclarationNode) parent)
+                                .typedBindingPattern().bindingPattern());
                     case OBJECT_FIELD:
                         return getObjectFieldName((ObjectFieldNode) parent);    
                     case LET_VAR_DECL:
@@ -297,23 +301,17 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
                 return Optional.empty();
         }
     }
-    
-    private Optional<String> getLocalVarName(VariableDeclarationNode node) {
-        BindingPatternNode bindingPatternNode = node.typedBindingPattern().bindingPattern();
+
+    private Optional<String> getVarNameFromBindingPattern(BindingPatternNode bindingPatternNode) {
+        if (bindingPatternNode.kind() == SyntaxKind.WILDCARD_BINDING_PATTERN) {
+            return Optional.of("_");
+        }
         if (bindingPatternNode.kind() != SyntaxKind.CAPTURE_BINDING_PATTERN) {
             return Optional.empty();
         }
-        return Optional.of(((CaptureBindingPatternNode) bindingPatternNode).variableName().text());        
+        return Optional.of(((CaptureBindingPatternNode) bindingPatternNode).variableName().text());
     }
-    
-    private Optional<String> getModuleVarName(ModuleVariableDeclarationNode node) {
-        BindingPatternNode bindingPattern = node.typedBindingPattern().bindingPattern();
-        if (bindingPattern.kind() != SyntaxKind.CAPTURE_BINDING_PATTERN) {
-            return Optional.empty();
-        }
-        return Optional.of(((CaptureBindingPatternNode) bindingPattern).variableName().text());      
-    }
-    
+
     private Optional<String> getObjectFieldName(ObjectFieldNode node) {
         return Optional.of(node.fieldName().text());
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
@@ -307,10 +307,10 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
         if (bindingPatternNode.kind() == SyntaxKind.WILDCARD_BINDING_PATTERN) {
             return Optional.of(UNDERSCORE);
         }
-        if (bindingPatternNode.kind() != SyntaxKind.CAPTURE_BINDING_PATTERN) {
-            return Optional.empty();
+        if (bindingPatternNode.kind() == SyntaxKind.CAPTURE_BINDING_PATTERN) {
+            return Optional.of(((CaptureBindingPatternNode) bindingPatternNode).variableName().text());
         }
-        return Optional.of(((CaptureBindingPatternNode) bindingPatternNode).variableName().text());
+        return Optional.empty();
     }
 
     private Optional<String> getObjectFieldName(ObjectFieldNode node) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
@@ -69,6 +69,7 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
 
     public static final String NAME = "Change Variable Type";
     public static final Set<String> DIAGNOSTIC_CODES = Set.of("BCE2066", "BCE2068", "BCE2652", "BCE3931");
+    private static final String UNDERSCORE = "_";
 
     @Override
     public boolean validate(Diagnostic diagnostic, DiagBasedPositionDetails positionDetails,
@@ -304,7 +305,7 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
 
     private Optional<String> getVarNameFromBindingPattern(BindingPatternNode bindingPatternNode) {
         if (bindingPatternNode.kind() == SyntaxKind.WILDCARD_BINDING_PATTERN) {
-            return Optional.of("_");
+            return Optional.of(UNDERSCORE);
         }
         if (bindingPatternNode.kind() != SyntaxKind.CAPTURE_BINDING_PATTERN) {
             return Optional.empty();

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
@@ -78,6 +78,8 @@ public class ChangeVariableTypeCodeActionTest extends AbstractCodeActionTest {
                 {"changeVarTypeOfWildcardBindings2.json"},
                 {"changeVarTypeOfWildcardBindings3.json"},
                 {"changeVarTypeOfWildcardBindings4.json"},
+                {"changeVarTypeOfWildcardBindings5.json"},
+                {"changeVarTypeOfWildcardBindings6.json"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
@@ -74,6 +74,10 @@ public class ChangeVariableTypeCodeActionTest extends AbstractCodeActionTest {
                 {"changeVarBasedOnLetExpr5.json"},
                 {"changeVarBasedOnLetExpr6.json"},
                 {"changeVarBasedOnLetExpr7.json"},
+                {"changeVarTypeOfWildcardBindings1.json"},
+                {"changeVarTypeOfWildcardBindings2.json"},
+                {"changeVarTypeOfWildcardBindings3.json"},
+                {"changeVarTypeOfWildcardBindings4.json"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeOfWildcardBindings1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeOfWildcardBindings1.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 0,
+    "character": 12
+  },
+  "source": "changeVarTypeOfWildcardBindings.bal",
+  "expected": [
+    {
+      "title": "Change variable '_' type to 'int'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 6
+            }
+          },
+          "newText": "int"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeOfWildcardBindings2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeOfWildcardBindings2.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 1,
+    "character": 33
+  },
+  "source": "changeVarTypeOfWildcardBindings.bal",
+  "expected": [
+    {
+      "title": "Change variable '_' type to 'int'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 0
+            },
+            "end": {
+              "line": 1,
+              "character": 6
+            }
+          },
+          "newText": "int"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeOfWildcardBindings3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeOfWildcardBindings3.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 4,
+    "character": 17
+  },
+  "source": "changeVarTypeOfWildcardBindings.bal",
+  "expected": [
+    {
+      "title": "Change variable '_' type to 'int'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 4,
+              "character": 4
+            },
+            "end": {
+              "line": 4,
+              "character": 10
+            }
+          },
+          "newText": "int"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeOfWildcardBindings4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeOfWildcardBindings4.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 5,
+    "character": 38
+  },
+  "source": "changeVarTypeOfWildcardBindings.bal",
+  "expected": [
+    {
+      "title": "Change variable '_' type to 'int'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 5,
+              "character": 4
+            },
+            "end": {
+              "line": 5,
+              "character": 10
+            }
+          },
+          "newText": "int"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeOfWildcardBindings5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeOfWildcardBindings5.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 11,
+    "character": 62
+  },
+  "source": "changeVarTypeOfWildcardBindings.bal",
+  "expected": [
+    {
+      "title": "Change variable '_' type to 'string[]'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 11,
+              "character": 4
+            },
+            "end": {
+              "line": 11,
+              "character": 7
+            }
+          },
+          "newText": "string[]"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeOfWildcardBindings6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeOfWildcardBindings6.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 13,
+    "character": 53
+  },
+  "source": "changeVarTypeOfWildcardBindings.bal",
+  "expected": [
+    {
+      "title": "Change variable '_' type to 'int'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 13,
+              "character": 4
+            },
+            "end": {
+              "line": 13,
+              "character": 10
+            }
+          },
+          "newText": "int"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/changeVarTypeOfWildcardBindings.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/changeVarTypeOfWildcardBindings.bal
@@ -7,3 +7,9 @@ function name() {
 }
 
 function fn() returns int => 2;
+
+function query() {
+    int _ = from string item in ["aa", "bb", "cc"] select item;
+
+    string _ = from var i in [1, 2, 3, 4] collect sum(i);
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/changeVarTypeOfWildcardBindings.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/changeVarTypeOfWildcardBindings.bal
@@ -1,0 +1,9 @@
+string _ = fn();
+string _ = let var v = fn() in v * 2;
+
+function name() {
+    string _ = fn();
+    string _ = let var v = fn() in v * 2;
+}
+
+function fn() returns int => 2;


### PR DESCRIPTION
## Purpose
$subject

Fixes #42823

## Approach
When extracting variable names from local and module variables, update the implementation to handle wildcard binding patterns.

## Samples
https://github.com/ballerina-platform/ballerina-lang/assets/46857198/b8d3c0f4-2c8d-4562-9ed6-453ab2ebec8a

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
