### PR TITLE
[Refactoring] Replace deprecated usage of `new JsonParser`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
@@ -309,7 +309,8 @@ public class FileUtils {
                     Files.write(path, content.getBytes(StandardCharsets.UTF_8));
                 }
             } catch (IOException e) {
-                throw new RuntimeException("Error while replacing template name in module import statements: " + path, e);
+                throw new RuntimeException(
+                        "Error while replacing template name in module import statements: " + path, e);
             }
         }
     }

--- a/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/BLangNodeTransformerTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/BLangNodeTransformerTest.java
@@ -50,10 +50,7 @@ import java.util.StringJoiner;
  */
 public class BLangNodeTransformerTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(BLangNodeTransformerTest.class);
-    private static final JsonParser JSON_PARSER = new JsonParser();
     public static final Path RES_DIR = Paths.get("src/test/resources/node-tree/").toAbsolutePath();
-
-    private final JsonParser jsonParser = new JsonParser();
 
     @Test(dataProvider = "testTransformationTestProvider", enabled = false)
     public void testTransformation(String configName, String sourcePackage)
@@ -67,7 +64,7 @@ public class BLangNodeTransformerTest {
         BLangPackage bLangPackage = pkg.getCompilation().defaultModuleBLangPackage();
         Set<Class<?>> skipList = new HashSet<>();
         String jsonStr = generateFieldJson(bLangPackage.getClass(), bLangPackage, skipList, bLangPackage);
-        JsonObject actualJsonObj = jsonParser.parse(jsonStr).getAsJsonObject();
+        JsonObject actualJsonObj = JsonParser.parseString(jsonStr).getAsJsonObject();
 
         // Fix test cases replacing expected using responses
 //        if (!expJsonObj.equals(actualJsonObj)) {
@@ -242,7 +239,7 @@ public class BLangNodeTransformerTest {
         } catch (IOException ex) {
             LOGGER.error(ex.getMessage());
         }
-        return JSON_PARSER.parse(contentAsString).getAsJsonObject();
+        return JsonParser.parseString(contentAsString).getAsJsonObject();
     }
 
     private static Project loadProject(String sourceFilePath) {

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/nodeparser/ParseImportDeclarationTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/nodeparser/ParseImportDeclarationTest.java
@@ -57,6 +57,7 @@ public class ParseImportDeclarationTest {
         ImportDeclarationNode importDeclNode = NodeParser.parseImportDeclaration("%import foobar/foo.bar.baz qux;;");
         Assert.assertEquals(importDeclNode.kind(), SyntaxKind.IMPORT_DECLARATION);
         Assert.assertTrue(importDeclNode.hasDiagnostics());
-        Assert.assertEquals(importDeclNode.toString(), " INVALID[%]import foobar/foo.bar.baz  MISSING[as]qux; INVALID[;]");
+        Assert.assertEquals(
+                importDeclNode.toString(), " INVALID[%]import foobar/foo.bar.baz  MISSING[as]qux; INVALID[;]");
     }
 }

--- a/language-server/modules/langserver-commons/src/test/java/org/ballerina/langserver/commons/toml/util/FileUtils.java
+++ b/language-server/modules/langserver-commons/src/test/java/org/ballerina/langserver/commons/toml/util/FileUtils.java
@@ -34,8 +34,6 @@ import java.nio.file.Paths;
  */
 public class FileUtils {
 
-    private static final JsonParser JSON_PARSER = new JsonParser();
-
     private static final Logger LOGGER = LoggerFactory.getLogger(FileUtils.class);
 
     public static final Path RES_DIR = Paths.get("src/test/resources/").toAbsolutePath();
@@ -54,7 +52,7 @@ public class FileUtils {
         } catch (IOException ex) {
             LOGGER.error(ex.getMessage());
         }
-        return JSON_PARSER.parse(contentAsString).getAsJsonObject();
+        return JsonParser.parseString(contentAsString).getAsJsonObject();
     }
 
     /**

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codelenses/CodeLensTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codelenses/CodeLensTest.java
@@ -45,7 +45,6 @@ import java.util.List;
 public class CodeLensTest {
     private final Path functionsBalPath = FileUtils.RES_DIR.resolve("codelens").resolve("functions.bal");
     private Endpoint serviceEndpoint;
-    private static final JsonParser JSON_PARSER = new JsonParser();
     private static final Logger log = LoggerFactory.getLogger(CodeLensTest.class);
     private static final Gson GSON = new Gson();
 
@@ -65,9 +64,9 @@ public class CodeLensTest {
         String expected = getExpectedValue(expectedConfigName);
 
         List<CodeLens> expectedItemList = getFlattenItemList(
-                JSON_PARSER.parse(expected).getAsJsonObject().getAsJsonArray("result"));
+                JsonParser.parseString(expected).getAsJsonObject().getAsJsonArray("result"));
         List<CodeLens> responseItemList = getFlattenItemList(
-                JSON_PARSER.parse(response).getAsJsonObject().getAsJsonArray("result"));
+                JsonParser.parseString(response).getAsJsonObject().getAsJsonArray("result"));
 
         boolean isSubList = getStringListForEvaluation(responseItemList).containsAll(
                 getStringListForEvaluation(expectedItemList));

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AbstractCommandExecutionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AbstractCommandExecutionTest.java
@@ -48,8 +48,6 @@ public abstract class AbstractCommandExecutionTest {
 
     private final Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
 
-    private final JsonParser parser = new JsonParser();
-
     private final Path resourcesPath = new File(getClass().getClassLoader().getResource("command").getFile()).toPath();
 
     private static final Logger log = LoggerFactory.getLogger(AbstractCommandExecutionTest.class);
@@ -126,7 +124,7 @@ public abstract class AbstractCommandExecutionTest {
         List argsList = argsToJson(args);
         ExecuteCommandParams params = new ExecuteCommandParams(command, argsList);
         String response = TestUtil.getExecuteCommandResponse(params, this.serviceEndpoint).replace("\\r\\n", "\\n");
-        JsonObject responseJson = parser.parse(response).getAsJsonObject();
+        JsonObject responseJson = JsonParser.parseString(response).getAsJsonObject();
         responseJson.remove("id");
         return responseJson;
     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/PullModuleExecutorTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/PullModuleExecutorTest.java
@@ -56,7 +56,6 @@ public class PullModuleExecutorTest {
     private Endpoint serviceEndpoint;
 
     private final Gson gson = new Gson();
-    private final JsonParser parser = new JsonParser();
 
     private final Path sourcesDir = new File(getClass().getClassLoader()
             .getResource("command").getFile()).toPath();
@@ -128,7 +127,7 @@ public class PullModuleExecutorTest {
         ExecuteCommandParams params = new ExecuteCommandParams(command, argsList);
         String response = TestUtil.getExecuteCommandResponse(params, this.serviceEndpoint)
                 .replace("\\r\\n", "\\n");
-        JsonObject responseJson = parser.parse(response).getAsJsonObject();
+        JsonObject responseJson = JsonParser.parseString(response).getAsJsonObject();
         responseJson.remove("id");
         return responseJson;
     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/diagnostics/DiagnosticsTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/diagnostics/DiagnosticsTest.java
@@ -62,8 +62,6 @@ public class DiagnosticsTest {
 
     private final Path testRoot = FileUtils.RES_DIR.resolve("diagnostics");
 
-    private final JsonParser parser = new JsonParser();
-
     private final Gson gson = new Gson();
 
     private final LanguageServerContext serverContext = new LanguageServerContextImpl();
@@ -82,7 +80,7 @@ public class DiagnosticsTest {
         JsonObject configJsonObject = FileUtils.fileContentAsObject(configJsonPath);
 
         String response = this.getResponse(configJsonObject);
-        JsonObject responseJson = parser.parse(response).getAsJsonObject();
+        JsonObject responseJson = JsonParser.parseString(response).getAsJsonObject();
         JsonObject responseDiags = unifyResponse(responseJson);
         JsonObject expectedDiags = configJsonObject.get("items").getAsJsonObject();
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/docsymbol/DocumentSymbolTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/docsymbol/DocumentSymbolTest.java
@@ -45,8 +45,6 @@ public class DocumentSymbolTest {
     
     private Endpoint serviceEndpoint;
 
-    private JsonParser parser = new JsonParser();
-
     private Path sourcesPath = new File(getClass().getClassLoader().getResource("docsymbol").getFile()).toPath();
 
     private static final Logger log = LoggerFactory.getLogger(DocumentSymbolTest.class);
@@ -64,7 +62,7 @@ public class DocumentSymbolTest {
         JsonObject configJsonObject = FileUtils.fileContentAsObject(configJsonPath);
         JsonObject expected = configJsonObject.get("expected").getAsJsonObject();
         String response = TestUtil.getDocumentSymbolResponse(this.serviceEndpoint, sourcePath.toString());
-        JsonObject jsonResponse = parser.parse(response).getAsJsonObject();
+        JsonObject jsonResponse = JsonParser.parseString(response).getAsJsonObject();
         JsonArray result = jsonResponse.getAsJsonArray("result");
         TestUtil.closeDocument(serviceEndpoint, sourcePath);
         for (JsonElement element : result) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolTest.java
@@ -24,7 +24,6 @@ public class DocumentSymbolTest {
     private Path configRoot;
     private Path sourceRoot;
     protected Gson gson = new Gson();
-    protected JsonParser parser = new JsonParser();
     protected Endpoint serviceEndpoint;
 
     @BeforeClass
@@ -44,7 +43,7 @@ public class DocumentSymbolTest {
         String response = TestUtil.getDocumentSymbolResponse(serviceEndpoint, sourcePath.toString());
         TestUtil.closeDocument(serviceEndpoint, sourcePath);
         JsonArray expected = resultJson.getAsJsonArray("result");
-        JsonArray actual = parser.parse(response).getAsJsonObject().getAsJsonArray("result");
+        JsonArray actual = JsonParser.parseString(response).getAsJsonObject().getAsJsonArray("result");
         Assert.assertEquals(actual, expected);
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/execpositions/ExecutorPositionsTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/execpositions/ExecutorPositionsTest.java
@@ -50,8 +50,6 @@ public class ExecutorPositionsTest {
     private static final String RANGE = "range";
     private static final String START_LINE = "startLine";
 
-    private static final JsonParser JSON_PARSER = new JsonParser();
-
     private Path resourceRoot;
     private Endpoint serviceEndpoint;
 
@@ -82,8 +80,8 @@ public class ExecutorPositionsTest {
         Path expectedPath = this.resourceRoot.resolve("expected").resolve(expected + ".json");
         JsonArray expectedJsonArray =
                 FileUtils.fileContentAsObject(expectedPath.toAbsolutePath().toString()).getAsJsonArray(EXEC_POSITIONS);
-        JsonArray actualJsonArray =
-                JSON_PARSER.parse(response).getAsJsonObject().getAsJsonObject("result").getAsJsonArray(EXEC_POSITIONS);
+        JsonArray actualJsonArray = JsonParser.parseString(response)
+                .getAsJsonObject().getAsJsonObject("result").getAsJsonArray(EXEC_POSITIONS);
         actualJsonArray.forEach(jsonExec -> {
             JsonPrimitive name = jsonExec.getAsJsonObject().getAsJsonPrimitive(NAME);
             List<JsonObject> execObjects = new ArrayList<>();

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/LSExtensionTestUtil.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/LSExtensionTestUtil.java
@@ -76,7 +76,6 @@ public class LSExtensionTestUtil {
     private static final String GET_NODE_DEFINITION_BY_POSITION = "ballerinaDocument/syntaxTreeNodeByPosition";
 
     private static final Gson GSON = new Gson();
-    private static final JsonParser parser = new JsonParser();
 
     /**
      * Get the ballerinaDocument/syntaxTree modification response.
@@ -179,7 +178,7 @@ public class LSExtensionTestUtil {
     }
 
     private static JsonObject getResult(CompletableFuture result) {
-        return parser.parse(TestUtil.getResponseString(result)).getAsJsonObject().getAsJsonObject("result");
+        return JsonParser.parseString(TestUtil.getResponseString(result)).getAsJsonObject().getAsJsonObject("result");
     }
 
     public static BallerinaConnectorListResponse getConnectors(BallerinaConnectorListRequest request,

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/foldingrange/LineFoldingOnlyTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/foldingrange/LineFoldingOnlyTest.java
@@ -35,8 +35,6 @@ import java.nio.file.Path;
  */
 public class LineFoldingOnlyTest {
 
-    private static final JsonParser JSON_PARSER = new JsonParser();
-
     private final Path resourcesPath =
             new File(getClass().getClassLoader().getResource("foldingrange").getFile()).toPath();
     private Endpoint serviceEndpoint;
@@ -64,7 +62,7 @@ public class LineFoldingOnlyTest {
         Path expectedPath = resourcesPath.resolve("expected").resolve(expected);
         JsonArray expectedJsonArray =
                 FileUtils.fileContentAsObject(expectedPath.toAbsolutePath().toString()).getAsJsonArray("result");
-        JsonArray responseJsonArray = JSON_PARSER.parse(response).getAsJsonObject().getAsJsonArray("result");
+        JsonArray responseJsonArray = JsonParser.parseString(response).getAsJsonObject().getAsJsonArray("result");
         Assert.assertEquals(responseJsonArray, expectedJsonArray, "LineFoldingOnlyTest fails with " + expected
                 + " test case.");
     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/implementation/GotoImplementationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/implementation/GotoImplementationTest.java
@@ -42,7 +42,6 @@ import java.nio.file.Path;
 public class GotoImplementationTest {
     private Endpoint serviceEndpoint;
     private String configRoot = "implementation" + CommonUtil.FILE_SEPARATOR + "expected";
-    private JsonParser jsonParser = new JsonParser();
     private static final Logger log = LoggerFactory.getLogger(GotoImplementationTest.class);
 
     @BeforeClass
@@ -60,7 +59,7 @@ public class GotoImplementationTest {
             JsonObject position = configJsonObject.getAsJsonObject("position");
             Position cursor = new Position(position.get("line").getAsInt(), position.get("col").getAsInt());
             String response = TestUtil.getGotoImplementationResponse(serviceEndpoint, sourcePath.toString(), cursor);
-            JsonObject responseJson = jsonParser.parse(response).getAsJsonObject();
+            JsonObject responseJson = JsonParser.parseString(response).getAsJsonObject();
             responseJson.getAsJsonArray("result").forEach(jsonElement -> jsonElement.getAsJsonObject().remove("uri"));
             JsonObject expected = configJsonObject.getAsJsonObject("expected");
             Assert.assertEquals(expected, responseJson, "Test Failed for" + configPath);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/packages/ComponentsTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/packages/ComponentsTest.java
@@ -43,7 +43,6 @@ public class ComponentsTest {
 
     private static final String NAME = "name";
     private static final String MODULES = "modules";
-    private static final JsonParser JSON_PARSER = new JsonParser();
     private static final Gson GSON = new Gson();
 
     private Path resourceRoot;
@@ -79,7 +78,7 @@ public class ComponentsTest {
         JsonArray expectedJsonArray =
                 FileUtils.fileContentAsObject(expectedPath.toAbsolutePath().toString()).getAsJsonArray("result");
         JsonArray responseJsonArray =
-                JSON_PARSER.parse(response).getAsJsonObject().getAsJsonObject("result").getAsJsonArray("packages");
+                JsonParser.parseString(response).getAsJsonObject().getAsJsonObject("result").getAsJsonArray("packages");
 
         Assert.assertEquals(responseJsonArray.size(), expectedJsonArray.size(), "Package ComponentsTest fails with " +
                 "incorrect package count.");

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/packages/ConfigSchemaTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/packages/ConfigSchemaTest.java
@@ -33,7 +33,6 @@ import java.nio.file.Path;
  * Tests Package Config Schema API in Language Server.
  */
 public class ConfigSchemaTest {
-    private static final JsonParser JSON_PARSER = new JsonParser();
 
     private Path resourceRoot;
     private Endpoint serviceEndpoint;

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/packages/MetadataTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/packages/MetadataTest.java
@@ -38,7 +38,6 @@ public class MetadataTest {
     private static final String PACKAGE_NAME = "packageName";
     private static final String PATH = "path";
     private static final String KIND = "kind";
-    private static final JsonParser JSON_PARSER = new JsonParser();
 
     private Path resourceRoot;
     private Endpoint serviceEndpoint;
@@ -67,7 +66,7 @@ public class MetadataTest {
         Path expectedPath = this.resourceRoot.resolve("metadata").resolve(projectName);
         JsonObject expectedJsonObject =
                 FileUtils.fileContentAsObject(expectedPath.toAbsolutePath().toString()).getAsJsonObject();
-        JsonObject responseJsonObject = JSON_PARSER.parse(response).getAsJsonObject().getAsJsonObject("result");
+        JsonObject responseJsonObject = JsonParser.parseString(response).getAsJsonObject().getAsJsonObject("result");
         JsonPrimitive packageName = expectedJsonObject.getAsJsonPrimitive(PACKAGE_NAME);
         if (packageName != null) {
             Assert.assertEquals(responseJsonObject.getAsJsonPrimitive(PACKAGE_NAME), packageName,

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/references/ReferenceTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/references/ReferenceTest.java
@@ -46,7 +46,6 @@ public class ReferenceTest {
     private Path configRoot;
     private Path sourceRoot;
     protected Gson gson = new Gson();
-    protected JsonParser parser = new JsonParser();
     protected Endpoint serviceEndpoint;
 
     @BeforeClass
@@ -69,7 +68,7 @@ public class ReferenceTest {
         TestUtil.closeDocument(serviceEndpoint, sourcePath);
 
         JsonArray expected = configObject.getAsJsonArray("result");
-        JsonArray actual = parser.parse(actualStr).getAsJsonObject().getAsJsonArray("result");
+        JsonArray actual = JsonParser.parseString(actualStr).getAsJsonObject().getAsJsonArray("result");
         this.alterExpectedUri(expected);
         this.alterActualUri(actual);
         Assert.assertEquals(actual, expected);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/references/ReferencesTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/references/ReferencesTest.java
@@ -52,7 +52,6 @@ public class ReferencesTest {
     protected Path configRoot;
     protected Path sourceRoot;
     protected Gson gson = new Gson();
-    protected JsonParser parser = new JsonParser();
     protected Endpoint serviceEndpoint;
     private static final Logger log = LoggerFactory.getLogger(ReferencesTest.class);
 
@@ -75,7 +74,7 @@ public class ReferencesTest {
         TestUtil.closeDocument(serviceEndpoint, sourcePath);
 
         JsonArray expected = configObject.getAsJsonArray("result");
-        JsonArray actual = parser.parse(actualStr).getAsJsonObject().get("result").getAsJsonArray();
+        JsonArray actual = JsonParser.parseString(actualStr).getAsJsonObject().get("result").getAsJsonArray();
         this.alterExpectedUri(expected, sourceRoot);
         this.alterActualUri(actual);
         
@@ -94,7 +93,7 @@ public class ReferencesTest {
         String actualStr = getReferencesResponseWithinStdLib(sourcePath, position);
 
         JsonArray expected = configObject.getAsJsonArray("result");
-        JsonArray actual = parser.parse(actualStr).getAsJsonObject().get("result").getAsJsonArray();
+        JsonArray actual = JsonParser.parseString(actualStr).getAsJsonObject().get("result").getAsJsonArray();
         this.alterExpectedUri(expected, ballerinaHome);
         this.alterActualStdLibUri(actual);
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/AbstractRenameTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/AbstractRenameTest.java
@@ -37,7 +37,6 @@ public abstract class AbstractRenameTest {
     private Path configRoot;
     private Path sourceRoot;
     protected Gson gson = new Gson();
-    protected JsonParser parser = new JsonParser();
     protected Endpoint serviceEndpoint;
 
     @BeforeClass
@@ -60,13 +59,13 @@ public abstract class AbstractRenameTest {
         String prepareResponse = TestUtil.getPrepareRenameResponse(sourcePath.toString(), position, serviceEndpoint);
 
         // For invalid positions, response result=null, and is removed by GSON.
-        Assert.assertEquals(parser.parse(prepareResponse).getAsJsonObject().has("result"), isValidRename,
+        Assert.assertEquals(JsonParser.parseString(prepareResponse).getAsJsonObject().has("result"), isValidRename,
                 "Expected valid rename position: " + String.valueOf(isValidRename));
 
         String actualStr = TestUtil.getRenameResponse(sourcePath.toString(), position, varName, serviceEndpoint);
         TestUtil.closeDocument(serviceEndpoint, sourcePath);
         JsonObject expected = resultJson.getAsJsonObject("result");
-        JsonObject actual = parser.parse(actualStr).getAsJsonObject().getAsJsonObject("result");
+        JsonObject actual = JsonParser.parseString(actualStr).getAsJsonObject().getAsJsonObject("result");
         if (actual == null) {
             actual = new JsonObject();
         } else {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/AbstractSignatureHelpTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/AbstractSignatureHelpTest.java
@@ -48,8 +48,6 @@ public abstract class AbstractSignatureHelpTest {
 
     private Endpoint serviceEndpoint;
 
-    private JsonParser parser = new JsonParser();
-
     private Path testRoot = new File(getClass().getClassLoader().getResource("signature").getFile()).toPath();
 
     private static final Logger log = LoggerFactory.getLogger(AbstractSignatureHelpTest.class);
@@ -69,7 +67,7 @@ public abstract class AbstractSignatureHelpTest {
         Path sourcePath = testRoot.resolve(configJsonObject.get("source").getAsString());
         expected.remove("id");
         String response = this.getSignatureResponse(configJsonObject, sourcePath).replace("\\r\\n", "\\n");
-        JsonObject responseJson = parser.parse(response).getAsJsonObject();
+        JsonObject responseJson = JsonParser.parseString(response).getAsJsonObject();
         responseJson.remove("id");
         boolean result = expected.equals(responseJson);
         if (!result) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/stnode/SyntaxTreeNodeTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/stnode/SyntaxTreeNodeTest.java
@@ -35,7 +35,6 @@ import java.nio.file.Path;
  */
 public class SyntaxTreeNodeTest {
 
-    private static final JsonParser JSON_PARSER = new JsonParser();
     private static final String STRING_LITERAL = "STRING_LITERAL";
     private static final String MINUTIAE = "WHITESPACE_MINUTIAE";
 
@@ -54,7 +53,7 @@ public class SyntaxTreeNodeTest {
         Range range = new Range(new Position(start, end), new Position(start, end));
         String response = TestUtil.getSyntaxTreeNodeResponse(serviceEndpoint,
                 this.resource.toAbsolutePath().toString(), range);
-        String actual = JSON_PARSER.parse(response).getAsJsonObject().getAsJsonObject("result")
+        String actual = JsonParser.parseString(response).getAsJsonObject().getAsJsonObject("result")
                 .getAsJsonPrimitive("kind").getAsString();
         Assert.assertEquals(actual, expected,
                 "Document syntaxTreeNode testcase failed for range " + start + " and " + end + ".");

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionTest.java
@@ -56,8 +56,6 @@ public abstract class BallerinaTomlCompletionTest {
     private final Path testRoot = FileUtils.RES_DIR.resolve("toml" + File.separator
             + "ballerina_toml" + File.separator + "completion");
 
-    private final JsonParser parser = new JsonParser();
-
     private final Gson gson = new Gson();
 
     @BeforeClass
@@ -72,7 +70,7 @@ public abstract class BallerinaTomlCompletionTest {
         JsonObject configJsonObject = FileUtils.fileContentAsObject(configJsonPath);
 
         String response = getResponse(configJsonObject);
-        JsonObject json = parser.parse(response).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(response).getAsJsonObject();
         Type collectionType = new TypeToken<List<CompletionItem>>() { }.getType();
         JsonArray resultList = json.getAsJsonObject("result").getAsJsonArray("left");
         List<CompletionItem> responseItemList = gson.fromJson(resultList, collectionType);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/util/FileUtils.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/util/FileUtils.java
@@ -32,8 +32,6 @@ import java.nio.file.Paths;
  */
 public class FileUtils {
 
-    private static final JsonParser JSON_PARSER = new JsonParser();
-
     private static final Logger LOGGER = LoggerFactory.getLogger(FileUtils.class);
     
     public static final Path RES_DIR = Paths.get("src/test/resources/").toAbsolutePath();
@@ -51,7 +49,7 @@ public class FileUtils {
         } catch (IOException ex) {
             LOGGER.error(ex.getMessage());
         }
-        return JSON_PARSER.parse(contentAsString).getAsJsonObject();
+        return JsonParser.parseString(contentAsString).getAsJsonObject();
     }
 
     /**

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -757,8 +757,7 @@ class AIDataMapperCodeActionUtil {
                     throw new IOException("Error: AI service error");
                 }
             }
-            JsonParser parser = new JsonParser();
-            return parser.parse(response.getData()).getAsJsonObject().get("answer").toString();
+            return JsonParser.parseString(response.getData()).getAsJsonObject().get("answer").toString();
         } catch (IOException e) {
             throw new IOException("Error connecting the AI service" + e.getMessage(), e);
         }
@@ -876,7 +875,7 @@ class AIDataMapperCodeActionUtil {
         //To generate the default values
         try {
             Map<String, Object> responseMap = new Gson().fromJson(
-                    new JsonParser().parse(mappingFromServer).getAsJsonObject(),
+                    JsonParser.parseString(mappingFromServer).getAsJsonObject(),
                     new TypeToken<HashMap<String, Object>>() {
                     }.getType());
             getResponseKeys(responseMap, "");

--- a/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/DataMapperTestUtils.java
+++ b/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/DataMapperTestUtils.java
@@ -44,7 +44,6 @@ import java.util.stream.Collectors;
  */
 public class DataMapperTestUtils {
 
-    private static JsonParser parser = new JsonParser();
     private static Path sourcesPath = new File(DataMapperTestUtils.class.getClassLoader().getResource("codeaction")
             .getFile()).toPath();
     private static final LanguageServerContext serverContext = new LanguageServerContextImpl();
@@ -58,7 +57,7 @@ public class DataMapperTestUtils {
      * @return {@link JsonObject}   Response as Jason Object
      */
     private static JsonObject getResponseJson(String response) {
-        JsonObject responseJson = parser.parse(response).getAsJsonObject();
+        JsonObject responseJson = JsonParser.parseString(response).getAsJsonObject();
         responseJson.remove("id");
         return responseJson;
     }

--- a/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/FileUtils.java
+++ b/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/FileUtils.java
@@ -32,8 +32,6 @@ import java.nio.file.Paths;
  */
 public class FileUtils {
 
-    private static final JsonParser JSON_PARSER = new JsonParser();
-
     private static final Logger LOGGER = LoggerFactory.getLogger(FileUtils.class);
 
     public static final Path RES_DIR = Paths.get("src/test/resources/").toAbsolutePath();
@@ -50,7 +48,7 @@ public class FileUtils {
         } catch (IOException ex) {
             LOGGER.error(ex.getMessage());
         }
-        return JSON_PARSER.parse(contentAsString).getAsJsonObject();
+        return JsonParser.parseString(contentAsString).getAsJsonObject();
     }
 
 }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
@@ -194,7 +194,6 @@ public class TestReportTest extends BaseTestCase {
     }
 
     private void validateCoverage() {
-        JsonParser parser = new JsonParser();
         //math module
         int[] mathAddCovered = new int[] {22, 23, 24, 26, 29, 31, 32}, mathAddMissed = new int[] {27};
         float mathAddPercentageVal =
@@ -247,16 +246,16 @@ public class TestReportTest extends BaseTestCase {
                 for (JsonElement element1 : moduleObj.get("sourceFiles").getAsJsonArray()) {
                     JsonObject fileObj = (JsonObject) element1;
                     if ("add.bal".equals(fileObj.get("name").getAsString())) {
-                        Assert.assertEquals(parser.parse(Arrays.toString(mathAddCovered)),
-                                parser.parse(fileObj.get("coveredLines").getAsJsonArray().toString()));
-                        Assert.assertEquals(parser.parse(Arrays.toString(mathAddMissed)),
-                                parser.parse(fileObj.get("missedLines").getAsJsonArray().toString()));
+                        Assert.assertEquals(JsonParser.parseString(Arrays.toString(mathAddCovered)),
+                                JsonParser.parseString(fileObj.get("coveredLines").getAsJsonArray().toString()));
+                        Assert.assertEquals(JsonParser.parseString(Arrays.toString(mathAddMissed)),
+                                JsonParser.parseString(fileObj.get("missedLines").getAsJsonArray().toString()));
                         Assert.assertEquals(mathAddPercentage, fileObj.get("coveragePercentage").getAsFloat());
                     } else if ("divide.bal".equals(fileObj.get("name").getAsString())) {
-                        Assert.assertEquals(parser.parse(Arrays.toString(mathDivideCovered)),
-                                parser.parse(fileObj.get("coveredLines").getAsJsonArray().toString()));
-                        Assert.assertEquals(parser.parse(Arrays.toString(mathDivideMissed)),
-                                parser.parse(fileObj.get("missedLines").getAsJsonArray().toString()));
+                        Assert.assertEquals(JsonParser.parseString(Arrays.toString(mathDivideCovered)),
+                                JsonParser.parseString(fileObj.get("coveredLines").getAsJsonArray().toString()));
+                        Assert.assertEquals(JsonParser.parseString(Arrays.toString(mathDivideMissed)),
+                                JsonParser.parseString(fileObj.get("missedLines").getAsJsonArray().toString()));
                         Assert.assertEquals(mathDividePercentage, fileObj.get("coveragePercentage").getAsFloat());
                     } else {
                         Assert.fail("unrecognized file: " + fileObj.get(
@@ -273,10 +272,10 @@ public class TestReportTest extends BaseTestCase {
                 // Verify coverage of source file
                 JsonObject fileObj = (JsonObject) moduleObj.get("sourceFiles").getAsJsonArray().get(0);
                 Assert.assertEquals("main.bal", fileObj.get("name").getAsString());
-                Assert.assertEquals(parser.parse(Arrays.toString(fooMainCovered)),
-                        parser.parse(fileObj.get("coveredLines").getAsJsonArray().toString()));
-                Assert.assertEquals(parser.parse(Arrays.toString(fooMainMissed)),
-                        parser.parse(fileObj.get("missedLines").getAsJsonArray().toString()));
+                Assert.assertEquals(JsonParser.parseString(Arrays.toString(fooMainCovered)),
+                        JsonParser.parseString(fileObj.get("coveredLines").getAsJsonArray().toString()));
+                Assert.assertEquals(JsonParser.parseString(Arrays.toString(fooMainMissed)),
+                        JsonParser.parseString(fileObj.get("missedLines").getAsJsonArray().toString()));
                 Assert.assertEquals(fooMainPercentage, fileObj.get("coveragePercentage").getAsFloat());
 
                 // Verify coverage of module
@@ -286,10 +285,10 @@ public class TestReportTest extends BaseTestCase {
             } else if ("foo.bar".equals(moduleObj.get("name").getAsString())) {
                 JsonObject fileObj = (JsonObject) moduleObj.get("sourceFiles").getAsJsonArray().get(0);
                 Assert.assertEquals("main.bal", fileObj.get("name").getAsString());
-                Assert.assertEquals(parser.parse(Arrays.toString(barMainCovered)),
-                        parser.parse(fileObj.get("coveredLines").getAsJsonArray().toString()));
-                Assert.assertEquals(parser.parse(Arrays.toString(barMainMissed)),
-                        parser.parse(fileObj.get("missedLines").getAsJsonArray().toString()));
+                Assert.assertEquals(JsonParser.parseString(Arrays.toString(barMainCovered)),
+                        JsonParser.parseString(fileObj.get("coveredLines").getAsJsonArray().toString()));
+                Assert.assertEquals(JsonParser.parseString(Arrays.toString(barMainMissed)),
+                        JsonParser.parseString(fileObj.get("missedLines").getAsJsonArray().toString()));
                 Assert.assertEquals(barMainPercentage, fileObj.get("coveragePercentage").getAsFloat());
 
                 // Verify coverage of module
@@ -310,7 +309,6 @@ public class TestReportTest extends BaseTestCase {
     }
 
     private void validateModuleWiseCoverage() {
-        JsonParser parser = new JsonParser();
         //math module
         int[] mathAddCovered = new int[]{22, 23, 24, 26, 29, 31, 32}, mathAddMissed = new int[]{27};
         float mathAddPercentageVal =
@@ -360,16 +358,16 @@ public class TestReportTest extends BaseTestCase {
                 for (JsonElement element1 : moduleObj.get("sourceFiles").getAsJsonArray()) {
                     JsonObject fileObj = (JsonObject) element1;
                     if ("add.bal".equals(fileObj.get("name").getAsString())) {
-                        Assert.assertEquals(parser.parse(Arrays.toString(mathAddCovered)),
-                                parser.parse(fileObj.get("coveredLines").getAsJsonArray().toString()));
-                        Assert.assertEquals(parser.parse(Arrays.toString(mathAddMissed)),
-                                parser.parse(fileObj.get("missedLines").getAsJsonArray().toString()));
+                        Assert.assertEquals(JsonParser.parseString(Arrays.toString(mathAddCovered)),
+                                JsonParser.parseString(fileObj.get("coveredLines").getAsJsonArray().toString()));
+                        Assert.assertEquals(JsonParser.parseString(Arrays.toString(mathAddMissed)),
+                                JsonParser.parseString(fileObj.get("missedLines").getAsJsonArray().toString()));
                         Assert.assertEquals(mathAddPercentage, fileObj.get("coveragePercentage").getAsFloat());
                     } else if ("divide.bal".equals(fileObj.get("name").getAsString())) {
-                        Assert.assertEquals(parser.parse(Arrays.toString(mathDivideCovered)),
-                                parser.parse(fileObj.get("coveredLines").getAsJsonArray().toString()));
-                        Assert.assertEquals(parser.parse(Arrays.toString(mathDivideMissed)),
-                                parser.parse(fileObj.get("missedLines").getAsJsonArray().toString()));
+                        Assert.assertEquals(JsonParser.parseString(Arrays.toString(mathDivideCovered)),
+                                JsonParser.parseString(fileObj.get("coveredLines").getAsJsonArray().toString()));
+                        Assert.assertEquals(JsonParser.parseString(Arrays.toString(mathDivideMissed)),
+                                JsonParser.parseString(fileObj.get("missedLines").getAsJsonArray().toString()));
                         Assert.assertEquals(mathDividePercentage, fileObj.get("coveragePercentage").getAsFloat());
                     } else {
                         Assert.fail("unrecognized file: " + fileObj.get(
@@ -386,10 +384,10 @@ public class TestReportTest extends BaseTestCase {
                 // Verify coverage of source file
                 JsonObject fileObj = (JsonObject) moduleObj.get("sourceFiles").getAsJsonArray().get(0);
                 Assert.assertEquals("main.bal", fileObj.get("name").getAsString());
-                Assert.assertEquals(parser.parse(Arrays.toString(fooMainCovered)),
-                        parser.parse(fileObj.get("coveredLines").getAsJsonArray().toString()));
-                Assert.assertEquals(parser.parse(Arrays.toString(fooMainMissed)),
-                        parser.parse(fileObj.get("missedLines").getAsJsonArray().toString()));
+                Assert.assertEquals(JsonParser.parseString(Arrays.toString(fooMainCovered)),
+                        JsonParser.parseString(fileObj.get("coveredLines").getAsJsonArray().toString()));
+                Assert.assertEquals(JsonParser.parseString(Arrays.toString(fooMainMissed)),
+                        JsonParser.parseString(fileObj.get("missedLines").getAsJsonArray().toString()));
                 Assert.assertEquals(fooMainPercentage, fileObj.get("coveragePercentage").getAsFloat());
 
                 // Verify coverage of module
@@ -399,10 +397,10 @@ public class TestReportTest extends BaseTestCase {
             } else if ("foo.bar".equals(moduleObj.get("name").getAsString())) {
                 JsonObject fileObj = (JsonObject) moduleObj.get("sourceFiles").getAsJsonArray().get(0);
                 Assert.assertEquals("main.bal", fileObj.get("name").getAsString());
-                Assert.assertEquals(parser.parse(Arrays.toString(barMainCovered)),
-                        parser.parse(fileObj.get("coveredLines").getAsJsonArray().toString()));
-                Assert.assertEquals(parser.parse(Arrays.toString(barMainMissed)),
-                        parser.parse(fileObj.get("missedLines").getAsJsonArray().toString()));
+                Assert.assertEquals(JsonParser.parseString(Arrays.toString(barMainCovered)),
+                        JsonParser.parseString(fileObj.get("coveredLines").getAsJsonArray().toString()));
+                Assert.assertEquals(JsonParser.parseString(Arrays.toString(barMainMissed)),
+                        JsonParser.parseString(fileObj.get("missedLines").getAsJsonArray().toString()));
                 Assert.assertEquals(barMainPercentage, fileObj.get("coveragePercentage").getAsFloat());
 
                 // Verify coverage of module


### PR DESCRIPTION
## Purpose
It is recommended to use the static methods of `JsonParser`.
See: https://github.com/google/gson/blob/99cc4cb11f73a6d672aa6381013d651b7921e00f/gson/src/main/java/com/google/gson/JsonParser.java#L74-L78

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
