### PR TITLE
[Refactoring] Replace normal switches with enhanced switch expressions

### DIFF
--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/snippet/factory/BasicSnippetFactory.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/snippet/factory/BasicSnippetFactory.java
@@ -287,23 +287,21 @@ public class BasicSnippetFactory extends SnippetFactory {
     }
 
     private boolean isSupportedAction(SyntaxKind nodeKind) {
-        switch (nodeKind) {
-            case REMOTE_METHOD_CALL_ACTION:
-            case BRACED_ACTION:
-            case CHECK_ACTION:
-            case START_ACTION:
-            case TRAP_ACTION:
-            case FLUSH_ACTION:
-            case ASYNC_SEND_ACTION:
-            case SYNC_SEND_ACTION:
-            case RECEIVE_ACTION:
-            case WAIT_ACTION:
-            case QUERY_ACTION:
-            case COMMIT_ACTION:
-            case CLIENT_RESOURCE_ACCESS_ACTION:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nodeKind) {
+            case REMOTE_METHOD_CALL_ACTION,
+                 BRACED_ACTION,
+                 CHECK_ACTION,
+                 START_ACTION,
+                 TRAP_ACTION,
+                 FLUSH_ACTION,
+                 ASYNC_SEND_ACTION,
+                 SYNC_SEND_ACTION,
+                 RECEIVE_ACTION,
+                 WAIT_ACTION,
+                 QUERY_ACTION,
+                 COMMIT_ACTION,
+                 CLIENT_RESOURCE_ACCESS_ACTION -> true;
+            default -> false;
+        };
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
@@ -91,39 +91,29 @@ public class TypeTags {
     public static boolean isIntegerTypeTag(int tag) {
 
         // TODO : Fix byte type. Ideally, byte belongs to here. But we have modeled it differently.
-        switch (tag) {
-            case INT_TAG:
-            case SIGNED32_INT_TAG:
-            case SIGNED16_INT_TAG:
-            case SIGNED8_INT_TAG:
-            case UNSIGNED32_INT_TAG:
-            case UNSIGNED16_INT_TAG:
-            case UNSIGNED8_INT_TAG:
-                return true;
-        }
-        return false;
+        return switch (tag) {
+            case INT_TAG,
+                 SIGNED32_INT_TAG,
+                 SIGNED16_INT_TAG,
+                 SIGNED8_INT_TAG,
+                 UNSIGNED32_INT_TAG,
+                 UNSIGNED16_INT_TAG,
+                 UNSIGNED8_INT_TAG -> true;
+            default -> false;
+        };
     }
 
     public static boolean isXMLTypeTag(int tag) {
-
-        switch (tag) {
-            case XML_TAG:
-            case XML_ELEMENT_TAG:
-            case XML_COMMENT_TAG:
-            case XML_PI_TAG:
-            case XML_TEXT_TAG:
-                return true;
-        }
-        return false;
+        return switch (tag) {
+            case XML_TAG, XML_ELEMENT_TAG, XML_COMMENT_TAG, XML_PI_TAG, XML_TEXT_TAG -> true;
+            default -> false;
+        };
     }
 
     public static boolean isStringTypeTag(int tag) {
-
-        switch (tag) {
-            case STRING_TAG:
-            case CHAR_STRING_TAG:
-                return true;
-        }
-        return false;
+        return switch (tag) {
+            case STRING_TAG, CHAR_STRING_TAG -> true;
+            default -> false;
+        };
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/StringUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/StringUtils.java
@@ -237,20 +237,19 @@ public class StringUtils {
         Object jsonValue = JsonUtils.convertToJson(value);
 
         Type type = TypeUtils.getImpliedType(TypeChecker.getType(jsonValue));
-        switch (type.getTag()) {
-            case TypeTags.NULL_TAG:
-                return "null";
-            case TypeTags.STRING_TAG:
-                return stringToJson((BString) jsonValue);
-            case TypeTags.MAP_TAG:
+        return switch (type.getTag()) {
+            case TypeTags.NULL_TAG -> "null";
+            case TypeTags.STRING_TAG -> stringToJson((BString) jsonValue);
+            case TypeTags.MAP_TAG -> {
                 MapValueImpl mapValue = (MapValueImpl) jsonValue;
-                return mapValue.getJSONString();
-            case TypeTags.ARRAY_TAG:
+                yield mapValue.getJSONString();
+            }
+            case TypeTags.ARRAY_TAG -> {
                 ArrayValue arrayValue = (ArrayValue) jsonValue;
-                return arrayValue.getJSONString();
-            default:
-                return String.valueOf(jsonValue);
-        }
+                yield arrayValue.getJSONString();
+            }
+            default -> String.valueOf(jsonValue);
+        };
     }
 
     private static String stringToJson(BString value) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/TypeUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/TypeUtils.java
@@ -57,68 +57,47 @@ public class TypeUtils {
 
     public static boolean isValueType(Type type) {
         Type referredType = TypeUtils.getImpliedType(type);
-        switch (referredType.getTag()) {
-            case TypeTags.INT_TAG:
-            case TypeTags.BYTE_TAG:
-            case TypeTags.FLOAT_TAG:
-            case TypeTags.DECIMAL_TAG:
-            case TypeTags.BOOLEAN_TAG:
-            case TypeTags.STRING_TAG:
-                return true;
-            case TypeTags.FINITE_TYPE_TAG:
+        return switch (referredType.getTag()) {
+            case TypeTags.INT_TAG,
+                 TypeTags.BYTE_TAG,
+                 TypeTags.FLOAT_TAG,
+                 TypeTags.DECIMAL_TAG,
+                 TypeTags.BOOLEAN_TAG,
+                 TypeTags.STRING_TAG -> true;
+            case TypeTags.FINITE_TYPE_TAG -> {
                 for (Object value : ((BFiniteType) referredType).valueSpace) {
                     if (!isValueType(TypeChecker.getType(value))) {
-                        return false;
+                        yield false;
                     }
                 }
-                return true;
-            default:
-                return false;
-
-        }
+                yield true;
+            }
+            default -> false;
+        };
     }
 
     public static Type getTypeFromName(String typeName) {
-        switch (typeName) {
-            case TypeConstants.INT_TNAME:
-                return TYPE_INT;
-            case TypeConstants.BYTE_TNAME:
-                return TYPE_BYTE;
-            case TypeConstants.FLOAT_TNAME:
-                return TYPE_FLOAT;
-            case TypeConstants.DECIMAL_TNAME:
-                return TYPE_DECIMAL;
-            case TypeConstants.STRING_TNAME:
-                return TYPE_STRING;
-            case TypeConstants.BOOLEAN_TNAME:
-                return TYPE_BOOLEAN;
-            case TypeConstants.JSON_TNAME:
-                return TYPE_JSON;
-            case TypeConstants.XML_TNAME:
-                return TYPE_XML;
-            case TypeConstants.MAP_TNAME:
-                return TYPE_MAP;
-            case TypeConstants.FUTURE_TNAME:
-                return TYPE_FUTURE;
-            case TypeConstants.STREAM_TNAME:
-                return TYPE_STREAM;
-            case TypeConstants.ANY_TNAME:
-                return TYPE_ANY;
-            case TypeConstants.TYPEDESC_TNAME:
-                return TYPE_TYPEDESC;
-            case TypeConstants.NULL_TNAME:
-                return TYPE_NULL;
-            case TypeConstants.XML_ATTRIBUTES_TNAME:
-                return TYPE_XML_ATTRIBUTES;
-            case TypeConstants.ERROR:
-                return TYPE_ERROR;
-            case TypeConstants.ANYDATA_TNAME:
-                return TYPE_ANYDATA;
-            case TypeConstants.NEVER_TNAME:
-                return TYPE_NEVER;
-            default:
-                throw new IllegalStateException("Unknown type name");
-        }
+        return switch (typeName) {
+            case TypeConstants.INT_TNAME -> TYPE_INT;
+            case TypeConstants.BYTE_TNAME -> TYPE_BYTE;
+            case TypeConstants.FLOAT_TNAME -> TYPE_FLOAT;
+            case TypeConstants.DECIMAL_TNAME -> TYPE_DECIMAL;
+            case TypeConstants.STRING_TNAME -> TYPE_STRING;
+            case TypeConstants.BOOLEAN_TNAME -> TYPE_BOOLEAN;
+            case TypeConstants.JSON_TNAME -> TYPE_JSON;
+            case TypeConstants.XML_TNAME -> TYPE_XML;
+            case TypeConstants.MAP_TNAME -> TYPE_MAP;
+            case TypeConstants.FUTURE_TNAME -> TYPE_FUTURE;
+            case TypeConstants.STREAM_TNAME -> TYPE_STREAM;
+            case TypeConstants.ANY_TNAME -> TYPE_ANY;
+            case TypeConstants.TYPEDESC_TNAME -> TYPE_TYPEDESC;
+            case TypeConstants.NULL_TNAME -> TYPE_NULL;
+            case TypeConstants.XML_ATTRIBUTES_TNAME -> TYPE_XML_ATTRIBUTES;
+            case TypeConstants.ERROR -> TYPE_ERROR;
+            case TypeConstants.ANYDATA_TNAME -> TYPE_ANYDATA;
+            case TypeConstants.NEVER_TNAME -> TYPE_NEVER;
+            default -> throw new IllegalStateException("Unknown type name");
+        };
     }
 
     public static Type fromString(String typeName) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonInternalUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonInternalUtils.java
@@ -392,24 +392,20 @@ public class JsonInternalUtils {
         }
 
         Type type = TypeUtils.getImpliedType(TypeChecker.getType(source));
-        switch (type.getTag()) {
-            case TypeTags.INT_TAG:
-            case TypeTags.FLOAT_TAG:
-            case TypeTags.DECIMAL_TAG:
-            case TypeTags.STRING_TAG:
-            case TypeTags.BOOLEAN_TAG:
-            case TypeTags.JSON_TAG:
-                return source;
-            case TypeTags.NULL_TAG:
-                return null;
-            case TypeTags.MAP_TAG:
-            case TypeTags.OBJECT_TYPE_TAG:
-            case TypeTags.RECORD_TYPE_TAG:
-                return convertMapToJSON((MapValueImpl<BString, Object>) source, targetType);
-            default:
-                throw ErrorHelper.getRuntimeException(ErrorCodes.INCOMPATIBLE_TYPE,
-                                                               PredefinedTypes.TYPE_JSON, type);
-        }
+        return switch (type.getTag()) {
+            case TypeTags.INT_TAG,
+                 TypeTags.FLOAT_TAG,
+                 TypeTags.DECIMAL_TAG,
+                 TypeTags.STRING_TAG,
+                 TypeTags.BOOLEAN_TAG,
+                 TypeTags.JSON_TAG -> source;
+            case TypeTags.NULL_TAG -> null;
+            case TypeTags.MAP_TAG,
+                 TypeTags.OBJECT_TYPE_TAG,
+                 TypeTags.RECORD_TYPE_TAG -> convertMapToJSON((MapValueImpl<BString, Object>) source, targetType);
+            default -> throw ErrorHelper.getRuntimeException(ErrorCodes.INCOMPATIBLE_TYPE,
+                    PredefinedTypes.TYPE_JSON, type);
+        };
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/Lists.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/Lists.java
@@ -36,21 +36,14 @@ public class Lists {
             return array.getRefValue(index);
         }
 
-        switch (TypeUtils.getImpliedType(((BArrayType) array.getType()).getElementType()).getTag()) {
-            case TypeTags.BOOLEAN_TAG:
-                return Boolean.valueOf(array.getBoolean(index));
-            case TypeTags.BYTE_TAG:
-                return new Long(array.getByte(index));
-            case TypeTags.FLOAT_TAG:
-                return new Double(array.getFloat(index));
-            case TypeTags.DECIMAL_TAG:
-                return array.getRefValue(index);
-            case TypeTags.INT_TAG:
-                return new Long((int) array.getInt(index));
-            case TypeTags.STRING_TAG:
-                return new String(array.getString(index));
-            default:
-                return array.getRefValue(index);
-        }
+        return switch (TypeUtils.getImpliedType(((BArrayType) array.getType()).getElementType()).getTag()) {
+            case TypeTags.BOOLEAN_TAG -> array.getBoolean(index);
+            case TypeTags.BYTE_TAG -> (long) array.getByte(index);
+            case TypeTags.FLOAT_TAG -> array.getFloat(index);
+            case TypeTags.DECIMAL_TAG -> array.getRefValue(index);
+            case TypeTags.INT_TAG -> array.getInt(index);
+            case TypeTags.STRING_TAG -> array.getString(index);
+            default -> array.getRefValue(index);
+        };
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -435,45 +435,48 @@ public class TypeChecker {
         Type lhsType = getImpliedType(getType(lhsValue));
         Type rhsType = getImpliedType(getType(rhsValue));
 
-        switch (lhsType.getTag()) {
-            case TypeTags.FLOAT_TAG:
+        return switch (lhsType.getTag()) {
+            case TypeTags.FLOAT_TAG -> {
                 if (rhsType.getTag() != TypeTags.FLOAT_TAG) {
-                    return false;
+                    yield false;
                 }
-                return lhsValue.equals(((Number) rhsValue).doubleValue());
-            case TypeTags.DECIMAL_TAG:
+                yield lhsValue.equals(((Number) rhsValue).doubleValue());
+            }
+            case TypeTags.DECIMAL_TAG -> {
                 if (rhsType.getTag() != TypeTags.DECIMAL_TAG) {
-                    return false;
+                    yield false;
                 }
-                return checkDecimalExactEqual((DecimalValue) lhsValue, (DecimalValue) rhsValue);
-            case TypeTags.INT_TAG:
-            case TypeTags.BYTE_TAG:
-            case TypeTags.BOOLEAN_TAG:
-            case TypeTags.STRING_TAG:
-                return isEqual(lhsValue, rhsValue);
-            case TypeTags.XML_TAG:
-            case TypeTags.XML_COMMENT_TAG:
-            case TypeTags.XML_ELEMENT_TAG:
-            case TypeTags.XML_PI_TAG:
-            case TypeTags.XML_TEXT_TAG:
+                yield checkDecimalExactEqual((DecimalValue) lhsValue, (DecimalValue) rhsValue);
+            }
+            case TypeTags.INT_TAG,
+                 TypeTags.BYTE_TAG,
+                 TypeTags.BOOLEAN_TAG,
+                 TypeTags.STRING_TAG -> isEqual(lhsValue, rhsValue);
+            case TypeTags.XML_TAG,
+                 TypeTags.XML_COMMENT_TAG,
+                 TypeTags.XML_ELEMENT_TAG,
+                 TypeTags.XML_PI_TAG,
+                 TypeTags.XML_TEXT_TAG -> {
                 if (!TypeTags.isXMLTypeTag(rhsType.getTag())) {
-                    return false;
+                    yield false;
                 }
-                return isXMLValueRefEqual((XmlValue) lhsValue, (XmlValue) rhsValue);
-            case TypeTags.HANDLE_TAG:
+                yield isXMLValueRefEqual((XmlValue) lhsValue, (XmlValue) rhsValue);
+            }
+            case TypeTags.HANDLE_TAG -> {
                 if (rhsType.getTag() != TypeTags.HANDLE_TAG) {
-                    return false;
+                    yield false;
                 }
-                return isHandleValueRefEqual(lhsValue, rhsValue);
-            case TypeTags.FUNCTION_POINTER_TAG:
-                return lhsType.getPackage().equals(rhsType.getPackage()) &&
-                        lhsType.getName().equals(rhsType.getName()) && rhsType.equals(lhsType);
-            default:
+                yield isHandleValueRefEqual(lhsValue, rhsValue);
+            }
+            case TypeTags.FUNCTION_POINTER_TAG -> lhsType.getPackage().equals(rhsType.getPackage()) &&
+                    lhsType.getName().equals(rhsType.getName()) && rhsType.equals(lhsType);
+            default -> {
                 if (lhsValue instanceof RegExpValue lhsRegExpValue && rhsValue instanceof RegExpValue) {
-                    return lhsRegExpValue.equals(rhsValue, new HashSet<>());
+                    yield lhsRegExpValue.equals(rhsValue, new HashSet<>());
                 }
-                return false;
-        }
+                yield false;
+            }
+        };
     }
 
     private static boolean isXMLValueRefEqual(XmlValue lhsValue, XmlValue rhsValue) {
@@ -606,62 +609,53 @@ public class TypeChecker {
                 break;
         }
 
-        switch (targetTypeTag) {
-            case TypeTags.BYTE_TAG:
-            case TypeTags.SIGNED8_INT_TAG:
-            case TypeTags.FLOAT_TAG:
-            case TypeTags.DECIMAL_TAG:
-            case TypeTags.CHAR_STRING_TAG:
-            case TypeTags.BOOLEAN_TAG:
-            case TypeTags.NULL_TAG:
-                return sourceTypeTag == targetTypeTag;
-            case TypeTags.STRING_TAG:
-                return TypeTags.isStringTypeTag(sourceTypeTag);
-            case TypeTags.XML_TEXT_TAG:
+        return switch (targetTypeTag) {
+            case TypeTags.BYTE_TAG,
+                 TypeTags.SIGNED8_INT_TAG,
+                 TypeTags.FLOAT_TAG,
+                 TypeTags.DECIMAL_TAG,
+                 TypeTags.CHAR_STRING_TAG,
+                 TypeTags.BOOLEAN_TAG,
+                 TypeTags.NULL_TAG -> sourceTypeTag == targetTypeTag;
+            case TypeTags.STRING_TAG -> TypeTags.isStringTypeTag(sourceTypeTag);
+            case TypeTags.XML_TEXT_TAG -> {
                 if (sourceTypeTag == TypeTags.XML_TAG) {
-                    return ((BXmlType) sourceType).constraint.getTag() == TypeTags.NEVER_TAG;
+                    yield ((BXmlType) sourceType).constraint.getTag() == TypeTags.NEVER_TAG;
                 }
-                return sourceTypeTag == targetTypeTag;
-            case TypeTags.INT_TAG:
-                return sourceTypeTag == TypeTags.INT_TAG || sourceTypeTag == TypeTags.BYTE_TAG ||
-                        (sourceTypeTag >= TypeTags.SIGNED8_INT_TAG && sourceTypeTag <= TypeTags.UNSIGNED32_INT_TAG);
-            case TypeTags.SIGNED16_INT_TAG:
-                return sourceTypeTag == TypeTags.BYTE_TAG ||
-                        (sourceTypeTag >= TypeTags.SIGNED8_INT_TAG && sourceTypeTag <= TypeTags.SIGNED16_INT_TAG);
-            case TypeTags.SIGNED32_INT_TAG:
-                return sourceTypeTag == TypeTags.BYTE_TAG ||
-                        (sourceTypeTag >= TypeTags.SIGNED8_INT_TAG && sourceTypeTag <= TypeTags.SIGNED32_INT_TAG);
-            case TypeTags.UNSIGNED8_INT_TAG:
-                return sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG;
-            case TypeTags.UNSIGNED16_INT_TAG:
-                return sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG ||
-                        sourceTypeTag == TypeTags.UNSIGNED16_INT_TAG;
-            case TypeTags.UNSIGNED32_INT_TAG:
-                return sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG ||
-                        sourceTypeTag == TypeTags.UNSIGNED16_INT_TAG || sourceTypeTag == TypeTags.UNSIGNED32_INT_TAG;
-            case TypeTags.ANY_TAG:
-                return checkIsAnyType(sourceType);
-            case TypeTags.ANYDATA_TAG:
-                return sourceType.isAnydata();
-            case TypeTags.SERVICE_TAG:
-                return checkIsServiceType(sourceType, targetType,
-                        unresolvedTypes == null ? new ArrayList<>() : unresolvedTypes);
-            case TypeTags.HANDLE_TAG:
-                return sourceTypeTag == TypeTags.HANDLE_TAG;
-            case TypeTags.READONLY_TAG:
-                return checkIsType(sourceType, PredefinedTypes.ANY_AND_READONLY_OR_ERROR_TYPE, unresolvedTypes);
-            case TypeTags.XML_ELEMENT_TAG:
-            case TypeTags.XML_COMMENT_TAG:
-            case TypeTags.XML_PI_TAG:
-                return targetTypeTag == sourceTypeTag;
-            case TypeTags.INTERSECTION_TAG:
-                return checkIsType(sourceType, ((BIntersectionType) targetType).getEffectiveType(), unresolvedTypes);
-            case TypeTags.TYPE_REFERENCED_TYPE_TAG:
-                return checkIsType(sourceType, ((BTypeReferenceType) targetType).getReferredType(), unresolvedTypes);
-            default:
-                return checkIsRecursiveType(sourceType, targetType,
-                        unresolvedTypes == null ? new ArrayList<>() : unresolvedTypes);
-        }
+                yield sourceTypeTag == targetTypeTag;
+            }
+            case TypeTags.INT_TAG -> sourceTypeTag == TypeTags.INT_TAG || sourceTypeTag == TypeTags.BYTE_TAG ||
+                    (sourceTypeTag >= TypeTags.SIGNED8_INT_TAG && sourceTypeTag <= TypeTags.UNSIGNED32_INT_TAG);
+            case TypeTags.SIGNED16_INT_TAG -> sourceTypeTag == TypeTags.BYTE_TAG ||
+                    (sourceTypeTag >= TypeTags.SIGNED8_INT_TAG && sourceTypeTag <= TypeTags.SIGNED16_INT_TAG);
+            case TypeTags.SIGNED32_INT_TAG -> sourceTypeTag == TypeTags.BYTE_TAG ||
+                    (sourceTypeTag >= TypeTags.SIGNED8_INT_TAG && sourceTypeTag <= TypeTags.SIGNED32_INT_TAG);
+            case TypeTags.UNSIGNED8_INT_TAG ->
+                    sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG;
+            case TypeTags.UNSIGNED16_INT_TAG ->
+                    sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG ||
+                            sourceTypeTag == TypeTags.UNSIGNED16_INT_TAG;
+            case TypeTags.UNSIGNED32_INT_TAG ->
+                    sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG ||
+                            sourceTypeTag == TypeTags.UNSIGNED16_INT_TAG ||
+                            sourceTypeTag == TypeTags.UNSIGNED32_INT_TAG;
+            case TypeTags.ANY_TAG -> checkIsAnyType(sourceType);
+            case TypeTags.ANYDATA_TAG -> sourceType.isAnydata();
+            case TypeTags.SERVICE_TAG -> checkIsServiceType(sourceType, targetType,
+                    unresolvedTypes == null ? new ArrayList<>() : unresolvedTypes);
+            case TypeTags.HANDLE_TAG -> sourceTypeTag == TypeTags.HANDLE_TAG;
+            case TypeTags.READONLY_TAG ->
+                    checkIsType(sourceType, PredefinedTypes.ANY_AND_READONLY_OR_ERROR_TYPE, unresolvedTypes);
+            case TypeTags.XML_ELEMENT_TAG,
+                 TypeTags.XML_COMMENT_TAG,
+                 TypeTags.XML_PI_TAG -> targetTypeTag == sourceTypeTag;
+            case TypeTags.INTERSECTION_TAG ->
+                    checkIsType(sourceType, ((BIntersectionType) targetType).getEffectiveType(), unresolvedTypes);
+            case TypeTags.TYPE_REFERENCED_TYPE_TAG ->
+                    checkIsType(sourceType, ((BTypeReferenceType) targetType).getReferredType(), unresolvedTypes);
+            default -> checkIsRecursiveType(sourceType, targetType,
+                    unresolvedTypes == null ? new ArrayList<>() : unresolvedTypes);
+        };
     }
 
     private static boolean checkIsType(Object sourceVal, Type sourceType, Type targetType,
@@ -698,15 +692,12 @@ public class TypeChecker {
             return false;
         }
 
-        switch (targetTypeTag) {
-            case TypeTags.ANY_TAG:
-                return checkIsAnyType(sourceType);
-            case TypeTags.READONLY_TAG:
-                return isInherentlyImmutableType(sourceType) || sourceType.isReadOnly();
-            default:
-                return checkIsRecursiveTypeOnValue(sourceVal, sourceType, targetType, sourceTypeTag, targetTypeTag,
-                                                   unresolvedTypes == null ? new ArrayList<>() : unresolvedTypes);
-        }
+        return switch (targetTypeTag) {
+            case TypeTags.ANY_TAG -> checkIsAnyType(sourceType);
+            case TypeTags.READONLY_TAG -> isInherentlyImmutableType(sourceType) || sourceType.isReadOnly();
+            default -> checkIsRecursiveTypeOnValue(sourceVal, sourceType, targetType, sourceTypeTag, targetTypeTag,
+                    unresolvedTypes == null ? new ArrayList<>() : unresolvedTypes);
+        };
     }
 
     // Private methods
@@ -722,72 +713,56 @@ public class TypeChecker {
     }
 
     private static boolean checkIsRecursiveType(Type sourceType, Type targetType, List<TypePair> unresolvedTypes) {
-        switch (targetType.getTag()) {
-            case TypeTags.MAP_TAG:
-                return checkIsMapType(sourceType, (BMapType) targetType, unresolvedTypes);
-            case TypeTags.STREAM_TAG:
-                return checkIsStreamType(sourceType, (BStreamType) targetType, unresolvedTypes);
-            case TypeTags.TABLE_TAG:
-                return checkIsTableType(sourceType, (BTableType) targetType, unresolvedTypes);
-            case TypeTags.JSON_TAG:
-                return checkIsJSONType(sourceType, unresolvedTypes);
-            case TypeTags.RECORD_TYPE_TAG:
-                return checkIsRecordType(sourceType, (BRecordType) targetType, unresolvedTypes);
-            case TypeTags.FUNCTION_POINTER_TAG:
-                return checkIsFunctionType(sourceType, (BFunctionType) targetType);
-            case TypeTags.ARRAY_TAG:
-                return checkIsArrayType(sourceType, (BArrayType) targetType, unresolvedTypes);
-            case TypeTags.TUPLE_TAG:
-                return checkIsTupleType(sourceType, (BTupleType) targetType, unresolvedTypes);
-            case TypeTags.UNION_TAG:
-                return checkIsUnionType(sourceType, (BUnionType) targetType, unresolvedTypes);
-            case TypeTags.OBJECT_TYPE_TAG:
-                return checkObjectEquivalency(sourceType, (BObjectType) targetType, unresolvedTypes);
-            case TypeTags.FINITE_TYPE_TAG:
-                return checkIsFiniteType(sourceType, (BFiniteType) targetType);
-            case TypeTags.FUTURE_TAG:
-                return checkIsFutureType(sourceType, (BFutureType) targetType, unresolvedTypes);
-            case TypeTags.ERROR_TAG:
-                return checkIsErrorType(sourceType, (BErrorType) targetType, unresolvedTypes);
-            case TypeTags.TYPEDESC_TAG:
-                return checkTypeDescType(sourceType, (BTypedescType) targetType, unresolvedTypes);
-            case TypeTags.XML_TAG:
-                return checkIsXMLType(sourceType, targetType, unresolvedTypes);
-            default:
-                // other non-recursive types shouldn't reach here
-                return false;
-        }
+        return switch (targetType.getTag()) {
+            case TypeTags.MAP_TAG -> checkIsMapType(sourceType, (BMapType) targetType, unresolvedTypes);
+            case TypeTags.STREAM_TAG -> checkIsStreamType(sourceType, (BStreamType) targetType, unresolvedTypes);
+            case TypeTags.TABLE_TAG -> checkIsTableType(sourceType, (BTableType) targetType, unresolvedTypes);
+            case TypeTags.JSON_TAG -> checkIsJSONType(sourceType, unresolvedTypes);
+            case TypeTags.RECORD_TYPE_TAG -> checkIsRecordType(sourceType, (BRecordType) targetType, unresolvedTypes);
+            case TypeTags.FUNCTION_POINTER_TAG -> checkIsFunctionType(sourceType, (BFunctionType) targetType);
+            case TypeTags.ARRAY_TAG -> checkIsArrayType(sourceType, (BArrayType) targetType, unresolvedTypes);
+            case TypeTags.TUPLE_TAG -> checkIsTupleType(sourceType, (BTupleType) targetType, unresolvedTypes);
+            case TypeTags.UNION_TAG -> checkIsUnionType(sourceType, (BUnionType) targetType, unresolvedTypes);
+            case TypeTags.OBJECT_TYPE_TAG ->
+                    checkObjectEquivalency(sourceType, (BObjectType) targetType, unresolvedTypes);
+            case TypeTags.FINITE_TYPE_TAG -> checkIsFiniteType(sourceType, (BFiniteType) targetType);
+            case TypeTags.FUTURE_TAG -> checkIsFutureType(sourceType, (BFutureType) targetType, unresolvedTypes);
+            case TypeTags.ERROR_TAG -> checkIsErrorType(sourceType, (BErrorType) targetType, unresolvedTypes);
+            case TypeTags.TYPEDESC_TAG -> checkTypeDescType(sourceType, (BTypedescType) targetType, unresolvedTypes);
+            case TypeTags.XML_TAG -> checkIsXMLType(sourceType, targetType, unresolvedTypes);
+            // other non-recursive types shouldn't reach here
+            default -> false;
+        };
     }
 
     private static boolean checkIsRecursiveTypeOnValue(Object sourceVal, Type sourceType, Type targetType,
                                                        int sourceTypeTag, int targetTypeTag,
                                                        List<TypePair> unresolvedTypes) {
-        switch (targetTypeTag) {
-            case TypeTags.ANYDATA_TAG:
+        return switch (targetTypeTag) {
+            case TypeTags.ANYDATA_TAG -> {
                 if (sourceTypeTag == TypeTags.OBJECT_TYPE_TAG) {
-                    return false;
+                    yield false;
                 }
-                return checkRecordBelongsToAnydataType((MapValue) sourceVal, (BRecordType) sourceType, unresolvedTypes);
-            case TypeTags.MAP_TAG:
-                return checkIsMapType(sourceVal, sourceType, (BMapType) targetType, unresolvedTypes);
-            case TypeTags.JSON_TAG:
-                return checkIsMapType(sourceVal, sourceType,
-                                      new BMapType(targetType.isReadOnly() ? TYPE_READONLY_JSON :
-                                                           TYPE_JSON), unresolvedTypes);
-            case TypeTags.RECORD_TYPE_TAG:
-                return checkIsRecordType(sourceVal, sourceType, (BRecordType) targetType, unresolvedTypes);
-            case TypeTags.UNION_TAG:
+                yield checkRecordBelongsToAnydataType((MapValue) sourceVal, (BRecordType) sourceType, unresolvedTypes);
+            }
+            case TypeTags.MAP_TAG -> checkIsMapType(sourceVal, sourceType, (BMapType) targetType, unresolvedTypes);
+            case TypeTags.JSON_TAG -> checkIsMapType(sourceVal, sourceType,
+                    new BMapType(targetType.isReadOnly() ? TYPE_READONLY_JSON :
+                            TYPE_JSON), unresolvedTypes);
+            case TypeTags.RECORD_TYPE_TAG ->
+                    checkIsRecordType(sourceVal, sourceType, (BRecordType) targetType, unresolvedTypes);
+            case TypeTags.UNION_TAG -> {
                 for (Type type : ((BUnionType) targetType).getMemberTypes()) {
                     if (checkIsType(sourceVal, sourceType, type, unresolvedTypes)) {
-                        return true;
+                        yield true;
                     }
                 }
-                return false;
-            case TypeTags.OBJECT_TYPE_TAG:
-                return checkObjectEquivalency(sourceVal, sourceType, (BObjectType) targetType, unresolvedTypes);
-            default:
-                return false;
-        }
+                yield false;
+            }
+            case TypeTags.OBJECT_TYPE_TAG ->
+                    checkObjectEquivalency(sourceVal, sourceType, (BObjectType) targetType, unresolvedTypes);
+            default -> false;
+        };
     }
 
     private static boolean isFiniteTypeMatch(BFiniteType sourceType, Type targetType) {
@@ -818,22 +793,20 @@ public class TypeChecker {
         }
         unresolvedTypes.add(pair);
 
-        switch (sourceType.getTag()) {
-            case TypeTags.UNION_TAG:
-            case TypeTags.JSON_TAG:
-            case TypeTags.ANYDATA_TAG:
-                return isUnionTypeMatch((BUnionType) sourceType, targetType, unresolvedTypes);
-            case TypeTags.FINITE_TYPE_TAG:
-                return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
-            default:
+        return switch (sourceType.getTag()) {
+            case TypeTags.UNION_TAG,
+                 TypeTags.JSON_TAG,
+                 TypeTags.ANYDATA_TAG -> isUnionTypeMatch((BUnionType) sourceType, targetType, unresolvedTypes);
+            case TypeTags.FINITE_TYPE_TAG -> isFiniteTypeMatch((BFiniteType) sourceType, targetType);
+            default -> {
                 for (Type type : targetType.getMemberTypes()) {
                     if (checkIsType(sourceType, type, unresolvedTypes)) {
-                        return true;
+                        yield true;
                     }
                 }
-                return false;
-
-        }
+                yield false;
+            }
+        };
     }
 
     private static boolean checkIsMapType(Type sourceType, BMapType targetType, List<TypePair> unresolvedTypes) {
@@ -856,16 +829,13 @@ public class TypeChecker {
                                           List<TypePair> unresolvedTypes) {
         Type targetConstrainedType = targetType.getConstrainedType();
         sourceType = getImpliedType(sourceType);
-        switch (sourceType.getTag()) {
-            case TypeTags.MAP_TAG:
-                return checkConstraints(((BMapType) sourceType).getConstrainedType(), targetConstrainedType,
-                                        unresolvedTypes);
-            case TypeTags.RECORD_TYPE_TAG:
-                return checkIsMapType((MapValue) sourceVal, (BRecordType) sourceType, unresolvedTypes,
-                                      targetConstrainedType);
-            default:
-                return false;
-        }
+        return switch (sourceType.getTag()) {
+            case TypeTags.MAP_TAG -> checkConstraints(((BMapType) sourceType).getConstrainedType(),
+                    targetConstrainedType, unresolvedTypes);
+            case TypeTags.RECORD_TYPE_TAG -> checkIsMapType((MapValue) sourceVal, (BRecordType) sourceType,
+                    unresolvedTypes, targetConstrainedType);
+            default -> false;
+        };
     }
 
     private static boolean checkIsMapType(MapValue sourceVal, BRecordType sourceType, List<TypePair> unresolvedTypes,
@@ -1100,14 +1070,11 @@ public class TypeChecker {
 
     private static boolean checkIsRecordType(Type sourceType, BRecordType targetType, List<TypePair> unresolvedTypes) {
         sourceType = getImpliedType(sourceType);
-        switch (sourceType.getTag()) {
-            case TypeTags.RECORD_TYPE_TAG:
-                return checkIsRecordType((BRecordType) sourceType, targetType, unresolvedTypes);
-            case TypeTags.MAP_TAG:
-                return checkIsRecordType((BMapType) sourceType, targetType, unresolvedTypes);
-            default:
-                return false;
-        }
+        return switch (sourceType.getTag()) {
+            case TypeTags.RECORD_TYPE_TAG -> checkIsRecordType((BRecordType) sourceType, targetType, unresolvedTypes);
+            case TypeTags.MAP_TAG -> checkIsRecordType((BMapType) sourceType, targetType, unresolvedTypes);
+            default -> false;
+        };
     }
 
     private static boolean checkIsRecordType(BRecordType sourceRecordType, BRecordType targetType,
@@ -1264,14 +1231,12 @@ public class TypeChecker {
     private static boolean checkIsRecordType(Object sourceVal, Type sourceType, BRecordType targetType,
                                              List<TypePair> unresolvedTypes) {
         sourceType = getImpliedType(sourceType);
-        switch (sourceType.getTag()) {
-            case TypeTags.RECORD_TYPE_TAG:
-                return checkIsRecordType((MapValue) sourceVal, (BRecordType) sourceType, targetType, unresolvedTypes);
-            case TypeTags.MAP_TAG:
-                return checkIsRecordType((BMapType) sourceType, targetType, unresolvedTypes);
-            default:
-                return false;
-        }
+        return switch (sourceType.getTag()) {
+            case TypeTags.RECORD_TYPE_TAG ->
+                    checkIsRecordType((MapValue) sourceVal, (BRecordType) sourceType, targetType, unresolvedTypes);
+            case TypeTags.MAP_TAG -> checkIsRecordType((BMapType) sourceType, targetType, unresolvedTypes);
+            default -> false;
+        };
     }
 
     private static boolean checkIsRecordType(MapValue sourceRecordValue, BRecordType sourceRecordType,
@@ -1604,22 +1569,21 @@ public class TypeChecker {
 
     private static boolean checkIsAnyType(Type sourceType) {
         sourceType = getImpliedType(sourceType);
-        switch (sourceType.getTag()) {
-            case TypeTags.ERROR_TAG:
-            case TypeTags.READONLY_TAG:
-                return false;
-            case TypeTags.UNION_TAG:
-            case TypeTags.ANYDATA_TAG:
-            case TypeTags.JSON_TAG:
+        return switch (sourceType.getTag()) {
+            case TypeTags.ERROR_TAG,
+                 TypeTags.READONLY_TAG -> false;
+            case TypeTags.UNION_TAG,
+                 TypeTags.ANYDATA_TAG,
+                 TypeTags.JSON_TAG -> {
                 for (Type memberType : ((BUnionType) sourceType).getMemberTypes()) {
                     if (!checkIsAnyType(memberType)) {
-                        return false;
+                        yield false;
                     }
                 }
-                return true;
-            default:
-                return true;
-        }
+                yield true;
+            }
+            default -> true;
+        };
     }
 
     private static boolean checkIsFiniteType(Type sourceType, BFiniteType targetType) {
@@ -1940,27 +1904,24 @@ public class TypeChecker {
             return true;
         }
 
-        switch (sourceType.getTag()) {
-            case TypeTags.XML_TEXT_TAG:
-            case TypeTags.FINITE_TYPE_TAG: // Assuming a finite type will only have members from simple basic types.
-            case TypeTags.READONLY_TAG:
-            case TypeTags.NULL_TAG:
-            case TypeTags.NEVER_TAG:
-            case TypeTags.ERROR_TAG:
-            case TypeTags.INVOKABLE_TAG:
-            case TypeTags.SERVICE_TAG:
-            case TypeTags.TYPEDESC_TAG:
-            case TypeTags.FUNCTION_POINTER_TAG:
-            case TypeTags.HANDLE_TAG:
-            case TypeTags.REG_EXP_TYPE_TAG:    
-                return true;
-            case TypeTags.XML_TAG:
-                return ((BXmlType) sourceType).constraint.getTag() == TypeTags.NEVER_TAG;
-            case TypeTags.TYPE_REFERENCED_TYPE_TAG:
-                return isInherentlyImmutableType(((BTypeReferenceType) sourceType).getReferredType());
-            default:
-                return false;
-        }
+        return switch (sourceType.getTag()) {
+            case TypeTags.XML_TEXT_TAG,
+                 TypeTags.FINITE_TYPE_TAG, // Assuming a finite type will only have members from simple basic types.
+                 TypeTags.READONLY_TAG,
+                 TypeTags.NULL_TAG,
+                 TypeTags.NEVER_TAG,
+                 TypeTags.ERROR_TAG,
+                 TypeTags.INVOKABLE_TAG,
+                 TypeTags.SERVICE_TAG,
+                 TypeTags.TYPEDESC_TAG,
+                 TypeTags.FUNCTION_POINTER_TAG,
+                 TypeTags.HANDLE_TAG,
+                 TypeTags.REG_EXP_TYPE_TAG -> true;
+            case TypeTags.XML_TAG -> ((BXmlType) sourceType).constraint.getTag() == TypeTags.NEVER_TAG;
+            case TypeTags.TYPE_REFERENCED_TYPE_TAG ->
+                    isInherentlyImmutableType(((BTypeReferenceType) sourceType).getReferredType());
+            default -> false;
+        };
     }
 
     public static boolean isSelectivelyImmutableType(Type type, Set<Type> unresolvedTypes) {
@@ -2198,85 +2159,78 @@ public class TypeChecker {
                 break;
         }
 
-        switch (targetTypeTag) {
-            case TypeTags.READONLY_TAG:
-                return true;
-            case TypeTags.BYTE_TAG:
+        return switch (targetTypeTag) {
+            case TypeTags.READONLY_TAG -> true;
+            case TypeTags.BYTE_TAG -> {
                 if (TypeTags.isIntegerTypeTag(sourceTypeTag)) {
-                    return isByteLiteral((Long) sourceValue);
+                    yield isByteLiteral((Long) sourceValue);
                 }
-                return allowNumericConversion && TypeConverter.isConvertibleToByte(sourceValue);
-            case TypeTags.INT_TAG:
-                return allowNumericConversion && TypeConverter.isConvertibleToInt(sourceValue);
-            case TypeTags.SIGNED32_INT_TAG:
-            case TypeTags.SIGNED16_INT_TAG:
-            case TypeTags.SIGNED8_INT_TAG:
-            case TypeTags.UNSIGNED32_INT_TAG:
-            case TypeTags.UNSIGNED16_INT_TAG:
-            case TypeTags.UNSIGNED8_INT_TAG:
+                yield allowNumericConversion && TypeConverter.isConvertibleToByte(sourceValue);
+            }
+            case TypeTags.INT_TAG -> allowNumericConversion && TypeConverter.isConvertibleToInt(sourceValue);
+            case TypeTags.SIGNED32_INT_TAG,
+                 TypeTags.SIGNED16_INT_TAG,
+                 TypeTags.SIGNED8_INT_TAG,
+                 TypeTags.UNSIGNED32_INT_TAG,
+                 TypeTags.UNSIGNED16_INT_TAG,
+                 TypeTags.UNSIGNED8_INT_TAG -> {
                 if (TypeTags.isIntegerTypeTag(sourceTypeTag)) {
-                    return TypeConverter.isConvertibleToIntSubType(sourceValue, targetType);
+                    yield TypeConverter.isConvertibleToIntSubType(sourceValue, targetType);
                 }
-                return allowNumericConversion && TypeConverter.isConvertibleToIntSubType(sourceValue, targetType);
-            case TypeTags.FLOAT_TAG:
-            case TypeTags.DECIMAL_TAG:
-                return allowNumericConversion && TypeConverter.isConvertibleToFloatingPointTypes(sourceValue);
-            case TypeTags.CHAR_STRING_TAG:
-                return TypeConverter.isConvertibleToChar(sourceValue);
-            case TypeTags.RECORD_TYPE_TAG:
-                return checkIsLikeRecordType(sourceValue, (BRecordType) targetType, unresolvedValues,
-                        allowNumericConversion, varName, errors);
-            case TypeTags.TABLE_TAG:
-                return checkIsLikeTableType(sourceValue, (BTableType) targetType, unresolvedValues,
-                        allowNumericConversion);
-            case TypeTags.JSON_TAG:
-                return checkIsLikeJSONType(sourceValue, sourceType, (BJsonType) targetType, unresolvedValues,
-                        allowNumericConversion);
-            case TypeTags.MAP_TAG:
-                return checkIsLikeMapType(sourceValue, (BMapType) targetType, unresolvedValues, allowNumericConversion);
-            case TypeTags.STREAM_TAG:
-                return checkIsLikeStreamType(sourceValue, (BStreamType) targetType);
-            case TypeTags.ARRAY_TAG:
-                return checkIsLikeArrayType(sourceValue, (BArrayType) targetType, unresolvedValues,
-                                            allowNumericConversion);
-            case TypeTags.TUPLE_TAG:
-                return checkIsLikeTupleType(sourceValue, (BTupleType) targetType, unresolvedValues,
-                                            allowNumericConversion);
-            case TypeTags.ERROR_TAG:
-                return checkIsLikeErrorType(sourceValue, (BErrorType) targetType, unresolvedValues,
-                                            allowNumericConversion);
-            case TypeTags.ANYDATA_TAG:
-                return checkIsLikeAnydataType(sourceValue, sourceType, unresolvedValues, allowNumericConversion);
-            case TypeTags.FINITE_TYPE_TAG:
-                return checkFiniteTypeAssignable(sourceValue, sourceType, (BFiniteType) targetType,
-                 unresolvedValues, allowNumericConversion);
-            case TypeTags.XML_ELEMENT_TAG:
-            case TypeTags.XML_COMMENT_TAG:
-            case TypeTags.XML_PI_TAG:
-            case TypeTags.XML_TEXT_TAG:
+                yield allowNumericConversion && TypeConverter.isConvertibleToIntSubType(sourceValue, targetType);
+            }
+            case TypeTags.FLOAT_TAG,
+                 TypeTags.DECIMAL_TAG ->
+                    allowNumericConversion && TypeConverter.isConvertibleToFloatingPointTypes(sourceValue);
+            case TypeTags.CHAR_STRING_TAG -> TypeConverter.isConvertibleToChar(sourceValue);
+            case TypeTags.RECORD_TYPE_TAG ->
+                    checkIsLikeRecordType(sourceValue, (BRecordType) targetType, unresolvedValues,
+                            allowNumericConversion, varName, errors);
+            case TypeTags.TABLE_TAG -> checkIsLikeTableType(sourceValue, (BTableType) targetType, unresolvedValues,
+                    allowNumericConversion);
+            case TypeTags.JSON_TAG ->
+                    checkIsLikeJSONType(sourceValue, sourceType, (BJsonType) targetType, unresolvedValues,
+                            allowNumericConversion);
+            case TypeTags.MAP_TAG ->
+                    checkIsLikeMapType(sourceValue, (BMapType) targetType, unresolvedValues, allowNumericConversion);
+            case TypeTags.STREAM_TAG -> checkIsLikeStreamType(sourceValue, (BStreamType) targetType);
+            case TypeTags.ARRAY_TAG -> checkIsLikeArrayType(sourceValue, (BArrayType) targetType, unresolvedValues,
+                    allowNumericConversion);
+            case TypeTags.TUPLE_TAG -> checkIsLikeTupleType(sourceValue, (BTupleType) targetType, unresolvedValues,
+                    allowNumericConversion);
+            case TypeTags.ERROR_TAG -> checkIsLikeErrorType(sourceValue, (BErrorType) targetType, unresolvedValues,
+                    allowNumericConversion);
+            case TypeTags.ANYDATA_TAG ->
+                    checkIsLikeAnydataType(sourceValue, sourceType, unresolvedValues, allowNumericConversion);
+            case TypeTags.FINITE_TYPE_TAG ->
+                    checkFiniteTypeAssignable(sourceValue, sourceType, (BFiniteType) targetType,
+                            unresolvedValues, allowNumericConversion);
+            case TypeTags.XML_ELEMENT_TAG,
+                 TypeTags.XML_COMMENT_TAG,
+                 TypeTags.XML_PI_TAG,
+                 TypeTags.XML_TEXT_TAG -> {
                 if (TypeTags.isXMLTypeTag(sourceTypeTag)) {
-                    return checkIsLikeXmlValueSingleton((XmlValue) sourceValue, targetType);
+                    yield checkIsLikeXmlValueSingleton((XmlValue) sourceValue, targetType);
                 }
-                return false;
-            case TypeTags.XML_TAG:
+                yield false;
+            }
+            case TypeTags.XML_TAG -> {
                 if (TypeTags.isXMLTypeTag(sourceTypeTag)) {
-                    return checkIsLikeXMLSequenceType((XmlValue) sourceValue, targetType);
+                    yield checkIsLikeXMLSequenceType((XmlValue) sourceValue, targetType);
                 }
-                return false;
-            case TypeTags.UNION_TAG:
-                return checkIsLikeUnionType(errors, sourceValue, (BUnionType) targetType, unresolvedValues,
-                        allowNumericConversion, varName);
-            case TypeTags.INTERSECTION_TAG:
-                return checkIsLikeOnValue(errors, sourceValue, sourceType,
-                        ((BIntersectionType) targetType).getEffectiveType(), unresolvedValues, allowNumericConversion,
-                        varName);
-            case TypeTags.TYPE_REFERENCED_TYPE_TAG:
-                return checkIsLikeOnValue(errors, sourceValue, sourceType,
-                        ((BTypeReferenceType) targetType).getReferredType(), unresolvedValues, allowNumericConversion,
-                        varName);
-            default:
-                return false;
-        }
+                yield false;
+            }
+            case TypeTags.UNION_TAG ->
+                    checkIsLikeUnionType(errors, sourceValue, (BUnionType) targetType, unresolvedValues,
+                            allowNumericConversion, varName);
+            case TypeTags.INTERSECTION_TAG -> checkIsLikeOnValue(errors, sourceValue, sourceType,
+                    ((BIntersectionType) targetType).getEffectiveType(), unresolvedValues, allowNumericConversion,
+                    varName);
+            case TypeTags.TYPE_REFERENCED_TYPE_TAG -> checkIsLikeOnValue(errors, sourceValue, sourceType,
+                    ((BTypeReferenceType) targetType).getReferredType(), unresolvedValues, allowNumericConversion,
+                    varName);
+            default -> false;
+        };
     }
 
     private static boolean checkIsLikeUnionType(List<String> errors, Object sourceValue, BUnionType targetType,
@@ -2337,16 +2291,12 @@ public class TypeChecker {
     }
 
     private static XmlNodeType getXmlNodeType(Type type) {
-        switch (getImpliedType(type).getTag()) {
-            case TypeTags.XML_ELEMENT_TAG:
-                return XmlNodeType.ELEMENT;
-            case TypeTags.XML_COMMENT_TAG:
-                return XmlNodeType.COMMENT;
-            case TypeTags.XML_PI_TAG:
-                return XmlNodeType.PI;
-            default:
-                return XmlNodeType.TEXT;
-        }
+        return switch (getImpliedType(type).getTag()) {
+            case TypeTags.XML_ELEMENT_TAG -> XmlNodeType.ELEMENT;
+            case TypeTags.XML_COMMENT_TAG -> XmlNodeType.COMMENT;
+            case TypeTags.XML_PI_TAG -> XmlNodeType.PI;
+            default -> XmlNodeType.TEXT;
+        };
     }
 
     private static boolean checkIsLikeXmlValueSingleton(XmlValue xmlSource, Type targetType) {
@@ -2441,17 +2391,15 @@ public class TypeChecker {
             case TypeTags.ARRAY_TAG:
                 ArrayValue arr = (ArrayValue) sourceValue;
                 BArrayType arrayType = (BArrayType) getImpliedType(arr.getType());
-                switch (getImpliedType(arrayType.getElementType()).getTag()) {
-                    case TypeTags.INT_TAG:
-                    case TypeTags.FLOAT_TAG:
-                    case TypeTags.DECIMAL_TAG:
-                    case TypeTags.STRING_TAG:
-                    case TypeTags.BOOLEAN_TAG:
-                    case TypeTags.BYTE_TAG:
-                        return true;
-                    default:
-                        return isLikeAnydataType(arr.getValues(), unresolvedValues, allowNumericConversion);
-                }
+                return switch (getImpliedType(arrayType.getElementType()).getTag()) {
+                    case TypeTags.INT_TAG,
+                         TypeTags.FLOAT_TAG,
+                         TypeTags.DECIMAL_TAG,
+                         TypeTags.STRING_TAG,
+                         TypeTags.BOOLEAN_TAG,
+                         TypeTags.BYTE_TAG -> true;
+                    default -> isLikeAnydataType(arr.getValues(), unresolvedValues, allowNumericConversion);
+                };
             case TypeTags.TUPLE_TAG:
                 return isLikeAnydataType(((ArrayValue) sourceValue).getValues(), unresolvedValues,
                                   allowNumericConversion);
@@ -3107,31 +3055,23 @@ public class TypeChecker {
                 !(typeTag == TypeTags.CHAR_STRING_TAG || typeTag == TypeTags.NEVER_TAG)) {
             return true;
         }
-        switch (typeTag) {
-            case TypeTags.STREAM_TAG:
-            case TypeTags.MAP_TAG:
-            case TypeTags.ANY_TAG:
-                return true;
-            case TypeTags.ARRAY_TAG:
-                return checkFillerValue((BArrayType) type, unanalyzedTypes);
-            case TypeTags.FINITE_TYPE_TAG:
-                return checkFillerValue((BFiniteType) type);
-            case TypeTags.OBJECT_TYPE_TAG:
-            case TypeTags.SERVICE_TAG:
-                return checkFillerValue((BObjectType) type);
-            case TypeTags.RECORD_TYPE_TAG:
-                return checkFillerValue((BRecordType) type, unanalyzedTypes);
-            case TypeTags.TUPLE_TAG:
-                return checkFillerValue((BTupleType) type, unanalyzedTypes);
-            case TypeTags.UNION_TAG:
-                return checkFillerValue((BUnionType) type, unanalyzedTypes);
-            case TypeTags.TYPE_REFERENCED_TYPE_TAG:
-                return hasFillerValue(((BTypeReferenceType) type).getReferredType(), unanalyzedTypes);
-            case TypeTags.INTERSECTION_TAG:
-                return hasFillerValue(((BIntersectionType) type).getEffectiveType(), unanalyzedTypes);
-            default:
-                return false;
-        }
+        return switch (typeTag) {
+            case TypeTags.STREAM_TAG,
+                 TypeTags.MAP_TAG,
+                 TypeTags.ANY_TAG -> true;
+            case TypeTags.ARRAY_TAG -> checkFillerValue((BArrayType) type, unanalyzedTypes);
+            case TypeTags.FINITE_TYPE_TAG -> checkFillerValue((BFiniteType) type);
+            case TypeTags.OBJECT_TYPE_TAG,
+                 TypeTags.SERVICE_TAG -> checkFillerValue((BObjectType) type);
+            case TypeTags.RECORD_TYPE_TAG -> checkFillerValue((BRecordType) type, unanalyzedTypes);
+            case TypeTags.TUPLE_TAG -> checkFillerValue((BTupleType) type, unanalyzedTypes);
+            case TypeTags.UNION_TAG -> checkFillerValue((BUnionType) type, unanalyzedTypes);
+            case TypeTags.TYPE_REFERENCED_TYPE_TAG ->
+                    hasFillerValue(((BTypeReferenceType) type).getReferredType(), unanalyzedTypes);
+            case TypeTags.INTERSECTION_TAG ->
+                    hasFillerValue(((BIntersectionType) type).getEffectiveType(), unanalyzedTypes);
+            default -> false;
+        };
     }
 
     private static boolean checkFillerValue(BTupleType tupleType,  List<Type> unAnalyzedTypes) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -108,106 +108,78 @@ public class TypeConverter {
 
     public static Object convertValues(Type targetType, Object inputValue) {
         Type inputType = TypeChecker.getType(inputValue);
-        switch (targetType.getTag()) {
-            case TypeTags.INT_TAG:
-            case TypeTags.SIGNED32_INT_TAG:
-            case TypeTags.SIGNED16_INT_TAG:
-            case TypeTags.SIGNED8_INT_TAG:
-            case TypeTags.UNSIGNED32_INT_TAG:
-            case TypeTags.UNSIGNED16_INT_TAG:
-            case TypeTags.UNSIGNED8_INT_TAG:
-                return anyToInt(inputValue, () ->
-                        ErrorUtils.createNumericConversionError(inputValue, PredefinedTypes.TYPE_INT));
-            case TypeTags.DECIMAL_TAG:
-                return anyToDecimal(inputValue, () ->
-                        ErrorUtils.createNumericConversionError(inputValue, PredefinedTypes.TYPE_DECIMAL));
-            case TypeTags.FLOAT_TAG:
-                return anyToFloat(inputValue, () ->
-                        ErrorUtils.createNumericConversionError(inputValue, PredefinedTypes.TYPE_FLOAT));
-            case TypeTags.STRING_TAG:
-                return StringUtils.fromString(anyToString(inputValue));
-            case TypeTags.BOOLEAN_TAG:
-                return anyToBoolean(inputValue, () ->
-                        ErrorUtils.createNumericConversionError(inputValue, PredefinedTypes.TYPE_BOOLEAN));
-            case TypeTags.BYTE_TAG:
-                return anyToByte(inputValue, () ->
-                        ErrorUtils.createNumericConversionError(inputValue, PredefinedTypes.TYPE_BYTE));
-            default:
-                throw ErrorCreator.createError(ErrorReasons.NUMBER_CONVERSION_ERROR,
-                        ErrorHelper.getErrorDetails(
-                                                          ErrorCodes.INCOMPATIBLE_SIMPLE_TYPE_CONVERT_OPERATION,
-                                                          inputType, inputValue, targetType));
-        }
+        return switch (targetType.getTag()) {
+            case TypeTags.INT_TAG,
+                 TypeTags.SIGNED32_INT_TAG,
+                 TypeTags.SIGNED16_INT_TAG,
+                 TypeTags.SIGNED8_INT_TAG,
+                 TypeTags.UNSIGNED32_INT_TAG,
+                 TypeTags.UNSIGNED16_INT_TAG,
+                 TypeTags.UNSIGNED8_INT_TAG -> anyToInt(inputValue, () ->
+                    ErrorUtils.createNumericConversionError(inputValue, PredefinedTypes.TYPE_INT));
+            case TypeTags.DECIMAL_TAG -> anyToDecimal(inputValue, () ->
+                    ErrorUtils.createNumericConversionError(inputValue, PredefinedTypes.TYPE_DECIMAL));
+            case TypeTags.FLOAT_TAG -> anyToFloat(inputValue, () ->
+                    ErrorUtils.createNumericConversionError(inputValue, PredefinedTypes.TYPE_FLOAT));
+            case TypeTags.STRING_TAG -> StringUtils.fromString(anyToString(inputValue));
+            case TypeTags.BOOLEAN_TAG -> anyToBoolean(inputValue, () ->
+                    ErrorUtils.createNumericConversionError(inputValue, PredefinedTypes.TYPE_BOOLEAN));
+            case TypeTags.BYTE_TAG -> anyToByte(inputValue, () ->
+                    ErrorUtils.createNumericConversionError(inputValue, PredefinedTypes.TYPE_BYTE));
+            default -> throw ErrorCreator.createError(ErrorReasons.NUMBER_CONVERSION_ERROR,
+                    ErrorHelper.getErrorDetails(
+                            ErrorCodes.INCOMPATIBLE_SIMPLE_TYPE_CONVERT_OPERATION, inputType, inputValue, targetType));
+        };
     }
 
     public static Object castValues(Type targetType, Object inputValue) {
-        switch (targetType.getTag()) {
-            case TypeTags.SIGNED32_INT_TAG:
-                return anyToSigned32(inputValue);
-            case TypeTags.SIGNED16_INT_TAG:
-                return anyToSigned16(inputValue);
-            case TypeTags.SIGNED8_INT_TAG:
-                return anyToSigned8(inputValue);
-            case TypeTags.UNSIGNED32_INT_TAG:
-                return anyToUnsigned32(inputValue);
-            case TypeTags.UNSIGNED16_INT_TAG:
-                return anyToUnsigned16(inputValue);
-            case TypeTags.UNSIGNED8_INT_TAG:
-                return anyToUnsigned8(inputValue);
-            case TypeTags.INT_TAG:
-                return anyToIntCast(inputValue, () ->
-                        ErrorUtils.createTypeCastError(inputValue, PredefinedTypes.TYPE_INT));
-            case TypeTags.DECIMAL_TAG:
-                return anyToDecimalCast(inputValue, () ->
-                        ErrorUtils.createTypeCastError(inputValue, PredefinedTypes.TYPE_DECIMAL));
-            case TypeTags.FLOAT_TAG:
-                return anyToFloatCast(inputValue, () ->
-                        ErrorUtils.createTypeCastError(inputValue, PredefinedTypes.TYPE_FLOAT));
-            case TypeTags.STRING_TAG:
-                return anyToStringCast(inputValue, () ->
-                        ErrorUtils.createTypeCastError(inputValue, PredefinedTypes.TYPE_STRING));
-            case TypeTags.BOOLEAN_TAG:
-                return anyToBooleanCast(inputValue, () ->
-                        ErrorUtils.createTypeCastError(inputValue, PredefinedTypes.TYPE_BOOLEAN));
-            case TypeTags.BYTE_TAG:
-                return anyToByteCast(inputValue, () ->
-                        ErrorUtils.createTypeCastError(inputValue, PredefinedTypes.TYPE_BYTE));
-            default:
-                throw ErrorUtils.createTypeCastError(inputValue, targetType);
-        }
+        return switch (targetType.getTag()) {
+            case TypeTags.SIGNED32_INT_TAG -> anyToSigned32(inputValue);
+            case TypeTags.SIGNED16_INT_TAG -> anyToSigned16(inputValue);
+            case TypeTags.SIGNED8_INT_TAG -> anyToSigned8(inputValue);
+            case TypeTags.UNSIGNED32_INT_TAG -> anyToUnsigned32(inputValue);
+            case TypeTags.UNSIGNED16_INT_TAG -> anyToUnsigned16(inputValue);
+            case TypeTags.UNSIGNED8_INT_TAG -> anyToUnsigned8(inputValue);
+            case TypeTags.INT_TAG -> anyToIntCast(inputValue, () ->
+                    ErrorUtils.createTypeCastError(inputValue, PredefinedTypes.TYPE_INT));
+            case TypeTags.DECIMAL_TAG -> anyToDecimalCast(inputValue, () ->
+                    ErrorUtils.createTypeCastError(inputValue, PredefinedTypes.TYPE_DECIMAL));
+            case TypeTags.FLOAT_TAG -> anyToFloatCast(inputValue, () ->
+                    ErrorUtils.createTypeCastError(inputValue, PredefinedTypes.TYPE_FLOAT));
+            case TypeTags.STRING_TAG -> anyToStringCast(inputValue, () ->
+                    ErrorUtils.createTypeCastError(inputValue, PredefinedTypes.TYPE_STRING));
+            case TypeTags.BOOLEAN_TAG -> anyToBooleanCast(inputValue, () ->
+                    ErrorUtils.createTypeCastError(inputValue, PredefinedTypes.TYPE_BOOLEAN));
+            case TypeTags.BYTE_TAG -> anyToByteCast(inputValue, () ->
+                    ErrorUtils.createTypeCastError(inputValue, PredefinedTypes.TYPE_BYTE));
+            default -> throw ErrorUtils.createTypeCastError(inputValue, targetType);
+        };
     }
 
     static boolean isConvertibleToByte(Object value) {
         Type inputType = TypeChecker.getType(value);
-        switch (inputType.getTag()) {
-            case TypeTags.BYTE_TAG:
-                return true;
-            case TypeTags.INT_TAG:
-                return TypeChecker.isByteLiteral((long) value);
-            case TypeTags.FLOAT_TAG:
+        return switch (inputType.getTag()) {
+            case TypeTags.BYTE_TAG -> true;
+            case TypeTags.INT_TAG -> TypeChecker.isByteLiteral((long) value);
+            case TypeTags.FLOAT_TAG -> {
                 Double doubleValue = (Double) value;
-                return isFloatWithinIntRange(doubleValue) && TypeChecker.isByteLiteral(doubleValue.longValue());
-            case TypeTags.DECIMAL_TAG:
-                return isDecimalWithinIntRange((DecimalValue) value)
-                        && TypeChecker.isByteLiteral(((DecimalValue) value).value().longValue());
-            default:
-                return false;
-        }
+                yield isFloatWithinIntRange(doubleValue) && TypeChecker.isByteLiteral(doubleValue.longValue());
+            }
+            case TypeTags.DECIMAL_TAG -> isDecimalWithinIntRange((DecimalValue) value) &&
+                    TypeChecker.isByteLiteral(((DecimalValue) value).value().longValue());
+            default -> false;
+        };
     }
 
     static boolean isConvertibleToInt(Object value) {
         Type inputType = TypeChecker.getType(value);
-        switch (inputType.getTag()) {
-            case TypeTags.BYTE_TAG:
-            case TypeTags.INT_TAG:
-                return true;
-            case TypeTags.FLOAT_TAG:
-                return isFloatWithinIntRange((double) value);
-            case TypeTags.DECIMAL_TAG:
-                return isDecimalWithinIntRange((DecimalValue) value);
-            default:
-                return false;
-        }
+        return switch (inputType.getTag()) {
+            case TypeTags.BYTE_TAG,
+                 TypeTags.INT_TAG -> true;
+            case TypeTags.FLOAT_TAG -> isFloatWithinIntRange((double) value);
+            case TypeTags.DECIMAL_TAG -> isDecimalWithinIntRange((DecimalValue) value);
+            default -> false;
+        };
     }
 
     static boolean isConvertibleToIntSubType(Object value, Type targetType) {
@@ -259,15 +231,10 @@ public class TypeConverter {
 
     static boolean isConvertibleToFloatingPointTypes(Object value) {
         Type inputType = TypeChecker.getType(value);
-        switch (inputType.getTag()) {
-            case TypeTags.BYTE_TAG:
-            case TypeTags.INT_TAG:
-            case TypeTags.FLOAT_TAG:
-            case TypeTags.DECIMAL_TAG:
-                return true;
-            default:
-                return false;
-        }
+        return switch (inputType.getTag()) {
+            case TypeTags.BYTE_TAG, TypeTags.INT_TAG, TypeTags.FLOAT_TAG, TypeTags.DECIMAL_TAG -> true;
+            default -> false;
+        };
     }
 
     public static Type getConvertibleType(Object inputValue, Type targetType, String varName,
@@ -965,15 +932,10 @@ public class TypeConverter {
             return false;
         }
 
-        switch (value.charAt(length - 1)) {
-            case 'F':
-            case 'f':
-            case 'D':
-            case 'd':
-                return true;
-            default:
-                return false;
-        }
+        return switch (value.charAt(length - 1)) {
+            case 'F', 'f', 'D', 'd' -> true;
+            default -> false;
+        };
     }
 
     public static Boolean stringToBoolean(String value) throws NumberFormatException {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueComparisonUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueComparisonUtils.java
@@ -305,14 +305,11 @@ public class ValueComparisonUtils {
     }
 
     private static boolean checkDecimalGreaterThan(DecimalValue lhsValue, DecimalValue rhsValue) {
-        switch (lhsValue.valueKind) {
-            case ZERO:
-            case OTHER:
-                return (isDecimalRealNumber(rhsValue) &&
-                        lhsValue.decimalValue().compareTo(rhsValue.decimalValue()) > 0);
-            default:
-                return false;
-        }
+        return switch (lhsValue.valueKind) {
+            case ZERO,
+                 OTHER -> (isDecimalRealNumber(rhsValue) &&
+                    lhsValue.decimalValue().compareTo(rhsValue.decimalValue()) > 0);
+        };
     }
 
     private static boolean isDecimalRealNumber(DecimalValue decimalValue) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/cli/CliUtil.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/cli/CliUtil.java
@@ -64,33 +64,26 @@ public class CliUtil {
     }
 
     static Object getBValue(Type type, String value, String parameterName) {
-        switch (TypeUtils.getImpliedType(type).getTag()) {
-            case TypeTags.STRING_TAG:
-                return StringUtils.fromString(value);
-            case TypeTags.CHAR_STRING_TAG:
-                return getCharValue(value, parameterName);
-            case TypeTags.INT_TAG:
-            case TypeTags.SIGNED32_INT_TAG:
-            case TypeTags.SIGNED16_INT_TAG:
-            case TypeTags.SIGNED8_INT_TAG:
-            case TypeTags.UNSIGNED32_INT_TAG:
-            case TypeTags.UNSIGNED16_INT_TAG:
-            case TypeTags.UNSIGNED8_INT_TAG:
-                return getIntegerValue(value, parameterName);
-            case TypeTags.BYTE_TAG:
-                return getByteValue(value, parameterName);
-            case TypeTags.FLOAT_TAG:
-                return getFloatValue(value, parameterName);
-            case TypeTags.DECIMAL_TAG:
-                return getDecimalValue(value, parameterName);
-            case TypeTags.TYPE_REFERENCED_TYPE_TAG:
-                return getBValue(TypeUtils.getImpliedType(type), value, parameterName);
-            case TypeTags.BOOLEAN_TAG:
-                throw ErrorCreator.createError(StringUtils.fromString("the option '" + parameterName + "' of type " +
-                                                                              "'boolean' is expected without a value"));
-            default:
-                throw getUnsupportedTypeException(type);
-        }
+        return switch (TypeUtils.getImpliedType(type).getTag()) {
+            case TypeTags.STRING_TAG -> StringUtils.fromString(value);
+            case TypeTags.CHAR_STRING_TAG -> getCharValue(value, parameterName);
+            case TypeTags.INT_TAG,
+                 TypeTags.SIGNED32_INT_TAG,
+                 TypeTags.SIGNED16_INT_TAG,
+                 TypeTags.SIGNED8_INT_TAG,
+                 TypeTags.UNSIGNED32_INT_TAG,
+                 TypeTags.UNSIGNED16_INT_TAG,
+                 TypeTags.UNSIGNED8_INT_TAG -> getIntegerValue(value, parameterName);
+            case TypeTags.BYTE_TAG -> getByteValue(value, parameterName);
+            case TypeTags.FLOAT_TAG -> getFloatValue(value, parameterName);
+            case TypeTags.DECIMAL_TAG -> getDecimalValue(value, parameterName);
+            case TypeTags.TYPE_REFERENCED_TYPE_TAG -> getBValue(TypeUtils.getImpliedType(type), value, parameterName);
+            case TypeTags.BOOLEAN_TAG ->
+                    throw ErrorCreator.createError(
+                            StringUtils.fromString("the option '" + parameterName + "' of type " +
+                                    "'boolean' is expected without a value"));
+            default -> throw getUnsupportedTypeException(type);
+        };
     }
 
     private static Object getCharValue(String argument, String parameterName) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/Utils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/Utils.java
@@ -88,59 +88,40 @@ public class Utils {
     }
 
     static Object getTomlTypeString(TomlNode tomlNode) {
-        switch (tomlNode.kind()) {
-            case STRING:
-                return "string";
-            case INTEGER:
-                return "int";
-            case DOUBLE:
-                return "float";
-            case BOOLEAN:
-                return "boolean";
-            case ARRAY:
-                return "array";
-            case TABLE:
-            case INLINE_TABLE:
-                return "record";
-            case TABLE_ARRAY:
-                return "table";
-            case KEY_VALUE:
-                return getTomlTypeString(((TomlKeyValueNode) tomlNode).value());
-            default:
-                return "unsupported type";
-        }
+        return switch (tomlNode.kind()) {
+            case STRING -> "string";
+            case INTEGER -> "int";
+            case DOUBLE -> "float";
+            case BOOLEAN -> "boolean";
+            case ARRAY -> "array";
+            case TABLE, INLINE_TABLE -> "record";
+            case TABLE_ARRAY -> "table";
+            case KEY_VALUE -> getTomlTypeString(((TomlKeyValueNode) tomlNode).value());
+            default -> "unsupported type";
+        };
     }
 
     static Object getBalValueFromToml(TomlNode tomlNode, Set<TomlNode> visitedNodes, BUnionType unionType,
                                       Set<LineRange> invalidTomlLines, String variableName) {
         visitedNodes.add(tomlNode);
-        switch (tomlNode.kind()) {
-            case STRING:
-                return validateAndGetStringValue((TomlStringValueNode) tomlNode, unionType, invalidTomlLines,
-                        variableName);
-            case INTEGER:
-                return ((TomlLongValueNode) tomlNode).getValue();
-            case DOUBLE:
-                return validateAndGetDoubleValue((TomlDoubleValueNodeNode) tomlNode, unionType, invalidTomlLines,
-                        variableName);
-            case BOOLEAN:
-                return ((TomlBooleanValueNode) tomlNode).getValue();
-            case KEY_VALUE:
-                return getBalValueFromToml(((TomlKeyValueNode) tomlNode).value(), visitedNodes, unionType,
-                        invalidTomlLines, variableName);
-            case ARRAY:
-                return getAnydataArray((TomlArrayValueNode) tomlNode, visitedNodes, invalidTomlLines, variableName);
-            case TABLE:
-                return getAnydataMap((TomlTableNode) tomlNode, visitedNodes, invalidTomlLines, variableName);
-            case TABLE_ARRAY:
-                return getMapAnydataArray((TomlTableArrayNode) tomlNode, visitedNodes, invalidTomlLines, variableName);
-            case INLINE_TABLE:
-                return getAnydataMap(((TomlInlineTableValueNode) tomlNode).toTable(), visitedNodes, invalidTomlLines,
-                        variableName);
-            default:
-                // should not come here
-                return null;
-        }
+        return switch (tomlNode.kind()) {
+            case STRING -> validateAndGetStringValue(
+                    (TomlStringValueNode) tomlNode, unionType, invalidTomlLines, variableName);
+            case INTEGER -> ((TomlLongValueNode) tomlNode).getValue();
+            case DOUBLE -> validateAndGetDoubleValue(
+                    (TomlDoubleValueNodeNode) tomlNode, unionType, invalidTomlLines, variableName);
+            case BOOLEAN -> ((TomlBooleanValueNode) tomlNode).getValue();
+            case KEY_VALUE -> getBalValueFromToml(
+                    ((TomlKeyValueNode) tomlNode).value(), visitedNodes, unionType, invalidTomlLines, variableName);
+            case ARRAY -> getAnydataArray((TomlArrayValueNode) tomlNode, visitedNodes, invalidTomlLines, variableName);
+            case TABLE -> getAnydataMap((TomlTableNode) tomlNode, visitedNodes, invalidTomlLines, variableName);
+            case TABLE_ARRAY -> getMapAnydataArray(
+                    (TomlTableArrayNode) tomlNode, visitedNodes, invalidTomlLines, variableName);
+            case INLINE_TABLE -> getAnydataMap(
+                    ((TomlInlineTableValueNode) tomlNode).toTable(), visitedNodes, invalidTomlLines, variableName);
+            // should not come here
+            default -> null;
+        };
     }
 
     private static Object getAnydataMap(TomlTableNode tomlNode, Set<TomlNode> visitedNodes,
@@ -183,38 +164,31 @@ public class Utils {
     }
 
     static boolean checkEffectiveTomlType(TomlType kind, Type expectedType, String variableName) {
-        switch (expectedType.getTag()) {
-            case TypeTags.INT_TAG:
-            case TypeTags.BYTE_TAG:
-                return kind == TomlType.INTEGER;
-            case TypeTags.BOOLEAN_TAG:
-                return kind == TomlType.BOOLEAN;
-            case TypeTags.FLOAT_TAG:
-            case TypeTags.DECIMAL_TAG:
-                return kind == TomlType.DOUBLE;
-            case TypeTags.STRING_TAG:
-            case TypeTags.UNION_TAG:
-            case TypeTags.XML_ATTRIBUTES_TAG:
-            case TypeTags.XML_COMMENT_TAG:
-            case TypeTags.XML_ELEMENT_TAG:
-            case TypeTags.XML_PI_TAG:
-            case TypeTags.XML_TAG:
-            case TypeTags.XML_TEXT_TAG:
-                return kind == TomlType.STRING;
-            case TypeTags.ARRAY_TAG:
-            case TypeTags.TUPLE_TAG:
-                return kind == TomlType.ARRAY;
-            case TypeTags.MAP_TAG:
-            case TypeTags.RECORD_TYPE_TAG:
-                return kind == TomlType.INLINE_TABLE || kind == TomlType.TABLE;
-            case TypeTags.TABLE_TAG:
-                return kind == TomlType.TABLE_ARRAY || kind == TomlType.ARRAY;
-            case TypeTags.INTERSECTION_TAG:
+        return switch (expectedType.getTag()) {
+            case TypeTags.INT_TAG,
+                 TypeTags.BYTE_TAG -> kind == TomlType.INTEGER;
+            case TypeTags.BOOLEAN_TAG -> kind == TomlType.BOOLEAN;
+            case TypeTags.FLOAT_TAG,
+                 TypeTags.DECIMAL_TAG -> kind == TomlType.DOUBLE;
+            case TypeTags.STRING_TAG,
+                 TypeTags.UNION_TAG,
+                 TypeTags.XML_ATTRIBUTES_TAG,
+                 TypeTags.XML_COMMENT_TAG,
+                 TypeTags.XML_ELEMENT_TAG,
+                 TypeTags.XML_PI_TAG,
+                 TypeTags.XML_TAG,
+                 TypeTags.XML_TEXT_TAG -> kind == TomlType.STRING;
+            case TypeTags.ARRAY_TAG,
+                 TypeTags.TUPLE_TAG -> kind == TomlType.ARRAY;
+            case TypeTags.MAP_TAG,
+                 TypeTags.RECORD_TYPE_TAG -> kind == TomlType.INLINE_TABLE || kind == TomlType.TABLE;
+            case TypeTags.TABLE_TAG -> kind == TomlType.TABLE_ARRAY || kind == TomlType.ARRAY;
+            case TypeTags.INTERSECTION_TAG -> {
                 Type effectiveType = ((IntersectionType) expectedType).getEffectiveType();
-                return checkEffectiveTomlType(kind, effectiveType, variableName);
-            default:
-                throw new ConfigException(CONFIG_TYPE_NOT_SUPPORTED, variableName, expectedType.toString());
-        }
+                yield checkEffectiveTomlType(kind, effectiveType, variableName);
+            }
+            default -> throw new ConfigException(CONFIG_TYPE_NOT_SUPPORTED, variableName, expectedType.toString());
+        };
     }
 
     static boolean isSimpleType(int typeTag) {
@@ -241,31 +215,23 @@ public class Utils {
     }
 
     public static Type getTypeFromTomlValue(TomlNode tomlNode) {
-        switch (tomlNode.kind()) {
-            case STRING:
-                return PredefinedTypes.TYPE_STRING;
-            case INTEGER:
-                return PredefinedTypes.TYPE_INT;
-            case DOUBLE:
-                return PredefinedTypes.TYPE_FLOAT;
-            case BOOLEAN:
-                return PredefinedTypes.TYPE_BOOLEAN;
-            case KEY_VALUE:
-                return getTypeFromTomlValue(((TomlKeyValueNode) tomlNode).value());
-            case ARRAY:
+        return switch (tomlNode.kind()) {
+            case STRING -> PredefinedTypes.TYPE_STRING;
+            case INTEGER -> PredefinedTypes.TYPE_INT;
+            case DOUBLE -> PredefinedTypes.TYPE_FLOAT;
+            case BOOLEAN -> PredefinedTypes.TYPE_BOOLEAN;
+            case KEY_VALUE -> getTypeFromTomlValue(((TomlKeyValueNode) tomlNode).value());
+            case ARRAY -> {
                 if (containsInlineTable((TomlArrayValueNode) tomlNode)) {
-                    return TypeCreator.createArrayType(TypeCreator.createMapType(TYPE_ANYDATA), true);
+                    yield TypeCreator.createArrayType(TypeCreator.createMapType(TYPE_ANYDATA), true);
                 }
-                return TypeCreator.createArrayType(TYPE_ANYDATA, true);
-            case TABLE:
-            case INLINE_TABLE:
-                return TypeCreator.createMapType(TYPE_ANYDATA, true);
-            case TABLE_ARRAY:
-                return TypeCreator.createArrayType(TypeCreator.createMapType(TYPE_ANYDATA), true);
-            default:
-                // should not come here
-                return null;
-        }
+                yield TypeCreator.createArrayType(TYPE_ANYDATA, true);
+            }
+            case TABLE, INLINE_TABLE -> TypeCreator.createMapType(TYPE_ANYDATA, true);
+            case TABLE_ARRAY -> TypeCreator.createArrayType(TypeCreator.createMapType(TYPE_ANYDATA), true);
+            // should not come here
+            default -> null;
+        };
     }
 
     private static boolean containsInlineTable(TomlArrayValueNode tomlNode) {
@@ -385,14 +351,11 @@ public class Utils {
     }
 
     static Type getEffectiveType(Type type) {
-        switch (type.getTag()) {
-            case TypeTags.INTERSECTION_TAG:
-                return ((IntersectionType) type).getEffectiveType();
-            case TypeTags.TYPE_REFERENCED_TYPE_TAG:
-                return getEffectiveType(((ReferenceType) type).getReferredType());
-            default:
-                return type;
-        }
+        return switch (type.getTag()) {
+            case TypeTags.INTERSECTION_TAG -> ((IntersectionType) type).getEffectiveType();
+            case TypeTags.TYPE_REFERENCED_TYPE_TAG -> getEffectiveType(((ReferenceType) type).getReferredType());
+            default -> type;
+        };
     }
 
     private static boolean isMappingType(int typeTag) {
@@ -412,23 +375,17 @@ public class Utils {
                                            BFiniteType finiteType, Set<LineRange> invalidTomlLines,
                                            String variableName) {
         visitedNodes.add(tomlNode);
-        switch (tomlNode.kind()) {
-            case STRING:
-                return StringUtils.fromString(((TomlStringValueNode) tomlNode).getValue());
-            case INTEGER:
-                return ((TomlLongValueNode) tomlNode).getValue();
-            case DOUBLE:
-                return validateAndGetFiniteDoubleValue((TomlDoubleValueNodeNode) tomlNode, finiteType, invalidTomlLines,
-                        variableName);
-            case BOOLEAN:
-                return ((TomlBooleanValueNode) tomlNode).getValue();
-            case KEY_VALUE:
-                return getFiniteBalValue(((TomlKeyValueNode) tomlNode).value(), visitedNodes, finiteType,
-                        invalidTomlLines, variableName);
-            default:
-                // should not come here
-                return null;
-        }
+        return switch (tomlNode.kind()) {
+            case STRING -> StringUtils.fromString(((TomlStringValueNode) tomlNode).getValue());
+            case INTEGER -> ((TomlLongValueNode) tomlNode).getValue();
+            case DOUBLE -> validateAndGetFiniteDoubleValue(
+                    (TomlDoubleValueNodeNode) tomlNode, finiteType, invalidTomlLines, variableName);
+            case BOOLEAN -> ((TomlBooleanValueNode) tomlNode).getValue();
+            case KEY_VALUE -> getFiniteBalValue(
+                    ((TomlKeyValueNode) tomlNode).value(), visitedNodes, finiteType, invalidTomlLines, variableName);
+            // should not come here
+            default -> null;
+        };
 
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TreeTraverser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TreeTraverser.java
@@ -41,18 +41,14 @@ public class TreeTraverser {
     }
 
     public Token nextToken() {
-        switch (this.mode) {
-            case RE_DISJUNCTION:
-                return readTokenInReDisjunction();
-            case RE_UNICODE_PROP_ESCAPE:
-            case RE_UNICODE_GENERAL_CATEGORY_NAME:     
-                return readTokenInReUnicodePropertyEscape();
-            case RE_UNICODE_PROPERTY_VALUE:
-                return readTokenInReUnicodePropertyValue();
-            default:
-                // Should not reach here.
-                return null;
-        }
+        return switch (this.mode) {
+            case RE_DISJUNCTION -> readTokenInReDisjunction();
+            case RE_UNICODE_PROP_ESCAPE,
+                 RE_UNICODE_GENERAL_CATEGORY_NAME -> readTokenInReUnicodePropertyEscape();
+            case RE_UNICODE_PROPERTY_VALUE -> readTokenInReUnicodePropertyValue();
+            // Should not reach here.
+            default -> null;
+        };
     }
 
     /**
@@ -81,47 +77,31 @@ public class TreeTraverser {
         int nextChar = peek();
 
         this.reader.advance();
-        switch (nextChar) {
-            case Terminals.BITWISE_XOR:
-                return getRegExpToken(TokenKind.BITWISE_XOR_TOKEN);
-            case Terminals.DOLLAR:
-                return getRegExpToken(TokenKind.DOLLAR_TOKEN);
-            case Terminals.DOT:
-                return getRegExpToken(TokenKind.DOT_TOKEN);
-            case Terminals.ASTERISK:
-                return getRegExpToken(TokenKind.ASTERISK_TOKEN);
-            case Terminals.PLUS:
-                return getRegExpToken(TokenKind.PLUS_TOKEN);
-            case Terminals.QUESTION_MARK:
-                return getRegExpToken(TokenKind.QUESTION_MARK_TOKEN);
-            case Terminals.BACKSLASH:
-                return processEscape();
-            case Terminals.OPEN_BRACKET:
-                return getRegExpToken(TokenKind.OPEN_BRACKET_TOKEN);
-            case Terminals.CLOSE_BRACKET:
-                return getRegExpToken(TokenKind.CLOSE_BRACKET_TOKEN);
-            case Terminals.OPEN_BRACE:
-                return getRegExpToken(TokenKind.OPEN_BRACE_TOKEN);
-            case Terminals.CLOSE_BRACE:
-                return getRegExpToken(TokenKind.CLOSE_BRACE_TOKEN);
-            case Terminals.OPEN_PARENTHESIS:
-                return getRegExpToken(TokenKind.OPEN_PAREN_TOKEN);
-            case Terminals.CLOSE_PARENTHESIS:
-                return getRegExpToken(TokenKind.CLOSE_PAREN_TOKEN);
-            case Terminals.COMMA:
-                return getRegExpToken(TokenKind.COMMA_TOKEN);
-            case Terminals.MINUS:
-                return getRegExpToken(TokenKind.MINUS_TOKEN);
-            case Terminals.COLON:
-                return getRegExpToken(TokenKind.COLON_TOKEN);
-            case Terminals.PIPE:
-                return getRegExpToken(TokenKind.PIPE_TOKEN);
-            default:
+        return switch (nextChar) {
+            case Terminals.BITWISE_XOR -> getRegExpToken(TokenKind.BITWISE_XOR_TOKEN);
+            case Terminals.DOLLAR -> getRegExpToken(TokenKind.DOLLAR_TOKEN);
+            case Terminals.DOT -> getRegExpToken(TokenKind.DOT_TOKEN);
+            case Terminals.ASTERISK -> getRegExpToken(TokenKind.ASTERISK_TOKEN);
+            case Terminals.PLUS -> getRegExpToken(TokenKind.PLUS_TOKEN);
+            case Terminals.QUESTION_MARK -> getRegExpToken(TokenKind.QUESTION_MARK_TOKEN);
+            case Terminals.BACKSLASH -> processEscape();
+            case Terminals.OPEN_BRACKET -> getRegExpToken(TokenKind.OPEN_BRACKET_TOKEN);
+            case Terminals.CLOSE_BRACKET -> getRegExpToken(TokenKind.CLOSE_BRACKET_TOKEN);
+            case Terminals.OPEN_BRACE -> getRegExpToken(TokenKind.OPEN_BRACE_TOKEN);
+            case Terminals.CLOSE_BRACE -> getRegExpToken(TokenKind.CLOSE_BRACE_TOKEN);
+            case Terminals.OPEN_PARENTHESIS -> getRegExpToken(TokenKind.OPEN_PAREN_TOKEN);
+            case Terminals.CLOSE_PARENTHESIS -> getRegExpToken(TokenKind.CLOSE_PAREN_TOKEN);
+            case Terminals.COMMA -> getRegExpToken(TokenKind.COMMA_TOKEN);
+            case Terminals.MINUS -> getRegExpToken(TokenKind.MINUS_TOKEN);
+            case Terminals.COLON -> getRegExpToken(TokenKind.COLON_TOKEN);
+            case Terminals.PIPE -> getRegExpToken(TokenKind.PIPE_TOKEN);
+            default -> {
                 if (isDigit(nextChar)) {
-                    return getRegExpText(TokenKind.DIGIT);
+                    yield getRegExpText(TokenKind.DIGIT);
                 }
-                return getRegExpText(TokenKind.RE_LITERAL_CHAR);
-        }
+                yield getRegExpText(TokenKind.RE_LITERAL_CHAR);
+            }
+        };
     }
 
     /**
@@ -496,25 +476,10 @@ public class TreeTraverser {
      * @return <code>true</code>, if the character is ReSyntaxChar. <code>false</code> otherwise.
      */
     private static boolean isReSyntaxChar(int c) {
-        switch (c) {
-            case '^':
-            case '$':
-            case '\\':
-            case '.':
-            case '*':
-            case '+':
-            case '?':
-            case '(':
-            case ')':
-            case '[':
-            case ']':
-            case '{':
-            case '}':
-            case '|':
-                return true;
-            default:
-                return false;
-        }
+        return switch (c) {
+            case '^', '$', '\\', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|' -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -528,17 +493,10 @@ public class TreeTraverser {
      * @return <code>true</code>, if the character is ReSimpleCharClassCode. <code>false</code> otherwise.
      */
     private static boolean isReSimpleCharClassCode(int c) {
-        switch (c) {
-            case 'd':
-            case 'D':
-            case 's':
-            case 'S':
-            case 'w':
-            case 'W':
-                return true;
-            default:
-                return false;
-        }
+        return switch (c) {
+            case 'd', 'D', 's', 'S', 'w', 'W' -> true;
+            default -> false;
+        };
     }
 
     private static boolean isHexDigit(int c) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -185,57 +185,63 @@ public class ArrayValueImpl extends AbstractArrayValue {
 
     @Override
     public Object reverse() {
-        switch (elementType.getTag()) {
-            case TypeTags.INT_TAG:
-            case TypeTags.SIGNED32_INT_TAG:
-            case TypeTags.SIGNED16_INT_TAG:
-            case TypeTags.SIGNED8_INT_TAG:
-            case TypeTags.UNSIGNED32_INT_TAG:
-            case TypeTags.UNSIGNED16_INT_TAG:
-            case TypeTags.UNSIGNED8_INT_TAG:
+        return switch (elementType.getTag()) {
+            case TypeTags.INT_TAG,
+                 TypeTags.SIGNED32_INT_TAG,
+                 TypeTags.SIGNED16_INT_TAG,
+                 TypeTags.SIGNED8_INT_TAG,
+                 TypeTags.UNSIGNED32_INT_TAG,
+                 TypeTags.UNSIGNED16_INT_TAG,
+                 TypeTags.UNSIGNED8_INT_TAG -> {
                 for (int i = size - 1, j = 0; j < size / 2; i--, j++) {
                     long temp = intValues[j];
                     intValues[j] = intValues[i];
                     intValues[i] = temp;
                 }
-                return intValues;
-            case TypeTags.STRING_TAG:
-            case TypeTags.CHAR_STRING_TAG:
+                yield intValues;
+            }
+            case TypeTags.STRING_TAG,
+                 TypeTags.CHAR_STRING_TAG -> {
                 for (int i = size - 1, j = 0; j < size / 2; i--, j++) {
                     BString temp = bStringValues[j];
                     bStringValues[j] = bStringValues[i];
                     bStringValues[i] = temp;
                 }
-                return bStringValues;
-            case TypeTags.FLOAT_TAG:
+                yield bStringValues;
+            }
+            case TypeTags.FLOAT_TAG -> {
                 for (int i = size - 1, j = 0; j < size / 2; i--, j++) {
                     double temp = floatValues[j];
                     floatValues[j] = floatValues[i];
                     floatValues[i] = temp;
                 }
-                return floatValues;
-            case TypeTags.BOOLEAN_TAG:
+                yield floatValues;
+            }
+            case TypeTags.BOOLEAN_TAG -> {
                 for (int i = size - 1, j = 0; j < size / 2; i--, j++) {
                     boolean temp = booleanValues[j];
                     booleanValues[j] = booleanValues[i];
                     booleanValues[i] = temp;
                 }
-                return booleanValues;
-            case TypeTags.BYTE_TAG:
+                yield booleanValues;
+            }
+            case TypeTags.BYTE_TAG -> {
                 for (int i = size - 1, j = 0; j < size / 2; i--, j++) {
                     byte temp = byteValues[j];
                     byteValues[j] = byteValues[i];
                     byteValues[i] = temp;
                 }
-                return byteValues;
-            default:
+                yield byteValues;
+            }
+            default -> {
                 for (int i = size - 1, j = 0; j < size / 2; i--, j++) {
                     Object temp = refValues[j];
                     refValues[j] = refValues[i];
                     refValues[i] = temp;
                 }
-                return refValues;
-        }
+                yield refValues;
+            }
+        };
     }
 
     public ArrayValueImpl(ArrayType type, long size) {
@@ -306,27 +312,21 @@ public class ArrayValueImpl extends AbstractArrayValue {
     @Override
     public Object get(long index) {
         rangeCheckForGet(index, size);
-        switch (this.elementReferredType.getTag()) {
-            case TypeTags.INT_TAG:
-            case TypeTags.SIGNED32_INT_TAG:
-            case TypeTags.SIGNED16_INT_TAG:
-            case TypeTags.SIGNED8_INT_TAG:
-            case TypeTags.UNSIGNED32_INT_TAG:
-            case TypeTags.UNSIGNED16_INT_TAG:
-            case TypeTags.UNSIGNED8_INT_TAG:
-                return intValues[(int) index];
-            case TypeTags.BOOLEAN_TAG:
-                return booleanValues[(int) index];
-            case TypeTags.BYTE_TAG:
-                return Byte.toUnsignedInt(byteValues[(int) index]);
-            case TypeTags.FLOAT_TAG:
-                return floatValues[(int) index];
-            case TypeTags.STRING_TAG:
-            case TypeTags.CHAR_STRING_TAG:
-                    return bStringValues[(int) index];
-            default:
-                return refValues[(int) index];
-        }
+        return switch (this.elementReferredType.getTag()) {
+            case TypeTags.INT_TAG,
+                 TypeTags.SIGNED32_INT_TAG,
+                 TypeTags.SIGNED16_INT_TAG,
+                 TypeTags.SIGNED8_INT_TAG,
+                 TypeTags.UNSIGNED32_INT_TAG,
+                 TypeTags.UNSIGNED16_INT_TAG,
+                 TypeTags.UNSIGNED8_INT_TAG -> intValues[(int) index];
+            case TypeTags.BOOLEAN_TAG -> booleanValues[(int) index];
+            case TypeTags.BYTE_TAG -> Byte.toUnsignedInt(byteValues[(int) index]);
+            case TypeTags.FLOAT_TAG -> floatValues[(int) index];
+            case TypeTags.STRING_TAG,
+                 TypeTags.CHAR_STRING_TAG -> bStringValues[(int) index];
+            default -> refValues[(int) index];
+        };
     }
 
     public Object getRefValue(int index) {
@@ -1339,51 +1339,39 @@ public class ArrayValueImpl extends AbstractArrayValue {
     }
 
     private Object getArrayFromType(int typeTag) {
-        switch (typeTag) {
-            case TypeTags.INT_TAG:
-            case TypeTags.SIGNED32_INT_TAG:
-            case TypeTags.SIGNED16_INT_TAG:
-            case TypeTags.SIGNED8_INT_TAG:
-            case TypeTags.UNSIGNED32_INT_TAG:
-            case TypeTags.UNSIGNED16_INT_TAG:
-            case TypeTags.UNSIGNED8_INT_TAG:
-                return intValues;
-            case TypeTags.BOOLEAN_TAG:
-                return booleanValues;
-            case TypeTags.BYTE_TAG:
-                return byteValues;
-            case TypeTags.FLOAT_TAG:
-                return floatValues;
-            case TypeTags.STRING_TAG:
-            case TypeTags.CHAR_STRING_TAG:
-                return bStringValues;
-            default:
-                return refValues;
-        }
+        return switch (typeTag) {
+            case TypeTags.INT_TAG,
+                 TypeTags.SIGNED32_INT_TAG,
+                 TypeTags.SIGNED16_INT_TAG,
+                 TypeTags.SIGNED8_INT_TAG,
+                 TypeTags.UNSIGNED32_INT_TAG,
+                 TypeTags.UNSIGNED16_INT_TAG,
+                 TypeTags.UNSIGNED8_INT_TAG -> intValues;
+            case TypeTags.BOOLEAN_TAG -> booleanValues;
+            case TypeTags.BYTE_TAG -> byteValues;
+            case TypeTags.FLOAT_TAG -> floatValues;
+            case TypeTags.STRING_TAG,
+                 TypeTags.CHAR_STRING_TAG -> bStringValues;
+            default -> refValues;
+        };
     }
 
     private int getCurrentArrayLength() {
-        switch (elementType.getTag()) {
-            case TypeTags.INT_TAG:
-            case TypeTags.SIGNED32_INT_TAG:
-            case TypeTags.SIGNED16_INT_TAG:
-            case TypeTags.SIGNED8_INT_TAG:
-            case TypeTags.UNSIGNED32_INT_TAG:
-            case TypeTags.UNSIGNED16_INT_TAG:
-            case TypeTags.UNSIGNED8_INT_TAG:
-                return intValues.length;
-            case TypeTags.BOOLEAN_TAG:
-                return booleanValues.length;
-            case TypeTags.BYTE_TAG:
-                return byteValues.length;
-            case TypeTags.FLOAT_TAG:
-                return floatValues.length;
-            case TypeTags.STRING_TAG:
-            case TypeTags.CHAR_STRING_TAG:
-                return bStringValues.length;
-            default:
-                return refValues.length;
-        }
+        return switch (elementType.getTag()) {
+            case TypeTags.INT_TAG,
+                 TypeTags.SIGNED32_INT_TAG,
+                 TypeTags.SIGNED16_INT_TAG,
+                 TypeTags.SIGNED8_INT_TAG,
+                 TypeTags.UNSIGNED32_INT_TAG,
+                 TypeTags.UNSIGNED16_INT_TAG,
+                 TypeTags.UNSIGNED8_INT_TAG -> intValues.length;
+            case TypeTags.BOOLEAN_TAG -> booleanValues.length;
+            case TypeTags.BYTE_TAG -> byteValues.length;
+            case TypeTags.FLOAT_TAG -> floatValues.length;
+            case TypeTags.STRING_TAG,
+                 TypeTags.CHAR_STRING_TAG -> bStringValues.length;
+            default -> refValues.length;
+        };
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -293,18 +293,13 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
             return putValue(key, value);
         }
 
-        String errMessage = "";
-        switch (getImpliedType(getType()).getTag()) {
-            case TypeTags.RECORD_TYPE_TAG:
-                errMessage = "Invalid update of record field: ";
-                break;
-            case TypeTags.MAP_TAG:
-                errMessage = "Invalid map insertion: ";
-                break;
-        }
+        String errMessage = switch (getImpliedType(getType()).getTag()) {
+            case TypeTags.RECORD_TYPE_TAG -> "Invalid update of record field: ";
+            case TypeTags.MAP_TAG -> "Invalid map insertion: ";
+            default -> "";
+        };
         throw ErrorCreator.createError(getModulePrefixedReason(MAP_LANG_LIB, INVALID_UPDATE_ERROR_IDENTIFIER),
-                                       StringUtils
-                                                .fromString(errMessage).concat(ErrorHelper.getErrorMessage(
+                                       StringUtils.fromString(errMessage).concat(ErrorHelper.getErrorMessage(
                                                   INVALID_READONLY_VALUE_UPDATE)));
     }
 

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/model/PackageResolutionRequest.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/model/PackageResolutionRequest.java
@@ -25,7 +25,6 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 
-
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -154,18 +153,14 @@ public class PackageResolutionRequest {
 
         @Override
         @Nonnull
-        @SuppressWarnings("EnumSwitchStatementWhichMissesCases")
         public String read(final JsonReader jsonReader)
                 throws IOException {
             final JsonToken token = jsonReader.peek();
-            switch (token) {
-                case NULL:
-                    return "";
-                case STRING:
-                    return jsonReader.nextString();
-                default:
-                    throw new IllegalStateException("Unexpected token: " + token);
-            }
+            return switch (token) {
+                case NULL -> "";
+                case STRING -> jsonReader.nextString();
+                default -> throw new IllegalStateException("Unexpected token: " + token);
+            };
         }
 
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibrary.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibrary.java
@@ -149,32 +149,24 @@ public class LangLibrary {
     }
 
     private String getAssociatedLangLibName(TypeKind typeKind) {
-        switch (typeKind) {
-            case INT:
-            case BYTE:
-                return TypeKind.INT.typeName();
-            case ARRAY:
-            case TUPLE:
-                return "array";
-            case RECORD:
-            case MAP:
-                return TypeKind.MAP.typeName();
-            case FLOAT:
-            case DECIMAL:
-            case STRING:
-            case BOOLEAN:
-            case STREAM:
-            case OBJECT:
-            case ERROR:
-            case FUTURE:
-            case TYPEDESC:
-            case XML:
-            case TABLE:
-            case REGEXP:
-                return typeKind.typeName();
-            default:
-                return LANG_VALUE;
-        }
+        return switch (typeKind) {
+            case INT, BYTE -> TypeKind.INT.typeName();
+            case ARRAY, TUPLE -> "array";
+            case RECORD, MAP -> TypeKind.MAP.typeName();
+            case FLOAT,
+                 DECIMAL,
+                 STRING,
+                 BOOLEAN,
+                 STREAM,
+                 OBJECT,
+                 ERROR,
+                 FUTURE,
+                 TYPEDESC,
+                 XML,
+                 TABLE,
+                 REGEXP -> typeKind.typeName();
+            default -> LANG_VALUE;
+        };
     }
 
     private static void addLangLibMethods(String basicType, BPackageSymbol langLibModule,

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -265,37 +265,25 @@ public class TypesFactory {
     }
 
     private IntTypeSymbol createIntSubType(BIntSubType internalType) {
-        switch (internalType.tag) {
-            case UNSIGNED8_INT:
-                return new BallerinaIntUnsigned8TypeSymbol(this.context, internalType);
-            case SIGNED8_INT:
-                return new BallerinaIntSigned8TypeSymbol(this.context, internalType);
-            case UNSIGNED16_INT:
-                return new BallerinaIntUnsigned16TypeSymbol(this.context, internalType);
-            case SIGNED16_INT:
-                return new BallerinaIntSigned16TypeSymbol(this.context, internalType);
-            case UNSIGNED32_INT:
-                return new BallerinaIntUnsigned32TypeSymbol(this.context, internalType);
-            case SIGNED32_INT:
-                return new BallerinaIntSigned32TypeSymbol(this.context, internalType);
-        }
-
-        throw new IllegalStateException("Invalid integer subtype type tag: " + internalType.tag);
+        return switch (internalType.tag) {
+            case UNSIGNED8_INT -> new BallerinaIntUnsigned8TypeSymbol(this.context, internalType);
+            case SIGNED8_INT -> new BallerinaIntSigned8TypeSymbol(this.context, internalType);
+            case UNSIGNED16_INT -> new BallerinaIntUnsigned16TypeSymbol(this.context, internalType);
+            case SIGNED16_INT -> new BallerinaIntSigned16TypeSymbol(this.context, internalType);
+            case UNSIGNED32_INT -> new BallerinaIntUnsigned32TypeSymbol(this.context, internalType);
+            case SIGNED32_INT -> new BallerinaIntSigned32TypeSymbol(this.context, internalType);
+            default -> throw new IllegalStateException("Invalid integer subtype type tag: " + internalType.tag);
+        };
     }
 
     private XMLTypeSymbol createXMLSubType(BXMLSubType internalType) {
-        switch (internalType.tag) {
-            case XML_ELEMENT:
-                return new BallerinaXMLElementTypeSymbol(this.context, internalType);
-            case XML_PI:
-                return new BallerinaXMLProcessingInstructionTypeSymbol(this.context, internalType);
-            case XML_COMMENT:
-                return new BallerinaXMLCommentTypeSymbol(this.context, internalType);
-            case XML_TEXT:
-                return new BallerinaXMLTextTypeSymbol(this.context, internalType);
-        }
-
-        throw new IllegalStateException("Invalid XML subtype type tag: " + internalType.tag);
+        return switch (internalType.tag) {
+            case XML_ELEMENT -> new BallerinaXMLElementTypeSymbol(this.context, internalType);
+            case XML_PI -> new BallerinaXMLProcessingInstructionTypeSymbol(this.context, internalType);
+            case XML_COMMENT -> new BallerinaXMLCommentTypeSymbol(this.context, internalType);
+            case XML_TEXT -> new BallerinaXMLTextTypeSymbol(this.context, internalType);
+            default -> throw new IllegalStateException("Invalid XML subtype type tag: " + internalType.tag);
+        };
     }
 
     public boolean isTypeReference(BType bType, BSymbol tSymbol, boolean rawTypeOnly) {
@@ -325,74 +313,34 @@ public class TypesFactory {
     }
 
     public static TypeDescKind getTypeDescKind(TypeKind bTypeKind) {
-        switch (bTypeKind) {
-            case ANY:
-                return TypeDescKind.ANY;
-            case ANYDATA:
-                return TypeDescKind.ANYDATA;
-            case ARRAY:
-                return TypeDescKind.ARRAY;
-            case BOOLEAN:
-                return TypeDescKind.BOOLEAN;
-            case BYTE:
-                return TypeDescKind.BYTE;
-            case DECIMAL:
-                return TypeDescKind.DECIMAL;
-            case FLOAT:
-                return TypeDescKind.FLOAT;
-            case HANDLE:
-                return TypeDescKind.HANDLE;
-            case INT:
-                return TypeDescKind.INT;
-            case NEVER:
-                return TypeDescKind.NEVER;
-            case NIL:
-                return TypeDescKind.NIL;
-            case STRING:
-                return TypeDescKind.STRING;
-            case JSON:
-                return TypeDescKind.JSON;
-            case XML:
-                return TypeDescKind.XML;
-            case FUNCTION:
-                return TypeDescKind.FUNCTION;
-            case FUTURE:
-                return TypeDescKind.FUTURE;
-            case MAP:
-                return TypeDescKind.MAP;
-            case OBJECT:
-                return TypeDescKind.OBJECT;
-            case STREAM:
-                return TypeDescKind.STREAM;
-            case TUPLE:
-                return TypeDescKind.TUPLE;
-            case TYPEDESC:
-                return TypeDescKind.TYPEDESC;
-            case UNION:
-                return TypeDescKind.UNION;
-            case INTERSECTION:
-                return TypeDescKind.INTERSECTION;
-            case ERROR:
-                return TypeDescKind.ERROR;
-            case NONE:
-            case OTHER:
-                return TypeDescKind.NONE;
-            case PARAMETERIZED:
-            case ANNOTATION:
-            case BLOB:
-            case CHANNEL:
-            case CONNECTOR:
-            case ENDPOINT:
-            case FINITE:
-            case PACKAGE:
-            case READONLY:
-            case SERVICE:
-            case TABLE:
-            case TYPEPARAM:
-            case VOID:
-            default:
-                return null;
-        }
+        return switch (bTypeKind) {
+            case ANY -> TypeDescKind.ANY;
+            case ANYDATA -> TypeDescKind.ANYDATA;
+            case ARRAY -> TypeDescKind.ARRAY;
+            case BOOLEAN -> TypeDescKind.BOOLEAN;
+            case BYTE -> TypeDescKind.BYTE;
+            case DECIMAL -> TypeDescKind.DECIMAL;
+            case FLOAT -> TypeDescKind.FLOAT;
+            case HANDLE -> TypeDescKind.HANDLE;
+            case INT -> TypeDescKind.INT;
+            case NEVER -> TypeDescKind.NEVER;
+            case NIL -> TypeDescKind.NIL;
+            case STRING -> TypeDescKind.STRING;
+            case JSON -> TypeDescKind.JSON;
+            case XML -> TypeDescKind.XML;
+            case FUNCTION -> TypeDescKind.FUNCTION;
+            case FUTURE -> TypeDescKind.FUTURE;
+            case MAP -> TypeDescKind.MAP;
+            case OBJECT -> TypeDescKind.OBJECT;
+            case STREAM -> TypeDescKind.STREAM;
+            case TUPLE -> TypeDescKind.TUPLE;
+            case TYPEDESC -> TypeDescKind.TYPEDESC;
+            case UNION -> TypeDescKind.UNION;
+            case INTERSECTION -> TypeDescKind.INTERSECTION;
+            case ERROR -> TypeDescKind.ERROR;
+            case NONE, OTHER -> TypeDescKind.NONE;
+            default -> null;
+        };
     }
 
     private static boolean isCustomError(BSymbol tSymbol) {
@@ -400,31 +348,29 @@ public class TypesFactory {
     }
 
     private static boolean isBuiltinNamedType(int tag) {
-        switch (tag) {
-            case INT:
-            case BYTE:
-            case FLOAT:
-            case DECIMAL:
-            case STRING:
-            case BOOLEAN:
-            case JSON:
-            case XML:
-            case NIL:
-            case ANY:
-            case ANYDATA:
-            case HANDLE:
-            case READONLY:
-            case NEVER:
-            case MAP:
-            case STREAM:
-            case TYPEDESC:
-            case TABLE:
-            case ERROR:
-            case FUTURE:
-            case SEMANTIC_ERROR:
-                return true;
-        }
-
-        return false;
+        return switch (tag) {
+            case INT,
+                 BYTE,
+                 FLOAT,
+                 DECIMAL,
+                 STRING,
+                 BOOLEAN,
+                 JSON,
+                 XML,
+                 NIL,
+                 ANY,
+                 ANYDATA,
+                 HANDLE,
+                 READONLY,
+                 NEVER,
+                 MAP,
+                 STREAM,
+                 TYPEDESC,
+                 TABLE,
+                 ERROR,
+                 FUTURE,
+                 SEMANTIC_ERROR -> true;
+            default -> false;
+        };
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/resourcepath/BallerinaPathSegmentList.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/resourcepath/BallerinaPathSegmentList.java
@@ -138,19 +138,11 @@ public class BallerinaPathSegmentList implements PathSegmentList {
         for (int i = 0, pathParamCount = 0, pathSegmentCount = this.internalPathSegmentSymbols.size();
              i < pathSegmentCount; i++) {
             BResourcePathSegmentSymbol pathSegmentSymbol = this.internalPathSegmentSymbols.get(i);
-            PathSegment segment;
-            switch (pathSegmentSymbol.getName().getValue()) {
-                case "$^":
-                case "^":
-                    segment = pathParams.get(pathParamCount++);
-                    break;
-                case "^^":
-                case "$^^":
-                    segment = pathRestParameter().get();
-                    break;
-                default:
-                    segment = symbolFactory.createPathNameSymbol(pathSegmentSymbol);
-            }
+            PathSegment segment = switch (pathSegmentSymbol.getName().getValue()) {
+                case "$^", "^" -> pathParams.get(pathParamCount++);
+                case "^^", "$^^" -> pathRestParameter().get();
+                default -> symbolFactory.createPathNameSymbol(pathSegmentSymbol);
+            };
             segments.add(segment);
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/type/builders/BallerinaSingletonTypeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/type/builders/BallerinaSingletonTypeBuilder.java
@@ -89,23 +89,16 @@ public class BallerinaSingletonTypeBuilder implements TypeBuilder.SINGLETON {
     }
 
     private boolean isValidValueType(Object value, TypeSymbol typeSymbol) {
-        switch (typeSymbol.typeKind()) {
-            case STRING:
-                return value instanceof String || value instanceof Character;
-            case INT:
-                return value instanceof Integer;
-            case DECIMAL:
-            case FLOAT:
-                return value instanceof Float || value instanceof Double;
-            case BYTE:
-                return value instanceof Byte;
-            case BOOLEAN:
-                return value instanceof Boolean;
-            case NIL:
-                return value.equals("()");
-        }
+        return switch (typeSymbol.typeKind()) {
+            case STRING -> value instanceof String || value instanceof Character;
+            case INT -> value instanceof Integer;
+            case DECIMAL, FLOAT -> value instanceof Float || value instanceof Double;
+            case BYTE -> value instanceof Byte;
+            case BOOLEAN -> value instanceof Boolean;
+            case NIL -> value.equals("()");
+            default -> false;
+        };
 
-        return false;
     }
 
     private BType getValueBType(TypeSymbol typeSymbol) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/util/SymbolUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/util/SymbolUtils.java
@@ -57,34 +57,22 @@ public class SymbolUtils {
         if (symbol == null) {
             return Optional.empty();
         }
-        switch (symbol.kind()) {
-            case TYPE_DEFINITION:
-                return Optional.ofNullable(((TypeDefinitionSymbol) symbol).typeDescriptor());
-            case VARIABLE:
-                return Optional.ofNullable(((VariableSymbol) symbol).typeDescriptor());
-            case PARAMETER:
-                return Optional.ofNullable(((ParameterSymbol) symbol).typeDescriptor());
-            case ANNOTATION:
-                return ((AnnotationSymbol) symbol).typeDescriptor();
-            case FUNCTION:
-            case METHOD:
-                return Optional.ofNullable(((FunctionSymbol) symbol).typeDescriptor());
-            case CONSTANT:
-            case ENUM_MEMBER:
-                return Optional.ofNullable(((ConstantSymbol) symbol).typeDescriptor());
-            case CLASS:
-                return Optional.of((ClassSymbol) symbol);
-            case RECORD_FIELD:
-                return Optional.ofNullable(((RecordFieldSymbol) symbol).typeDescriptor());
-            case OBJECT_FIELD:
-                return Optional.of(((ObjectFieldSymbol) symbol).typeDescriptor());
-            case CLASS_FIELD:
-                return Optional.of(((ClassFieldSymbol) symbol).typeDescriptor());
-            case TYPE:
-                return Optional.of((TypeSymbol) symbol);
-            default:
-                return Optional.empty();
-        }
+        return switch (symbol.kind()) {
+            case TYPE_DEFINITION -> Optional.ofNullable(((TypeDefinitionSymbol) symbol).typeDescriptor());
+            case VARIABLE -> Optional.ofNullable(((VariableSymbol) symbol).typeDescriptor());
+            case PARAMETER -> Optional.ofNullable(((ParameterSymbol) symbol).typeDescriptor());
+            case ANNOTATION -> ((AnnotationSymbol) symbol).typeDescriptor();
+            case FUNCTION,
+                 METHOD -> Optional.ofNullable(((FunctionSymbol) symbol).typeDescriptor());
+            case CONSTANT,
+                 ENUM_MEMBER -> Optional.ofNullable(((ConstantSymbol) symbol).typeDescriptor());
+            case CLASS -> Optional.of((ClassSymbol) symbol);
+            case RECORD_FIELD -> Optional.ofNullable(((RecordFieldSymbol) symbol).typeDescriptor());
+            case OBJECT_FIELD -> Optional.of(((ObjectFieldSymbol) symbol).typeDescriptor());
+            case CLASS_FIELD -> Optional.of(((ClassFieldSymbol) symbol).typeDescriptor());
+            case TYPE -> Optional.of((TypeSymbol) symbol);
+            default -> Optional.empty();
+        };
     }
 
     /**
@@ -94,24 +82,20 @@ public class SymbolUtils {
      * @return The bound type based on the kind of the input BType. Returns null if the kind is not supported.
      */
      public static BType getTypeParamBoundType(BType type) {
-        switch (type.getKind()) {
-            case MAP:
-                return ((BMapType) type).constraint;
-            case ARRAY:
-                return ((BArrayType) type).eType;
-            case TABLE:
-                return ((BTableType) type).constraint;
-            case STREAM:
-                return ((BStreamType) type).constraint;
-            case XML:
-                if (type.tag == TypeTags.XML) {
-                    return ((BXMLType) type).constraint;
-                }
-                return type;
-            // The following explicitly mentioned type kinds should be supported, but they are not for the moment.
-            case ERROR:
-            default:
-                return null;
-        }
+         return switch (type.getKind()) {
+             case MAP -> ((BMapType) type).constraint;
+             case ARRAY -> ((BArrayType) type).eType;
+             case TABLE -> ((BTableType) type).constraint;
+             case STREAM -> ((BStreamType) type).constraint;
+             case XML -> {
+                 if (type.tag == TypeTags.XML) {
+                     yield ((BXMLType) type).constraint;
+                 }
+                 yield type;
+             }
+             // The following explicitly mentioned type kinds should be supported, but they are not for the moment.
+             case ERROR -> null;
+             default -> null;
+         };
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeDescKind.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeDescKind.java
@@ -77,32 +77,26 @@ public enum TypeDescKind {
     }
 
     public boolean isIntegerType() {
-        switch (this) {
-            case INT:
-            case INT_SIGNED8:
-            case INT_UNSIGNED8:
-            case INT_SIGNED16:
-            case INT_UNSIGNED16:
-            case INT_SIGNED32:
-            case INT_UNSIGNED32:
-            case BYTE:
-                return true;
-        }
+        return switch (this) {
+            case INT,
+                 INT_SIGNED8,
+                 INT_UNSIGNED8,
+                 INT_SIGNED16,
+                 INT_UNSIGNED16,
+                 INT_SIGNED32,
+                 INT_UNSIGNED32,
+                 BYTE -> true;
+            default -> false;
+        };
 
-        return false;
     }
 
     public boolean isXMLType() {
-        switch (this) {
-            case XML:
-            case XML_COMMENT:
-            case XML_ELEMENT:
-            case XML_PROCESSING_INSTRUCTION:
-            case XML_TEXT:
-                return true;
-        }
+        return switch (this) {
+            case XML, XML_COMMENT, XML_ELEMENT, XML_PROCESSING_INSTRUCTION, XML_TEXT -> true;
+            default -> false;
+        };
 
-        return false;
     }
 
     public boolean isStringType() {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ProjectEnvironmentBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ProjectEnvironmentBuilder.java
@@ -59,18 +59,12 @@ public class ProjectEnvironmentBuilder {
         if (compilationCacheFactory != null) {
             compilationCache = compilationCacheFactory.createCompilationCache(project);
         } else {
-            switch (project.kind()) {
-                case BUILD_PROJECT:
-                    compilationCache = BuildProjectCompilationCache.from(project);
-                    break;
-                case SINGLE_FILE_PROJECT:
-                    compilationCache = TempDirCompilationCache.from(project);
-                    break;
-                case BALA_PROJECT:
-                    throw new IllegalStateException("BALAProject should always be created with a CompilationCache");
-                default:
-                    throw new UnsupportedOperationException("Unsupported ProjectKind: " + project.kind());
-            }
+            compilationCache = switch (project.kind()) {
+                case BUILD_PROJECT -> BuildProjectCompilationCache.from(project);
+                case SINGLE_FILE_PROJECT -> TempDirCompilationCache.from(project);
+                case BALA_PROJECT ->
+                        throw new IllegalStateException("BALAProject should always be created with a CompilationCache");
+            };
         }
         services.put(CompilationCache.class, compilationCache);
         return new DefaultProjectEnvironment(project, environment, services);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/TypeConverter.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/TypeConverter.java
@@ -301,17 +301,12 @@ public class TypeConverter {
         } else if (TypeTags.isStringTypeTag(type.tag)) {
             return "string";
         } else {
-            switch (type.tag) {
-                case FLOAT:
-                case DECIMAL:
-                    return "number";
-                case BOOLEAN:
-                    return "boolean";
-                case BYTE:
-                    return "integer";
-                default:
-                    return "";
-            }
+            return switch (type.tag) {
+                case FLOAT, DECIMAL -> "number";
+                case BOOLEAN -> "boolean";
+                case BYTE -> "integer";
+                default -> "";
+            };
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
@@ -416,18 +416,11 @@ public class RemotePackageRepository implements PackageRepository {
     private PackageResolutionRequest toPackageResolutionRequest(Collection<ResolutionRequest> resolutionRequests) {
         PackageResolutionRequest packageResolutionRequest = new PackageResolutionRequest();
         for (ResolutionRequest resolutionRequest : resolutionRequests) {
-            PackageResolutionRequest.Mode mode = PackageResolutionRequest.Mode.HARD;
-            switch (resolutionRequest.packageLockingMode()) {
-                case HARD:
-                    mode = PackageResolutionRequest.Mode.HARD;
-                    break;
-                case MEDIUM:
-                    mode = PackageResolutionRequest.Mode.MEDIUM;
-                    break;
-                case SOFT:
-                    mode = PackageResolutionRequest.Mode.SOFT;
-                    break;
-            }
+            PackageResolutionRequest.Mode mode = switch (resolutionRequest.packageLockingMode()) {
+                case HARD -> PackageResolutionRequest.Mode.HARD;
+                case MEDIUM -> PackageResolutionRequest.Mode.MEDIUM;
+                case SOFT -> PackageResolutionRequest.Mode.SOFT;
+            };
             String version = resolutionRequest.version().map(v -> v.value().toString()).orElse("");
             packageResolutionRequest.addPackage(resolutionRequest.orgName().value(),
                     resolutionRequest.packageName().value(),

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectPaths.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectPaths.java
@@ -238,15 +238,13 @@ public class ProjectPaths {
      */
     private static boolean isBallerinaRelatedToml(Path filepath) {
         String fileName = Optional.of(filepath.getFileName()).get().toString();
-        switch (fileName) {
-            case ProjectConstants.BALLERINA_TOML:
-            case ProjectConstants.CLOUD_TOML:
-            case ProjectConstants.CONFIGURATION_TOML:
-            case ProjectConstants.DEPENDENCIES_TOML:
-                return true;
-            default:
-                return false;
-        }
+        return switch (fileName) {
+            case ProjectConstants.BALLERINA_TOML,
+                 ProjectConstants.CLOUD_TOML,
+                 ProjectConstants.CONFIGURATION_TOML,
+                 ProjectConstants.DEPENDENCIES_TOML -> true;
+            default -> false;
+        };
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerPhase.java
@@ -57,30 +57,19 @@ public enum CompilerPhase {
     }
 
     public static CompilerPhase fromValue(String value) {
-        switch (value) {
-            case "define":
-                return DEFINE;
-            case "typeCheck":
-                return TYPE_CHECK;
-            case "codeAnalyze":
-                return CODE_ANALYZE;
-            case "documentationAnalyze":
-                return DOCUMENTATION_ANALYZE;
-            case "constantPropagation":
-                return CONSTANT_PROPAGATION;
-            case "compilerPlugin":
-                return COMPILER_PLUGIN;
-            case "desugar":
-                return DESUGAR;
-            case "codeGen":
-                return CODE_GEN;
-            case "birGen":
-                return BIR_GEN;
-            case "birEmit":
-                return BIR_EMIT;
-            default:
-                throw new IllegalArgumentException("invalid compiler phase: " + value);
-        }
+        return switch (value) {
+            case "define" -> DEFINE;
+            case "typeCheck" -> TYPE_CHECK;
+            case "codeAnalyze" -> CODE_ANALYZE;
+            case "documentationAnalyze" -> DOCUMENTATION_ANALYZE;
+            case "constantPropagation" -> CONSTANT_PROPAGATION;
+            case "compilerPlugin" -> COMPILER_PLUGIN;
+            case "desugar" -> DESUGAR;
+            case "codeGen" -> CODE_GEN;
+            case "birGen" -> BIR_GEN;
+            case "birEmit" -> BIR_EMIT;
+            default -> throw new IllegalArgumentException("invalid compiler phase: " + value);
+        };
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/SymbolOrigin.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/SymbolOrigin.java
@@ -110,17 +110,12 @@ public enum SymbolOrigin {
      * @return The corresponding enum value if there's a corresponding value. If not, an exception is thrown.
      */
     public static SymbolOrigin toOrigin(byte value) {
-        switch (value) {
-            case 1:
-                return BUILTIN;
-            case 2:
-                return SOURCE;
-            case 3:
-                return COMPILED_SOURCE;
-            case 4:
-                return VIRTUAL;
-            default:
-                throw new IllegalStateException("Invalid symbol origin value: " + value);
-        }
+        return switch (value) {
+            case 1 -> BUILTIN;
+            case 2 -> SOURCE;
+            case 3 -> COMPILED_SOURCE;
+            case 4 -> VIRTUAL;
+            default -> throw new IllegalStateException("Invalid symbol origin value: " + value);
+        };
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/XMLNavigationAccess.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/XMLNavigationAccess.java
@@ -50,16 +50,12 @@ public interface XMLNavigationAccess extends  VariableReferenceNode {
         }
 
         public static NavAccessType fromInt(int number) {
-            switch (number) {
-                case 0:
-                    return CHILD_ELEMS;
-                case 1:
-                    return CHILDREN;
-                case 2:
-                    return DESCENDANTS;
-                default:
-                    throw new IllegalArgumentException();
-            }
+            return switch (number) {
+                case 0 -> CHILD_ELEMS;
+                case 1 -> CHILDREN;
+                case 2 -> DESCENDANTS;
+                default -> throw new IllegalArgumentException();
+            };
         }
 
     }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/Transactions.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/Transactions.java
@@ -74,18 +74,13 @@ public class Transactions {
         }
 
         public static TransactionStatus getConst(int statusValue) {
-            switch (statusValue) {
-                case 0:
-                    return BLOCK_END;
-                case 1:
-                    return END;
-                case -1:
-                    return FAILED;
-                case -2:
-                    return ABORTED;
-                default:
-                    throw new IllegalArgumentException();
-            }
+            return switch (statusValue) {
+                case 0 -> BLOCK_END;
+                case 1 -> END;
+                case -1 -> FAILED;
+                case -2 -> ABORTED;
+                default -> throw new IllegalArgumentException();
+            };
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProgramDirectory.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProgramDirectory.java
@@ -174,15 +174,9 @@ public class FileSystemProgramDirectory implements SourceDirectory {
     }
 
     private String getTopLevelDirNameInPackage(CompilerOutputEntry.Kind kind, FileSystem fs) {
-        switch (kind) {
-            case SRC:
-            case BIR:
-            case OBJ:
-                return kind.getValue();
-            case ROOT:
-                return fs.getSeparator();
-
-        }
-        return null;
+        return switch (kind) {
+            case SRC, BIR, OBJ -> kind.getValue();
+            case ROOT -> fs.getSeparator();
+        };
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProjectDirectory.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProjectDirectory.java
@@ -208,15 +208,9 @@ public class FileSystemProjectDirectory extends FileSystemProgramDirectory {
     }
 
     private String getTopLevelDirNameInPackage(Kind kind, FileSystem fs) {
-        switch (kind) {
-            case SRC:
-            case BIR:
-            case OBJ:
-                return kind.getValue();
-            case ROOT:
-                return fs.getSeparator();
-
-        }
-        return null;
+        return switch (kind) {
+            case SRC, BIR, OBJ -> kind.getValue();
+            case ROOT -> fs.getSeparator();
+        };
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClassClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClassClosureDesugar.java
@@ -371,19 +371,14 @@ public class ClassClosureDesugar extends BLangNodeVisitor {
 
     private BVarSymbol createMapSymbolIfAbsent(BLangNode node, int closureMapCount) {
         NodeKind kind = node.getKind();
-        switch (kind) {
-            case BLOCK_FUNCTION_BODY:
-                return createMapSymbolIfAbsent((BLangBlockFunctionBody) node, closureMapCount);
-            case BLOCK:
-                return createMapSymbolIfAbsent((BLangBlockStmt) node, closureMapCount);
-            case FUNCTION:
-                return createMapSymbolIfAbsent((BLangFunction) node, closureMapCount);
-            case RESOURCE_FUNC:
-                return createMapSymbolIfAbsent((BLangResourceFunction) node, closureMapCount);
-            case CLASS_DEFN:
-                return createMapSymbolIfAbsent((BLangClassDefinition) node, closureMapCount);
-        }
-        return null;
+        return switch (kind) {
+            case BLOCK_FUNCTION_BODY -> createMapSymbolIfAbsent((BLangBlockFunctionBody) node, closureMapCount);
+            case BLOCK -> createMapSymbolIfAbsent((BLangBlockStmt) node, closureMapCount);
+            case FUNCTION -> createMapSymbolIfAbsent((BLangFunction) node, closureMapCount);
+            case RESOURCE_FUNC -> createMapSymbolIfAbsent((BLangResourceFunction) node, closureMapCount);
+            case CLASS_DEFN -> createMapSymbolIfAbsent((BLangClassDefinition) node, closureMapCount);
+            default -> null;
+        };
     }
 
     private BVarSymbol createMapSymbolIfAbsent(BLangBlockFunctionBody body, int closureMapCount) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -775,19 +775,14 @@ public class ClosureDesugar extends BLangNodeVisitor {
 
     private BVarSymbol createMapSymbolIfAbsent(BLangNode node, int closureMapCount) {
         NodeKind kind = node.getKind();
-        switch (kind) {
-            case BLOCK_FUNCTION_BODY:
-                return createMapSymbolIfAbsent((BLangBlockFunctionBody) node, closureMapCount);
-            case BLOCK:
-                return createMapSymbolIfAbsent((BLangBlockStmt) node, closureMapCount);
-            case FUNCTION:
-                return createMapSymbolIfAbsent((BLangFunction) node, closureMapCount);
-            case RESOURCE_FUNC:
-                return createMapSymbolIfAbsent((BLangResourceFunction) node, closureMapCount);
-            case CLASS_DEFN:
-                return createMapSymbolIfAbsent((BLangClassDefinition) node, closureMapCount);
-        }
-        return null;
+        return switch (kind) {
+            case BLOCK_FUNCTION_BODY -> createMapSymbolIfAbsent((BLangBlockFunctionBody) node, closureMapCount);
+            case BLOCK -> createMapSymbolIfAbsent((BLangBlockStmt) node, closureMapCount);
+            case FUNCTION -> createMapSymbolIfAbsent((BLangFunction) node, closureMapCount);
+            case RESOURCE_FUNC -> createMapSymbolIfAbsent((BLangResourceFunction) node, closureMapCount);
+            case CLASS_DEFN -> createMapSymbolIfAbsent((BLangClassDefinition) node, closureMapCount);
+            default -> null;
+        };
     }
 
     private BVarSymbol createMapSymbolIfAbsent(BLangBlockFunctionBody body, int closureMapCount) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
@@ -746,25 +746,21 @@ public class ClosureGenerator extends BLangNodeVisitor {
         if (parent == null) {
             return DOLLAR + name;
         }
-        switch (parent.getKind()) {
-            case CLASS_DEFN:
-                return generateName(((BLangClassDefinition) parent).name.getValue() + UNDERSCORE + name, parent.parent);
-            case FUNCTION:
-                name = ((BLangFunction) parent).symbol.name.value.replace(".", UNDERSCORE) + UNDERSCORE + name;
-                return generateName(name, parent.parent);
-            case RESOURCE_FUNC:
-                return generateName(((BLangResourceFunction) parent).name.value + UNDERSCORE + name, parent.parent);
-            case VARIABLE:
-                return generateName(((BLangSimpleVariable) parent).name.getValue() + UNDERSCORE + name, parent.parent);
-            case TYPE_DEFINITION:
-                return generateName(((BLangTypeDefinition) parent).name.getValue() + UNDERSCORE + name, parent.parent);
-            case RECORD_TYPE:
-                name = RECORD_DELIMITER + ((BLangRecordTypeNode) parent).symbol.name.getValue() + RECORD_DELIMITER
-                        + name;
-                return generateName(name, parent.parent);
-            default:
-                return generateName(name, parent.parent);
-        }
+        return switch (parent.getKind()) {
+            case CLASS_DEFN ->
+                    generateName(((BLangClassDefinition) parent).name.getValue() + UNDERSCORE + name, parent.parent);
+            case FUNCTION -> generateName(((BLangFunction) parent).symbol.name.value.replace(".", UNDERSCORE)
+                    + UNDERSCORE + name, parent.parent);
+            case RESOURCE_FUNC ->
+                    generateName(((BLangResourceFunction) parent).name.value + UNDERSCORE + name, parent.parent);
+            case VARIABLE ->
+                    generateName(((BLangSimpleVariable) parent).name.getValue() + UNDERSCORE + name, parent.parent);
+            case TYPE_DEFINITION ->
+                    generateName(((BLangTypeDefinition) parent).name.getValue() + UNDERSCORE + name, parent.parent);
+            case RECORD_TYPE -> generateName(RECORD_DELIMITER + ((BLangRecordTypeNode) parent).symbol.name.getValue()
+                    + RECORD_DELIMITER + name, parent.parent);
+            default -> generateName(name, parent.parent);
+        };
     }
     @Override
     public void visit(BLangTupleVariable varNode) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3717,26 +3717,24 @@ public class Desugar extends BLangNodeVisitor {
     private BLangExpression createConditionForMatchPattern(BLangMatchPattern matchPattern,
                                                            BLangSimpleVarRef matchExprVarRef) {
         NodeKind patternKind = matchPattern.getKind();
-        switch (patternKind) {
-            case WILDCARD_MATCH_PATTERN:
-                return createConditionForWildCardMatchPattern((BLangWildCardMatchPattern) matchPattern,
-                        matchExprVarRef);
-            case CONST_MATCH_PATTERN:
-                return createConditionForConstMatchPattern((BLangConstPattern) matchPattern, matchExprVarRef);
-            case VAR_BINDING_PATTERN_MATCH_PATTERN:
-                return createConditionForVarBindingPatternMatchPattern(
-                        (BLangVarBindingPatternMatchPattern) matchPattern, matchExprVarRef);
-            case LIST_MATCH_PATTERN:
-                return createConditionForListMatchPattern((BLangListMatchPattern) matchPattern, matchExprVarRef);
-            case MAPPING_MATCH_PATTERN:
-                return createConditionForMappingMatchPattern((BLangMappingMatchPattern) matchPattern, matchExprVarRef);
-            case ERROR_MATCH_PATTERN:
-                return createConditionForErrorMatchPattern((BLangErrorMatchPattern) matchPattern, matchExprVarRef);
-            default:
-                // If some patterns are not implemented, those should be detected before this phase
-                // TODO : Remove this after all patterns are implemented
-                return null;
-        }
+        return switch (patternKind) {
+            case WILDCARD_MATCH_PATTERN ->
+                    createConditionForWildCardMatchPattern((BLangWildCardMatchPattern) matchPattern,
+                            matchExprVarRef);
+            case CONST_MATCH_PATTERN ->
+                    createConditionForConstMatchPattern((BLangConstPattern) matchPattern, matchExprVarRef);
+            case VAR_BINDING_PATTERN_MATCH_PATTERN -> createConditionForVarBindingPatternMatchPattern(
+                    (BLangVarBindingPatternMatchPattern) matchPattern, matchExprVarRef);
+            case LIST_MATCH_PATTERN ->
+                    createConditionForListMatchPattern((BLangListMatchPattern) matchPattern, matchExprVarRef);
+            case MAPPING_MATCH_PATTERN ->
+                    createConditionForMappingMatchPattern((BLangMappingMatchPattern) matchPattern, matchExprVarRef);
+            case ERROR_MATCH_PATTERN ->
+                    createConditionForErrorMatchPattern((BLangErrorMatchPattern) matchPattern, matchExprVarRef);
+            // If some patterns are not implemented, those should be detected before this phase
+            // TODO : Remove this after all patterns are implemented
+            default -> null;
+        };
     }
 
     private BLangExpression createConditionForWildCardMatchPattern(BLangWildCardMatchPattern wildCardMatchPattern,
@@ -3864,23 +3862,22 @@ public class Desugar extends BLangNodeVisitor {
 
     private BLangExpression createVarCheckCondition(BLangBindingPattern bindingPattern, BLangSimpleVarRef varRef) {
         NodeKind bindingPatternKind = bindingPattern.getKind();
-        switch (bindingPatternKind) {
-            case WILDCARD_BINDING_PATTERN:
-                return createConditionForWildCardBindingPattern((BLangWildCardBindingPattern) bindingPattern, varRef);
-            case CAPTURE_BINDING_PATTERN:
-                return createConditionForCaptureBindingPattern((BLangCaptureBindingPattern) bindingPattern, varRef);
-            case LIST_BINDING_PATTERN:
-                return createVarCheckConditionForListBindingPattern((BLangListBindingPattern) bindingPattern, varRef);
-            case MAPPING_BINDING_PATTERN:
-                return createVarCheckConditionForMappingBindingPattern((BLangMappingBindingPattern) bindingPattern,
-                        varRef);
-            case ERROR_BINDING_PATTERN:
-                return createConditionForErrorBindingPattern((BLangErrorBindingPattern) bindingPattern, varRef);
-            default:
-                // If some patterns are not implemented, those should be detected before this phase
-                // TODO : Remove this after all patterns are implemented
-                return null;
-        }
+        return switch (bindingPatternKind) {
+            case WILDCARD_BINDING_PATTERN ->
+                    createConditionForWildCardBindingPattern((BLangWildCardBindingPattern) bindingPattern, varRef);
+            case CAPTURE_BINDING_PATTERN ->
+                    createConditionForCaptureBindingPattern((BLangCaptureBindingPattern) bindingPattern, varRef);
+            case LIST_BINDING_PATTERN ->
+                    createVarCheckConditionForListBindingPattern((BLangListBindingPattern) bindingPattern, varRef);
+            case MAPPING_BINDING_PATTERN ->
+                    createVarCheckConditionForMappingBindingPattern((BLangMappingBindingPattern) bindingPattern,
+                            varRef);
+            case ERROR_BINDING_PATTERN ->
+                    createConditionForErrorBindingPattern((BLangErrorBindingPattern) bindingPattern, varRef);
+            // If some patterns are not implemented, those should be detected before this phase
+            // TODO : Remove this after all patterns are implemented
+            default -> null;
+        };
     }
 
     private BLangExpression createVarCheckConditionForListBindingPattern(BLangListBindingPattern listBindingPattern,
@@ -3955,26 +3952,25 @@ public class Desugar extends BLangNodeVisitor {
         BLangBindingPattern bindingPattern = varBindingPatternMatchPattern.getBindingPattern();
         Location pos = bindingPattern.pos;
 
-        switch (bindingPattern.getKind()) {
-            case WILDCARD_BINDING_PATTERN:
-                return createConditionForWildCardBindingPattern((BLangWildCardBindingPattern) bindingPattern,
-                        matchExprVarRef);
-            case CAPTURE_BINDING_PATTERN:
-                return createConditionForCaptureBindingPattern((BLangCaptureBindingPattern) bindingPattern,
-                        matchExprVarRef, pos);
-            case LIST_BINDING_PATTERN:
-                return createConditionForListBindingPattern((BLangListBindingPattern) bindingPattern, matchExprVarRef);
-            case MAPPING_BINDING_PATTERN:
-                return createConditionForMappingBindingPattern((BLangMappingBindingPattern) bindingPattern,
-                        matchExprVarRef);
-            case ERROR_BINDING_PATTERN:
-                return createConditionForErrorBindingPattern((BLangErrorBindingPattern) bindingPattern,
-                        matchExprVarRef);
-            default:
-                // If some patterns are not implemented, those should be detected before this phase
-                // TODO : Remove this after all patterns are implemented
-                return null;
-        }
+        return switch (bindingPattern.getKind()) {
+            case WILDCARD_BINDING_PATTERN ->
+                    createConditionForWildCardBindingPattern((BLangWildCardBindingPattern) bindingPattern,
+                            matchExprVarRef);
+            case CAPTURE_BINDING_PATTERN ->
+                    createConditionForCaptureBindingPattern((BLangCaptureBindingPattern) bindingPattern,
+                            matchExprVarRef, pos);
+            case LIST_BINDING_PATTERN ->
+                    createConditionForListBindingPattern((BLangListBindingPattern) bindingPattern, matchExprVarRef);
+            case MAPPING_BINDING_PATTERN ->
+                    createConditionForMappingBindingPattern((BLangMappingBindingPattern) bindingPattern,
+                            matchExprVarRef);
+            case ERROR_BINDING_PATTERN ->
+                    createConditionForErrorBindingPattern((BLangErrorBindingPattern) bindingPattern,
+                            matchExprVarRef);
+            // If some patterns are not implemented, those should be detected before this phase
+            // TODO : Remove this after all patterns are implemented
+            default -> null;
+        };
     }
 
     private BLangExpression createConditionForCaptureBindingPattern(BLangCaptureBindingPattern captureBindingPattern,
@@ -4449,25 +4445,23 @@ public class Desugar extends BLangNodeVisitor {
     private BLangExpression createVarCheckCondition(BLangMatchPattern matchPattern, BLangSimpleVarRef varRef) {
 
         NodeKind patternKind = matchPattern.getKind();
-        switch (patternKind) {
-            case WILDCARD_MATCH_PATTERN:
-                return createConditionForWildCardMatchPattern((BLangWildCardMatchPattern) matchPattern, varRef);
-            case CONST_MATCH_PATTERN:
-                return createConditionForConstMatchPattern((BLangConstPattern) matchPattern, varRef);
-            case VAR_BINDING_PATTERN_MATCH_PATTERN:
-                return createVarCheckCondition(((BLangVarBindingPatternMatchPattern) matchPattern).getBindingPattern(),
-                        varRef);
-            case LIST_MATCH_PATTERN:
-                return createVarCheckConditionForListMatchPattern((BLangListMatchPattern) matchPattern, varRef);
-            case MAPPING_MATCH_PATTERN:
-                return createVarCheckConditionForMappingMatchPattern((BLangMappingMatchPattern) matchPattern, varRef);
-            case ERROR_MATCH_PATTERN:
-                return createConditionForErrorMatchPattern((BLangErrorMatchPattern) matchPattern, varRef);
-            default:
-                // If some patterns are not implemented, those should be detected before this phase
-                // TODO : Remove this after all patterns are implemented
-                return null;
-        }
+        return switch (patternKind) {
+            case WILDCARD_MATCH_PATTERN ->
+                    createConditionForWildCardMatchPattern((BLangWildCardMatchPattern) matchPattern, varRef);
+            case CONST_MATCH_PATTERN -> createConditionForConstMatchPattern((BLangConstPattern) matchPattern, varRef);
+            case VAR_BINDING_PATTERN_MATCH_PATTERN ->
+                    createVarCheckCondition(((BLangVarBindingPatternMatchPattern) matchPattern).getBindingPattern(),
+                            varRef);
+            case LIST_MATCH_PATTERN ->
+                    createVarCheckConditionForListMatchPattern((BLangListMatchPattern) matchPattern, varRef);
+            case MAPPING_MATCH_PATTERN ->
+                    createVarCheckConditionForMappingMatchPattern((BLangMappingMatchPattern) matchPattern, varRef);
+            case ERROR_MATCH_PATTERN ->
+                    createConditionForErrorMatchPattern((BLangErrorMatchPattern) matchPattern, varRef);
+            // If some patterns are not implemented, those should be detected before this phase
+            // TODO : Remove this after all patterns are implemented
+            default -> null;
+        };
     }
 
     private BLangExpression createVarCheckConditionForMappingBindingPattern(BLangMappingBindingPattern
@@ -10367,15 +10361,12 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangValueExpression cloneExpression(BLangExpression expr) {
-        switch (expr.getKind()) {
-            case SIMPLE_VARIABLE_REF:
-                return ASTBuilderUtil.createVariableRef(expr.pos, ((BLangSimpleVarRef) expr).symbol);
-            case FIELD_BASED_ACCESS_EXPR:
-            case INDEX_BASED_ACCESS_EXPR:
-                return cloneAccessExpr((BLangAccessExpression) expr);
-            default:
-                throw new IllegalStateException();
-        }
+        return switch (expr.getKind()) {
+            case SIMPLE_VARIABLE_REF -> ASTBuilderUtil.createVariableRef(expr.pos, ((BLangSimpleVarRef) expr).symbol);
+            case FIELD_BASED_ACCESS_EXPR,
+                 INDEX_BASED_ACCESS_EXPR -> cloneAccessExpr((BLangAccessExpression) expr);
+            default -> throw new IllegalStateException();
+        };
     }
 
     private BLangAccessExpression cloneAccessExpr(BLangAccessExpression originalAccessExpr) {
@@ -10392,19 +10383,13 @@ public class Desugar extends BLangNodeVisitor {
         }
         varRef.setBType(types.getSafeType(originalAccessExpr.expr.getBType(), true, false));
 
-        BLangAccessExpression accessExpr;
-        switch (originalAccessExpr.getKind()) {
-            case FIELD_BASED_ACCESS_EXPR:
-                accessExpr = ASTBuilderUtil.createFieldAccessExpr(varRef,
-                        ((BLangFieldBasedAccess) originalAccessExpr).field);
-                break;
-            case INDEX_BASED_ACCESS_EXPR:
-                accessExpr = ASTBuilderUtil.createIndexAccessExpr(varRef,
-                        ((BLangIndexBasedAccess) originalAccessExpr).indexExpr);
-                break;
-            default:
-                throw new IllegalStateException();
-        }
+        BLangAccessExpression accessExpr = switch (originalAccessExpr.getKind()) {
+            case FIELD_BASED_ACCESS_EXPR -> ASTBuilderUtil.createFieldAccessExpr(varRef,
+                    ((BLangFieldBasedAccess) originalAccessExpr).field);
+            case INDEX_BASED_ACCESS_EXPR -> ASTBuilderUtil.createIndexAccessExpr(varRef,
+                    ((BLangIndexBasedAccess) originalAccessExpr).indexExpr);
+            default -> throw new IllegalStateException();
+        };
 
         accessExpr.originalType = originalAccessExpr.originalType;
         accessExpr.pos = originalAccessExpr.pos;
@@ -10529,18 +10514,15 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     protected boolean isMappingOrObjectConstructorOrObjInit(BLangExpression expression) {
-        switch (expression.getKind()) {
-            case TYPE_INIT_EXPR:
-            case RECORD_LITERAL_EXPR:
-            case OBJECT_CTOR_EXPRESSION:
-                return true;
-            case CHECK_EXPR:
-                return isMappingOrObjectConstructorOrObjInit(((BLangCheckedExpr) expression).expr);
-            case TYPE_CONVERSION_EXPR:
-                return isMappingOrObjectConstructorOrObjInit(((BLangTypeConversionExpr) expression).expr);
-            default:
-                return false;
-        }
+        return switch (expression.getKind()) {
+            case TYPE_INIT_EXPR,
+                 RECORD_LITERAL_EXPR,
+                 OBJECT_CTOR_EXPRESSION -> true;
+            case CHECK_EXPR -> isMappingOrObjectConstructorOrObjInit(((BLangCheckedExpr) expression).expr);
+            case TYPE_CONVERSION_EXPR ->
+                    isMappingOrObjectConstructorOrObjInit(((BLangTypeConversionExpr) expression).expr);
+            default -> false;
+        };
     }
 
     private BType getRestType(BInvokableSymbol invokableSymbol) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -365,17 +365,17 @@ public class QueryDesugar extends BLangNodeVisitor {
         if (TypeTags.isXMLTypeTag(refType.tag)) {
             return true;
         }
-        switch (refType.tag) {
-            case TypeTags.UNION:
+        return switch (refType.tag) {
+            case TypeTags.UNION -> {
                 for (BType memberType : ((BUnionType) refType).getMemberTypes()) {
                     if (!isXml(memberType)) {
-                        return false;
+                        yield false;
                     }
                 }
-                return true;
-            default:
-                return false;
-        }
+                yield true;
+            }
+            default -> false;
+        };
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
@@ -1158,15 +1158,11 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
     }
 
     private TypeKind getParameterizedTypeKind(SyntaxKind syntaxKind) {
-        switch (syntaxKind) {
-            case TYPEDESC_TYPE_DESC:
-                return TypeKind.TYPEDESC;
-            case FUTURE_TYPE_DESC:
-                return TypeKind.FUTURE;
-            case XML_TYPE_DESC:
-            default:
-                return TypeKind.XML;
-        }
+        return switch (syntaxKind) {
+            case TYPEDESC_TYPE_DESC -> TypeKind.TYPEDESC;
+            case FUTURE_TYPE_DESC -> TypeKind.FUTURE;
+            default -> TypeKind.XML;
+        };
     }
     
     private BLangNode transformErrorTypeDescriptor(ParameterizedTypeDescriptorNode parameterizedTypeDescNode) {
@@ -1963,18 +1959,13 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
             switch (firstIndent.kind()) {
                 case OBJECT_KEYWORD:
                     Token secondIndent = idents.get(1);
-                    switch (secondIndent.kind()) {
-                        case FUNCTION_KEYWORD:
-                            bLAttachPoint =
-                                    AttachPoint.getAttachmentPoint(AttachPoint.Point.OBJECT_METHOD.getValue(), source);
-                            break;
-                        case FIELD_KEYWORD:
-                            bLAttachPoint =
-                                    AttachPoint.getAttachmentPoint(AttachPoint.Point.OBJECT_FIELD.getValue(), source);
-                            break;
-                        default:
-                            throw new RuntimeException("Syntax kind is not supported: " + secondIndent.kind());
-                    }
+                    bLAttachPoint = switch (secondIndent.kind()) {
+                        case FUNCTION_KEYWORD ->
+                                AttachPoint.getAttachmentPoint(AttachPoint.Point.OBJECT_METHOD.getValue(), source);
+                        case FIELD_KEYWORD ->
+                                AttachPoint.getAttachmentPoint(AttachPoint.Point.OBJECT_FIELD.getValue(), source);
+                        default -> throw new RuntimeException("Syntax kind is not supported: " + secondIndent.kind());
+                    };
                     break;
                 case SERVICE_KEYWORD:
                     String value;
@@ -2429,54 +2420,50 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
     @Override
     public BLangNode transform(Token token) {
         SyntaxKind kind = token.kind();
-        switch (kind) {
-            case XML_TEXT_CONTENT:
-            case TEMPLATE_STRING:
-            case CLOSE_BRACE_TOKEN:
-                return createSimpleLiteral(token);
-            default:
+        return switch (kind) {
+            case XML_TEXT_CONTENT, TEMPLATE_STRING, CLOSE_BRACE_TOKEN -> createSimpleLiteral(token);
+            default -> {
                 if (isTokenInRegExp(kind)) {
-                    return createSimpleLiteral(token);
+                    yield createSimpleLiteral(token);
                 }
                 throw new RuntimeException("Syntax kind is not supported: " + kind);
-        }
+            }
+        };
     }
 
     private boolean isTokenInRegExp(SyntaxKind kind) {
-        switch (kind) {
-            case RE_LITERAL_CHAR:
-            case RE_CONTROL_ESCAPE:
-            case RE_NUMERIC_ESCAPE:
-            case RE_SIMPLE_CHAR_CLASS_CODE:
-            case RE_PROPERTY:
-            case RE_UNICODE_SCRIPT_START:
-            case RE_UNICODE_PROPERTY_VALUE:
-            case RE_UNICODE_GENERAL_CATEGORY_START:
-            case RE_UNICODE_GENERAL_CATEGORY_NAME:
-            case RE_FLAGS_VALUE:
-            case DIGIT:
-            case ASTERISK_TOKEN:
-            case PLUS_TOKEN:
-            case QUESTION_MARK_TOKEN:
-            case DOT_TOKEN:
-            case OPEN_BRACE_TOKEN:
-            case CLOSE_BRACE_TOKEN:
-            case OPEN_BRACKET_TOKEN:
-            case CLOSE_BRACKET_TOKEN:
-            case OPEN_PAREN_TOKEN:
-            case CLOSE_PAREN_TOKEN:
-            case DOLLAR_TOKEN:
-            case BITWISE_XOR_TOKEN:
-            case COLON_TOKEN:
-            case BACK_SLASH_TOKEN:
-            case MINUS_TOKEN:
-            case ESCAPED_MINUS_TOKEN:
-            case PIPE_TOKEN:
-            case COMMA_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (kind) {
+            case RE_LITERAL_CHAR,
+                 RE_CONTROL_ESCAPE,
+                 RE_NUMERIC_ESCAPE,
+                 RE_SIMPLE_CHAR_CLASS_CODE,
+                 RE_PROPERTY,
+                 RE_UNICODE_SCRIPT_START,
+                 RE_UNICODE_PROPERTY_VALUE,
+                 RE_UNICODE_GENERAL_CATEGORY_START,
+                 RE_UNICODE_GENERAL_CATEGORY_NAME,
+                 RE_FLAGS_VALUE,
+                 DIGIT,
+                 ASTERISK_TOKEN,
+                 PLUS_TOKEN,
+                 QUESTION_MARK_TOKEN,
+                 DOT_TOKEN,
+                 OPEN_BRACE_TOKEN,
+                 CLOSE_BRACE_TOKEN,
+                 OPEN_BRACKET_TOKEN,
+                 CLOSE_BRACKET_TOKEN,
+                 OPEN_PAREN_TOKEN,
+                 CLOSE_PAREN_TOKEN,
+                 DOLLAR_TOKEN,
+                 BITWISE_XOR_TOKEN,
+                 COLON_TOKEN,
+                 BACK_SLASH_TOKEN,
+                 MINUS_TOKEN,
+                 ESCAPED_MINUS_TOKEN,
+                 PIPE_TOKEN,
+                 COMMA_TOKEN -> true;
+            default -> false;
+        };
     }
 
     @Override
@@ -4444,14 +4431,11 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
             for (Node node : xmlNamePatternChainingNode.xmlNamePattern()) {
                 filters.add(createXMLElementFilter(node));
             }
-            switch (xmlNamePatternChainingNode.startToken().kind()) {
-                case DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN:
-                    starCount = 2;
-                    break;
-                case SLASH_ASTERISK_TOKEN:
-                    starCount = 1;
-                    break;
-            }
+            starCount = switch (xmlNamePatternChainingNode.startToken().kind()) {
+                case DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN -> 2;
+                case SLASH_ASTERISK_TOKEN -> 1;
+                default -> starCount;
+            };
         }
 
         BLangExpression expr = createExpression(xmlStepExpressionNode.expression());
@@ -4839,26 +4823,22 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
     private BLangBindingPattern transformBindingPattern(Node bindingPattern) {
         Location pos = getPosition(bindingPattern);
         SyntaxKind patternKind = bindingPattern.kind();
-        switch (patternKind) {
-            case CAPTURE_BINDING_PATTERN:
-                return transformCaptureBindingPattern((CaptureBindingPatternNode) bindingPattern, pos);
-            case LIST_BINDING_PATTERN:
-                return transformListBindingPattern((ListBindingPatternNode) bindingPattern, pos);
-            case NAMED_ARG_BINDING_PATTERN:
-                return transformNamedArgBindingPattern((NamedArgBindingPatternNode) bindingPattern, pos);
-            case REST_BINDING_PATTERN:
-                return transformRestBindingPattern((RestBindingPatternNode) bindingPattern, pos);
-            case MAPPING_BINDING_PATTERN:
-                return transformMappingBindingPattern((MappingBindingPatternNode) bindingPattern, pos);
-            case FIELD_BINDING_PATTERN:
-                return transformFieldBindingPattern(bindingPattern, pos);
-            case ERROR_BINDING_PATTERN:
-                return transformErrorBindingPattern((ErrorBindingPatternNode) bindingPattern, pos);
-            case WILDCARD_BINDING_PATTERN:
-            default:
+        return switch (patternKind) {
+            case CAPTURE_BINDING_PATTERN ->
+                    transformCaptureBindingPattern((CaptureBindingPatternNode) bindingPattern, pos);
+            case LIST_BINDING_PATTERN -> transformListBindingPattern((ListBindingPatternNode) bindingPattern, pos);
+            case NAMED_ARG_BINDING_PATTERN ->
+                    transformNamedArgBindingPattern((NamedArgBindingPatternNode) bindingPattern, pos);
+            case REST_BINDING_PATTERN -> transformRestBindingPattern((RestBindingPatternNode) bindingPattern, pos);
+            case MAPPING_BINDING_PATTERN ->
+                    transformMappingBindingPattern((MappingBindingPatternNode) bindingPattern, pos);
+            case FIELD_BINDING_PATTERN -> transformFieldBindingPattern(bindingPattern, pos);
+            case ERROR_BINDING_PATTERN -> transformErrorBindingPattern((ErrorBindingPatternNode) bindingPattern, pos);
+            default -> {
                 assert patternKind == SyntaxKind.WILDCARD_BINDING_PATTERN;
-                return transformWildCardBindingPattern(pos);
-        }
+                yield transformWildCardBindingPattern(pos);
+            }
+        };
     }
 
     private BLangWildCardBindingPattern transformWildCardBindingPattern(Location pos) {
@@ -6658,28 +6638,18 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
     }
 
     private DocumentationReferenceType stringToRefType(String refTypeName) {
-        switch (refTypeName) {
-            case "type":
-                return DocumentationReferenceType.TYPE;
-            case "service":
-                return DocumentationReferenceType.SERVICE;
-            case "variable":
-                return DocumentationReferenceType.VARIABLE;
-            case "var":
-                return DocumentationReferenceType.VAR;
-            case "annotation":
-                return DocumentationReferenceType.ANNOTATION;
-            case "module":
-                return DocumentationReferenceType.MODULE;
-            case "function":
-                return DocumentationReferenceType.FUNCTION;
-            case "parameter":
-                return DocumentationReferenceType.PARAMETER;
-            case "const":
-                return DocumentationReferenceType.CONST;
-            default:
-                return DocumentationReferenceType.BACKTICK_CONTENT;
-        }
+        return switch (refTypeName) {
+            case "type" -> DocumentationReferenceType.TYPE;
+            case "service" -> DocumentationReferenceType.SERVICE;
+            case "variable" -> DocumentationReferenceType.VARIABLE;
+            case "var" -> DocumentationReferenceType.VAR;
+            case "annotation" -> DocumentationReferenceType.ANNOTATION;
+            case "module" -> DocumentationReferenceType.MODULE;
+            case "function" -> DocumentationReferenceType.FUNCTION;
+            case "parameter" -> DocumentationReferenceType.PARAMETER;
+            case "const" -> DocumentationReferenceType.CONST;
+            default -> DocumentationReferenceType.BACKTICK_CONTENT;
+        };
     }
 
     private Object getIntegerLiteral(Node literal, String nodeValue) {
@@ -6768,56 +6738,48 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
     }
 
     private boolean isSimpleLiteral(SyntaxKind syntaxKind) {
-        switch (syntaxKind) {
-            case STRING_LITERAL:
-            case NUMERIC_LITERAL:
-            case BOOLEAN_LITERAL:
-            case NIL_LITERAL:
-            case NULL_LITERAL:
-                return true;
-            default:
-                return false;
-        }
+        return switch (syntaxKind) {
+            case STRING_LITERAL, NUMERIC_LITERAL, BOOLEAN_LITERAL, NIL_LITERAL, NULL_LITERAL -> true;
+            default -> false;
+        };
     }
 
     static boolean isType(SyntaxKind nodeKind) {
-        switch (nodeKind) {
-            case RECORD_TYPE_DESC:
-            case OBJECT_TYPE_DESC:
-            case NIL_TYPE_DESC:
-            case OPTIONAL_TYPE_DESC:
-            case ARRAY_TYPE_DESC:
-            case INT_TYPE_DESC:
-            case BYTE_TYPE_DESC:
-            case FLOAT_TYPE_DESC:
-            case DECIMAL_TYPE_DESC:
-            case STRING_TYPE_DESC:
-            case BOOLEAN_TYPE_DESC:
-            case XML_TYPE_DESC:
-            case JSON_TYPE_DESC:
-            case HANDLE_TYPE_DESC:
-            case ANY_TYPE_DESC:
-            case ANYDATA_TYPE_DESC:
-            case NEVER_TYPE_DESC:
-            case VAR_TYPE_DESC:
-            case SERVICE_TYPE_DESC:
-            case MAP_TYPE_DESC:
-            case UNION_TYPE_DESC:
-            case ERROR_TYPE_DESC:
-            case STREAM_TYPE_DESC:
-            case TABLE_TYPE_DESC:
-            case FUNCTION_TYPE_DESC:
-            case TUPLE_TYPE_DESC:
-            case PARENTHESISED_TYPE_DESC:
-            case READONLY_TYPE_DESC:
-            case DISTINCT_TYPE_DESC:
-            case INTERSECTION_TYPE_DESC:
-            case SINGLETON_TYPE_DESC:
-            case TYPE_REFERENCE_TYPE_DESC:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nodeKind) {
+            case RECORD_TYPE_DESC,
+                 OBJECT_TYPE_DESC,
+                 NIL_TYPE_DESC,
+                 OPTIONAL_TYPE_DESC,
+                 ARRAY_TYPE_DESC,
+                 INT_TYPE_DESC,
+                 BYTE_TYPE_DESC,
+                 FLOAT_TYPE_DESC,
+                 DECIMAL_TYPE_DESC,
+                 STRING_TYPE_DESC,
+                 BOOLEAN_TYPE_DESC,
+                 XML_TYPE_DESC,
+                 JSON_TYPE_DESC,
+                 HANDLE_TYPE_DESC,
+                 ANY_TYPE_DESC,
+                 ANYDATA_TYPE_DESC,
+                 NEVER_TYPE_DESC,
+                 VAR_TYPE_DESC,
+                 SERVICE_TYPE_DESC,
+                 MAP_TYPE_DESC,
+                 UNION_TYPE_DESC,
+                 ERROR_TYPE_DESC,
+                 STREAM_TYPE_DESC,
+                 TABLE_TYPE_DESC,
+                 FUNCTION_TYPE_DESC,
+                 TUPLE_TYPE_DESC,
+                 PARENTHESISED_TYPE_DESC,
+                 READONLY_TYPE_DESC,
+                 DISTINCT_TYPE_DESC,
+                 INTERSECTION_TYPE_DESC,
+                 SINGLETON_TYPE_DESC,
+                 TYPE_REFERENCE_TYPE_DESC -> true;
+            default -> false;
+        };
     }
 
     private boolean isInTypeDefinitionContext(Node parent) {
@@ -6831,12 +6793,10 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
     }
 
     private boolean isNumericLiteral(SyntaxKind syntaxKind) {
-        switch (syntaxKind) {
-            case NUMERIC_LITERAL:
-                return true;
-            default:
-                return false;
-        }
+        return switch (syntaxKind) {
+            case NUMERIC_LITERAL -> true;
+            default -> false;
+        };
     }
 
     private boolean isPresent(Node node) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -878,29 +878,22 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
             return false;
         }
 
-        switch (firstPatternKind) {
-            case WILDCARD_MATCH_PATTERN:
-            case REST_MATCH_PATTERN:
-                return true;
-            case CONST_MATCH_PATTERN:
-                return checkSimilarConstMatchPattern((BLangConstPattern) firstPattern,
-                        (BLangConstPattern) secondPattern);
-            case VAR_BINDING_PATTERN_MATCH_PATTERN:
-                return checkSimilarBindingPatterns(
-                        ((BLangVarBindingPatternMatchPattern) firstPattern).getBindingPattern(),
-                        ((BLangVarBindingPatternMatchPattern) secondPattern).getBindingPattern());
-            case LIST_MATCH_PATTERN:
-                return checkSimilarListMatchPattern((BLangListMatchPattern) firstPattern,
-                        (BLangListMatchPattern) secondPattern);
-            case MAPPING_MATCH_PATTERN:
-                return checkSimilarMappingMatchPattern((BLangMappingMatchPattern) firstPattern,
-                        (BLangMappingMatchPattern) secondPattern);
-            case ERROR_MATCH_PATTERN:
-                return checkSimilarErrorMatchPattern((BLangErrorMatchPattern) firstPattern,
-                        (BLangErrorMatchPattern) secondPattern);
-            default:
-                return false;
-        }
+        return switch (firstPatternKind) {
+            case WILDCARD_MATCH_PATTERN,
+                 REST_MATCH_PATTERN -> true;
+            case CONST_MATCH_PATTERN -> checkSimilarConstMatchPattern((BLangConstPattern) firstPattern,
+                    (BLangConstPattern) secondPattern);
+            case VAR_BINDING_PATTERN_MATCH_PATTERN -> checkSimilarBindingPatterns(
+                    ((BLangVarBindingPatternMatchPattern) firstPattern).getBindingPattern(),
+                    ((BLangVarBindingPatternMatchPattern) secondPattern).getBindingPattern());
+            case LIST_MATCH_PATTERN -> checkSimilarListMatchPattern((BLangListMatchPattern) firstPattern,
+                    (BLangListMatchPattern) secondPattern);
+            case MAPPING_MATCH_PATTERN -> checkSimilarMappingMatchPattern((BLangMappingMatchPattern) firstPattern,
+                    (BLangMappingMatchPattern) secondPattern);
+            case ERROR_MATCH_PATTERN -> checkSimilarErrorMatchPattern((BLangErrorMatchPattern) firstPattern,
+                    (BLangErrorMatchPattern) secondPattern);
+            default -> false;
+        };
     }
 
     private boolean checkEmptyListOrMapMatchWithVarBindingPatternMatch(BLangMatchPattern firstPattern,
@@ -1162,23 +1155,20 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
             return false;
         }
 
-        switch (firstBindingPatternKind) {
-            case WILDCARD_BINDING_PATTERN:
-            case REST_BINDING_PATTERN:
-            case CAPTURE_BINDING_PATTERN:
-                return true;
-            case LIST_BINDING_PATTERN:
-                return checkSimilarListBindingPatterns((BLangListBindingPattern) firstBidingPattern,
-                        (BLangListBindingPattern) secondBindingPattern);
-            case MAPPING_BINDING_PATTERN:
-                return checkSimilarMappingBindingPattern((BLangMappingBindingPattern) firstBidingPattern,
-                        (BLangMappingBindingPattern) secondBindingPattern);
-            case ERROR_BINDING_PATTERN:
-                return checkSimilarErrorBindingPatterns((BLangErrorBindingPattern) firstBidingPattern,
-                        (BLangErrorBindingPattern) secondBindingPattern);
-            default:
-                return false;
-        }
+        return switch (firstBindingPatternKind) {
+            case WILDCARD_BINDING_PATTERN,
+                 REST_BINDING_PATTERN,
+                 CAPTURE_BINDING_PATTERN -> true;
+            case LIST_BINDING_PATTERN -> checkSimilarListBindingPatterns((BLangListBindingPattern) firstBidingPattern,
+                    (BLangListBindingPattern) secondBindingPattern);
+            case MAPPING_BINDING_PATTERN ->
+                    checkSimilarMappingBindingPattern((BLangMappingBindingPattern) firstBidingPattern,
+                            (BLangMappingBindingPattern) secondBindingPattern);
+            case ERROR_BINDING_PATTERN ->
+                    checkSimilarErrorBindingPatterns((BLangErrorBindingPattern) firstBidingPattern,
+                            (BLangErrorBindingPattern) secondBindingPattern);
+            default -> false;
+        };
     }
 
     private boolean checkSimilarMappingBindingPattern(BLangMappingBindingPattern firstMappingBindingPattern,
@@ -1435,27 +1425,27 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
     }
 
     private boolean isConstMatchPatternExist(BLangMatchPattern matchPattern) {
-        switch (matchPattern.getKind()) {
-            case CONST_MATCH_PATTERN:
-                return true;
-            case LIST_MATCH_PATTERN:
+        return switch (matchPattern.getKind()) {
+            case CONST_MATCH_PATTERN -> true;
+            case LIST_MATCH_PATTERN -> {
                 for (BLangMatchPattern memberMatchPattern : ((BLangListMatchPattern) matchPattern).matchPatterns) {
                     if (isConstMatchPatternExist(memberMatchPattern)) {
-                        return true;
+                        yield true;
                     }
                 }
-                return false;
-            case MAPPING_MATCH_PATTERN:
+                yield false;
+            }
+            case MAPPING_MATCH_PATTERN -> {
                 for (BLangFieldMatchPattern fieldMatchPattern :
                         ((BLangMappingMatchPattern) matchPattern).fieldMatchPatterns) {
                     if (isConstMatchPatternExist(fieldMatchPattern.matchPattern)) {
-                        return true;
+                        yield true;
                     }
                 }
-                return false;
-            default:
-                return false;
-        }
+                yield false;
+            }
+            default -> false;
+        };
     }
 
     @Override
@@ -1755,17 +1745,14 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
     }
 
     private boolean isValidContextForInferredArray(BLangNode node) {
-        switch (node.getKind()) {
-            case PACKAGE:
-            case EXPR_FUNCTION_BODY:
-            case BLOCK_FUNCTION_BODY:
-            case BLOCK:
-                return true;
-            case VARIABLE_DEF:
-                return isValidContextForInferredArray(node.parent);
-            default:
-                return false;
-        }
+        return switch (node.getKind()) {
+            case PACKAGE,
+                 EXPR_FUNCTION_BODY,
+                 BLOCK_FUNCTION_BODY,
+                 BLOCK -> true;
+            case VARIABLE_DEF -> isValidContextForInferredArray(node.parent);
+            default -> false;
+        };
     }
 
     private boolean isValidVariableForInferredArray(BLangNode node) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantTypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantTypeChecker.java
@@ -542,21 +542,21 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
 
         BType possibleType = getMappingConstructorCompatibleNonUnionType(expType, data);
 
-        switch (possibleType.tag) {
-            case TypeTags.MAP:
-                return validateSpecifiedFieldsAndGetType(mappingConstructor, possibleType, data);
-            case TypeTags.RECORD:
+        return switch (possibleType.tag) {
+            case TypeTags.MAP -> validateSpecifiedFieldsAndGetType(mappingConstructor, possibleType, data);
+            case TypeTags.RECORD -> {
                 boolean hasAllRequiredFields = validateRequiredFields((BRecordType) possibleType,
                         mappingConstructor.fields,
                         mappingConstructor.pos, data);
-                return hasAllRequiredFields ? validateSpecifiedFieldsAndGetType(mappingConstructor, possibleType, data)
+                yield hasAllRequiredFields ? validateSpecifiedFieldsAndGetType(mappingConstructor, possibleType, data)
                         : symTable.semanticError;
-            case TypeTags.READONLY:
-                return checkConstExpr(mappingConstructor, possibleType, data);
-            default:
+            }
+            case TypeTags.READONLY -> checkConstExpr(mappingConstructor, possibleType, data);
+            default -> {
                 reportIncompatibleMappingConstructorError(mappingConstructor, expType);
-                return symTable.semanticError;
-        }
+                yield symTable.semanticError;
+            }
+        };
     }
 
     /**
@@ -665,15 +665,12 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
 
     private BType validateSpecifiedFieldsAndGetType(BLangRecordLiteral mappingConstructor, BType possibleType,
                                                     AnalyzerData data) {
-        switch (possibleType.tag) {
-            case TypeTags.MAP:
-                BType expType = ((BMapType) possibleType).constraint;
-                return validateMapTypeAndInferredType(mappingConstructor, expType, possibleType, data);
-            case TypeTags.RECORD:
-                return validateRecordType(mappingConstructor, (BRecordType) possibleType, data);
-            default:
-                return symTable.semanticError;
-        }
+        return switch (possibleType.tag) {
+            case TypeTags.MAP -> validateMapTypeAndInferredType(mappingConstructor,
+                    ((BMapType) possibleType).constraint, possibleType, data);
+            case TypeTags.RECORD -> validateRecordType(mappingConstructor, (BRecordType) possibleType, data);
+            default -> symTable.semanticError;
+        };
     }
 
     private BType validateMapTypeAndInferredType(BLangRecordLiteral mappingConstructor, BType expType,
@@ -1109,18 +1106,16 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
 
         BType possibleType = getListConstructorCompatibleNonUnionType(expType, data);
 
-        switch (possibleType.tag) {
-            case TypeTags.ARRAY:
-            case TypeTags.BYTE_ARRAY:
-                return checkArrayType((BArrayType) possibleType, listConstructor, data);
-            case TypeTags.TUPLE:
-                return checkTupleType((BTupleType) possibleType, listConstructor, data);
-            case TypeTags.READONLY:
-                return checkConstExpr(listConstructor, possibleType, data);
-            default:
+        return switch (possibleType.tag) {
+            case TypeTags.ARRAY,
+                 TypeTags.BYTE_ARRAY -> checkArrayType((BArrayType) possibleType, listConstructor, data);
+            case TypeTags.TUPLE -> checkTupleType((BTupleType) possibleType, listConstructor, data);
+            case TypeTags.READONLY -> checkConstExpr(listConstructor, possibleType, data);
+            default -> {
                 dlog.error(listConstructor.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES, expType, listConstructor);
-                return symTable.semanticError;
-        }
+                yield symTable.semanticError;
+            }
+        };
     }
 
     private BType checkArrayType(BArrayType arrayType, BLangListConstructorExpr listConstructor, AnalyzerData data) {
@@ -1384,30 +1379,24 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
     }
 
     private BType getListConstructorCompatibleNonUnionType(BType type, AnalyzerData data) {
-        switch (type.tag) {
-            case TypeTags.ARRAY:
-            case TypeTags.BYTE_ARRAY:
-            case TypeTags.TUPLE:
-            case TypeTags.READONLY:
-            case TypeTags.TYPEDESC:
-                return type;
-            case TypeTags.JSON:
-                return !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.arrayJsonType :
-                        ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayJsonType,
-                                data.env, symTable, anonymousModelHelper, names);
-            case TypeTags.ANYDATA:
-                return !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.arrayAnydataType :
-                        ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayAnydataType,
-                                data.env, symTable, anonymousModelHelper, names);
-            case TypeTags.ANY:
-                return !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.arrayAllType :
-                        ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayAllType, data.env,
-                                symTable, anonymousModelHelper, names);
-            case TypeTags.INTERSECTION:
-                return ((BIntersectionType) type).effectiveType;
-            default:
-                return symTable.semanticError;
-        }
+        return switch (type.tag) {
+            case TypeTags.ARRAY,
+                 TypeTags.BYTE_ARRAY,
+                 TypeTags.TUPLE,
+                 TypeTags.READONLY,
+                 TypeTags.TYPEDESC -> type;
+            case TypeTags.JSON -> !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.arrayJsonType :
+                    ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayJsonType,
+                            data.env, symTable, anonymousModelHelper, names);
+            case TypeTags.ANYDATA -> !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.arrayAnydataType :
+                    ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayAnydataType,
+                            data.env, symTable, anonymousModelHelper, names);
+            case TypeTags.ANY -> !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.arrayAllType :
+                    ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayAllType, data.env,
+                            symTable, anonymousModelHelper, names);
+            case TypeTags.INTERSECTION -> ((BIntersectionType) type).effectiveType;
+            default -> symTable.semanticError;
+        };
     }
 
     private BType getBroadType(BType type) {
@@ -1681,16 +1670,12 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
     }
 
     private Object calculateNegation(Object value, BType type, AnalyzerData data) {
-        switch (type.tag) {
-            case TypeTags.INT:
-                return calculateNegationForInt(value, data);
-            case TypeTags.FLOAT:
-                return calculateNegationForFloat(value);
-            case TypeTags.DECIMAL:
-                return calculateNegationForDecimal(value);
-            default:
-                return null;
-        }
+        return switch (type.tag) {
+            case TypeTags.INT -> calculateNegationForInt(value, data);
+            case TypeTags.FLOAT -> calculateNegationForFloat(value);
+            case TypeTags.DECIMAL -> calculateNegationForDecimal(value);
+            default -> null;
+        };
     }
 
     private Object calculateBitWiseComplement(Object value, BType type) {
@@ -1936,42 +1921,37 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
     }
 
     private BType getFiniteType(Object value, BConstantSymbol constantSymbol, Location pos, BType type) {
-        switch (type.tag) {
-            case TypeTags.INT:
-            case TypeTags.FLOAT:
-            case TypeTags.DECIMAL:
-            case TypeTags.BYTE:
+        return switch (type.tag) {
+            case TypeTags.INT,
+                 TypeTags.FLOAT,
+                 TypeTags.DECIMAL,
+                 TypeTags.BYTE -> {
                 BLangNumericLiteral numericLiteral = (BLangNumericLiteral) TreeBuilder.createNumericLiteralExpression();
-                return createFiniteType(constantSymbol, updateLiteral(numericLiteral, value, type, pos));
-//            case TypeTags.BYTE:
+                yield createFiniteType(constantSymbol, updateLiteral(numericLiteral, value, type, pos));
+            }
+//            case TypeTags.BYTE -> {
 //                BLangNumericLiteral byteLiteral = (BLangNumericLiteral) TreeBuilder.createNumericLiteralExpression();
-//                return createFiniteType(constantSymbol, updateLiteral(byteLiteral, value, symTable.intType, pos));
-            case TypeTags.STRING:
-            case TypeTags.NIL:
-            case TypeTags.BOOLEAN:
+//                yield createFiniteType(constantSymbol, updateLiteral(byteLiteral, value, symTable.intType, pos));
+//            }
+            case TypeTags.STRING,
+                 TypeTags.NIL,
+                 TypeTags.BOOLEAN -> {
                 BLangLiteral literal = (BLangLiteral) TreeBuilder.createLiteralExpression();
-                return createFiniteType(constantSymbol, updateLiteral(literal, value, type, pos));
-            case TypeTags.UNION:
-                return createFiniteType(constantSymbol, value, (BUnionType) type, pos);
-            default:
-                return type;
-        }
+                yield createFiniteType(constantSymbol, updateLiteral(literal, value, type, pos));
+            }
+            case TypeTags.UNION -> createFiniteType(constantSymbol, value, (BUnionType) type, pos);
+            default -> type;
+        };
     }
 
     private BLangLiteral getLiteral(Object value, Location pos, BType type) {
-        switch (type.tag) {
-            case TypeTags.INT:
-            case TypeTags.FLOAT:
-            case TypeTags.DECIMAL:
-                BLangNumericLiteral numericLiteral = (BLangNumericLiteral) TreeBuilder.createNumericLiteralExpression();
-                return updateLiteral(numericLiteral, value, type, pos);
-            case TypeTags.BYTE:
-                BLangNumericLiteral byteLiteral = (BLangNumericLiteral) TreeBuilder.createNumericLiteralExpression();
-                return updateLiteral(byteLiteral, value, symTable.byteType, pos);
-            default:
-                BLangLiteral literal = (BLangLiteral) TreeBuilder.createLiteralExpression();
-                return updateLiteral(literal, value, type, pos);
-        }
+        return switch (type.tag) {
+            case TypeTags.INT, TypeTags.FLOAT, TypeTags.DECIMAL ->
+                    updateLiteral((BLangNumericLiteral) TreeBuilder.createNumericLiteralExpression(), value, type, pos);
+            case TypeTags.BYTE -> updateLiteral((BLangNumericLiteral) TreeBuilder.createNumericLiteralExpression(),
+                    value, symTable.byteType, pos);
+            default -> updateLiteral((BLangLiteral) TreeBuilder.createLiteralExpression(), value, type, pos);
+        };
     }
 
     private BLangLiteral updateLiteral(BLangLiteral literal, Object value, BType type, Location pos) {
@@ -1998,18 +1978,12 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
             BTypeSymbol finiteTypeSymbol = Symbols.createTypeSymbol(SymTag.FINITE_TYPE, constantSymbol.flags,
                     Names.EMPTY, constantSymbol.pkgID, null, constantSymbol.owner, constantSymbol.pos, VIRTUAL);
             BFiniteType finiteType = new BFiniteType(finiteTypeSymbol);
-            Object memberValue;
-            switch (memberType.tag) {
-                case TypeTags.FLOAT:
-                    memberValue = value instanceof String ?
-                            Double.parseDouble((String) value) : ((Long) value).doubleValue();
-                    break;
-                case TypeTags.DECIMAL:
-                    memberValue = new BigDecimal(String.valueOf(value));
-                    break;
-                default:
-                    memberValue = value;
-            }
+            Object memberValue = switch (memberType.tag) {
+                case TypeTags.FLOAT -> value instanceof String ?
+                        Double.parseDouble((String) value) : ((Long) value).doubleValue();
+                case TypeTags.DECIMAL -> new BigDecimal(String.valueOf(value));
+                default -> value;
+            };
             finiteType.addValue(getLiteral(memberValue, pos, memberType));
             finiteType.tsymbol.type = finiteType;
             memberTypes.add(finiteType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
@@ -543,17 +543,12 @@ public class ConstantValueResolver extends BLangNodeVisitor {
         BType constSymbolValType = value.type;
         int constSymbolValTypeTag = Types.getImpliedType(constSymbolValType).tag;
 
-        switch (constSymbolValTypeTag) {
-            case TypeTags.INT:
-                result = calculateNegationForInt(value);
-                break;
-            case TypeTags.FLOAT:
-                result = calculateNegationForFloat(value);
-                break;
-            case TypeTags.DECIMAL:
-                result = calculateNegationForDecimal(value);
-                break;
-        }
+        result = switch (constSymbolValTypeTag) {
+            case TypeTags.INT -> calculateNegationForInt(value);
+            case TypeTags.FLOAT -> calculateNegationForFloat(value);
+            case TypeTags.DECIMAL -> calculateNegationForDecimal(value);
+            default -> result;
+        };
 
         return new BLangConstantValue(result, constSymbolValType);
     }
@@ -696,14 +691,10 @@ public class ConstantValueResolver extends BLangNodeVisitor {
     }
 
     private boolean isListOrMapping(int tag) {
-        switch (tag) {
-            case TypeTags.RECORD:
-            case TypeTags.MAP:
-            case TypeTags.ARRAY:
-            case TypeTags.TUPLE:
-                return true;
-        }
-        return false;
+        return switch (tag) {
+            case TypeTags.RECORD, TypeTags.MAP, TypeTags.ARRAY, TypeTags.TUPLE -> true;
+            default -> false;
+        };
     }
 
     private BFiniteType createFiniteType(BConstantSymbol constantSymbol, BLangExpression expr) {
@@ -725,35 +716,39 @@ public class ConstantValueResolver extends BLangNodeVisitor {
 
         type = Types.getImpliedType(type);
 
-        switch (type.tag) {
-            case TypeTags.INT:
-            case TypeTags.FLOAT:
-            case TypeTags.DECIMAL:
+        return switch (type.tag) {
+            case TypeTags.INT,
+                 TypeTags.FLOAT,
+                 TypeTags.DECIMAL -> {
                 BLangNumericLiteral numericLiteral = (BLangNumericLiteral) TreeBuilder.createNumericLiteralExpression();
-                return createFiniteType(constantSymbol, updateLiteral(numericLiteral, value, type, pos));
-            case TypeTags.BYTE:
+                yield createFiniteType(constantSymbol, updateLiteral(numericLiteral, value, type, pos));
+            }
+            case TypeTags.BYTE -> {
                 BLangNumericLiteral byteLiteral = (BLangNumericLiteral) TreeBuilder.createNumericLiteralExpression();
-                return createFiniteType(constantSymbol, updateLiteral(byteLiteral, value, symTable.intType, pos));
-            case TypeTags.STRING:
-            case TypeTags.NIL:
-            case TypeTags.BOOLEAN:
+                yield createFiniteType(constantSymbol, updateLiteral(byteLiteral, value, symTable.intType, pos));
+            }
+            case TypeTags.STRING,
+                 TypeTags.NIL,
+                 TypeTags.BOOLEAN -> {
                 BLangLiteral literal = (BLangLiteral) TreeBuilder.createLiteralExpression();
-                return createFiniteType(constantSymbol, updateLiteral(literal, value, type, pos));
-            case TypeTags.MAP:
-            case TypeTags.RECORD:
+                yield createFiniteType(constantSymbol, updateLiteral(literal, value, type, pos));
+            }
+            case TypeTags.MAP,
+                 TypeTags.RECORD -> {
                 if (value != null) {
-                    return createRecordType(expr, constantSymbol, value, pos, env);
+                    yield createRecordType(expr, constantSymbol, value, pos, env);
                 }
-                return null;
-            case TypeTags.ARRAY:
-            case TypeTags.TUPLE:
+                yield null;
+            }
+            case TypeTags.ARRAY,
+                 TypeTags.TUPLE -> {
                 if (value != null) {
-                    return createTupleType(expr, constantSymbol, pos, value, env);
+                    yield createTupleType(expr, constantSymbol, pos, value, env);
                 }
-                return null;
-            default:
-                return null;
-        }
+                yield null;
+            }
+            default -> null;
+        };
     }
 
     private BLangLiteral updateLiteral(BLangLiteral literal, Object value, BType type, Location pos) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsAnydataUniqueVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsAnydataUniqueVisitor.java
@@ -60,34 +60,32 @@ public class IsAnydataUniqueVisitor implements UniqueTypeVisitor<Boolean> {
     }
 
     private boolean isAnydata(BType type) {
-        switch (Types.getImpliedType(type).tag) {
-            case TypeTags.INT:
-            case TypeTags.BYTE:
-            case TypeTags.FLOAT:
-            case TypeTags.DECIMAL:
-            case TypeTags.STRING:
-            case TypeTags.CHAR_STRING:
-            case TypeTags.BOOLEAN:
-            case TypeTags.JSON:
-            case TypeTags.XML:
-            case TypeTags.XML_TEXT:
-            case TypeTags.XML_ELEMENT:
-            case TypeTags.XML_COMMENT:
-            case TypeTags.XML_PI:
-            case TypeTags.NIL:
-            case TypeTags.NEVER:
-            case TypeTags.ANYDATA:
-            case TypeTags.SIGNED8_INT:
-            case TypeTags.SIGNED16_INT:
-            case TypeTags.SIGNED32_INT:
-            case TypeTags.UNSIGNED8_INT:
-            case TypeTags.UNSIGNED16_INT:
-            case TypeTags.UNSIGNED32_INT:
-            case TypeTags.REGEXP:
-                return true;
-            default:
-                return false;
-        }
+        return switch (Types.getImpliedType(type).tag) {
+            case TypeTags.INT,
+                 TypeTags.BYTE,
+                 TypeTags.FLOAT,
+                 TypeTags.DECIMAL,
+                 TypeTags.STRING,
+                 TypeTags.CHAR_STRING,
+                 TypeTags.BOOLEAN,
+                 TypeTags.JSON,
+                 TypeTags.XML,
+                 TypeTags.XML_TEXT,
+                 TypeTags.XML_ELEMENT,
+                 TypeTags.XML_COMMENT,
+                 TypeTags.XML_PI,
+                 TypeTags.NIL,
+                 TypeTags.NEVER,
+                 TypeTags.ANYDATA,
+                 TypeTags.SIGNED8_INT,
+                 TypeTags.SIGNED16_INT,
+                 TypeTags.SIGNED32_INT,
+                 TypeTags.UNSIGNED8_INT,
+                 TypeTags.UNSIGNED16_INT,
+                 TypeTags.UNSIGNED32_INT,
+                 TypeTags.REGEXP -> true;
+            default -> false;
+        };
     }
 
     @Override
@@ -296,43 +294,30 @@ public class IsAnydataUniqueVisitor implements UniqueTypeVisitor<Boolean> {
 
     @Override
     public Boolean visit(BType type) {
-        switch (type.tag) {
-            case TypeTags.TABLE:
-                return visit((BTableType) type);
-            case TypeTags.ANYDATA:
-                return visit((BAnydataType) type);
-            case TypeTags.RECORD:
-                return visit((BRecordType) type);
-            case TypeTags.ARRAY:
-                return visit((BArrayType) type);
-            case TypeTags.UNION:
-                return visit((BUnionType) type);
-            case TypeTags.TYPEDESC:
-                return visit((BTypedescType) type);
-            case TypeTags.MAP:
-                return visit((BMapType) type);
-            case TypeTags.FINITE:
-                return visit((BFiniteType) type);
-            case TypeTags.TUPLE:
-                return visit((BTupleType) type);
-            case TypeTags.INTERSECTION:
-                return visit((BIntersectionType) type);
-            case TypeTags.TYPEREFDESC:
-                return visit((BTypeReferenceType) type);
-            case TypeTags.SIGNED8_INT:
-            case TypeTags.SIGNED16_INT:
-            case TypeTags.SIGNED32_INT:
-            case TypeTags.UNSIGNED8_INT:
-            case TypeTags.UNSIGNED16_INT:
-            case TypeTags.UNSIGNED32_INT:
-                return visit((BIntSubType) type);
-            case TypeTags.XML_ELEMENT:
-            case TypeTags.XML_PI:
-            case TypeTags.XML_COMMENT:
-            case TypeTags.XML_TEXT:
-                return visit((BXMLSubType) type);
-        }
-        return isAnydata(type);
+        return switch (type.tag) {
+            case TypeTags.TABLE -> visit((BTableType) type);
+            case TypeTags.ANYDATA -> visit((BAnydataType) type);
+            case TypeTags.RECORD -> visit((BRecordType) type);
+            case TypeTags.ARRAY -> visit((BArrayType) type);
+            case TypeTags.UNION -> visit((BUnionType) type);
+            case TypeTags.TYPEDESC -> visit((BTypedescType) type);
+            case TypeTags.MAP -> visit((BMapType) type);
+            case TypeTags.FINITE -> visit((BFiniteType) type);
+            case TypeTags.TUPLE -> visit((BTupleType) type);
+            case TypeTags.INTERSECTION -> visit((BIntersectionType) type);
+            case TypeTags.TYPEREFDESC -> visit((BTypeReferenceType) type);
+            case TypeTags.SIGNED8_INT,
+                 TypeTags.SIGNED16_INT,
+                 TypeTags.SIGNED32_INT,
+                 TypeTags.UNSIGNED8_INT,
+                 TypeTags.UNSIGNED16_INT,
+                 TypeTags.UNSIGNED32_INT -> visit((BIntSubType) type);
+            case TypeTags.XML_ELEMENT,
+                 TypeTags.XML_PI,
+                 TypeTags.XML_COMMENT,
+                 TypeTags.XML_TEXT -> visit((BXMLSubType) type);
+            default -> isAnydata(type);
+        };
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsPureTypeUniqueVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsPureTypeUniqueVisitor.java
@@ -58,31 +58,29 @@ public class IsPureTypeUniqueVisitor implements UniqueTypeVisitor<Boolean> {
     }
 
     private boolean isAnyData(BType type) {
-        switch (Types.getImpliedType(type).tag) {
-            case TypeTags.INT:
-            case TypeTags.BYTE:
-            case TypeTags.FLOAT:
-            case TypeTags.DECIMAL:
-            case TypeTags.STRING:
-            case TypeTags.BOOLEAN:
-            case TypeTags.JSON:
-            case TypeTags.XML:
-            case TypeTags.XML_TEXT:
-            case TypeTags.TABLE:
-            case TypeTags.NIL:
-            case TypeTags.NEVER:
-            case TypeTags.ANYDATA:
-            case TypeTags.SIGNED8_INT:
-            case TypeTags.SIGNED16_INT:
-            case TypeTags.SIGNED32_INT:
-            case TypeTags.UNSIGNED8_INT:
-            case TypeTags.UNSIGNED16_INT:
-            case TypeTags.UNSIGNED32_INT:
-            case TypeTags.CHAR_STRING:
-                return true;
-            default:
-                return false;
-        }
+        return switch (Types.getImpliedType(type).tag) {
+            case TypeTags.INT,
+                 TypeTags.BYTE,
+                 TypeTags.FLOAT,
+                 TypeTags.DECIMAL,
+                 TypeTags.STRING,
+                 TypeTags.BOOLEAN,
+                 TypeTags.JSON,
+                 TypeTags.XML,
+                 TypeTags.XML_TEXT,
+                 TypeTags.TABLE,
+                 TypeTags.NIL,
+                 TypeTags.NEVER,
+                 TypeTags.ANYDATA,
+                 TypeTags.SIGNED8_INT,
+                 TypeTags.SIGNED16_INT,
+                 TypeTags.SIGNED32_INT,
+                 TypeTags.UNSIGNED8_INT,
+                 TypeTags.UNSIGNED16_INT,
+                 TypeTags.UNSIGNED32_INT,
+                 TypeTags.CHAR_STRING -> true;
+            default -> false;
+        };
     }
 
     @Override
@@ -253,38 +251,26 @@ public class IsPureTypeUniqueVisitor implements UniqueTypeVisitor<Boolean> {
 
     @Override
     public Boolean visit(BType type) {
-        switch (type.tag) {
-            case TypeTags.TABLE:
-                return visit((BTableType) type);
-            case TypeTags.ANYDATA:
-                return visit((BAnydataType) type);
-            case TypeTags.RECORD:
-                return visit((BRecordType) type);
-            case TypeTags.ARRAY:
-                return visit((BArrayType) type);
-            case TypeTags.UNION:
-                return visit((BUnionType) type);
-            case TypeTags.TYPEDESC:
-                return visit((BTypedescType) type);
-            case TypeTags.MAP:
-                return visit((BMapType) type);
-            case TypeTags.FINITE:
-                return visit((BFiniteType) type);
-            case TypeTags.TUPLE:
-                return visit((BTupleType) type);
-            case TypeTags.INTERSECTION:
-                return visit((BIntersectionType) type);
-            case TypeTags.TYPEREFDESC:
-                return visit((BTypeReferenceType) type);
-            case TypeTags.SIGNED8_INT:
-            case TypeTags.SIGNED16_INT:
-            case TypeTags.SIGNED32_INT:
-            case TypeTags.UNSIGNED8_INT:
-            case TypeTags.UNSIGNED16_INT:
-            case TypeTags.UNSIGNED32_INT:
-                return visit((BIntSubType) type);
-        }
-        return isAnyData(type);
+        return switch (type.tag) {
+            case TypeTags.TABLE -> visit((BTableType) type);
+            case TypeTags.ANYDATA -> visit((BAnydataType) type);
+            case TypeTags.RECORD -> visit((BRecordType) type);
+            case TypeTags.ARRAY -> visit((BArrayType) type);
+            case TypeTags.UNION -> visit((BUnionType) type);
+            case TypeTags.TYPEDESC -> visit((BTypedescType) type);
+            case TypeTags.MAP -> visit((BMapType) type);
+            case TypeTags.FINITE -> visit((BFiniteType) type);
+            case TypeTags.TUPLE -> visit((BTupleType) type);
+            case TypeTags.INTERSECTION -> visit((BIntersectionType) type);
+            case TypeTags.TYPEREFDESC -> visit((BTypeReferenceType) type);
+            case TypeTags.SIGNED8_INT,
+                 TypeTags.SIGNED16_INT,
+                 TypeTags.SIGNED32_INT,
+                 TypeTags.UNSIGNED8_INT,
+                 TypeTags.UNSIGNED16_INT,
+                 TypeTags.UNSIGNED32_INT -> visit((BIntSubType) type);
+            default -> isAnyData(type);
+        };
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
@@ -3115,28 +3115,26 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
     }
 
     private boolean isDependentlyIsolatedExpressionKind(BLangExpression expression) {
-        switch (expression.getKind()) {
-            case LIST_CONSTRUCTOR_EXPR:
-            case TABLE_CONSTRUCTOR_EXPR:
-            case RECORD_LITERAL_EXPR:
-            case XML_COMMENT_LITERAL:
-            case XML_TEXT_LITERAL:
-            case XML_PI_LITERAL:
-            case XML_ELEMENT_LITERAL:
-            case XML_SEQUENCE_LITERAL:
-            case RAW_TEMPLATE_LITERAL:
-            case STRING_TEMPLATE_LITERAL:
-            case TYPE_CONVERSION_EXPR:
-            case CHECK_EXPR:
-            case CHECK_PANIC_EXPR:
-            case TRAP_EXPR:
-            case TERNARY_EXPR:
-            case ELVIS_EXPR:
-                return true;
-            case GROUP_EXPR:
-                return isDependentlyIsolatedExpressionKind(((BLangGroupExpr) expression).expression);
-        }
-        return false;
+        return switch (expression.getKind()) {
+            case LIST_CONSTRUCTOR_EXPR,
+                 TABLE_CONSTRUCTOR_EXPR,
+                 RECORD_LITERAL_EXPR,
+                 XML_COMMENT_LITERAL,
+                 XML_TEXT_LITERAL,
+                 XML_PI_LITERAL,
+                 XML_ELEMENT_LITERAL,
+                 XML_SEQUENCE_LITERAL,
+                 RAW_TEMPLATE_LITERAL,
+                 STRING_TEMPLATE_LITERAL,
+                 TYPE_CONVERSION_EXPR,
+                 CHECK_EXPR,
+                 CHECK_PANIC_EXPR,
+                 TRAP_EXPR,
+                 TERNARY_EXPR,
+                 ELVIS_EXPR -> true;
+            case GROUP_EXPR -> isDependentlyIsolatedExpressionKind(((BLangGroupExpr) expression).expression);
+            default -> false;
+        };
     }
 
     private boolean isCloneOrCloneReadOnlyInvocation(BLangInvocation invocation) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/MainParameterVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/MainParameterVisitor.java
@@ -80,15 +80,10 @@ public class MainParameterVisitor {
     }
 
     public boolean isOperandType(BType type) {
-        switch (Types.getImpliedType(type).tag) {
-            case TypeTags.FLOAT:
-            case TypeTags.DECIMAL:
-            case TypeTags.BYTE:
-                return true;
-            case TypeTags.BOOLEAN:
-                return option;
-            default:
-                return TypeTags.isIntegerTypeTag(type.tag) || TypeTags.isStringTypeTag(type.tag);
-        }
+        return switch (Types.getImpliedType(type).tag) {
+            case TypeTags.FLOAT, TypeTags.DECIMAL, TypeTags.BYTE -> true;
+            case TypeTags.BOOLEAN -> option;
+            default -> TypeTags.isIntegerTypeTag(type.tag) || TypeTags.isStringTypeTag(type.tag);
+        };
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1438,20 +1438,18 @@ public class SymbolEnter extends BLangNodeVisitor {
     }
 
     private boolean isTypeConstructorAvailable(NodeKind unresolvedType) {
-        switch (unresolvedType) {
-            case OBJECT_TYPE:
-            case RECORD_TYPE:
-            case CONSTRAINED_TYPE:
-            case ARRAY_TYPE:
-            case TUPLE_TYPE_NODE:
-            case TABLE_TYPE:
-            case ERROR_TYPE:
-            case FUNCTION_TYPE:
-            case STREAM_TYPE:
-                return true;
-            default:
-                return false;
-        }
+        return switch (unresolvedType) {
+            case OBJECT_TYPE,
+                 RECORD_TYPE,
+                 CONSTRAINED_TYPE,
+                 ARRAY_TYPE,
+                 TUPLE_TYPE_NODE,
+                 TABLE_TYPE,
+                 ERROR_TYPE,
+                 FUNCTION_TYPE,
+                 STREAM_TYPE -> true;
+            default -> false;
+        };
     }
 
     private void checkErrorsOfUserDefinedType(SymbolEnv env, BLangNode unresolvedType,
@@ -1882,19 +1880,20 @@ public class SymbolEnter extends BLangNodeVisitor {
         BTypeSymbol typeDefSymbol;
         BType newTypeNode;
 
-        switch (typeDef.typeNode.getKind()) {
-            case TUPLE_TYPE_NODE:
+        typeDefSymbol = switch (typeDef.typeNode.getKind()) {
+            case TUPLE_TYPE_NODE -> {
                 newTypeNode = new BTupleType(null, new ArrayList<>(), true);
-                typeDefSymbol = Symbols.createTypeSymbol(SymTag.TUPLE_TYPE, Flags.asMask(typeDef.flagSet),
+                yield Symbols.createTypeSymbol(SymTag.TUPLE_TYPE, Flags.asMask(typeDef.flagSet),
                         newTypeDefName, env.enclPkg.symbol.pkgID, newTypeNode, env.scope.owner,
                         typeDef.name.pos, SOURCE);
-                break;
-            default:
+            }
+            default -> {
                 newTypeNode = BUnionType.create(null, new LinkedHashSet<>(), true);
-                typeDefSymbol = Symbols.createTypeSymbol(SymTag.UNION_TYPE, Flags.asMask(typeDef.flagSet),
+                yield Symbols.createTypeSymbol(SymTag.UNION_TYPE, Flags.asMask(typeDef.flagSet),
                         newTypeDefName, env.enclPkg.symbol.pkgID, newTypeNode, env.scope.owner,
                         typeDef.name.pos, SOURCE);
-        }
+            }
+        };
         typeDef.symbol = typeDefSymbol;
         defineTypeInMainScope(typeDefSymbol, typeDef, env);
         newTypeNode.tsymbol = typeDefSymbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1881,18 +1881,14 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 types.setImplicitCastExpr(binaryExpr.rhsExpr, rhsType, symTable.anyType);
                 types.setImplicitCastExpr(binaryExpr.lhsExpr, lhsType, symTable.anyType);
 
-                switch (opKind) {
-                    case REF_EQUAL:
-                        // if one is a value type, consider === the same as ==
-                        return createEqualityOperator(OperatorKind.EQUAL, symTable.anyType,
-                                symTable.anyType);
-                    case REF_NOT_EQUAL:
-                        // if one is a value type, consider !== the same as !=
-                        return createEqualityOperator(OperatorKind.NOT_EQUAL, symTable.anyType,
-                                                      symTable.anyType);
-                    default:
-                        return createEqualityOperator(opKind, symTable.anyType, symTable.anyType);
-                }
+                return switch (opKind) {
+                    // if one is a value type, consider === the same as ==
+                    case REF_EQUAL -> createEqualityOperator(OperatorKind.EQUAL, symTable.anyType, symTable.anyType);
+                    // if one is a value type, consider !== the same as !=
+                    case REF_NOT_EQUAL -> createEqualityOperator(OperatorKind.NOT_EQUAL, symTable.anyType,
+                            symTable.anyType);
+                    default -> createEqualityOperator(opKind, symTable.anyType, symTable.anyType);
+                };
             }
         }
         return symTable.notFoundSymbol;
@@ -1916,15 +1912,13 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                     return createShiftOperator(opKind, lhsType, rhsType);
                 case BITWISE_RIGHT_SHIFT:
                 case BITWISE_UNSIGNED_RIGHT_SHIFT:
-                    switch (Types.getImpliedType(lhsType).tag) {
-                        case TypeTags.UNSIGNED32_INT:
-                        case TypeTags.UNSIGNED16_INT:
-                        case TypeTags.UNSIGNED8_INT:
-                        case TypeTags.BYTE:
-                            return createBinaryOperator(opKind, lhsType, rhsType, lhsType);
-                        default:
-                            return createShiftOperator(opKind, lhsType, rhsType);
-                    }
+                    return switch (Types.getImpliedType(lhsType).tag) {
+                        case TypeTags.UNSIGNED32_INT,
+                             TypeTags.UNSIGNED16_INT,
+                             TypeTags.UNSIGNED8_INT,
+                             TypeTags.BYTE -> createBinaryOperator(opKind, lhsType, rhsType, lhsType);
+                        default -> createShiftOperator(opKind, lhsType, rhsType);
+                    };
             }
         }
         return symTable.notFoundSymbol;
@@ -1990,16 +1984,13 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
 
     private boolean isIntFloatingPointMultiplication(OperatorKind opKind, BType lhsCompatibleType,
                                                      BType rhsCompatibleType) {
-        switch (opKind) {
-            case MUL:
-                return lhsCompatibleType.tag == TypeTags.INT && isFloatingPointType(rhsCompatibleType) ||
-                        rhsCompatibleType.tag == TypeTags.INT && isFloatingPointType(lhsCompatibleType);
-            case DIV:
-            case MOD:
-                return isFloatingPointType(lhsCompatibleType) && rhsCompatibleType.tag == TypeTags.INT;
-            default:
-                return false;
-        }
+        return switch (opKind) {
+            case MUL -> lhsCompatibleType.tag == TypeTags.INT && isFloatingPointType(rhsCompatibleType) ||
+                    rhsCompatibleType.tag == TypeTags.INT && isFloatingPointType(lhsCompatibleType);
+            case DIV,
+                 MOD -> isFloatingPointType(lhsCompatibleType) && rhsCompatibleType.tag == TypeTags.INT;
+            default -> false;
+        };
     }
 
     private boolean isFloatingPointType(BType type) {
@@ -2102,16 +2093,12 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         }
 
         if (validOrderedTypesExist) {
-            switch (opKind) {
-                case LESS_THAN:
-                    return createBinaryComparisonOperator(OperatorKind.LESS_THAN, lhsType, rhsType);
-                case LESS_EQUAL:
-                    return createBinaryComparisonOperator(OperatorKind.LESS_EQUAL, lhsType, rhsType);
-                case GREATER_THAN:
-                    return createBinaryComparisonOperator(OperatorKind.GREATER_THAN, lhsType, rhsType);
-                default:
-                    return createBinaryComparisonOperator(OperatorKind.GREATER_EQUAL, lhsType, rhsType);
-            }
+            return switch (opKind) {
+                case LESS_THAN -> createBinaryComparisonOperator(OperatorKind.LESS_THAN, lhsType, rhsType);
+                case LESS_EQUAL -> createBinaryComparisonOperator(OperatorKind.LESS_EQUAL, lhsType, rhsType);
+                case GREATER_THAN -> createBinaryComparisonOperator(OperatorKind.GREATER_THAN, lhsType, rhsType);
+                default -> createBinaryComparisonOperator(OperatorKind.GREATER_EQUAL, lhsType, rhsType);
+            };
         }
         return symTable.notFoundSymbol;
     }
@@ -2648,14 +2635,10 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
     }
 
     public boolean isReAtomNode(NodeKind kind) {
-        switch (kind) {
-            case REG_EXP_ATOM_CHAR_ESCAPE:
-            case REG_EXP_CHARACTER_CLASS:
-            case REG_EXP_CAPTURING_GROUP:
-                return true;
-            default:
-                return false;
-        }
+        return switch (kind) {
+            case REG_EXP_ATOM_CHAR_ESCAPE, REG_EXP_CHARACTER_CLASS, REG_EXP_CAPTURING_GROUP -> true;
+            default -> false;
+        };
     }
 
     private boolean isDistinctXMLNSSymbol(BXMLNSSymbol symbol, BXMLNSSymbol foundSym) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1951,26 +1951,22 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
     private BType getListConstructorCompatibleNonUnionType(BType type, AnalyzerData data) {
         BType referredType = Types.getImpliedType(type);
-        switch (referredType.tag) {
-            case TypeTags.ARRAY:
-            case TypeTags.TUPLE:
-            case TypeTags.READONLY:
-            case TypeTags.TYPEDESC:
-                return type;
-            case TypeTags.JSON:
-                return !Symbols.isFlagOn(referredType.flags, Flags.READONLY) ? symTable.arrayJsonType :
-                        ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayJsonType,
-                                data.env, symTable, anonymousModelHelper, names);
-            case TypeTags.ANYDATA:
-                return !Symbols.isFlagOn(referredType.flags, Flags.READONLY) ? symTable.arrayAnydataType :
-                        ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayAnydataType,
-                                data.env, symTable, anonymousModelHelper, names);
-            case TypeTags.ANY:
-                return !Symbols.isFlagOn(referredType.flags, Flags.READONLY) ? symTable.arrayAllType :
-                        ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayAllType, data.env,
-                                                                      symTable, anonymousModelHelper, names);
-        }
-        return symTable.semanticError;
+        return switch (referredType.tag) {
+            case TypeTags.ARRAY,
+                 TypeTags.TUPLE,
+                 TypeTags.READONLY,
+                 TypeTags.TYPEDESC -> type;
+            case TypeTags.JSON -> !Symbols.isFlagOn(referredType.flags, Flags.READONLY) ? symTable.arrayJsonType :
+                    ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayJsonType,
+                            data.env, symTable, anonymousModelHelper, names);
+            case TypeTags.ANYDATA -> !Symbols.isFlagOn(referredType.flags, Flags.READONLY) ? symTable.arrayAnydataType :
+                    ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayAnydataType,
+                            data.env, symTable, anonymousModelHelper, names);
+            case TypeTags.ANY -> !Symbols.isFlagOn(referredType.flags, Flags.READONLY) ? symTable.arrayAllType :
+                    ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayAllType, data.env,
+                            symTable, anonymousModelHelper, names);
+            default -> symTable.semanticError;
+        };
     }
 
     private BType checkArrayType(BLangListConstructorExpr listConstructor, BArrayType arrayType, AnalyzerData data) {
@@ -6101,17 +6097,13 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
     }
 
     public BType getXMLSequenceType(BType xmlSubType) {
-        switch (Types.getImpliedType(xmlSubType).tag) {
-            case TypeTags.XML_ELEMENT:
-                return new BXMLType(symTable.xmlElementType,  null);
-            case TypeTags.XML_COMMENT:
-                return new BXMLType(symTable.xmlCommentType,  null);
-            case TypeTags.XML_PI:
-                return new BXMLType(symTable.xmlPIType,  null);
-            default:
-                // Since 'xml:Text is same as xml<'xml:Text>
-                return symTable.xmlTextType;
-        }
+        return switch (Types.getImpliedType(xmlSubType).tag) {
+            case TypeTags.XML_ELEMENT -> new BXMLType(symTable.xmlElementType, null);
+            case TypeTags.XML_COMMENT -> new BXMLType(symTable.xmlCommentType, null);
+            case TypeTags.XML_PI -> new BXMLType(symTable.xmlPIType, null);
+            // Since 'xml:Text is same as xml<'xml:Text>
+            default -> symTable.xmlTextType;
+        };
     }
 
     @Override
@@ -6655,19 +6647,19 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
     // Private methods
 
     private boolean isValidVariableReference(BLangExpression varRef) {
-        switch (varRef.getKind()) {
-            case SIMPLE_VARIABLE_REF:
-            case RECORD_VARIABLE_REF:
-            case TUPLE_VARIABLE_REF:
-            case ERROR_VARIABLE_REF:
-            case FIELD_BASED_ACCESS_EXPR:
-            case INDEX_BASED_ACCESS_EXPR:
-            case XML_ATTRIBUTE_ACCESS_EXPR:
-                return true;
-            default:
+        return switch (varRef.getKind()) {
+            case SIMPLE_VARIABLE_REF,
+                 RECORD_VARIABLE_REF,
+                 TUPLE_VARIABLE_REF,
+                 ERROR_VARIABLE_REF,
+                 FIELD_BASED_ACCESS_EXPR,
+                 INDEX_BASED_ACCESS_EXPR,
+                 XML_ATTRIBUTE_ACCESS_EXPR -> true;
+            default -> {
                 dlog.error(varRef.pos, DiagnosticErrorCode.INVALID_RECORD_BINDING_PATTERN, varRef.getBType());
-                return false;
-        }
+                yield false;
+            }
+        };
     }
 
     private BType getEffectiveReadOnlyType(Location pos, BType type, AnalyzerData data) {
@@ -7756,25 +7748,21 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
     private boolean requireTypeInference(BLangExpression expr, boolean inferTypeForNumericLiteral) {
 
-        switch (expr.getKind()) {
-            case GROUP_EXPR:
-                return requireTypeInference(((BLangGroupExpr) expr).expression, inferTypeForNumericLiteral);
-            case ARROW_EXPR:
-            case LIST_CONSTRUCTOR_EXPR:
-            case RECORD_LITERAL_EXPR:
-            case OBJECT_CTOR_EXPRESSION:
-            case RAW_TEMPLATE_LITERAL:
-            case TABLE_CONSTRUCTOR_EXPR:
-            case TYPE_INIT_EXPR:
-            case ERROR_CONSTRUCTOR_EXPRESSION:
-                return true;
-            case ELVIS_EXPR:
-            case TERNARY_EXPR:
-            case NUMERIC_LITERAL:
-                return inferTypeForNumericLiteral;
-            default:
-                return false;
-        }
+        return switch (expr.getKind()) {
+            case GROUP_EXPR -> requireTypeInference(((BLangGroupExpr) expr).expression, inferTypeForNumericLiteral);
+            case ARROW_EXPR,
+                 LIST_CONSTRUCTOR_EXPR,
+                 RECORD_LITERAL_EXPR,
+                 OBJECT_CTOR_EXPRESSION,
+                 RAW_TEMPLATE_LITERAL,
+                 TABLE_CONSTRUCTOR_EXPR,
+                 TYPE_INIT_EXPR,
+                 ERROR_CONSTRUCTOR_EXPRESSION -> true;
+            case ELVIS_EXPR,
+                 TERNARY_EXPR,
+                 NUMERIC_LITERAL -> inferTypeForNumericLiteral;
+            default -> false;
+        };
     }
 
     private boolean isNotObjectConstructorWithObjectSuperTypeInTypeCastExpr(BLangExpression expression,
@@ -8943,31 +8931,30 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
     }
 
     private Long getConstIndex(BLangExpression indexExpr) {
-        switch (indexExpr.getKind()) {
-            case GROUP_EXPR:
+        return switch (indexExpr.getKind()) {
+            case GROUP_EXPR -> {
                 BLangGroupExpr groupExpr = (BLangGroupExpr) indexExpr;
-                return getConstIndex(groupExpr.expression);
-            case NUMERIC_LITERAL:
-                return (Long) ((BLangLiteral) indexExpr).value;
-            case UNARY_EXPR:
+                yield getConstIndex(groupExpr.expression);
+            }
+            case NUMERIC_LITERAL -> (Long) ((BLangLiteral) indexExpr).value;
+            case UNARY_EXPR -> {
                 BLangNumericLiteral numericLiteral =
                         Types.constructNumericLiteralFromUnaryExpr((BLangUnaryExpr) indexExpr);
-                return (Long) numericLiteral.value;
-            default:
-                return (Long) ((BConstantSymbol) ((BLangSimpleVarRef) indexExpr).symbol).value.value;
-        }
+                yield (Long) numericLiteral.value;
+            }
+            default -> (Long) ((BConstantSymbol) ((BLangSimpleVarRef) indexExpr).symbol).value.value;
+        };
     }
 
     private String getConstFieldName(BLangExpression indexExpr) {
-        switch (indexExpr.getKind()) {
-            case GROUP_EXPR:
+        return switch (indexExpr.getKind()) {
+            case GROUP_EXPR -> {
                 BLangGroupExpr groupExpr = (BLangGroupExpr) indexExpr;
-                return getConstFieldName(groupExpr.expression);
-            case LITERAL:
-                return (String) ((BLangLiteral) indexExpr).value;
-            default:
-                return (String) ((BConstantSymbol) ((BLangSimpleVarRef) indexExpr).symbol).value.value;
-        }
+                yield getConstFieldName(groupExpr.expression);
+            }
+            case LITERAL -> (String) ((BLangLiteral) indexExpr).value;
+            default -> (String) ((BConstantSymbol) ((BLangSimpleVarRef) indexExpr).symbol).value.value;
+        };
     }
 
     private BType checkArrayIndexBasedAccess(BLangIndexBasedAccess indexBasedAccess, BType indexExprType,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -270,23 +270,19 @@ public class TypeParamAnalyzer {
         BType referredType = Types.getImpliedType(type);
         int tag = referredType.tag;
         // Handle built-in types.
-        switch (tag) {
-            case TypeTags.INT:
-            case TypeTags.BYTE:
-            case TypeTags.FLOAT:
-            case TypeTags.DECIMAL:
-            case TypeTags.STRING:
-            case TypeTags.BOOLEAN:
-                return new BType(tag, null, name, flags);
-            case TypeTags.ANY:
-                return new BAnyType(tag, null, name, flags);
-            case TypeTags.ANYDATA:
-                return createAnydataType((BUnionType) referredType, name, flags);
-            case TypeTags.READONLY:
-                return new BReadonlyType(tag, null, name, flags);
-        }
-        // For others, we will use TSymbol.
-        return type;
+        return switch (tag) {
+            case TypeTags.INT,
+                 TypeTags.BYTE,
+                 TypeTags.FLOAT,
+                 TypeTags.DECIMAL,
+                 TypeTags.STRING,
+                 TypeTags.BOOLEAN -> new BType(tag, null, name, flags);
+            case TypeTags.ANY -> new BAnyType(tag, null, name, flags);
+            case TypeTags.ANYDATA -> createAnydataType((BUnionType) referredType, name, flags);
+            case TypeTags.READONLY -> new BReadonlyType(tag, null, name, flags);
+            // For others, we will use TSymbol.
+            default -> type;
+        };
     }
 
     private BType createTypeParamType(BSymbol symbol, BType type, Name name, long flags) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -593,15 +593,10 @@ public class TypeResolver {
     }
 
     private boolean isNotRestrictedCyclicTypeNode(BLangType typeNode) {
-        switch (typeNode.getKind()) {
-            case USER_DEFINED_TYPE:
-            case ARRAY_TYPE:
-            case CONSTRAINED_TYPE:
-            case INTERSECTION_TYPE_NODE:
-                return false;
-            default:
-                return true;
-        }
+        return switch (typeNode.getKind()) {
+            case USER_DEFINED_TYPE, ARRAY_TYPE, CONSTRAINED_TYPE, INTERSECTION_TYPE_NODE -> false;
+            default -> true;
+        };
     }
 
     private void logInvalidCyclicReferenceError(String currentDefnName, Location pos) {
@@ -699,56 +694,25 @@ public class TypeResolver {
         data.typeDefinition = defn;
         data.depth = depth;
 
-        BType resultType;
-        switch (td.getKind()) {
-            case VALUE_TYPE:
-                resultType = resolveTypeDesc((BLangValueType) td, symEnv);
-                break;
-            case CONSTRAINED_TYPE: // map<?> and typedesc<?>
-                resultType = resolveTypeDesc((BLangConstrainedType) td, data);
-                break;
-            case ARRAY_TYPE:
-                resultType = resolveTypeDesc(((BLangArrayType) td), data);
-                break;
-            case TUPLE_TYPE_NODE:
-                resultType = resolveTypeDesc((BLangTupleTypeNode) td, data);
-                break;
-            case RECORD_TYPE:
-                resultType = resolveTypeDesc((BLangRecordTypeNode) td, data);
-                break;
-            case OBJECT_TYPE:
-                resultType = resolveTypeDesc((BLangObjectTypeNode) td, data);
-                break;
-            case FUNCTION_TYPE:
-                resultType = resolveTypeDesc((BLangFunctionTypeNode) td, data);
-                break;
-            case ERROR_TYPE:
-                resultType = resolveTypeDesc((BLangErrorType) td, data);
-                break;
-            case UNION_TYPE_NODE:
-                resultType = resolveTypeDesc((BLangUnionTypeNode) td, data);
-                break;
-            case INTERSECTION_TYPE_NODE:
-                resultType = resolveTypeDesc((BLangIntersectionTypeNode) td, data, anonymous);
-                break;
-            case USER_DEFINED_TYPE:
-                resultType = resolveTypeDesc((BLangUserDefinedType) td, data);
-                break;
-            case BUILT_IN_REF_TYPE:
-                resultType = resolveTypeDesc((BLangBuiltInRefTypeNode) td, symEnv);
-                break;
-            case FINITE_TYPE_NODE:
-                resultType = resolveSingletonType((BLangFiniteTypeNode) td, symEnv);
-                break;
-            case TABLE_TYPE:
-                resultType = resolveTypeDesc((BLangTableTypeNode) td, data);
-                break;
-            case STREAM_TYPE:
-                resultType = resolveTypeDesc((BLangStreamType) td, data);
-                break;
-            default:
-                throw new AssertionError("Invalid type");
-        }
+        BType resultType = switch (td.getKind()) {
+            case VALUE_TYPE -> resolveTypeDesc((BLangValueType) td, symEnv);
+            // map<?> and typedesc<?>
+            case CONSTRAINED_TYPE -> resolveTypeDesc((BLangConstrainedType) td, data);
+            case ARRAY_TYPE -> resolveTypeDesc(((BLangArrayType) td), data);
+            case TUPLE_TYPE_NODE -> resolveTypeDesc((BLangTupleTypeNode) td, data);
+            case RECORD_TYPE -> resolveTypeDesc((BLangRecordTypeNode) td, data);
+            case OBJECT_TYPE -> resolveTypeDesc((BLangObjectTypeNode) td, data);
+            case FUNCTION_TYPE -> resolveTypeDesc((BLangFunctionTypeNode) td, data);
+            case ERROR_TYPE -> resolveTypeDesc((BLangErrorType) td, data);
+            case UNION_TYPE_NODE -> resolveTypeDesc((BLangUnionTypeNode) td, data);
+            case INTERSECTION_TYPE_NODE -> resolveTypeDesc((BLangIntersectionTypeNode) td, data, anonymous);
+            case USER_DEFINED_TYPE -> resolveTypeDesc((BLangUserDefinedType) td, data);
+            case BUILT_IN_REF_TYPE -> resolveTypeDesc((BLangBuiltInRefTypeNode) td, symEnv);
+            case FINITE_TYPE_NODE -> resolveSingletonType((BLangFiniteTypeNode) td, symEnv);
+            case TABLE_TYPE -> resolveTypeDesc((BLangTableTypeNode) td, data);
+            case STREAM_TYPE -> resolveTypeDesc((BLangStreamType) td, data);
+            default -> throw new AssertionError("Invalid type");
+        };
 
         BType refType = Types.getImpliedType(resultType);
         if (refType != symTable.noType) {
@@ -779,17 +743,13 @@ public class TypeResolver {
         currentDepth = data.depth;
         TypeKind typeKind = ((BLangBuiltInRefTypeNode) td.getType()).getTypeKind();
 
-        switch (typeKind) {
-            case MAP:
-                return resolveMapTypeDesc(td, data);
-            case XML:
-                return resolveXmlTypeDesc(td, data);
-            case FUTURE:
-                return resolveFutureTypeDesc(td, data);
-            case TYPEDESC:
-                return resolveTypedescTypeDesc(td, data);
-        }
-        throw new IllegalStateException("unknown constrained type found: " + typeKind);
+        return switch (typeKind) {
+            case MAP -> resolveMapTypeDesc(td, data);
+            case XML -> resolveXmlTypeDesc(td, data);
+            case FUTURE -> resolveFutureTypeDesc(td, data);
+            case TYPEDESC -> resolveTypedescTypeDesc(td, data);
+            default -> throw new IllegalStateException("unknown constrained type found: " + typeKind);
+        };
     }
 
     private BType resolveTypedescTypeDesc(BLangConstrainedType td, ResolverData data) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -439,24 +439,22 @@ public class Types {
     }
 
     public boolean isValueType(BType type) {
-        switch (getImpliedType(type).tag) {
-            case TypeTags.BOOLEAN:
-            case TypeTags.BYTE:
-            case TypeTags.DECIMAL:
-            case TypeTags.FLOAT:
-            case TypeTags.INT:
-            case TypeTags.STRING:
-            case TypeTags.SIGNED32_INT:
-            case TypeTags.SIGNED16_INT:
-            case TypeTags.SIGNED8_INT:
-            case TypeTags.UNSIGNED32_INT:
-            case TypeTags.UNSIGNED16_INT:
-            case TypeTags.UNSIGNED8_INT:
-            case TypeTags.CHAR_STRING:
-                return true;
-            default:
-                return false;
-        }
+        return switch (getImpliedType(type).tag) {
+            case TypeTags.BOOLEAN,
+                 TypeTags.BYTE,
+                 TypeTags.DECIMAL,
+                 TypeTags.FLOAT,
+                 TypeTags.INT,
+                 TypeTags.STRING,
+                 TypeTags.SIGNED32_INT,
+                 TypeTags.SIGNED16_INT,
+                 TypeTags.SIGNED8_INT,
+                 TypeTags.UNSIGNED32_INT,
+                 TypeTags.UNSIGNED16_INT,
+                 TypeTags.UNSIGNED8_INT,
+                 TypeTags.CHAR_STRING -> true;
+            default -> false;
+        };
     }
 
     boolean isBasicNumericType(BType bType) {
@@ -1088,17 +1086,11 @@ public class Types {
         }
 
         type = getImpliedType(type);
-        BType targetType;
-        switch (type.tag) {
-            case TypeTags.MAP:
-                targetType = ((BMapType) type).constraint;
-                break;
-            case TypeTags.JSON:
-                targetType = type;
-                break;
-            default:
-                throw new IllegalArgumentException("Incompatible target type: " + type.toString());
-        }
+        BType targetType = switch (type.tag) {
+            case TypeTags.MAP -> ((BMapType) type).constraint;
+            case TypeTags.JSON -> type;
+            default -> throw new IllegalArgumentException("Incompatible target type: " + type);
+        };
         return recordFieldsAssignableToType(recordType, targetType, unresolvedTypes);
     }
 
@@ -1487,22 +1479,20 @@ public class Types {
             return true;
         }
 
-        switch (type.tag) {
-            case TypeTags.XML_TEXT:
-            case TypeTags.FINITE: // Assuming a finite type will only have members from simple basic types.
-            case TypeTags.READONLY:
-            case TypeTags.NIL:
-            case TypeTags.NEVER:
-            case TypeTags.ERROR:
-            case TypeTags.INVOKABLE:
-            case TypeTags.TYPEDESC:
-            case TypeTags.HANDLE:
-            case TypeTags.REGEXP:    
-                return true;
-            case TypeTags.XML:
-                return getImpliedType(((BXMLType) type).constraint).tag == TypeTags.NEVER;
-        }
-        return false;
+        return switch (type.tag) {
+            case TypeTags.XML_TEXT,
+                 TypeTags.FINITE, // Assuming a finite type will only have members from simple basic types.
+                 TypeTags.READONLY,
+                 TypeTags.NIL,
+                 TypeTags.NEVER,
+                 TypeTags.ERROR,
+                 TypeTags.INVOKABLE,
+                 TypeTags.TYPEDESC,
+                 TypeTags.HANDLE,
+                 TypeTags.REGEXP -> true;
+            case TypeTags.XML -> getImpliedType(((BXMLType) type).constraint).tag == TypeTags.NEVER;
+            default -> false;
+        };
     }
 
     /**
@@ -2712,12 +2702,10 @@ public class Types {
     }
 
     public boolean isValidErrorDetailType(BType detailType) {
-        switch (getImpliedType(detailType).tag) {
-            case TypeTags.MAP:
-            case TypeTags.RECORD:
-                return isAssignable(detailType, symTable.detailType);
-        }
-        return false;
+        return switch (getImpliedType(detailType).tag) {
+            case TypeTags.MAP, TypeTags.RECORD -> isAssignable(detailType, symTable.detailType);
+            default -> false;
+        };
     }
 
     // private methods
@@ -2749,23 +2737,20 @@ public class Types {
                 return true;
             }
 
-            switch (t.tag) {
-                case TypeTags.INT:
-                case TypeTags.BYTE:
-                case TypeTags.FLOAT:
-                case TypeTags.DECIMAL:
-                case TypeTags.STRING:
-                case TypeTags.BOOLEAN:
-                    return t.tag == s.tag
-                            && ((TypeParamAnalyzer.isTypeParam(t) || TypeParamAnalyzer.isTypeParam(s)) ||
-                            (t.tag == TypeTags.TYPEREFDESC || s.tag == TypeTags.TYPEREFDESC));
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                    return t.tag == s.tag && hasSameReadonlyFlag(s, t)
-                            && (TypeParamAnalyzer.isTypeParam(t) || TypeParamAnalyzer.isTypeParam(s));
-                default:
-                    return false;
-            }
+            return switch (t.tag) {
+                case TypeTags.INT,
+                     TypeTags.BYTE,
+                     TypeTags.FLOAT,
+                     TypeTags.DECIMAL,
+                     TypeTags.STRING,
+                     TypeTags.BOOLEAN -> t.tag == s.tag &&
+                        ((TypeParamAnalyzer.isTypeParam(t) || TypeParamAnalyzer.isTypeParam(s)) ||
+                        (t.tag == TypeTags.TYPEREFDESC || s.tag == TypeTags.TYPEREFDESC));
+                case TypeTags.ANY,
+                     TypeTags.ANYDATA -> t.tag == s.tag && hasSameReadonlyFlag(s, t) &&
+                        (TypeParamAnalyzer.isTypeParam(t) || TypeParamAnalyzer.isTypeParam(s));
+                default -> false;
+            };
         }
 
         @Override
@@ -3069,24 +3054,20 @@ public class Types {
             if (t == s) {
                 return true;
             }
-            switch (t.tag) {
-                case TypeTags.INT:
-                case TypeTags.BYTE:
-                case TypeTags.FLOAT:
-                case TypeTags.DECIMAL:
-                case TypeTags.STRING:
-                case TypeTags.BOOLEAN:
-                    return t.tag == s.tag
-                            && ((TypeParamAnalyzer.isTypeParam(t) || TypeParamAnalyzer.isTypeParam(s)) ||
-                            (t.tag == TypeTags.TYPEREFDESC || s.tag == TypeTags.TYPEREFDESC));
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                    return t.tag == s.tag && hasSameReadonlyFlag(s, t)
-                            && (TypeParamAnalyzer.isTypeParam(t) || TypeParamAnalyzer.isTypeParam(s));
-                default:
-                    break;
-            }
-            return false;
+            return switch (t.tag) {
+                case TypeTags.INT,
+                     TypeTags.BYTE,
+                     TypeTags.FLOAT,
+                     TypeTags.DECIMAL,
+                     TypeTags.STRING,
+                     TypeTags.BOOLEAN -> t.tag == s.tag &&
+                        ((TypeParamAnalyzer.isTypeParam(t) || TypeParamAnalyzer.isTypeParam(s)) ||
+                        (t.tag == TypeTags.TYPEREFDESC || s.tag == TypeTags.TYPEREFDESC));
+                case TypeTags.ANY,
+                     TypeTags.ANYDATA -> t.tag == s.tag && hasSameReadonlyFlag(s, t) &&
+                        (TypeParamAnalyzer.isTypeParam(t) || TypeParamAnalyzer.isTypeParam(s));
+                default -> false;
+            };
 
         }
 
@@ -3570,19 +3551,18 @@ public class Types {
         }
 
         BType restFieldType = rhsType.restFieldType;
-        switch (restFieldType.tag) {
-            case TypeTags.UNION:
+        return switch (restFieldType.tag) {
+            case TypeTags.UNION -> {
                 for (BType member : ((BUnionType) restFieldType).getOriginalMemberTypes()) {
                     if (getImpliedType(member).tag == NEVER) {
-                        return false;
+                        yield false;
                     }
                 }
-                return true;
-            case NEVER:
-                return false;
-            default:
-                return true;
-        }
+                yield true;
+            }
+            case NEVER -> false;
+            default -> true;
+        };
     }
 
     private Optional<BAttachedFunction> getMatchingInvokableType(List<BAttachedFunction> rhsFuncList,
@@ -4272,26 +4252,23 @@ public class Types {
             return true;
         }
 
-        switch (targetType.tag) {
-            case TypeTags.BYTE:
-                return literalType.tag == TypeTags.INT && isByteLiteralValue((Long) literal.value);
-            case TypeTags.SIGNED32_INT:
-                return literalType.tag == TypeTags.INT && isSigned32LiteralValue((Long) literal.value);
-            case TypeTags.SIGNED16_INT:
-                return literalType.tag == TypeTags.INT && isSigned16LiteralValue((Long) literal.value);
-            case TypeTags.SIGNED8_INT:
-                return literalType.tag == TypeTags.INT && isSigned8LiteralValue((Long) literal.value);
-            case TypeTags.UNSIGNED32_INT:
-                return literalType.tag == TypeTags.INT && isUnsigned32LiteralValue((Long) literal.value);
-            case TypeTags.UNSIGNED16_INT:
-                return literalType.tag == TypeTags.INT && isUnsigned16LiteralValue((Long) literal.value);
-            case TypeTags.UNSIGNED8_INT:
-                return literalType.tag == TypeTags.INT && isUnsigned8LiteralValue((Long) literal.value);
-            case TypeTags.CHAR_STRING:
-                return literalType.tag == TypeTags.STRING && isCharLiteralValue((String) literal.value);
-            default:
-                return false;
-        }
+        return switch (targetType.tag) {
+            case TypeTags.BYTE -> literalType.tag == TypeTags.INT && isByteLiteralValue((Long) literal.value);
+            case TypeTags.SIGNED32_INT ->
+                    literalType.tag == TypeTags.INT && isSigned32LiteralValue((Long) literal.value);
+            case TypeTags.SIGNED16_INT ->
+                    literalType.tag == TypeTags.INT && isSigned16LiteralValue((Long) literal.value);
+            case TypeTags.SIGNED8_INT -> literalType.tag == TypeTags.INT && isSigned8LiteralValue((Long) literal.value);
+            case TypeTags.UNSIGNED32_INT ->
+                    literalType.tag == TypeTags.INT && isUnsigned32LiteralValue((Long) literal.value);
+            case TypeTags.UNSIGNED16_INT ->
+                    literalType.tag == TypeTags.INT && isUnsigned16LiteralValue((Long) literal.value);
+            case TypeTags.UNSIGNED8_INT ->
+                    literalType.tag == TypeTags.INT && isUnsigned8LiteralValue((Long) literal.value);
+            case TypeTags.CHAR_STRING ->
+                    literalType.tag == TypeTags.STRING && isCharLiteralValue((String) literal.value);
+            default -> false;
+        };
     }
 
     /**
@@ -4824,28 +4801,21 @@ public class Types {
 
     public BType getRemainingMatchExprType(BType originalType, BType typeToRemove, SymbolEnv env) {
         originalType = getImpliedType(originalType);
-        switch (originalType.tag) {
-            case TypeTags.UNION:
-                return getRemainingType((BUnionType) originalType, getAllTypes(typeToRemove, true));
-            case TypeTags.FINITE:
-                return getRemainingType((BFiniteType) originalType, getAllTypes(typeToRemove, true));
-            case TypeTags.TUPLE:
-                return getRemainingType((BTupleType) originalType, typeToRemove, env);
-            default:
-                return originalType;
-        }
+        return switch (originalType.tag) {
+            case TypeTags.UNION -> getRemainingType((BUnionType) originalType, getAllTypes(typeToRemove, true));
+            case TypeTags.FINITE -> getRemainingType((BFiniteType) originalType, getAllTypes(typeToRemove, true));
+            case TypeTags.TUPLE -> getRemainingType((BTupleType) originalType, typeToRemove, env);
+            default -> originalType;
+        };
     }
 
     private BType getRemainingType(BTupleType originalType, BType typeToRemove, SymbolEnv env) {
         typeToRemove = getImpliedType(typeToRemove);
-        switch (typeToRemove.tag) {
-            case TypeTags.TUPLE:
-                return getRemainingType(originalType, (BTupleType) typeToRemove, env);
-            case TypeTags.ARRAY:
-                return getRemainingType(originalType, (BArrayType) typeToRemove, env);
-            default:
-                return originalType;
-        }
+        return switch (typeToRemove.tag) {
+            case TypeTags.TUPLE -> getRemainingType(originalType, (BTupleType) typeToRemove, env);
+            case TypeTags.ARRAY -> getRemainingType(originalType, (BArrayType) typeToRemove, env);
+            default -> originalType;
+        };
     }
 
     private BType getRemainingType(BTupleType originalType, BTupleType typeToRemove, SymbolEnv env) {
@@ -4965,19 +4935,21 @@ public class Types {
 
     private boolean isClosedRecordTypes(BType type) {
         type = getImpliedType(type);
-        switch (type.tag) {
-            case RECORD:
+        return switch (type.tag) {
+            case RECORD -> {
                 BRecordType recordType = (BRecordType) type;
-                return recordType.sealed || recordType.restFieldType == symTable.neverType;
-            case UNION:
+                yield recordType.sealed || recordType.restFieldType == symTable.neverType;
+            }
+            case UNION -> {
                 for (BType memberType : ((BUnionType) type).getMemberTypes()) {
                     if (!isClosedRecordTypes(getImpliedType(memberType))) {
-                        return false;
+                        yield false;
                     }
                 }
-                return true;
-        }
-        return false;
+                yield true;
+            }
+            default -> false;
+        };
     }
 
     private boolean removesDistinctRecords(BType typeToRemove, BType remainingType) {
@@ -5323,12 +5295,10 @@ public class Types {
     }
 
     private boolean isAnydataOrJson(BType type) {
-        switch (getImpliedType(type).tag) {
-            case TypeTags.ANYDATA:
-            case TypeTags.JSON:
-                return true;
-        }
-        return false;
+        return switch (getImpliedType(type).tag) {
+            case TypeTags.ANYDATA, TypeTags.JSON -> true;
+            default -> false;
+        };
     }
 
     private BMapType getMapTypeForAnydataOrJson(BType type, SymbolEnv env) {
@@ -5971,50 +5941,49 @@ public class Types {
 
     public boolean isAllowedConstantType(BType type) {
         type = getImpliedType(type);
-        switch (type.tag) {
-            case TypeTags.BOOLEAN:
-            case TypeTags.INT:
-            case TypeTags.SIGNED32_INT:
-            case TypeTags.SIGNED16_INT:
-            case TypeTags.SIGNED8_INT:
-            case TypeTags.UNSIGNED32_INT:
-            case TypeTags.UNSIGNED16_INT:
-            case TypeTags.UNSIGNED8_INT:
-            case TypeTags.BYTE:
-            case TypeTags.FLOAT:
-            case TypeTags.DECIMAL:
-            case TypeTags.STRING:
-                // TODO : Fix this, Issue : #21542
-//            case TypeTags.CHAR_STRING:
-            case TypeTags.NIL:
-            case TypeTags.UNION:
-            case TypeTags.ANY:
-            case TypeTags.ANYDATA:
-                return true;
-            case TypeTags.MAP:
-                return isAllowedConstantType(((BMapType) type).constraint);
-            case TypeTags.RECORD:
+        return switch (type.tag) {
+            case TypeTags.BOOLEAN,
+                 TypeTags.INT,
+                 TypeTags.SIGNED32_INT,
+                 TypeTags.SIGNED16_INT,
+                 TypeTags.SIGNED8_INT,
+                 TypeTags.UNSIGNED32_INT,
+                 TypeTags.UNSIGNED16_INT,
+                 TypeTags.UNSIGNED8_INT,
+                 TypeTags.BYTE,
+                 TypeTags.FLOAT,
+                 TypeTags.DECIMAL,
+                 TypeTags.STRING,
+                 // TODO : Fix this, Issue : #21542
+                 //TypeTags.CHAR_STRING:
+                 TypeTags.NIL,
+                 TypeTags.UNION,
+                 TypeTags.ANY,
+                 TypeTags.ANYDATA -> true;
+            case TypeTags.MAP -> isAllowedConstantType(((BMapType) type).constraint);
+            case TypeTags.RECORD -> {
                 for (BField field : ((BRecordType) type).fields.values()) {
                     if (field.symbol.isDefaultable || !isAllowedConstantType(field.type)) {
-                        return false;
+                        yield false;
                     }
                 }
-                return true;
-            case TypeTags.ARRAY:
-                return isAllowedConstantType(((BArrayType) type).eType);
-            case TypeTags.TUPLE:
+                yield true;
+            }
+            case TypeTags.ARRAY -> isAllowedConstantType(((BArrayType) type).eType);
+            case TypeTags.TUPLE -> {
                 for (BType memberType : ((BTupleType) type).getTupleTypes()) {
                     if (!isAllowedConstantType(memberType)) {
-                        return false;
+                        yield false;
                     }
                 }
-                return true;
-            case TypeTags.FINITE:
+                yield true;
+            }
+            case TypeTags.FINITE -> {
                 BLangExpression finiteValue = ((BFiniteType) type).getValueSpace().toArray(new BLangExpression[0])[0];
-                return isAllowedConstantType(finiteValue.getBType());
-            default:
-                return false;
-        }
+                yield isAllowedConstantType(finiteValue.getBType());
+            }
+            default -> false;
+        };
     }
 
     public boolean isValidLiteral(BLangLiteral literal, BType targetType) {
@@ -6023,30 +5992,25 @@ public class Types {
             return true;
         }
 
-        switch (targetType.tag) {
-            case TypeTags.BYTE:
-                return literalType.tag == TypeTags.INT && isByteLiteralValue((Long) literal.value);
-            case TypeTags.DECIMAL:
-                return literalType.tag == TypeTags.FLOAT || literalType.tag == TypeTags.INT;
-            case TypeTags.FLOAT:
-                return literalType.tag == TypeTags.INT;
-            case TypeTags.SIGNED32_INT:
-                return literalType.tag == TypeTags.INT && isSigned32LiteralValue((Long) literal.value);
-            case TypeTags.SIGNED16_INT:
-                return literalType.tag == TypeTags.INT && isSigned16LiteralValue((Long) literal.value);
-            case TypeTags.SIGNED8_INT:
-                return literalType.tag == TypeTags.INT && isSigned8LiteralValue((Long) literal.value);
-            case TypeTags.UNSIGNED32_INT:
-                return literalType.tag == TypeTags.INT && isUnsigned32LiteralValue((Long) literal.value);
-            case TypeTags.UNSIGNED16_INT:
-                return literalType.tag == TypeTags.INT && isUnsigned16LiteralValue((Long) literal.value);
-            case TypeTags.UNSIGNED8_INT:
-                return literalType.tag == TypeTags.INT && isUnsigned8LiteralValue((Long) literal.value);
-            case TypeTags.CHAR_STRING:
-                return literalType.tag == TypeTags.STRING && isCharLiteralValue((String) literal.value);
-            default:
-                return false;
-        }
+        return switch (targetType.tag) {
+            case TypeTags.BYTE -> literalType.tag == TypeTags.INT && isByteLiteralValue((Long) literal.value);
+            case TypeTags.DECIMAL -> literalType.tag == TypeTags.FLOAT || literalType.tag == TypeTags.INT;
+            case TypeTags.FLOAT -> literalType.tag == TypeTags.INT;
+            case TypeTags.SIGNED32_INT ->
+                    literalType.tag == TypeTags.INT && isSigned32LiteralValue((Long) literal.value);
+            case TypeTags.SIGNED16_INT ->
+                    literalType.tag == TypeTags.INT && isSigned16LiteralValue((Long) literal.value);
+            case TypeTags.SIGNED8_INT -> literalType.tag == TypeTags.INT && isSigned8LiteralValue((Long) literal.value);
+            case TypeTags.UNSIGNED32_INT ->
+                    literalType.tag == TypeTags.INT && isUnsigned32LiteralValue((Long) literal.value);
+            case TypeTags.UNSIGNED16_INT ->
+                    literalType.tag == TypeTags.INT && isUnsigned16LiteralValue((Long) literal.value);
+            case TypeTags.UNSIGNED8_INT ->
+                    literalType.tag == TypeTags.INT && isUnsigned8LiteralValue((Long) literal.value);
+            case TypeTags.CHAR_STRING ->
+                    literalType.tag == TypeTags.STRING && isCharLiteralValue((String) literal.value);
+            default -> false;
+        };
     }
 
     /**
@@ -6304,23 +6268,15 @@ public class Types {
             BLangLiteral literalExpression = (BLangLiteral) expression;
             BType literalExprType = literalExpression.getBType();
             Object value = literalExpression.getValue();
-            switch (literalExprType.getKind()) {
-                case INT:
-                case BYTE:
-                    return value.equals(0L);
-                case STRING:
-                    return value == null || value.equals("");
-                case DECIMAL:
-                    return value.equals(String.valueOf(0)) || value.equals(0L);
-                case FLOAT:
-                    return value.equals(String.valueOf(0.0));
-                case BOOLEAN:
-                    return value.equals(Boolean.FALSE);
-                case NIL:
-                    return true;
-                default:
-                    return false;
-            }
+            return switch (literalExprType.getKind()) {
+                case INT, BYTE -> value.equals(0L);
+                case STRING -> value == null || value.equals("");
+                case DECIMAL -> value.equals(String.valueOf(0)) || value.equals(0L);
+                case FLOAT -> value.equals(String.valueOf(0.0));
+                case BOOLEAN -> value.equals(Boolean.FALSE);
+                case NIL -> true;
+                default -> false;
+            };
         }
         return false;
     }
@@ -6475,34 +6431,33 @@ public class Types {
 
     public BType findCompatibleType(BType type) {
         type = getImpliedType(type);
-        switch (type.tag) {
-            case TypeTags.DECIMAL:
-            case TypeTags.FLOAT:
-            case TypeTags.XML:
-            case TypeTags.XML_TEXT:
-            case TypeTags.XML_ELEMENT:
-            case TypeTags.XML_PI:
-            case TypeTags.XML_COMMENT:
-                return type;
-            case TypeTags.INT:
-            case TypeTags.BYTE:
-            case TypeTags.SIGNED32_INT:
-            case TypeTags.SIGNED16_INT:
-            case TypeTags.SIGNED8_INT:
-            case TypeTags.UNSIGNED32_INT:
-            case TypeTags.UNSIGNED16_INT:
-            case TypeTags.UNSIGNED8_INT:
-                return symTable.intType;
-            case TypeTags.STRING:
-            case TypeTags.CHAR_STRING:
-                return symTable.stringType;
-            case TypeTags.UNION:
+        return switch (type.tag) {
+            case TypeTags.DECIMAL,
+                 TypeTags.FLOAT,
+                 TypeTags.XML,
+                 TypeTags.XML_TEXT,
+                 TypeTags.XML_ELEMENT,
+                 TypeTags.XML_PI,
+                 TypeTags.XML_COMMENT -> type;
+            case TypeTags.INT,
+                 TypeTags.BYTE,
+                 TypeTags.SIGNED32_INT,
+                 TypeTags.SIGNED16_INT,
+                 TypeTags.SIGNED8_INT,
+                 TypeTags.UNSIGNED32_INT,
+                 TypeTags.UNSIGNED16_INT,
+                 TypeTags.UNSIGNED8_INT -> symTable.intType;
+            case TypeTags.STRING,
+                 TypeTags.CHAR_STRING -> symTable.stringType;
+            case TypeTags.UNION -> {
                 LinkedHashSet<BType> memberTypes = ((BUnionType) type).getMemberTypes();
-                return findCompatibleType(memberTypes.iterator().next());
-            default:
+                yield findCompatibleType(memberTypes.iterator().next());
+            }
+            default -> {
                 Set<BLangExpression> valueSpace = ((BFiniteType) type).getValueSpace();
-                return findCompatibleType(valueSpace.iterator().next().getBType());
-        }
+                yield findCompatibleType(valueSpace.iterator().next().getBType());
+            }
+        };
     }
 
     public boolean isNonNilSimpleBasicTypeOrString(BType bType) {
@@ -7234,25 +7189,24 @@ public class Types {
     }
 
     public boolean isContainSubtypeOfInt(BType type) {
-        switch (type.tag) {
-            case TypeTags.BYTE:
-            case TypeTags.SIGNED32_INT:
-            case TypeTags.SIGNED16_INT:
-            case TypeTags.SIGNED8_INT:
-            case TypeTags.UNSIGNED32_INT:
-            case TypeTags.UNSIGNED16_INT:
-            case TypeTags.UNSIGNED8_INT:
-                return true;
-            case TypeTags.UNION:
+        return switch (type.tag) {
+            case TypeTags.BYTE,
+                 TypeTags.SIGNED32_INT,
+                 TypeTags.SIGNED16_INT,
+                 TypeTags.SIGNED8_INT,
+                 TypeTags.UNSIGNED32_INT,
+                 TypeTags.UNSIGNED16_INT,
+                 TypeTags.UNSIGNED8_INT -> true;
+            case TypeTags.UNION -> {
                 for (BType memberType : ((BUnionType) type).getMemberTypes()) {
                     if (isContainSubtypeOfInt(memberType)) {
-                        return true;
+                        yield true;
                     }
                 }
-                return false;
-            default:
-                return false;
-        }
+                yield false;
+            }
+            default -> false;
+        };
     }
 
     public boolean isMappingConstructorCompatibleType(BType type) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -335,93 +335,54 @@ public class SymbolTable {
     }
 
     public BType getTypeFromTag(int tag) {
-        switch (tag) {
-            case TypeTags.INT:
-                return intType;
-            case TypeTags.BYTE:
-                return byteType;
-            case TypeTags.FLOAT:
-                return floatType;
-            case TypeTags.DECIMAL:
-                return decimalType;
-            case TypeTags.STRING:
-                return stringType;
-            case TypeTags.BOOLEAN:
-                return booleanType;
-            case TypeTags.JSON:
-                return jsonType;
-            case TypeTags.XML:
-                return xmlType;
-            case TypeTags.XML_COMMENT:
-                return xmlCommentType;
-            case TypeTags.XML_PI:
-                return xmlPIType;
-            case TypeTags.XML_ELEMENT:
-                return xmlElementType;
-            case TypeTags.XML_TEXT:
-                return xmlTextType;
-            case TypeTags.STREAM:
-                return streamType;
-            case TypeTags.TABLE:
-                return tableType;
-            case TypeTags.NIL:
-                return nilType;
-            case TypeTags.NEVER:
-                return neverType;
-            case TypeTags.ERROR:
-                return errorType;
-            case TypeTags.SIGNED32_INT:
-                return signed32IntType;
-            case TypeTags.SIGNED16_INT:
-                return signed16IntType;
-            case TypeTags.SIGNED8_INT:
-                return signed8IntType;
-            case TypeTags.UNSIGNED32_INT:
-                return unsigned32IntType;
-            case TypeTags.UNSIGNED16_INT:
-                return unsigned16IntType;
-            case TypeTags.UNSIGNED8_INT:
-                return unsigned8IntType;
-            case TypeTags.CHAR_STRING:
-                return charStringType;
-            case TypeTags.REGEXP:
-                return regExpType;
-            case TypeTags.BYTE_ARRAY:
-                return byteArrayType;
-            default:
-                return semanticError;
-        }
+        return switch (tag) {
+            case TypeTags.INT -> intType;
+            case TypeTags.BYTE -> byteType;
+            case TypeTags.FLOAT -> floatType;
+            case TypeTags.DECIMAL -> decimalType;
+            case TypeTags.STRING -> stringType;
+            case TypeTags.BOOLEAN -> booleanType;
+            case TypeTags.JSON -> jsonType;
+            case TypeTags.XML -> xmlType;
+            case TypeTags.XML_COMMENT -> xmlCommentType;
+            case TypeTags.XML_PI -> xmlPIType;
+            case TypeTags.XML_ELEMENT -> xmlElementType;
+            case TypeTags.XML_TEXT -> xmlTextType;
+            case TypeTags.STREAM -> streamType;
+            case TypeTags.TABLE -> tableType;
+            case TypeTags.NIL -> nilType;
+            case TypeTags.NEVER -> neverType;
+            case TypeTags.ERROR -> errorType;
+            case TypeTags.SIGNED32_INT -> signed32IntType;
+            case TypeTags.SIGNED16_INT -> signed16IntType;
+            case TypeTags.SIGNED8_INT -> signed8IntType;
+            case TypeTags.UNSIGNED32_INT -> unsigned32IntType;
+            case TypeTags.UNSIGNED16_INT -> unsigned16IntType;
+            case TypeTags.UNSIGNED8_INT -> unsigned8IntType;
+            case TypeTags.CHAR_STRING -> charStringType;
+            case TypeTags.REGEXP -> regExpType;
+            case TypeTags.BYTE_ARRAY -> byteArrayType;
+            default -> semanticError;
+        };
     }
 
     public BType getLangLibSubType(String name) {
         // Assuming subtype names are unique across LangLib
-        switch (name) {
-            case Names.STRING_SIGNED32:
-                return this.signed32IntType;
-            case Names.STRING_SIGNED16:
-                return this.signed16IntType;
-            case Names.STRING_SIGNED8:
-                return this.signed8IntType;
-            case Names.STRING_UNSIGNED32:
-                return this.unsigned32IntType;
-            case Names.STRING_UNSIGNED16:
-                return this.unsigned16IntType;
-            case Names.STRING_UNSIGNED8:
-                return this.unsigned8IntType;
-            case Names.STRING_CHAR:
-                return this.charStringType;
-            case Names.STRING_XML_ELEMENT:
-                return this.xmlElementType;
-            case Names.STRING_XML_PI:
-                return this.xmlPIType;
-            case Names.STRING_XML_COMMENT:
-                return this.xmlCommentType;
-            case Names.STRING_XML_TEXT:
-                return this.xmlTextType;
-            case Names.STRING_REGEXP:
-                return this.regExpType;
-        }
-        throw new IllegalStateException("LangLib Subtype not found: " + name);
+        return switch (name) {
+            case Names.STRING_SIGNED32 -> this.signed32IntType;
+            case Names.STRING_SIGNED16 -> this.signed16IntType;
+            case Names.STRING_SIGNED8 -> this.signed8IntType;
+            case Names.STRING_UNSIGNED32 -> this.unsigned32IntType;
+            case Names.STRING_UNSIGNED16 -> this.unsigned16IntType;
+            case Names.STRING_UNSIGNED8 -> this.unsigned8IntType;
+            case Names.STRING_CHAR -> this.charStringType;
+            case Names.STRING_XML_ELEMENT -> this.xmlElementType;
+            case Names.STRING_XML_PI -> this.xmlPIType;
+            case Names.STRING_XML_COMMENT -> this.xmlCommentType;
+            case Names.STRING_XML_TEXT -> this.xmlTextType;
+            case Names.STRING_REGEXP -> this.regExpType;
+            default -> throw new IllegalStateException("LangLib Subtype not found: " + name);
+        };
     }
 
     public void loadPredeclaredModules() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BBuiltInRefType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BBuiltInRefType.java
@@ -51,27 +51,17 @@ public class BBuiltInRefType extends BType implements ReferenceType {
 
     @Override
     public TypeKind getKind() {
-        switch (tag) {
-            case JSON:
-                return TypeKind.JSON;
-            case XML:
-                return TypeKind.XML;
-            case STREAM:
-                return TypeKind.STREAM;
-            case TABLE:
-                return TypeKind.TABLE;
-            case ANY:
-                return TypeKind.ANY;
-            case ANYDATA:
-                return TypeKind.ANYDATA;
-            case MAP:
-                return TypeKind.MAP;
-            case FUTURE:
-                return TypeKind.FUTURE;
-            case TYPEDESC:
-                return TypeKind.TYPEDESC;
-            default:
-                return TypeKind.OTHER;
-        }
+        return switch (tag) {
+            case JSON -> TypeKind.JSON;
+            case XML -> TypeKind.XML;
+            case STREAM -> TypeKind.STREAM;
+            case TABLE -> TypeKind.TABLE;
+            case ANY -> TypeKind.ANY;
+            case ANYDATA -> TypeKind.ANYDATA;
+            case MAP -> TypeKind.MAP;
+            case FUTURE -> TypeKind.FUTURE;
+            case TYPEDESC -> TypeKind.TYPEDESC;
+            default -> TypeKind.OTHER;
+        };
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BType.java
@@ -88,34 +88,21 @@ public class BType implements ValueType {
 
     @Override
     public TypeKind getKind() {
-        switch (tag) {
-            case INT:
-                return TypeKind.INT;
-            case BYTE:
-                return TypeKind.BYTE;
-            case FLOAT:
-                return TypeKind.FLOAT;
-            case DECIMAL:
-                return TypeKind.DECIMAL;
-            case STRING:
-                return TypeKind.STRING;
-            case BOOLEAN:
-                return TypeKind.BOOLEAN;
-            case TYPEDESC:
-                return TypeKind.TYPEDESC;
-            case NIL:
-                return TypeKind.NIL;
-            case NEVER:
-                return TypeKind.NEVER;
-            case ERROR:
-                return TypeKind.ERROR;
-            case READONLY:
-                return TypeKind.READONLY;
-            case PARAMETERIZED_TYPE:
-                return TypeKind.PARAMETERIZED;
-            default:
-                return TypeKind.OTHER;
-        }
+        return switch (tag) {
+            case INT -> TypeKind.INT;
+            case BYTE -> TypeKind.BYTE;
+            case FLOAT -> TypeKind.FLOAT;
+            case DECIMAL -> TypeKind.DECIMAL;
+            case STRING -> TypeKind.STRING;
+            case BOOLEAN -> TypeKind.BOOLEAN;
+            case TYPEDESC -> TypeKind.TYPEDESC;
+            case NIL -> TypeKind.NIL;
+            case NEVER -> TypeKind.NEVER;
+            case ERROR -> TypeKind.ERROR;
+            case READONLY -> TypeKind.READONLY;
+            case PARAMETERIZED_TYPE -> TypeKind.PARAMETERIZED;
+            default -> TypeKind.OTHER;
+        };
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangResourcePathSegment.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangResourcePathSegment.java
@@ -54,14 +54,11 @@ public class BLangResourcePathSegment extends BLangNode {
 
     @Override
     public String toString() {
-        switch (this.kind) {
-            case RESOURCE_PATH_PARAM_SEGMENT:
-                return "[" + type + "]";
-            case RESOURCE_PATH_REST_PARAM_SEGMENT:
-                return "[" + type + "...]";
-            default:
-                return name.value;
-        }
+        return switch (this.kind) {
+            case RESOURCE_PATH_PARAM_SEGMENT -> "[" + type + "]";
+            case RESOURCE_PATH_REST_PARAM_SEGMENT -> "[" + type + "...]";
+            default -> name.value;
+        };
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeTags.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeTags.java
@@ -92,75 +92,57 @@ public class TypeTags {
     public static boolean isIntegerTypeTag(int tag) {
 
         // TODO : Fix byte type. Ideally, byte belongs to here. But we have modeled it differently.
-        switch (tag) {
-            case INT:
-            case SIGNED32_INT:
-            case SIGNED16_INT:
-            case SIGNED8_INT:
-            case UNSIGNED32_INT:
-            case UNSIGNED16_INT:
-            case UNSIGNED8_INT:
-                return true;
-        }
-        return false;
+        return switch (tag) {
+            case INT,
+                 SIGNED32_INT,
+                 SIGNED16_INT,
+                 SIGNED8_INT,
+                 UNSIGNED32_INT,
+                 UNSIGNED16_INT,
+                 UNSIGNED8_INT -> true;
+            default -> false;
+        };
     }
 
     public static boolean isSignedIntegerTypeTag(int tag) {
 
-        switch (tag) {
-            case INT:
-            case SIGNED32_INT:
-            case SIGNED16_INT:
-            case SIGNED8_INT:
-                return true;
-        }
-        return false;
+        return switch (tag) {
+            case INT, SIGNED32_INT, SIGNED16_INT, SIGNED8_INT -> true;
+            default -> false;
+        };
     }
 
     public static boolean isXMLTypeTag(int tag) {
-        switch (tag) {
-            case XML:
-            case XML_ELEMENT:
-            case XML_PI:
-            case XML_COMMENT:
-            case XML_TEXT:
-                return true;
-        }
-        return false;
+        return switch (tag) {
+            case XML, XML_ELEMENT, XML_PI, XML_COMMENT, XML_TEXT -> true;
+            default -> false;
+        };
     }
 
     public static boolean isXMLNonSequenceType(int tag) {
-        switch (tag) {
-            case XML_ELEMENT:
-            case XML_PI:
-            case XML_COMMENT:
-            case XML_TEXT:
-                return true;
-        }
-        return false;
+        return switch (tag) {
+            case XML_ELEMENT, XML_PI, XML_COMMENT, XML_TEXT -> true;
+            default -> false;
+        };
     }
 
     public static boolean isStringTypeTag(int tag) {
 
-        switch (tag) {
-            case STRING:
-            case CHAR_STRING:
-                return true;
-        }
-        return false;
+        return switch (tag) {
+            case STRING, CHAR_STRING -> true;
+            default -> false;
+        };
     }
 
     public static boolean isSimpleBasicType(int tag) {
-        switch (tag) {
-            case TypeTags.BYTE:
-            case TypeTags.FLOAT:
-            case TypeTags.DECIMAL:
-            case TypeTags.BOOLEAN:
-            case TypeTags.NIL:
-                return true;
-            default:
-                return (TypeTags.isIntegerTypeTag(tag)) || (TypeTags.isStringTypeTag(tag));
-        }
+        return switch (tag) {
+            case TypeTags.BYTE,
+                 TypeTags.FLOAT,
+                 TypeTags.DECIMAL,
+                 TypeTags.BOOLEAN,
+                 TypeTags.NIL -> true;
+            default -> (TypeTags.isIntegerTypeTag(tag)) || (TypeTags.isStringTypeTag(tag));
+        };
     }
 
 }

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/PackageRepositoryBuilder.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/PackageRepositoryBuilder.java
@@ -76,16 +76,11 @@ public class PackageRepositoryBuilder {
     }
 
     private Optional<Path> getRepPath(TestCaseFilePaths filePaths, RepositoryKind repoKind) {
-        switch (repoKind) {
-            case DIST:
-                return filePaths.distRepoPath();
-            case CENTRAL:
-                return filePaths.centralRepoPath();
-            case LOCAL:
-                return filePaths.localRepoDirPath();
-            default:
-                throw new IllegalStateException("Unsupported package repository kind " + repoKind);
-        }
+        return switch (repoKind) {
+            case DIST -> filePaths.distRepoPath();
+            case CENTRAL -> filePaths.centralRepoPath();
+            case LOCAL -> filePaths.localRepoDirPath();
+        };
     }
 
     private PackageRepository buildLocalRepo(Path localRepoDirPath) {
@@ -190,15 +185,10 @@ public class PackageRepositoryBuilder {
     private PackageRepository buildInternal(PackageVersionContainer<PackageDescWrapper> pkgContainer,
                                             Map<PackageDescriptor, DependencyGraph<PackageDescriptor>> graphMap,
                                             RepositoryKind repoKind) {
-        switch (repoKind) {
-            case LOCAL:
-                return new LocalPackageRepository(pkgContainer, graphMap);
-            case CENTRAL:
-            case DIST:
-                return new DefaultPackageRepository(pkgContainer, graphMap);
-            default:
-                throw new IllegalStateException("Unsupported package repository kind " + repoKind);
-        }
+        return switch (repoKind) {
+            case LOCAL -> new LocalPackageRepository(pkgContainer, graphMap);
+            case CENTRAL, DIST -> new DefaultPackageRepository(pkgContainer, graphMap);
+        };
     }
 
     private static class GraphNodeMarker {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
@@ -45,28 +45,22 @@ public class BallerinaLexer extends AbstractLexer {
      */
     @Override
     public STToken nextToken() {
-        STToken token;
-        switch (this.mode) {
-            case TEMPLATE:
-                token = readTemplateToken();
-                break;
-            case REGEXP:
-                token = readRegExpTemplateToken();
-                break;
-            case INTERPOLATION:
+        STToken token = switch (this.mode) {
+            case TEMPLATE -> readTemplateToken();
+            case REGEXP -> readRegExpTemplateToken();
+            case INTERPOLATION -> {
                 processLeadingTrivia();
-                token = readTokenInInterpolation();
-                break;
-            case INTERPOLATION_BRACED_CONTENT:
+                yield readTokenInInterpolation();
+            }
+            case INTERPOLATION_BRACED_CONTENT -> {
                 processLeadingTrivia();
-                token = readTokenInBracedContentInInterpolation();
-                break;
-            case DEFAULT:
-            case IMPORT:
-            default:
+                yield readTokenInBracedContentInInterpolation();
+            }
+            default -> {
                 processLeadingTrivia();
-                token = readToken();
-        }
+                yield readToken();
+            }
+        };
 
         // Can we improve this logic by creating the token with diagnostics then and there?
         return cloneWithDiagnostics(token);
@@ -574,18 +568,11 @@ public class BallerinaLexer extends AbstractLexer {
             nextChar = peek();
         }
 
-        switch (nextChar) {
-            case 'e':
-            case 'E':
-                return processExponent(false);
-            case 'f':
-            case 'F':
-            case 'd':
-            case 'D':
-                return parseFloatingPointTypeSuffix();
-        }
-
-        return getLiteral(SyntaxKind.DECIMAL_FLOATING_POINT_LITERAL_TOKEN);
+        return switch (nextChar) {
+            case 'e', 'E' -> processExponent(false);
+            case 'f', 'F', 'd', 'D' -> parseFloatingPointTypeSuffix();
+            default -> getLiteral(SyntaxKind.DECIMAL_FLOATING_POINT_LITERAL_TOKEN);
+        };
     }
 
     /**
@@ -636,15 +623,11 @@ public class BallerinaLexer extends AbstractLexer {
             return getLiteral(SyntaxKind.HEX_FLOATING_POINT_LITERAL_TOKEN);
         }
 
-        switch (nextChar) {
-            case 'f':
-            case 'F':
-            case 'd':
-            case 'D':
-                return parseFloatingPointTypeSuffix();
-        }
+        return switch (nextChar) {
+            case 'f', 'F', 'd', 'D' -> parseFloatingPointTypeSuffix();
+            default -> getLiteral(SyntaxKind.DECIMAL_FLOATING_POINT_LITERAL_TOKEN);
+        };
 
-        return getLiteral(SyntaxKind.DECIMAL_FLOATING_POINT_LITERAL_TOKEN);
     }
 
     /**
@@ -842,213 +825,118 @@ public class BallerinaLexer extends AbstractLexer {
     private STToken processIdentifierOrKeyword() {
         processUnquotedIdentifier();
         String tokenText = getLexeme();
-        switch (tokenText) {
+        return switch (tokenText) {
             // built-in named-types
-            case LexerTerminals.INT:
-                return getSyntaxToken(SyntaxKind.INT_KEYWORD);
-            case LexerTerminals.FLOAT:
-                return getSyntaxToken(SyntaxKind.FLOAT_KEYWORD);
-            case LexerTerminals.STRING:
-                return getSyntaxToken(SyntaxKind.STRING_KEYWORD);
-            case LexerTerminals.BOOLEAN:
-                return getSyntaxToken(SyntaxKind.BOOLEAN_KEYWORD);
-            case LexerTerminals.DECIMAL:
-                return getSyntaxToken(SyntaxKind.DECIMAL_KEYWORD);
-            case LexerTerminals.XML:
-                return getSyntaxToken(SyntaxKind.XML_KEYWORD);
-            case LexerTerminals.JSON:
-                return getSyntaxToken(SyntaxKind.JSON_KEYWORD);
-            case LexerTerminals.HANDLE:
-                return getSyntaxToken(SyntaxKind.HANDLE_KEYWORD);
-            case LexerTerminals.ANY:
-                return getSyntaxToken(SyntaxKind.ANY_KEYWORD);
-            case LexerTerminals.ANYDATA:
-                return getSyntaxToken(SyntaxKind.ANYDATA_KEYWORD);
-            case LexerTerminals.NEVER:
-                return getSyntaxToken(SyntaxKind.NEVER_KEYWORD);
-            case LexerTerminals.BYTE:
-                return getSyntaxToken(SyntaxKind.BYTE_KEYWORD);
+            case LexerTerminals.INT -> getSyntaxToken(SyntaxKind.INT_KEYWORD);
+            case LexerTerminals.FLOAT -> getSyntaxToken(SyntaxKind.FLOAT_KEYWORD);
+            case LexerTerminals.STRING -> getSyntaxToken(SyntaxKind.STRING_KEYWORD);
+            case LexerTerminals.BOOLEAN -> getSyntaxToken(SyntaxKind.BOOLEAN_KEYWORD);
+            case LexerTerminals.DECIMAL -> getSyntaxToken(SyntaxKind.DECIMAL_KEYWORD);
+            case LexerTerminals.XML -> getSyntaxToken(SyntaxKind.XML_KEYWORD);
+            case LexerTerminals.JSON -> getSyntaxToken(SyntaxKind.JSON_KEYWORD);
+            case LexerTerminals.HANDLE -> getSyntaxToken(SyntaxKind.HANDLE_KEYWORD);
+            case LexerTerminals.ANY -> getSyntaxToken(SyntaxKind.ANY_KEYWORD);
+            case LexerTerminals.ANYDATA -> getSyntaxToken(SyntaxKind.ANYDATA_KEYWORD);
+            case LexerTerminals.NEVER -> getSyntaxToken(SyntaxKind.NEVER_KEYWORD);
+            case LexerTerminals.BYTE -> getSyntaxToken(SyntaxKind.BYTE_KEYWORD);
 
             // Keywords
-            case LexerTerminals.PUBLIC:
-                return getSyntaxToken(SyntaxKind.PUBLIC_KEYWORD);
-            case LexerTerminals.PRIVATE:
-                return getSyntaxToken(SyntaxKind.PRIVATE_KEYWORD);
-            case LexerTerminals.FUNCTION:
-                return getSyntaxToken(SyntaxKind.FUNCTION_KEYWORD);
-            case LexerTerminals.RETURN:
-                return getSyntaxToken(SyntaxKind.RETURN_KEYWORD);
-            case LexerTerminals.RETURNS:
-                return getSyntaxToken(SyntaxKind.RETURNS_KEYWORD);
-            case LexerTerminals.EXTERNAL:
-                return getSyntaxToken(SyntaxKind.EXTERNAL_KEYWORD);
-            case LexerTerminals.TYPE:
-                return getSyntaxToken(SyntaxKind.TYPE_KEYWORD);
-            case LexerTerminals.RECORD:
-                return getSyntaxToken(SyntaxKind.RECORD_KEYWORD);
-            case LexerTerminals.OBJECT:
-                return getSyntaxToken(SyntaxKind.OBJECT_KEYWORD);
-            case LexerTerminals.REMOTE:
-                return getSyntaxToken(SyntaxKind.REMOTE_KEYWORD);
-            case LexerTerminals.ABSTRACT:
-                return getSyntaxToken(SyntaxKind.ABSTRACT_KEYWORD);
-            case LexerTerminals.CLIENT:
-                return getSyntaxToken(SyntaxKind.CLIENT_KEYWORD);
-            case LexerTerminals.IF:
-                return getSyntaxToken(SyntaxKind.IF_KEYWORD);
-            case LexerTerminals.ELSE:
-                return getSyntaxToken(SyntaxKind.ELSE_KEYWORD);
-            case LexerTerminals.WHILE:
-                return getSyntaxToken(SyntaxKind.WHILE_KEYWORD);
-            case LexerTerminals.TRUE:
-                return getSyntaxToken(SyntaxKind.TRUE_KEYWORD);
-            case LexerTerminals.FALSE:
-                return getSyntaxToken(SyntaxKind.FALSE_KEYWORD);
-            case LexerTerminals.CHECK:
-                return getSyntaxToken(SyntaxKind.CHECK_KEYWORD);
-            case LexerTerminals.FAIL:
-                return getSyntaxToken(SyntaxKind.FAIL_KEYWORD);
-            case LexerTerminals.CHECKPANIC:
-                return getSyntaxToken(SyntaxKind.CHECKPANIC_KEYWORD);
-            case LexerTerminals.CONTINUE:
-                return getSyntaxToken(SyntaxKind.CONTINUE_KEYWORD);
-            case LexerTerminals.BREAK:
-                return getSyntaxToken(SyntaxKind.BREAK_KEYWORD);
-            case LexerTerminals.PANIC:
-                return getSyntaxToken(SyntaxKind.PANIC_KEYWORD);
-            case LexerTerminals.IMPORT:
-                return getSyntaxToken(SyntaxKind.IMPORT_KEYWORD);
-            case LexerTerminals.AS:
-                return getSyntaxToken(SyntaxKind.AS_KEYWORD);
-            case LexerTerminals.SERVICE:
-                return getSyntaxToken(SyntaxKind.SERVICE_KEYWORD);
-            case LexerTerminals.ON:
-                return getSyntaxToken(SyntaxKind.ON_KEYWORD);
-            case LexerTerminals.RESOURCE:
-                return getSyntaxToken(SyntaxKind.RESOURCE_KEYWORD);
-            case LexerTerminals.LISTENER:
-                return getSyntaxToken(SyntaxKind.LISTENER_KEYWORD);
-            case LexerTerminals.CONST:
-                return getSyntaxToken(SyntaxKind.CONST_KEYWORD);
-            case LexerTerminals.FINAL:
-                return getSyntaxToken(SyntaxKind.FINAL_KEYWORD);
-            case LexerTerminals.TYPEOF:
-                return getSyntaxToken(SyntaxKind.TYPEOF_KEYWORD);
-            case LexerTerminals.IS:
-                return getSyntaxToken(SyntaxKind.IS_KEYWORD);
-            case LexerTerminals.NULL:
-                return getSyntaxToken(SyntaxKind.NULL_KEYWORD);
-            case LexerTerminals.LOCK:
-                return getSyntaxToken(SyntaxKind.LOCK_KEYWORD);
-            case LexerTerminals.ANNOTATION:
-                return getSyntaxToken(SyntaxKind.ANNOTATION_KEYWORD);
-            case LexerTerminals.SOURCE:
-                return getSyntaxToken(SyntaxKind.SOURCE_KEYWORD);
-            case LexerTerminals.VAR:
-                return getSyntaxToken(SyntaxKind.VAR_KEYWORD);
-            case LexerTerminals.WORKER:
-                return getSyntaxToken(SyntaxKind.WORKER_KEYWORD);
-            case LexerTerminals.PARAMETER:
-                return getSyntaxToken(SyntaxKind.PARAMETER_KEYWORD);
-            case LexerTerminals.FIELD:
-                return getSyntaxToken(SyntaxKind.FIELD_KEYWORD);
-            case LexerTerminals.ISOLATED:
-                return getSyntaxToken(SyntaxKind.ISOLATED_KEYWORD);
-            case LexerTerminals.XMLNS:
-                return getSyntaxToken(SyntaxKind.XMLNS_KEYWORD);
-            case LexerTerminals.FORK:
-                return getSyntaxToken(SyntaxKind.FORK_KEYWORD);
-            case LexerTerminals.MAP:
-                return getSyntaxToken(SyntaxKind.MAP_KEYWORD);
-            case LexerTerminals.FUTURE:
-                return getSyntaxToken(SyntaxKind.FUTURE_KEYWORD);
-            case LexerTerminals.TYPEDESC:
-                return getSyntaxToken(SyntaxKind.TYPEDESC_KEYWORD);
-            case LexerTerminals.TRAP:
-                return getSyntaxToken(SyntaxKind.TRAP_KEYWORD);
-            case LexerTerminals.IN:
-                return getSyntaxToken(SyntaxKind.IN_KEYWORD);
-            case LexerTerminals.FOREACH:
-                return getSyntaxToken(SyntaxKind.FOREACH_KEYWORD);
-            case LexerTerminals.TABLE:
-                return getSyntaxToken(SyntaxKind.TABLE_KEYWORD);
-            case LexerTerminals.ERROR:
-                return getSyntaxToken(SyntaxKind.ERROR_KEYWORD);
-            case LexerTerminals.LET:
-                return getSyntaxToken(SyntaxKind.LET_KEYWORD);
-            case LexerTerminals.STREAM:
-                return getSyntaxToken(SyntaxKind.STREAM_KEYWORD);
-            case LexerTerminals.NEW:
-                return getSyntaxToken(SyntaxKind.NEW_KEYWORD);
-            case LexerTerminals.READONLY:
-                return getSyntaxToken(SyntaxKind.READONLY_KEYWORD);
-            case LexerTerminals.DISTINCT:
-                return getSyntaxToken(SyntaxKind.DISTINCT_KEYWORD);
-            case LexerTerminals.FROM:
-                return getSyntaxToken(SyntaxKind.FROM_KEYWORD);
-            case LexerTerminals.START:
-                return getSyntaxToken(SyntaxKind.START_KEYWORD);
-            case LexerTerminals.FLUSH:
-                return getSyntaxToken(SyntaxKind.FLUSH_KEYWORD);
-            case LexerTerminals.WAIT:
-                return getSyntaxToken(SyntaxKind.WAIT_KEYWORD);
-            case LexerTerminals.DO:
-                return getSyntaxToken(SyntaxKind.DO_KEYWORD);
-            case LexerTerminals.TRANSACTION:
-                return getSyntaxToken(SyntaxKind.TRANSACTION_KEYWORD);
-            case LexerTerminals.COMMIT:
-                return getSyntaxToken(SyntaxKind.COMMIT_KEYWORD);
-            case LexerTerminals.RETRY:
-                return getSyntaxToken(SyntaxKind.RETRY_KEYWORD);
-            case LexerTerminals.ROLLBACK:
-                return getSyntaxToken(SyntaxKind.ROLLBACK_KEYWORD);
-            case LexerTerminals.TRANSACTIONAL:
-                return getSyntaxToken(SyntaxKind.TRANSACTIONAL_KEYWORD);
-            case LexerTerminals.ENUM:
-                return getSyntaxToken(SyntaxKind.ENUM_KEYWORD);
-            case LexerTerminals.BASE16:
-                return getSyntaxToken(SyntaxKind.BASE16_KEYWORD);
-            case LexerTerminals.BASE64:
-                return getSyntaxToken(SyntaxKind.BASE64_KEYWORD);
-            case LexerTerminals.MATCH:
-                return getSyntaxToken(SyntaxKind.MATCH_KEYWORD);
-            case LexerTerminals.CONFLICT:
-                return getSyntaxToken(SyntaxKind.CONFLICT_KEYWORD);
-            case LexerTerminals.CLASS:
-                return getSyntaxToken(SyntaxKind.CLASS_KEYWORD);
-            case LexerTerminals.CONFIGURABLE:
-                return getSyntaxToken(SyntaxKind.CONFIGURABLE_KEYWORD);
-            case LexerTerminals.WHERE:
-                return getSyntaxToken(SyntaxKind.WHERE_KEYWORD);
-            case LexerTerminals.SELECT:
-                return getSyntaxToken(SyntaxKind.SELECT_KEYWORD);
-            case LexerTerminals.LIMIT:
-                return getSyntaxToken(SyntaxKind.LIMIT_KEYWORD);
-            case LexerTerminals.OUTER:
-                return getSyntaxToken(SyntaxKind.OUTER_KEYWORD);
-            case LexerTerminals.EQUALS:
-                return getSyntaxToken(SyntaxKind.EQUALS_KEYWORD);
-            case LexerTerminals.ORDER:
-                return getSyntaxToken(SyntaxKind.ORDER_KEYWORD);
-            case LexerTerminals.BY:
-                return getSyntaxToken(SyntaxKind.BY_KEYWORD);
-            case LexerTerminals.ASCENDING:
-                return getSyntaxToken(SyntaxKind.ASCENDING_KEYWORD);
-            case LexerTerminals.DESCENDING:
-                return getSyntaxToken(SyntaxKind.DESCENDING_KEYWORD);
-            case LexerTerminals.JOIN:
-                return getSyntaxToken(SyntaxKind.JOIN_KEYWORD);
-            case LexerTerminals.RE:
+            case LexerTerminals.PUBLIC -> getSyntaxToken(SyntaxKind.PUBLIC_KEYWORD);
+            case LexerTerminals.PRIVATE -> getSyntaxToken(SyntaxKind.PRIVATE_KEYWORD);
+            case LexerTerminals.FUNCTION -> getSyntaxToken(SyntaxKind.FUNCTION_KEYWORD);
+            case LexerTerminals.RETURN -> getSyntaxToken(SyntaxKind.RETURN_KEYWORD);
+            case LexerTerminals.RETURNS -> getSyntaxToken(SyntaxKind.RETURNS_KEYWORD);
+            case LexerTerminals.EXTERNAL -> getSyntaxToken(SyntaxKind.EXTERNAL_KEYWORD);
+            case LexerTerminals.TYPE -> getSyntaxToken(SyntaxKind.TYPE_KEYWORD);
+            case LexerTerminals.RECORD -> getSyntaxToken(SyntaxKind.RECORD_KEYWORD);
+            case LexerTerminals.OBJECT -> getSyntaxToken(SyntaxKind.OBJECT_KEYWORD);
+            case LexerTerminals.REMOTE -> getSyntaxToken(SyntaxKind.REMOTE_KEYWORD);
+            case LexerTerminals.ABSTRACT -> getSyntaxToken(SyntaxKind.ABSTRACT_KEYWORD);
+            case LexerTerminals.CLIENT -> getSyntaxToken(SyntaxKind.CLIENT_KEYWORD);
+            case LexerTerminals.IF -> getSyntaxToken(SyntaxKind.IF_KEYWORD);
+            case LexerTerminals.ELSE -> getSyntaxToken(SyntaxKind.ELSE_KEYWORD);
+            case LexerTerminals.WHILE -> getSyntaxToken(SyntaxKind.WHILE_KEYWORD);
+            case LexerTerminals.TRUE -> getSyntaxToken(SyntaxKind.TRUE_KEYWORD);
+            case LexerTerminals.FALSE -> getSyntaxToken(SyntaxKind.FALSE_KEYWORD);
+            case LexerTerminals.CHECK -> getSyntaxToken(SyntaxKind.CHECK_KEYWORD);
+            case LexerTerminals.FAIL -> getSyntaxToken(SyntaxKind.FAIL_KEYWORD);
+            case LexerTerminals.CHECKPANIC -> getSyntaxToken(SyntaxKind.CHECKPANIC_KEYWORD);
+            case LexerTerminals.CONTINUE -> getSyntaxToken(SyntaxKind.CONTINUE_KEYWORD);
+            case LexerTerminals.BREAK -> getSyntaxToken(SyntaxKind.BREAK_KEYWORD);
+            case LexerTerminals.PANIC -> getSyntaxToken(SyntaxKind.PANIC_KEYWORD);
+            case LexerTerminals.IMPORT -> getSyntaxToken(SyntaxKind.IMPORT_KEYWORD);
+            case LexerTerminals.AS -> getSyntaxToken(SyntaxKind.AS_KEYWORD);
+            case LexerTerminals.SERVICE -> getSyntaxToken(SyntaxKind.SERVICE_KEYWORD);
+            case LexerTerminals.ON -> getSyntaxToken(SyntaxKind.ON_KEYWORD);
+            case LexerTerminals.RESOURCE -> getSyntaxToken(SyntaxKind.RESOURCE_KEYWORD);
+            case LexerTerminals.LISTENER -> getSyntaxToken(SyntaxKind.LISTENER_KEYWORD);
+            case LexerTerminals.CONST -> getSyntaxToken(SyntaxKind.CONST_KEYWORD);
+            case LexerTerminals.FINAL -> getSyntaxToken(SyntaxKind.FINAL_KEYWORD);
+            case LexerTerminals.TYPEOF -> getSyntaxToken(SyntaxKind.TYPEOF_KEYWORD);
+            case LexerTerminals.IS -> getSyntaxToken(SyntaxKind.IS_KEYWORD);
+            case LexerTerminals.NULL -> getSyntaxToken(SyntaxKind.NULL_KEYWORD);
+            case LexerTerminals.LOCK -> getSyntaxToken(SyntaxKind.LOCK_KEYWORD);
+            case LexerTerminals.ANNOTATION -> getSyntaxToken(SyntaxKind.ANNOTATION_KEYWORD);
+            case LexerTerminals.SOURCE -> getSyntaxToken(SyntaxKind.SOURCE_KEYWORD);
+            case LexerTerminals.VAR -> getSyntaxToken(SyntaxKind.VAR_KEYWORD);
+            case LexerTerminals.WORKER -> getSyntaxToken(SyntaxKind.WORKER_KEYWORD);
+            case LexerTerminals.PARAMETER -> getSyntaxToken(SyntaxKind.PARAMETER_KEYWORD);
+            case LexerTerminals.FIELD -> getSyntaxToken(SyntaxKind.FIELD_KEYWORD);
+            case LexerTerminals.ISOLATED -> getSyntaxToken(SyntaxKind.ISOLATED_KEYWORD);
+            case LexerTerminals.XMLNS -> getSyntaxToken(SyntaxKind.XMLNS_KEYWORD);
+            case LexerTerminals.FORK -> getSyntaxToken(SyntaxKind.FORK_KEYWORD);
+            case LexerTerminals.MAP -> getSyntaxToken(SyntaxKind.MAP_KEYWORD);
+            case LexerTerminals.FUTURE -> getSyntaxToken(SyntaxKind.FUTURE_KEYWORD);
+            case LexerTerminals.TYPEDESC -> getSyntaxToken(SyntaxKind.TYPEDESC_KEYWORD);
+            case LexerTerminals.TRAP -> getSyntaxToken(SyntaxKind.TRAP_KEYWORD);
+            case LexerTerminals.IN -> getSyntaxToken(SyntaxKind.IN_KEYWORD);
+            case LexerTerminals.FOREACH -> getSyntaxToken(SyntaxKind.FOREACH_KEYWORD);
+            case LexerTerminals.TABLE -> getSyntaxToken(SyntaxKind.TABLE_KEYWORD);
+            case LexerTerminals.ERROR -> getSyntaxToken(SyntaxKind.ERROR_KEYWORD);
+            case LexerTerminals.LET -> getSyntaxToken(SyntaxKind.LET_KEYWORD);
+            case LexerTerminals.STREAM -> getSyntaxToken(SyntaxKind.STREAM_KEYWORD);
+            case LexerTerminals.NEW -> getSyntaxToken(SyntaxKind.NEW_KEYWORD);
+            case LexerTerminals.READONLY -> getSyntaxToken(SyntaxKind.READONLY_KEYWORD);
+            case LexerTerminals.DISTINCT -> getSyntaxToken(SyntaxKind.DISTINCT_KEYWORD);
+            case LexerTerminals.FROM -> getSyntaxToken(SyntaxKind.FROM_KEYWORD);
+            case LexerTerminals.START -> getSyntaxToken(SyntaxKind.START_KEYWORD);
+            case LexerTerminals.FLUSH -> getSyntaxToken(SyntaxKind.FLUSH_KEYWORD);
+            case LexerTerminals.WAIT -> getSyntaxToken(SyntaxKind.WAIT_KEYWORD);
+            case LexerTerminals.DO -> getSyntaxToken(SyntaxKind.DO_KEYWORD);
+            case LexerTerminals.TRANSACTION -> getSyntaxToken(SyntaxKind.TRANSACTION_KEYWORD);
+            case LexerTerminals.COMMIT -> getSyntaxToken(SyntaxKind.COMMIT_KEYWORD);
+            case LexerTerminals.RETRY -> getSyntaxToken(SyntaxKind.RETRY_KEYWORD);
+            case LexerTerminals.ROLLBACK -> getSyntaxToken(SyntaxKind.ROLLBACK_KEYWORD);
+            case LexerTerminals.TRANSACTIONAL -> getSyntaxToken(SyntaxKind.TRANSACTIONAL_KEYWORD);
+            case LexerTerminals.ENUM -> getSyntaxToken(SyntaxKind.ENUM_KEYWORD);
+            case LexerTerminals.BASE16 -> getSyntaxToken(SyntaxKind.BASE16_KEYWORD);
+            case LexerTerminals.BASE64 -> getSyntaxToken(SyntaxKind.BASE64_KEYWORD);
+            case LexerTerminals.MATCH -> getSyntaxToken(SyntaxKind.MATCH_KEYWORD);
+            case LexerTerminals.CONFLICT -> getSyntaxToken(SyntaxKind.CONFLICT_KEYWORD);
+            case LexerTerminals.CLASS -> getSyntaxToken(SyntaxKind.CLASS_KEYWORD);
+            case LexerTerminals.CONFIGURABLE -> getSyntaxToken(SyntaxKind.CONFIGURABLE_KEYWORD);
+            case LexerTerminals.WHERE -> getSyntaxToken(SyntaxKind.WHERE_KEYWORD);
+            case LexerTerminals.SELECT -> getSyntaxToken(SyntaxKind.SELECT_KEYWORD);
+            case LexerTerminals.LIMIT -> getSyntaxToken(SyntaxKind.LIMIT_KEYWORD);
+            case LexerTerminals.OUTER -> getSyntaxToken(SyntaxKind.OUTER_KEYWORD);
+            case LexerTerminals.EQUALS -> getSyntaxToken(SyntaxKind.EQUALS_KEYWORD);
+            case LexerTerminals.ORDER -> getSyntaxToken(SyntaxKind.ORDER_KEYWORD);
+            case LexerTerminals.BY -> getSyntaxToken(SyntaxKind.BY_KEYWORD);
+            case LexerTerminals.ASCENDING -> getSyntaxToken(SyntaxKind.ASCENDING_KEYWORD);
+            case LexerTerminals.DESCENDING -> getSyntaxToken(SyntaxKind.DESCENDING_KEYWORD);
+            case LexerTerminals.JOIN -> getSyntaxToken(SyntaxKind.JOIN_KEYWORD);
+            case LexerTerminals.RE -> {
                 if (getNextNonWSOrNonCommentChar() == LexerTerminals.BACKTICK) {
-                    return getSyntaxToken(SyntaxKind.RE_KEYWORD);
+                    yield getSyntaxToken(SyntaxKind.RE_KEYWORD);
                 }
-                return getIdentifierToken();
-            default:
+                yield getIdentifierToken();
+            }
+            default ->
 //                if (this.keywordModes.contains(KeywordMode.QUERY)) {
 //                    return getQueryCtxKeywordOrIdentifier(tokenText);
 //                }
-                return getIdentifierToken();
-        }
+                    getIdentifierToken();
+        };
     }
 
     private int getNextNonWSOrNonCommentChar() {
@@ -1155,50 +1043,46 @@ public class BallerinaLexer extends AbstractLexer {
         }
 
         int currentChar = peek();
-        switch (currentChar) {
-            case LexerTerminals.NEWLINE:
-            case LexerTerminals.CARRIAGE_RETURN:
-            case LexerTerminals.SPACE:
-            case LexerTerminals.TAB:
-
-                // Separators
-            case LexerTerminals.SEMICOLON:
-            case LexerTerminals.COLON:
-            case LexerTerminals.DOT:
-            case LexerTerminals.COMMA:
-            case LexerTerminals.OPEN_PARANTHESIS:
-            case LexerTerminals.CLOSE_PARANTHESIS:
-            case LexerTerminals.OPEN_BRACE:
-            case LexerTerminals.CLOSE_BRACE:
-            case LexerTerminals.OPEN_BRACKET:
-            case LexerTerminals.CLOSE_BRACKET:
-            case LexerTerminals.PIPE:
-            case LexerTerminals.QUESTION_MARK:
-            case LexerTerminals.DOUBLE_QUOTE:
-            case LexerTerminals.SINGLE_QUOTE:
-            case LexerTerminals.HASH:
-            case LexerTerminals.AT:
-            case LexerTerminals.BACKTICK:
-            case LexerTerminals.DOLLAR:
-
-                // Arithmetic operators
-            case LexerTerminals.EQUAL:
-            case LexerTerminals.PLUS:
-            case LexerTerminals.MINUS:
-            case LexerTerminals.ASTERISK:
-            case LexerTerminals.SLASH:
-            case LexerTerminals.PERCENT:
-            case LexerTerminals.GT:
-            case LexerTerminals.LT:
-            case LexerTerminals.BACKSLASH:
-            case LexerTerminals.EXCLAMATION_MARK:
-            case LexerTerminals.BITWISE_AND:
-            case LexerTerminals.BITWISE_XOR:
-            case LexerTerminals.NEGATION:
-                return true;
-            default:
-                return isIdentifierFollowingChar(currentChar);
-        }
+        return switch (currentChar) {
+            case LexerTerminals.NEWLINE,
+                 LexerTerminals.CARRIAGE_RETURN,
+                 LexerTerminals.SPACE,
+                 LexerTerminals.TAB,
+                 // Separators
+                 LexerTerminals.SEMICOLON,
+                 LexerTerminals.COLON,
+                 LexerTerminals.DOT,
+                 LexerTerminals.COMMA,
+                 LexerTerminals.OPEN_PARANTHESIS,
+                 LexerTerminals.CLOSE_PARANTHESIS,
+                 LexerTerminals.OPEN_BRACE,
+                 LexerTerminals.CLOSE_BRACE,
+                 LexerTerminals.OPEN_BRACKET,
+                 LexerTerminals.CLOSE_BRACKET,
+                 LexerTerminals.PIPE,
+                 LexerTerminals.QUESTION_MARK,
+                 LexerTerminals.DOUBLE_QUOTE,
+                 LexerTerminals.SINGLE_QUOTE,
+                 LexerTerminals.HASH,
+                 LexerTerminals.AT,
+                 LexerTerminals.BACKTICK,
+                 LexerTerminals.DOLLAR,
+                 // Arithmetic operators
+                 LexerTerminals.EQUAL,
+                 LexerTerminals.PLUS,
+                 LexerTerminals.MINUS,
+                 LexerTerminals.ASTERISK,
+                 LexerTerminals.SLASH,
+                 LexerTerminals.PERCENT,
+                 LexerTerminals.GT,
+                 LexerTerminals.LT,
+                 LexerTerminals.BACKSLASH,
+                 LexerTerminals.EXCLAMATION_MARK,
+                 LexerTerminals.BITWISE_AND,
+                 LexerTerminals.BITWISE_XOR,
+                 LexerTerminals.NEGATION -> true;
+            default -> isIdentifierFollowingChar(currentChar);
+        };
     }
 
     /**
@@ -1337,16 +1221,17 @@ public class BallerinaLexer extends AbstractLexer {
      * @return One of the tokens: <code>'|', '|}', '||'</code>
      */
     private STToken processPipeOperator() {
-        switch (peek()) { // check for the second char
-            case LexerTerminals.CLOSE_BRACE:
+        return switch (peek()) { // check for the second char
+            case LexerTerminals.CLOSE_BRACE -> {
                 reader.advance();
-                return getSyntaxToken(SyntaxKind.CLOSE_BRACE_PIPE_TOKEN);
-            case LexerTerminals.PIPE:
+                yield getSyntaxToken(SyntaxKind.CLOSE_BRACE_PIPE_TOKEN);
+            }
+            case LexerTerminals.PIPE -> {
                 reader.advance();
-                return getSyntaxToken(SyntaxKind.LOGICAL_OR_TOKEN);
-            default:
-                return getSyntaxToken(SyntaxKind.PIPE_TOKEN);
-        }
+                yield getSyntaxToken(SyntaxKind.LOGICAL_OR_TOKEN);
+            }
+            default -> getSyntaxToken(SyntaxKind.PIPE_TOKEN);
+        };
     }
 
     /**
@@ -1691,21 +1576,22 @@ public class BallerinaLexer extends AbstractLexer {
         }
 
         char nextChar = reader.peek(1);
-        switch (nextChar) {
-            case LexerTerminals.GT:
+        return switch (nextChar) {
+            case LexerTerminals.GT -> {
                 if (reader.peek(2) == LexerTerminals.EQUAL) {
                     // ">>>="
                     reader.advance(2);
-                    return getSyntaxToken(SyntaxKind.TRIPPLE_GT_TOKEN);
+                    yield getSyntaxToken(SyntaxKind.TRIPPLE_GT_TOKEN);
                 }
-                return getSyntaxToken(SyntaxKind.GT_TOKEN);
-            case LexerTerminals.EQUAL:
+                yield getSyntaxToken(SyntaxKind.GT_TOKEN);
+            }
+            case LexerTerminals.EQUAL -> {
                 // ">>="
                 reader.advance(1);
-                return getSyntaxToken(SyntaxKind.DOUBLE_GT_TOKEN);
-            default:
-                return getSyntaxToken(SyntaxKind.GT_TOKEN);
-        }
+                yield getSyntaxToken(SyntaxKind.DOUBLE_GT_TOKEN);
+            }
+            default -> getSyntaxToken(SyntaxKind.GT_TOKEN);
+        };
     }
 
     /*

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
@@ -633,44 +633,41 @@ public class BallerinaParser extends AbstractParser {
     private boolean isModuleVarDeclStart(int lookahead) {
         // Assumes that we reach here after a peek()
         STToken nextToken = peek(lookahead + 1);
-        switch (nextToken.kind) {
-            case EQUAL_TOKEN: // Scenario: foo = . Even though this is not valid, consider this as a var-decl and
-                // continue;
-            case OPEN_BRACKET_TOKEN: // Scenario foo[] (Array type descriptor with custom type)
-            case QUESTION_MARK_TOKEN: // Scenario foo? (Optional type descriptor with custom type)
-            case PIPE_TOKEN: // Scenario foo | (Union type descriptor with custom type)
-            case BITWISE_AND_TOKEN: // Scenario foo & (Intersection type descriptor with custom type)
-            case OPEN_BRACE_TOKEN: // Scenario foo{} (mapping-binding-pattern)
-            case ERROR_KEYWORD: // Scenario foo error (error-binding-pattern)
-            case EOF_TOKEN:
-                return true;
-            case IDENTIFIER_TOKEN:
-                switch (peek(lookahead + 2).kind) {
-                    case EQUAL_TOKEN: // Scenario: foo bar =
-                    case SEMICOLON_TOKEN: // Scenario: foo bar;
-                    case EOF_TOKEN:
-                        return true;
-                    default:
-                        return false;
-                }
-            case COLON_TOKEN:
+        return switch (nextToken.kind) {
+            case EQUAL_TOKEN, // Scenario: foo = . Even though this is not valid, consider this as a var-decl and
+                 // continue;
+                 OPEN_BRACKET_TOKEN, // Scenario foo[] (Array type descriptor with custom type)
+                 QUESTION_MARK_TOKEN, // Scenario foo? (Optional type descriptor with custom type)
+                 PIPE_TOKEN, // Scenario foo | (Union type descriptor with custom type)
+                 BITWISE_AND_TOKEN, // Scenario foo & (Intersection type descriptor with custom type)
+                 OPEN_BRACE_TOKEN, // Scenario foo{} (mapping-binding-pattern)
+                 ERROR_KEYWORD, // Scenario foo error (error-binding-pattern)
+                 EOF_TOKEN -> true;
+            case IDENTIFIER_TOKEN -> switch (peek(lookahead + 2).kind) {
+                case EQUAL_TOKEN,
+                     // Scenario: foo bar =
+                     SEMICOLON_TOKEN,
+                     // Scenario: foo bar;
+                     EOF_TOKEN -> true;
+                default -> false;
+            };
+            case COLON_TOKEN -> {
                 if (lookahead > 1) {
                     // This means there's a colon somewhere after the type name.
                     // This is not a valid var-decl.
-                    return false;
+                    yield false;
                 }
 
-                switch (peek(lookahead + 2).kind) {
-                    case IDENTIFIER_TOKEN: // Scenario: foo:bar baz ...
-                        return isModuleVarDeclStart(lookahead + 2);
-                    case EOF_TOKEN: // Scenario: foo: recovery
-                        return true;
-                    default:
-                        return false;
-                }
-            default:
-                return false;
-        }
+                yield switch (peek(lookahead + 2).kind) {
+                    // Scenario: foo:bar baz ...
+                    case IDENTIFIER_TOKEN -> isModuleVarDeclStart(lookahead + 2);
+                    // Scenario: foo: recovery
+                    case EOF_TOKEN -> true;
+                    default -> false;
+                };
+            }
+            default -> false;
+        };
     }
 
     /**
@@ -831,36 +828,32 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseModuleNameRhs() {
-        switch(peek().kind) {
-            case DOT_TOKEN:
-                return consume();
-            case AS_KEYWORD:
-            case SEMICOLON_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case DOT_TOKEN -> consume();
+            case AS_KEYWORD, SEMICOLON_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.AFTER_IMPORT_MODULE_NAME);
-                return parseModuleNameRhs();
-        }
+                yield parseModuleNameRhs();
+            }
+        };
     }
 
     private boolean isEndOfImportDecl(STToken nextToken) {
-        switch (nextToken.kind) {
-            case SEMICOLON_TOKEN:
-            case PUBLIC_KEYWORD:
-            case FUNCTION_KEYWORD:
-            case TYPE_KEYWORD:
-            case ABSTRACT_KEYWORD:
-            case CONST_KEYWORD:
-            case EOF_TOKEN:
-            case SERVICE_KEYWORD:
-            case IMPORT_KEYWORD:
-            case FINAL_KEYWORD:
-            case TRANSACTIONAL_KEYWORD:
-            case ISOLATED_KEYWORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextToken.kind) {
+            case SEMICOLON_TOKEN,
+                 PUBLIC_KEYWORD,
+                 FUNCTION_KEYWORD,
+                 TYPE_KEYWORD,
+                 ABSTRACT_KEYWORD,
+                 CONST_KEYWORD,
+                 EOF_TOKEN,
+                 SERVICE_KEYWORD,
+                 IMPORT_KEYWORD,
+                 FINAL_KEYWORD,
+                 TRANSACTIONAL_KEYWORD,
+                 ISOLATED_KEYWORD -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -1105,14 +1098,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     boolean isModuleVarDeclQualifier(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case FINAL_KEYWORD:
-            case ISOLATED_KEYWORD:
-            case CONFIGURABLE_KEYWORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case FINAL_KEYWORD, ISOLATED_KEYWORD, CONFIGURABLE_KEYWORD -> true;
+            default -> false;
+        };
     }
 
     private void reportInvalidQualifier(STNode qualifier) {
@@ -1158,85 +1147,81 @@ public class BallerinaParser extends AbstractParser {
 
     private boolean isTopLevelQualifier(SyntaxKind tokenKind) {
         STToken nextNextToken;
-        switch (tokenKind) {
-            case FINAL_KEYWORD: // final-qualifier
-            case CONFIGURABLE_KEYWORD: // configurable-qualifier
-                return true;
-            case READONLY_KEYWORD: // readonly-type-desc, class-def
+        return switch (tokenKind) {
+            case FINAL_KEYWORD, // final-qualifier
+                 CONFIGURABLE_KEYWORD // configurable-qualifier
+                    -> true;
+            // readonly-type-desc, class-def
+            case READONLY_KEYWORD -> {
                 nextNextToken = getNextNextToken();
                 // Treat readonly as a top level qualifier only with class definition.
-                switch (nextNextToken.kind) {
-                    case CLIENT_KEYWORD:
-                    case SERVICE_KEYWORD:
-                    case DISTINCT_KEYWORD:
-                    case ISOLATED_KEYWORD:
-                    case CLASS_KEYWORD:
-                        return true;
-                    default:
-                        return false;
-                }
-            case DISTINCT_KEYWORD: // class-def, distinct-type-desc
+                yield switch (nextNextToken.kind) {
+                    case CLIENT_KEYWORD,
+                         SERVICE_KEYWORD,
+                         DISTINCT_KEYWORD,
+                         ISOLATED_KEYWORD,
+                         CLASS_KEYWORD -> true;
+                    default -> false;
+                };
+            }
+            // class-def, distinct-type-desc
+            case DISTINCT_KEYWORD -> {
                 nextNextToken = getNextNextToken();
                 // distinct-type-desc can occur recursively.
                 // e.g. `distinct distinct student` is a valid type descriptor
                 // Treat distinct as a top level qualifier only with class definition.
-                switch (nextNextToken.kind) {
-                    case CLIENT_KEYWORD:
-                    case SERVICE_KEYWORD:
-                    case READONLY_KEYWORD:
-                    case ISOLATED_KEYWORD:
-                    case CLASS_KEYWORD:
-                        return true;
-                    default:
-                        return false;
-                }
-            default:
-                return isTypeDescQualifier(tokenKind);
-        }
+                yield switch (nextNextToken.kind) {
+                    case CLIENT_KEYWORD,
+                         SERVICE_KEYWORD,
+                         READONLY_KEYWORD,
+                         ISOLATED_KEYWORD,
+                         CLASS_KEYWORD -> true;
+                    default -> false;
+                };
+            }
+            default -> isTypeDescQualifier(tokenKind);
+        };
     }
 
     private boolean isTypeDescQualifier(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case TRANSACTIONAL_KEYWORD: // func-type-dec, func-def
-            case ISOLATED_KEYWORD: // func-type-dec, object-type-desc, func-def, class-def, isolated-final-qual
-            case CLIENT_KEYWORD: // object-type-desc, class-def
-            case ABSTRACT_KEYWORD: // object-type-desc(outdated)
-            case SERVICE_KEYWORD: // object-type-desc, object-constructor, class-def, service-decl
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case TRANSACTIONAL_KEYWORD, // func-type-dec, func-def
+                 ISOLATED_KEYWORD, // func-type-dec, object-type-desc, func-def, class-def, isolated-final-qual
+                 CLIENT_KEYWORD, // object-type-desc, class-def
+                 ABSTRACT_KEYWORD, // object-type-desc(outdated)
+                 SERVICE_KEYWORD // object-type-desc, object-constructor, class-def, service-decl
+                    -> true;
+            default -> false;
+        };
     }
 
     private boolean isObjectMemberQualifier(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case REMOTE_KEYWORD: // method-def, method-decl
-            case RESOURCE_KEYWORD: // resource-method-def
-            case FINAL_KEYWORD: // final-qualifier
-                return true;
-            default:
-                return isTypeDescQualifier(tokenKind);
-        }
+        return switch (tokenKind) {
+            case REMOTE_KEYWORD, // method-def, method-decl
+                 RESOURCE_KEYWORD, // resource-method-def
+                 FINAL_KEYWORD // final-qualifier
+                    -> true;
+            default -> isTypeDescQualifier(tokenKind);
+        };
     }
 
     private boolean isExprQualifier(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case TRANSACTIONAL_KEYWORD: // transactional-expr, object-type, func-type
+        return switch (tokenKind) {
+            // transactional-expr, object-type, func-type
+            case TRANSACTIONAL_KEYWORD -> {
                 STToken nextNextToken = getNextNextToken();
                 // Treat transactional as a expr level qualifier only with object-type and func-type.
-                switch (nextNextToken.kind) {
-                    case CLIENT_KEYWORD:
-                    case ABSTRACT_KEYWORD:
-                    case ISOLATED_KEYWORD:
-                    case OBJECT_KEYWORD:
-                    case FUNCTION_KEYWORD:
-                        return true;
-                    default:
-                        return false;
-                }
-            default:
-                return isTypeDescQualifier(tokenKind);
-        }
+                yield switch (nextNextToken.kind) {
+                    case CLIENT_KEYWORD,
+                         ABSTRACT_KEYWORD,
+                         ISOLATED_KEYWORD,
+                         OBJECT_KEYWORD,
+                         FUNCTION_KEYWORD -> true;
+                    default -> false;
+                };
+            }
+            default -> isTypeDescQualifier(tokenKind);
+        };
     }
 
     private void parseTopLevelQualifiers(List<STNode> qualifiers) {
@@ -1412,15 +1397,13 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isBindingPatternsStartToken(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case IDENTIFIER_TOKEN:
-            case OPEN_BRACKET_TOKEN:
-            case OPEN_BRACE_TOKEN:
-            case ERROR_KEYWORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case IDENTIFIER_TOKEN,
+                 OPEN_BRACKET_TOKEN,
+                 OPEN_BRACE_TOKEN,
+                 ERROR_KEYWORD -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -2184,14 +2167,11 @@ public class BallerinaParser extends AbstractParser {
 
         // Check for [isolated] service match
         STNode firstElement = nodeList.get(0);
-        switch (firstElement.kind) {
-            case SERVICE_KEYWORD:
-                return true;
-            case ISOLATED_KEYWORD:
-                return nodeList.size() > 1 && nodeList.get(1).kind == SyntaxKind.SERVICE_KEYWORD;
-            default:
-                return false;
-        }
+        return switch (firstElement.kind) {
+            case SERVICE_KEYWORD -> true;
+            case ISOLATED_KEYWORD -> nodeList.size() > 1 && nodeList.get(1).kind == SyntaxKind.SERVICE_KEYWORD;
+            default -> false;
+        };
     }
 
     private STNode parseParameterRhs() {
@@ -2199,15 +2179,14 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseParameterRhs(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case COMMA_TOKEN:
-                return consume();
-            case CLOSE_PAREN_TOKEN:
-                return null;
-            default:
+        return switch (tokenKind) {
+            case COMMA_TOKEN -> consume();
+            case CLOSE_PAREN_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.PARAM_END);
-                return parseParameterRhs();
-        }
+                yield parseParameterRhs();
+            }
+        };
 
     }
 
@@ -2452,21 +2431,19 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isSafeMissingReturnsParseCtx(ParserRuleContext ctx) {
-        switch (ctx) {
-            case TYPE_DESC_IN_ANNOTATION_DECL:
-            case TYPE_DESC_BEFORE_IDENTIFIER:
-            case TYPE_DESC_BEFORE_IDENTIFIER_IN_GROUPING_KEY:
-            case TYPE_DESC_IN_RECORD_FIELD:
-            case TYPE_DESC_IN_PARAM:
-            case TYPE_DESC_IN_TYPE_BINDING_PATTERN:
-            case VAR_DECL_STARTED_WITH_DENTIFIER:
-            case TYPE_DESC_IN_PATH_PARAM:
-            case AMBIGUOUS_STMT:
-                // Contexts that expect an identifier after function type are not safe to parse as a missing return type
-                return false;
-            default:
-                return true;
-        }
+        return switch (ctx) {
+            // Contexts that expect an identifier after function type are not safe to parse as a missing return type
+            case TYPE_DESC_IN_ANNOTATION_DECL,
+                 TYPE_DESC_BEFORE_IDENTIFIER,
+                 TYPE_DESC_BEFORE_IDENTIFIER_IN_GROUPING_KEY,
+                 TYPE_DESC_IN_RECORD_FIELD,
+                 TYPE_DESC_IN_PARAM,
+                 TYPE_DESC_IN_TYPE_BINDING_PATTERN,
+                 VAR_DECL_STARTED_WITH_DENTIFIER,
+                 TYPE_DESC_IN_PATH_PARAM,
+                 AMBIGUOUS_STMT -> false;
+            default -> true;
+        };
     }
 
     /**
@@ -2640,15 +2617,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isValidTypeContinuationToken(STToken token) {
-        switch (token.kind) {
-            case QUESTION_MARK_TOKEN:
-            case OPEN_BRACKET_TOKEN:
-            case PIPE_TOKEN:
-            case BITWISE_AND_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (token.kind) {
+            case QUESTION_MARK_TOKEN, OPEN_BRACKET_TOKEN, PIPE_TOKEN, BITWISE_AND_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode validateForUsageOfVar(STNode typeDesc) {
@@ -2761,17 +2733,12 @@ public class BallerinaParser extends AbstractParser {
         }
 
         STNode lastQualifier = getLastNodeInList(qualifiers);
-        switch (lastQualifier.kind) {
-            case ISOLATED_KEYWORD:
-                return ParserRuleContext.TYPE_DESC_WITHOUT_ISOLATED;
-            case TRANSACTIONAL_KEYWORD:
-                return ParserRuleContext.FUNC_TYPE_DESC;
-            case SERVICE_KEYWORD:
-            case CLIENT_KEYWORD:
-            default:
-                // We reach here for service and client only.
-                return ParserRuleContext.OBJECT_TYPE_DESCRIPTOR;
-        }
+        return switch (lastQualifier.kind) {
+            case ISOLATED_KEYWORD -> ParserRuleContext.TYPE_DESC_WITHOUT_ISOLATED;
+            case TRANSACTIONAL_KEYWORD -> ParserRuleContext.FUNC_TYPE_DESC;
+            // We reach here for service and client only.
+            default -> ParserRuleContext.OBJECT_TYPE_DESCRIPTOR;
+        };
     }
 
     /**
@@ -2781,15 +2748,10 @@ public class BallerinaParser extends AbstractParser {
      * @return <code>true</code> if the given token is a parameterized type keyword. <code>false</code> otherwise
      */
     static boolean isParameterizedTypeToken(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case TYPEDESC_KEYWORD:
-            case FUTURE_KEYWORD:
-            case XML_KEYWORD:
-            case ERROR_KEYWORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case TYPEDESC_KEYWORD, FUTURE_KEYWORD, XML_KEYWORD, ERROR_KEYWORD -> true;
+            default -> false;
+        };
     }
 
     private STNode parseQualifiedIdentWithTransactionPrefix(ParserRuleContext context) {
@@ -2843,27 +2805,31 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseTypeDescStartWithPredeclPrefix(STToken preDeclaredPrefix, List<STNode> qualifiers) {
-        switch (preDeclaredPrefix.kind) {
-            case MAP_KEYWORD:
+        return switch (preDeclaredPrefix.kind) {
+            case MAP_KEYWORD -> {
                 reportInvalidQualifierList(qualifiers);
-                return parseMapTypeDescriptor(preDeclaredPrefix);
-            case OBJECT_KEYWORD:
+                yield parseMapTypeDescriptor(preDeclaredPrefix);
+            }
+            case OBJECT_KEYWORD -> {
                 STNode objectTypeQualifiers = createObjectTypeQualNodeList(qualifiers);
-                return parseObjectTypeDescriptor(preDeclaredPrefix, objectTypeQualifiers);
-            case STREAM_KEYWORD:
+                yield parseObjectTypeDescriptor(preDeclaredPrefix, objectTypeQualifiers);
+            }
+            case STREAM_KEYWORD -> {
                 reportInvalidQualifierList(qualifiers);
-                return parseStreamTypeDescriptor(preDeclaredPrefix);
-            case TABLE_KEYWORD:
+                yield parseStreamTypeDescriptor(preDeclaredPrefix);
+            }
+            case TABLE_KEYWORD -> {
                 reportInvalidQualifierList(qualifiers);
-                return parseTableTypeDescriptor(preDeclaredPrefix);
-            default:
+                yield parseTableTypeDescriptor(preDeclaredPrefix);
+            }
+            default -> {
                 if (isParameterizedTypeToken(preDeclaredPrefix.kind)) {
                     reportInvalidQualifierList(qualifiers);
-                    return parseParameterizedTypeDescriptor(preDeclaredPrefix);
+                    yield parseParameterizedTypeDescriptor(preDeclaredPrefix);
                 }
-                
-                return createBuiltinSimpleNameReference(preDeclaredPrefix);
-        }
+                yield createBuiltinSimpleNameReference(preDeclaredPrefix);
+            }
+        };
     }
 
     private STNode parseQualifiedIdentifierWithPredeclPrefix(STToken preDeclaredPrefix, boolean isInConditionalExpr) {
@@ -2959,17 +2925,15 @@ public class BallerinaParser extends AbstractParser {
      */
     protected STNode parseFunctionBody() {
         STToken token = peek();
-        switch (token.kind) {
-            case EQUAL_TOKEN:
-                return parseExternalFunctionBody();
-            case OPEN_BRACE_TOKEN:
-                return parseFunctionBodyBlock(false);
-            case RIGHT_DOUBLE_ARROW_TOKEN:
-                return parseExpressionFuncBody(false, false);
-            default:
+        return switch (token.kind) {
+            case EQUAL_TOKEN -> parseExternalFunctionBody();
+            case OPEN_BRACE_TOKEN -> parseFunctionBodyBlock(false);
+            case RIGHT_DOUBLE_ARROW_TOKEN -> parseExpressionFuncBody(false, false);
+            default -> {
                 recover(token, ParserRuleContext.FUNC_BODY);
-                return parseFunctionBody();
-        }
+                yield parseFunctionBody();
+            }
+        };
     }
 
     /**
@@ -3083,12 +3047,7 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfRecordTypeNode(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case TYPE_KEYWORD:
-            case PUBLIC_KEYWORD:
-            default:
-                return isEndOfModuleLevelNode(1);
-        }
+        return isEndOfModuleLevelNode(1);
     }
 
     private boolean isEndOfObjectTypeNode() {
@@ -3096,12 +3055,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfStatements() {
-        switch (peek().kind) {
-            case RESOURCE_KEYWORD:
-                return true;
-            default:
-                return isEndOfModuleLevelNode(1);
-        }
+        return switch (peek().kind) {
+            case RESOURCE_KEYWORD -> true;
+            default -> isEndOfModuleLevelNode(1);
+        };
     }
 
     private boolean isEndOfModuleLevelNode(int peekIndex) {
@@ -3109,31 +3066,28 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfModuleLevelNode(int peekIndex, boolean isObject) {
-        switch (peek(peekIndex).kind) {
-            case EOF_TOKEN:
-            case CLOSE_BRACE_TOKEN:
-            case CLOSE_BRACE_PIPE_TOKEN:
-            case IMPORT_KEYWORD:
-            case ANNOTATION_KEYWORD:
-            case LISTENER_KEYWORD:
-            case CLASS_KEYWORD:
-                return true;
-            case SERVICE_KEYWORD:
-                return isServiceDeclStart(ParserRuleContext.OBJECT_CONSTRUCTOR_MEMBER, 1);
-            case PUBLIC_KEYWORD:
-                return !isObject && isEndOfModuleLevelNode(peekIndex + 1, false);
-            case FUNCTION_KEYWORD:
+        return switch (peek(peekIndex).kind) {
+            case EOF_TOKEN,
+                 CLOSE_BRACE_TOKEN,
+                 CLOSE_BRACE_PIPE_TOKEN,
+                 IMPORT_KEYWORD,
+                 ANNOTATION_KEYWORD,
+                 LISTENER_KEYWORD,
+                 CLASS_KEYWORD -> true;
+            case SERVICE_KEYWORD -> isServiceDeclStart(ParserRuleContext.OBJECT_CONSTRUCTOR_MEMBER, 1);
+            case PUBLIC_KEYWORD -> !isObject && isEndOfModuleLevelNode(peekIndex + 1, false);
+            case FUNCTION_KEYWORD -> {
                 if (isObject) {
-                    return false;
+                    yield false;
                 }
 
                 // if function keyword follows by a identifier treat is as
                 // the function name. Only function def can have func-name
-                return peek(peekIndex + 1).kind == SyntaxKind.IDENTIFIER_TOKEN &&
+                yield peek(peekIndex + 1).kind == SyntaxKind.IDENTIFIER_TOKEN &&
                         peek(peekIndex + 2).kind == SyntaxKind.OPEN_PAREN_TOKEN;
-            default:
-                return false;
-        }
+            }
+            default -> false;
+        };
     }
 
     /**
@@ -3143,21 +3097,19 @@ public class BallerinaParser extends AbstractParser {
      * @return <code>true</code> if the token represents an end of a parameter. <code>false</code> otherwise
      */
     private boolean isEndOfParameter(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case CLOSE_PAREN_TOKEN:
-            case CLOSE_BRACKET_TOKEN:
-            case SEMICOLON_TOKEN:
-            case COMMA_TOKEN:
-            case RETURNS_KEYWORD:
-            case TYPE_KEYWORD:
-            case IF_KEYWORD:
-            case WHILE_KEYWORD:
-            case DO_KEYWORD:
-            case AT_TOKEN:
-                return true;
-            default:
-                return isEndOfModuleLevelNode(1);
-        }
+        return switch (tokenKind) {
+            case CLOSE_PAREN_TOKEN,
+                 CLOSE_BRACKET_TOKEN,
+                 SEMICOLON_TOKEN,
+                 COMMA_TOKEN,
+                 RETURNS_KEYWORD,
+                 TYPE_KEYWORD,
+                 IF_KEYWORD,
+                 WHILE_KEYWORD,
+                 DO_KEYWORD,
+                 AT_TOKEN -> true;
+            default -> isEndOfModuleLevelNode(1);
+        };
     }
 
     /**
@@ -3167,19 +3119,17 @@ public class BallerinaParser extends AbstractParser {
      * @return <code>true</code> if the token represents an end of a parameter-list. <code>false</code> otherwise
      */
     private boolean isEndOfParametersList(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case CLOSE_PAREN_TOKEN:
-            case SEMICOLON_TOKEN:
-            case RETURNS_KEYWORD:
-            case TYPE_KEYWORD:
-            case IF_KEYWORD:
-            case WHILE_KEYWORD:
-            case DO_KEYWORD:
-            case RIGHT_DOUBLE_ARROW_TOKEN:
-                return true;
-            default:
-                return isEndOfModuleLevelNode(1);
-        }
+        return switch (tokenKind) {
+            case CLOSE_PAREN_TOKEN,
+                 SEMICOLON_TOKEN,
+                 RETURNS_KEYWORD,
+                 TYPE_KEYWORD,
+                 IF_KEYWORD,
+                 WHILE_KEYWORD,
+                 DO_KEYWORD,
+                 RIGHT_DOUBLE_ARROW_TOKEN -> true;
+            default -> isEndOfModuleLevelNode(1);
+        };
     }
 
     /**
@@ -3357,35 +3307,33 @@ public class BallerinaParser extends AbstractParser {
      * @return <code>true</code> if the token kind refers to a binary operator. <code>false</code> otherwise
      */
     private boolean isBinaryOperator(SyntaxKind kind) {
-        switch (kind) {
-            case PLUS_TOKEN:
-            case MINUS_TOKEN:
-            case SLASH_TOKEN:
-            case ASTERISK_TOKEN:
-            case GT_TOKEN:
-            case LT_TOKEN:
-            case DOUBLE_EQUAL_TOKEN:
-            case TRIPPLE_EQUAL_TOKEN:
-            case LT_EQUAL_TOKEN:
-            case GT_EQUAL_TOKEN:
-            case NOT_EQUAL_TOKEN:
-            case NOT_DOUBLE_EQUAL_TOKEN:
-            case BITWISE_AND_TOKEN:
-            case BITWISE_XOR_TOKEN:
-            case PIPE_TOKEN:
-            case LOGICAL_AND_TOKEN:
-            case LOGICAL_OR_TOKEN:
-            case PERCENT_TOKEN:
-            case DOUBLE_LT_TOKEN:
-            case DOUBLE_GT_TOKEN:
-            case TRIPPLE_GT_TOKEN:
-            case ELLIPSIS_TOKEN:
-            case DOUBLE_DOT_LT_TOKEN:
-            case ELVIS_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (kind) {
+            case PLUS_TOKEN,
+                 MINUS_TOKEN,
+                 SLASH_TOKEN,
+                 ASTERISK_TOKEN,
+                 GT_TOKEN,
+                 LT_TOKEN,
+                 DOUBLE_EQUAL_TOKEN,
+                 TRIPPLE_EQUAL_TOKEN,
+                 LT_EQUAL_TOKEN,
+                 GT_EQUAL_TOKEN,
+                 NOT_EQUAL_TOKEN,
+                 NOT_DOUBLE_EQUAL_TOKEN,
+                 BITWISE_AND_TOKEN,
+                 BITWISE_XOR_TOKEN,
+                 PIPE_TOKEN,
+                 LOGICAL_AND_TOKEN,
+                 LOGICAL_OR_TOKEN,
+                 PERCENT_TOKEN,
+                 DOUBLE_LT_TOKEN,
+                 DOUBLE_GT_TOKEN,
+                 TRIPPLE_GT_TOKEN,
+                 ELLIPSIS_TOKEN,
+                 DOUBLE_DOT_LT_TOKEN,
+                 ELVIS_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -3395,67 +3343,50 @@ public class BallerinaParser extends AbstractParser {
      * @return Precedence of the given operator
      */
     private OperatorPrecedence getOpPrecedence(SyntaxKind binaryOpKind) {
-        switch (binaryOpKind) {
-            case ASTERISK_TOKEN: // multiplication
-            case SLASH_TOKEN: // division
-            case PERCENT_TOKEN: // remainder
-                return OperatorPrecedence.MULTIPLICATIVE;
-            case PLUS_TOKEN:
-            case MINUS_TOKEN:
-                return OperatorPrecedence.ADDITIVE;
-            case GT_TOKEN:
-            case LT_TOKEN:
-            case GT_EQUAL_TOKEN:
-            case LT_EQUAL_TOKEN:
-            case IS_KEYWORD:
-            case NOT_IS_KEYWORD:
-                return OperatorPrecedence.BINARY_COMPARE;
-            case DOT_TOKEN:
-            case OPEN_BRACKET_TOKEN:
-            case OPEN_PAREN_TOKEN:
-            case ANNOT_CHAINING_TOKEN:
-            case OPTIONAL_CHAINING_TOKEN:
-            case DOT_LT_TOKEN:
-            case SLASH_LT_TOKEN:
-            case DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN:
-            case SLASH_ASTERISK_TOKEN:
-                return OperatorPrecedence.MEMBER_ACCESS;
-            case DOUBLE_EQUAL_TOKEN:
-            case TRIPPLE_EQUAL_TOKEN:
-            case NOT_EQUAL_TOKEN:
-            case NOT_DOUBLE_EQUAL_TOKEN:
-                return OperatorPrecedence.EQUALITY;
-            case BITWISE_AND_TOKEN:
-                return OperatorPrecedence.BITWISE_AND;
-            case BITWISE_XOR_TOKEN:
-                return OperatorPrecedence.BITWISE_XOR;
-            case PIPE_TOKEN:
-                return OperatorPrecedence.BITWISE_OR;
-            case LOGICAL_AND_TOKEN:
-                return OperatorPrecedence.LOGICAL_AND;
-            case LOGICAL_OR_TOKEN:
-                return OperatorPrecedence.LOGICAL_OR;
-            case RIGHT_ARROW_TOKEN:
-                return OperatorPrecedence.REMOTE_CALL_ACTION;
-            case RIGHT_DOUBLE_ARROW_TOKEN:
-                return OperatorPrecedence.ANON_FUNC_OR_LET;
-            case SYNC_SEND_TOKEN:
-                return OperatorPrecedence.ACTION;
-            case DOUBLE_LT_TOKEN:
-            case DOUBLE_GT_TOKEN:
-            case TRIPPLE_GT_TOKEN:
-                return OperatorPrecedence.SHIFT;
-            case ELLIPSIS_TOKEN:
-            case DOUBLE_DOT_LT_TOKEN:
-                return OperatorPrecedence.RANGE;
-            case ELVIS_TOKEN:
-                return OperatorPrecedence.ELVIS_CONDITIONAL;
-            case QUESTION_MARK_TOKEN:
-            case COLON_TOKEN:
-                return OperatorPrecedence.CONDITIONAL;
-            default:
-                throw new UnsupportedOperationException("Unsupported binary operator '" + binaryOpKind + "'");
-        }
+        return switch (binaryOpKind) {
+            case ASTERISK_TOKEN, // multiplication
+                 SLASH_TOKEN, // division
+                 PERCENT_TOKEN // remainder
+                    -> OperatorPrecedence.MULTIPLICATIVE;
+            case PLUS_TOKEN,
+                 MINUS_TOKEN -> OperatorPrecedence.ADDITIVE;
+            case GT_TOKEN,
+                 LT_TOKEN,
+                 GT_EQUAL_TOKEN,
+                 LT_EQUAL_TOKEN,
+                 IS_KEYWORD,
+                 NOT_IS_KEYWORD -> OperatorPrecedence.BINARY_COMPARE;
+            case DOT_TOKEN,
+                 OPEN_BRACKET_TOKEN,
+                 OPEN_PAREN_TOKEN,
+                 ANNOT_CHAINING_TOKEN,
+                 OPTIONAL_CHAINING_TOKEN,
+                 DOT_LT_TOKEN,
+                 SLASH_LT_TOKEN,
+                 DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN,
+                 SLASH_ASTERISK_TOKEN -> OperatorPrecedence.MEMBER_ACCESS;
+            case DOUBLE_EQUAL_TOKEN,
+                 TRIPPLE_EQUAL_TOKEN,
+                 NOT_EQUAL_TOKEN,
+                 NOT_DOUBLE_EQUAL_TOKEN -> OperatorPrecedence.EQUALITY;
+            case BITWISE_AND_TOKEN -> OperatorPrecedence.BITWISE_AND;
+            case BITWISE_XOR_TOKEN -> OperatorPrecedence.BITWISE_XOR;
+            case PIPE_TOKEN -> OperatorPrecedence.BITWISE_OR;
+            case LOGICAL_AND_TOKEN -> OperatorPrecedence.LOGICAL_AND;
+            case LOGICAL_OR_TOKEN -> OperatorPrecedence.LOGICAL_OR;
+            case RIGHT_ARROW_TOKEN -> OperatorPrecedence.REMOTE_CALL_ACTION;
+            case RIGHT_DOUBLE_ARROW_TOKEN -> OperatorPrecedence.ANON_FUNC_OR_LET;
+            case SYNC_SEND_TOKEN -> OperatorPrecedence.ACTION;
+            case DOUBLE_LT_TOKEN,
+                 DOUBLE_GT_TOKEN,
+                 TRIPPLE_GT_TOKEN -> OperatorPrecedence.SHIFT;
+            case ELLIPSIS_TOKEN,
+                 DOUBLE_DOT_LT_TOKEN -> OperatorPrecedence.RANGE;
+            case ELVIS_TOKEN -> OperatorPrecedence.ELVIS_CONDITIONAL;
+            case QUESTION_MARK_TOKEN,
+                 COLON_TOKEN -> OperatorPrecedence.CONDITIONAL;
+            default -> throw new UnsupportedOperationException("Unsupported binary operator '" + binaryOpKind + "'");
+        };
     }
 
     /**
@@ -3467,43 +3398,30 @@ public class BallerinaParser extends AbstractParser {
      * @return Kind of the operator to insert
      */
     private SyntaxKind getBinaryOperatorKindToInsert(OperatorPrecedence opPrecedenceLevel) {
-        switch (opPrecedenceLevel) {
-            case MULTIPLICATIVE:
-                return SyntaxKind.ASTERISK_TOKEN;
-            case DEFAULT:
-            case UNARY:
-            case ACTION:
-            case EXPRESSION_ACTION:
-            case REMOTE_CALL_ACTION:
-            case ANON_FUNC_OR_LET:
-            case QUERY:
-            case TRAP:
-            case ADDITIVE:
-                return SyntaxKind.PLUS_TOKEN;
-            case SHIFT:
-                return SyntaxKind.DOUBLE_LT_TOKEN;
-            case RANGE:
-                return SyntaxKind.ELLIPSIS_TOKEN;
-            case BINARY_COMPARE:
-                return SyntaxKind.LT_TOKEN;
-            case EQUALITY:
-                return SyntaxKind.DOUBLE_EQUAL_TOKEN;
-            case BITWISE_AND:
-                return SyntaxKind.BITWISE_AND_TOKEN;
-            case BITWISE_XOR:
-                return SyntaxKind.BITWISE_XOR_TOKEN;
-            case BITWISE_OR:
-                return SyntaxKind.PIPE_TOKEN;
-            case LOGICAL_AND:
-                return SyntaxKind.LOGICAL_AND_TOKEN;
-            case LOGICAL_OR:
-                return SyntaxKind.LOGICAL_OR_TOKEN;
-            case ELVIS_CONDITIONAL:
-                return SyntaxKind.ELVIS_TOKEN;
-            default:
-                throw new UnsupportedOperationException(
-                        "Unsupported operator precedence level'" + opPrecedenceLevel + "'");
-        }
+        return switch (opPrecedenceLevel) {
+            case MULTIPLICATIVE -> SyntaxKind.ASTERISK_TOKEN;
+            case DEFAULT,
+                 UNARY,
+                 ACTION,
+                 EXPRESSION_ACTION,
+                 REMOTE_CALL_ACTION,
+                 ANON_FUNC_OR_LET,
+                 QUERY,
+                 TRAP,
+                 ADDITIVE -> SyntaxKind.PLUS_TOKEN;
+            case SHIFT -> SyntaxKind.DOUBLE_LT_TOKEN;
+            case RANGE -> SyntaxKind.ELLIPSIS_TOKEN;
+            case BINARY_COMPARE -> SyntaxKind.LT_TOKEN;
+            case EQUALITY -> SyntaxKind.DOUBLE_EQUAL_TOKEN;
+            case BITWISE_AND -> SyntaxKind.BITWISE_AND_TOKEN;
+            case BITWISE_XOR -> SyntaxKind.BITWISE_XOR_TOKEN;
+            case BITWISE_OR -> SyntaxKind.PIPE_TOKEN;
+            case LOGICAL_AND -> SyntaxKind.LOGICAL_AND_TOKEN;
+            case LOGICAL_OR -> SyntaxKind.LOGICAL_OR_TOKEN;
+            case ELVIS_CONDITIONAL -> SyntaxKind.ELVIS_TOKEN;
+            default -> throw new UnsupportedOperationException(
+                    "Unsupported operator precedence level'" + opPrecedenceLevel + "'");
+        };
     }
     /**
      * <p>
@@ -3514,43 +3432,30 @@ public class BallerinaParser extends AbstractParser {
      * @return Context of the missing operator
      */
     private ParserRuleContext getMissingBinaryOperatorContext(OperatorPrecedence opPrecedenceLevel) {
-        switch (opPrecedenceLevel) {
-            case MULTIPLICATIVE:
-                return ParserRuleContext.ASTERISK;
-            case DEFAULT:
-            case UNARY:
-            case ACTION:
-            case EXPRESSION_ACTION:
-            case REMOTE_CALL_ACTION:
-            case ANON_FUNC_OR_LET:
-            case QUERY:
-            case TRAP:
-            case ADDITIVE:
-                return ParserRuleContext.PLUS_TOKEN;
-            case SHIFT:
-                return ParserRuleContext.DOUBLE_LT;
-            case RANGE:
-                return ParserRuleContext.ELLIPSIS;
-            case BINARY_COMPARE:
-                return ParserRuleContext.LT_TOKEN;
-            case EQUALITY:
-                return ParserRuleContext.DOUBLE_EQUAL;
-            case BITWISE_AND:
-                return ParserRuleContext.BITWISE_AND_OPERATOR;
-            case BITWISE_XOR:
-                return ParserRuleContext.BITWISE_XOR;
-            case BITWISE_OR:
-                return ParserRuleContext.PIPE;
-            case LOGICAL_AND:
-                return ParserRuleContext.LOGICAL_AND;
-            case LOGICAL_OR:
-                return ParserRuleContext.LOGICAL_OR;
-            case ELVIS_CONDITIONAL:
-                return ParserRuleContext.ELVIS;
-            default:
-                throw new UnsupportedOperationException(
-                        "Unsupported operator precedence level'" + opPrecedenceLevel + "'");
-        }
+        return switch (opPrecedenceLevel) {
+            case MULTIPLICATIVE -> ParserRuleContext.ASTERISK;
+            case DEFAULT,
+                 UNARY,
+                 ACTION,
+                 EXPRESSION_ACTION,
+                 REMOTE_CALL_ACTION,
+                 ANON_FUNC_OR_LET,
+                 QUERY,
+                 TRAP,
+                 ADDITIVE -> ParserRuleContext.PLUS_TOKEN;
+            case SHIFT -> ParserRuleContext.DOUBLE_LT;
+            case RANGE -> ParserRuleContext.ELLIPSIS;
+            case BINARY_COMPARE -> ParserRuleContext.LT_TOKEN;
+            case EQUALITY -> ParserRuleContext.DOUBLE_EQUAL;
+            case BITWISE_AND -> ParserRuleContext.BITWISE_AND_OPERATOR;
+            case BITWISE_XOR -> ParserRuleContext.BITWISE_XOR;
+            case BITWISE_OR -> ParserRuleContext.PIPE;
+            case LOGICAL_AND -> ParserRuleContext.LOGICAL_AND;
+            case LOGICAL_OR -> ParserRuleContext.LOGICAL_OR;
+            case ELVIS_CONDITIONAL -> ParserRuleContext.ELVIS;
+            default -> throw new UnsupportedOperationException(
+                    "Unsupported operator precedence level'" + opPrecedenceLevel + "'");
+        };
     }
 
     /**
@@ -3604,33 +3509,24 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isClassTypeQual(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case READONLY_KEYWORD:
-            case DISTINCT_KEYWORD:
-            case ISOLATED_KEYWORD:
-                return true;
-            default:
-                return isObjectNetworkQual(tokenKind);
-        }
+        return switch (tokenKind) {
+            case READONLY_KEYWORD, DISTINCT_KEYWORD, ISOLATED_KEYWORD -> true;
+            default -> isObjectNetworkQual(tokenKind);
+        };
     }
 
     private boolean isObjectTypeQual(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case ISOLATED_KEYWORD:
-                return true;
-            default:
-                return isObjectNetworkQual(tokenKind);
-        }
+        return switch (tokenKind) {
+            case ISOLATED_KEYWORD -> true;
+            default -> isObjectNetworkQual(tokenKind);
+        };
     }
 
     private boolean isObjectNetworkQual(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case SERVICE_KEYWORD:
-            case CLIENT_KEYWORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case SERVICE_KEYWORD, CLIENT_KEYWORD -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -3868,15 +3764,14 @@ public class BallerinaParser extends AbstractParser {
      */
     private STNode parseRecordBodyStartDelimiter() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case OPEN_BRACE_PIPE_TOKEN:
-                return parseClosedRecordBodyStart();
-            case OPEN_BRACE_TOKEN:
-                return parseOpenBrace();
-            default:
+        return switch (nextToken.kind) {
+            case OPEN_BRACE_PIPE_TOKEN -> parseClosedRecordBodyStart();
+            case OPEN_BRACE_TOKEN -> parseOpenBrace();
+            default -> {
                 recover(nextToken, ParserRuleContext.RECORD_BODY_START);
-                return parseRecordBodyStartDelimiter();
-        }
+                yield parseRecordBodyStartDelimiter();
+            }
+        };
     }
 
     /**
@@ -4337,16 +4232,17 @@ public class BallerinaParser extends AbstractParser {
      * @return <code>true</code> if the statement is not valid <code>false</code> otherwise
      */
     boolean validateStatement(STNode statement) {
-        switch (statement.kind) {
-            case LOCAL_TYPE_DEFINITION_STATEMENT:
+        return switch (statement.kind) {
+            case LOCAL_TYPE_DEFINITION_STATEMENT -> {
                 addInvalidNodeToNextToken(statement, DiagnosticErrorCode.ERROR_LOCAL_TYPE_DEFINITION_NOT_ALLOWED);
-                return true;
-            case CONST_DECLARATION:
+                yield true;
+            }
+            case CONST_DECLARATION -> {
                 addInvalidNodeToNextToken(statement, DiagnosticErrorCode.ERROR_LOCAL_CONST_DECL_NOT_ALLOWED);
-                return true;
-            default:
-                return false;
-        }
+                yield true;
+            }
+            default -> false;
+        };
     }
 
     private STNode getAnnotations(STNode nullbaleAnnot) {
@@ -4850,17 +4746,12 @@ public class BallerinaParser extends AbstractParser {
         STTypedBindingPatternNode typedBindingPatternNode = (STTypedBindingPatternNode) typedBindingPattern;
         STNode typeDescriptor = typedBindingPatternNode.typeDescriptor;
         STNode bindingPattern = typedBindingPatternNode.bindingPattern;
-        switch (typeDescriptor.kind) {
-            case OBJECT_TYPE_DESC:
-                typeDescriptor = modifyObjectTypeDescWithALeadingQualifier(typeDescriptor, isolatedQualifier);
-                break;
-            case FUNCTION_TYPE_DESC:
-                typeDescriptor = modifyFuncTypeDescWithALeadingQualifier(typeDescriptor, isolatedQualifier);
-                break;
-            default:
-                typeDescriptor = SyntaxErrors.cloneWithLeadingInvalidNodeMinutiae(typeDescriptor, isolatedQualifier,
-                        DiagnosticErrorCode.ERROR_QUALIFIER_NOT_ALLOWED, ((STToken) isolatedQualifier).text());
-        }
+        typeDescriptor = switch (typeDescriptor.kind) {
+            case OBJECT_TYPE_DESC -> modifyObjectTypeDescWithALeadingQualifier(typeDescriptor, isolatedQualifier);
+            case FUNCTION_TYPE_DESC -> modifyFuncTypeDescWithALeadingQualifier(typeDescriptor, isolatedQualifier);
+            default -> SyntaxErrors.cloneWithLeadingInvalidNodeMinutiae(typeDescriptor, isolatedQualifier,
+                    DiagnosticErrorCode.ERROR_QUALIFIER_NOT_ALLOWED, ((STToken) isolatedQualifier).text());
+        };
 
         return STNodeFactory.createTypedBindingPatternNode(typeDescriptor, bindingPattern);
     }
@@ -4994,37 +4885,28 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isValidLVExpr(STNode expression) {
-        switch (expression.kind) {
-            case SIMPLE_NAME_REFERENCE:
-            case QUALIFIED_NAME_REFERENCE:
-            case LIST_BINDING_PATTERN:
-            case MAPPING_BINDING_PATTERN:
-            case ERROR_BINDING_PATTERN:
-            case WILDCARD_BINDING_PATTERN:
-                return true;
-            case FIELD_ACCESS:
-                return isValidLVMemberExpr(((STFieldAccessExpressionNode) expression).expression);
-            case INDEXED_EXPRESSION:
-                return isValidLVMemberExpr(((STIndexedExpressionNode) expression).containerExpression);
-            default:
-                return (expression instanceof STMissingToken);
-        }
+        return switch (expression.kind) {
+            case SIMPLE_NAME_REFERENCE,
+                 QUALIFIED_NAME_REFERENCE,
+                 LIST_BINDING_PATTERN,
+                 MAPPING_BINDING_PATTERN,
+                 ERROR_BINDING_PATTERN,
+                 WILDCARD_BINDING_PATTERN -> true;
+            case FIELD_ACCESS -> isValidLVMemberExpr(((STFieldAccessExpressionNode) expression).expression);
+            case INDEXED_EXPRESSION -> isValidLVMemberExpr(((STIndexedExpressionNode) expression).containerExpression);
+            default -> (expression instanceof STMissingToken);
+        };
     }
 
     private boolean isValidLVMemberExpr(STNode expression) {
-        switch (expression.kind) {
-            case SIMPLE_NAME_REFERENCE:
-            case QUALIFIED_NAME_REFERENCE:
-                return true;
-            case FIELD_ACCESS:
-                return isValidLVMemberExpr(((STFieldAccessExpressionNode) expression).expression);
-            case INDEXED_EXPRESSION:
-                return isValidLVMemberExpr(((STIndexedExpressionNode) expression).containerExpression);
-            case BRACED_EXPRESSION:
-                return isValidLVMemberExpr(((STBracedExpressionNode) expression).expression);
-            default:
-                return (expression instanceof STMissingToken);
-        }
+        return switch (expression.kind) {
+            case SIMPLE_NAME_REFERENCE,
+                 QUALIFIED_NAME_REFERENCE -> true;
+            case FIELD_ACCESS -> isValidLVMemberExpr(((STFieldAccessExpressionNode) expression).expression);
+            case INDEXED_EXPRESSION -> isValidLVMemberExpr(((STIndexedExpressionNode) expression).containerExpression);
+            case BRACED_EXPRESSION -> isValidLVMemberExpr(((STBracedExpressionNode) expression).expression);
+            default -> (expression instanceof STMissingToken);
+        };
     }
 
     /**
@@ -5266,70 +5148,66 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isAnnotAllowedExprStart(STToken nextToken) {
-        switch (nextToken.kind) {
-            case START_KEYWORD:
-            case FUNCTION_KEYWORD:
-            case OBJECT_KEYWORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextToken.kind) {
+            case START_KEYWORD, FUNCTION_KEYWORD, OBJECT_KEYWORD -> true;
+            default -> false;
+        };
     }
 
     private boolean isValidExprStart(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case DECIMAL_INTEGER_LITERAL_TOKEN:
-            case HEX_INTEGER_LITERAL_TOKEN:
-            case STRING_LITERAL_TOKEN:
-            case NULL_KEYWORD:
-            case TRUE_KEYWORD:
-            case FALSE_KEYWORD:
-            case DECIMAL_FLOATING_POINT_LITERAL_TOKEN:
-            case HEX_FLOATING_POINT_LITERAL_TOKEN:
-            case IDENTIFIER_TOKEN:
-            case OPEN_PAREN_TOKEN:
-            case CHECK_KEYWORD:
-            case CHECKPANIC_KEYWORD:
-            case OPEN_BRACE_TOKEN:
-            case TYPEOF_KEYWORD:
-            case PLUS_TOKEN:
-            case MINUS_TOKEN:
-            case NEGATION_TOKEN:
-            case EXCLAMATION_MARK_TOKEN:
-            case TRAP_KEYWORD:
-            case OPEN_BRACKET_TOKEN:
-            case LT_TOKEN:
-            case TABLE_KEYWORD:
-            case STREAM_KEYWORD:
-            case FROM_KEYWORD:
-            case ERROR_KEYWORD:
-            case LET_KEYWORD:
-            case BACKTICK_TOKEN:
-            case XML_KEYWORD:
-            case RE_KEYWORD:
-            case STRING_KEYWORD:
-            case FUNCTION_KEYWORD:
-            case AT_TOKEN:
-            case NEW_KEYWORD:
-            case START_KEYWORD:
-            case FLUSH_KEYWORD:
-            case LEFT_ARROW_TOKEN:
-            case WAIT_KEYWORD:
-            case COMMIT_KEYWORD:
-            case SERVICE_KEYWORD:
-            case BASE16_KEYWORD:
-            case BASE64_KEYWORD:
-            case ISOLATED_KEYWORD:
-            case TRANSACTIONAL_KEYWORD:
-            case CLIENT_KEYWORD:
-            case OBJECT_KEYWORD:
-                return true;
-            default:
+        return switch (tokenKind) {
+            case DECIMAL_INTEGER_LITERAL_TOKEN,
+                 HEX_INTEGER_LITERAL_TOKEN,
+                 STRING_LITERAL_TOKEN,
+                 NULL_KEYWORD,
+                 TRUE_KEYWORD,
+                 FALSE_KEYWORD,
+                 DECIMAL_FLOATING_POINT_LITERAL_TOKEN,
+                 HEX_FLOATING_POINT_LITERAL_TOKEN,
+                 IDENTIFIER_TOKEN,
+                 OPEN_PAREN_TOKEN,
+                 CHECK_KEYWORD,
+                 CHECKPANIC_KEYWORD,
+                 OPEN_BRACE_TOKEN,
+                 TYPEOF_KEYWORD,
+                 PLUS_TOKEN,
+                 MINUS_TOKEN,
+                 NEGATION_TOKEN,
+                 EXCLAMATION_MARK_TOKEN,
+                 TRAP_KEYWORD,
+                 OPEN_BRACKET_TOKEN,
+                 LT_TOKEN,
+                 TABLE_KEYWORD,
+                 STREAM_KEYWORD,
+                 FROM_KEYWORD,
+                 ERROR_KEYWORD,
+                 LET_KEYWORD,
+                 BACKTICK_TOKEN,
+                 XML_KEYWORD,
+                 RE_KEYWORD,
+                 STRING_KEYWORD,
+                 FUNCTION_KEYWORD,
+                 AT_TOKEN,
+                 NEW_KEYWORD,
+                 START_KEYWORD,
+                 FLUSH_KEYWORD,
+                 LEFT_ARROW_TOKEN,
+                 WAIT_KEYWORD,
+                 COMMIT_KEYWORD,
+                 SERVICE_KEYWORD,
+                 BASE16_KEYWORD,
+                 BASE64_KEYWORD,
+                 ISOLATED_KEYWORD,
+                 TRANSACTIONAL_KEYWORD,
+                 CLIENT_KEYWORD,
+                 OBJECT_KEYWORD -> true;
+            default -> {
                 if (isPredeclaredPrefix(tokenKind)) {
-                    return true;
+                    yield true;
                 }
-                return isSimpleTypeInExpression(tokenKind);
-        }
+                yield isSimpleTypeInExpression(tokenKind);
+            }
+        };
     }
 
     /**
@@ -5762,32 +5640,29 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isValidExprRhsStart(SyntaxKind tokenKind, SyntaxKind precedingNodeKind) {
-        switch (tokenKind) {
-            case OPEN_PAREN_TOKEN:
-                // Only an identifier or a qualified identifier is followed by a function call.
-                return precedingNodeKind == SyntaxKind.QUALIFIED_NAME_REFERENCE ||
-                        precedingNodeKind == SyntaxKind.SIMPLE_NAME_REFERENCE;
-            case DOT_TOKEN:
-            case OPEN_BRACKET_TOKEN:
-            case IS_KEYWORD:
-            case RIGHT_ARROW_TOKEN:
-            case RIGHT_DOUBLE_ARROW_TOKEN:
-            case SYNC_SEND_TOKEN:
-            case ANNOT_CHAINING_TOKEN:
-            case OPTIONAL_CHAINING_TOKEN:
-            case COLON_TOKEN:
-            case DOT_LT_TOKEN:
-            case SLASH_LT_TOKEN:
-            case DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN:
-            case SLASH_ASTERISK_TOKEN:
-            case NOT_IS_KEYWORD:
-                return true;
-            case QUESTION_MARK_TOKEN:
-                // TODO : Should fix properly #33259
-                return getNextNextToken().kind != SyntaxKind.EQUAL_TOKEN && peek(3).kind != SyntaxKind.EQUAL_TOKEN;
-            default:
-                return isBinaryOperator(tokenKind);
-        }
+        return switch (tokenKind) {
+            // Only an identifier or a qualified identifier is followed by a function call.
+            case OPEN_PAREN_TOKEN -> precedingNodeKind == SyntaxKind.QUALIFIED_NAME_REFERENCE ||
+                    precedingNodeKind == SyntaxKind.SIMPLE_NAME_REFERENCE;
+            case DOT_TOKEN,
+                 OPEN_BRACKET_TOKEN,
+                 IS_KEYWORD,
+                 RIGHT_ARROW_TOKEN,
+                 RIGHT_DOUBLE_ARROW_TOKEN,
+                 SYNC_SEND_TOKEN,
+                 ANNOT_CHAINING_TOKEN,
+                 OPTIONAL_CHAINING_TOKEN,
+                 COLON_TOKEN,
+                 DOT_LT_TOKEN,
+                 SLASH_LT_TOKEN,
+                 DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN,
+                 SLASH_ASTERISK_TOKEN,
+                 NOT_IS_KEYWORD -> true;
+            // TODO : Should fix properly #33259
+            case QUESTION_MARK_TOKEN ->
+                    getNextNextToken().kind != SyntaxKind.EQUAL_TOKEN && peek(3).kind != SyntaxKind.EQUAL_TOKEN;
+            default -> isBinaryOperator(tokenKind);
+        };
     }
 
     /**
@@ -5854,15 +5729,14 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseMemberAccessKeyExprEnd() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_BRACKET_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> parseComma();
+            case CLOSE_BRACKET_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.MEMBER_ACCESS_KEY_EXPR_END);
-                return parseMemberAccessKeyExprEnd();
-        }
+                yield parseMemberAccessKeyExprEnd();
+            }
+        };
     }
 
     /**
@@ -5995,24 +5869,22 @@ public class BallerinaParser extends AbstractParser {
      * @return <code>true</code> if the node is an action node. <code>false</code> otherwise
      */
     private boolean isAction(STNode node) {
-        switch (node.kind) {
-            case REMOTE_METHOD_CALL_ACTION:
-            case BRACED_ACTION:
-            case CHECK_ACTION:
-            case START_ACTION:
-            case TRAP_ACTION:
-            case FLUSH_ACTION:
-            case ASYNC_SEND_ACTION:
-            case SYNC_SEND_ACTION:
-            case RECEIVE_ACTION:
-            case WAIT_ACTION:
-            case QUERY_ACTION:
-            case COMMIT_ACTION:
-            case CLIENT_RESOURCE_ACCESS_ACTION:    
-                return true;
-            default:
-                return false;
-        }
+        return switch (node.kind) {
+            case REMOTE_METHOD_CALL_ACTION,
+                 BRACED_ACTION,
+                 CHECK_ACTION,
+                 START_ACTION,
+                 TRAP_ACTION,
+                 FLUSH_ACTION,
+                 ASYNC_SEND_ACTION,
+                 SYNC_SEND_ACTION,
+                 RECEIVE_ACTION,
+                 WAIT_ACTION,
+                 QUERY_ACTION,
+                 COMMIT_ACTION,
+                 CLIENT_RESOURCE_ACCESS_ACTION -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -6034,48 +5906,44 @@ public class BallerinaParser extends AbstractParser {
             }
         }
 
-        switch (tokenKind) {
-            case EOF_TOKEN:
-            case CLOSE_BRACE_TOKEN:
-            case OPEN_BRACE_TOKEN:
-            case CLOSE_PAREN_TOKEN:
-            case CLOSE_BRACKET_TOKEN:
-            case SEMICOLON_TOKEN:
-            case COMMA_TOKEN:
-            case PUBLIC_KEYWORD:
-            case CONST_KEYWORD:
-            case LISTENER_KEYWORD:
-            case RESOURCE_KEYWORD:
-            case EQUAL_TOKEN:
-            case DOCUMENTATION_STRING:
-            case AT_TOKEN:
-            case AS_KEYWORD:
-            case IN_KEYWORD:
-            case FROM_KEYWORD:
-            case WHERE_KEYWORD:
-            case LET_KEYWORD:
-            case SELECT_KEYWORD:
-            case DO_KEYWORD:
-            case COLON_TOKEN:
-            case ON_KEYWORD:
-            case CONFLICT_KEYWORD:
-            case LIMIT_KEYWORD:
-            case JOIN_KEYWORD:
-            case OUTER_KEYWORD:
-            case ORDER_KEYWORD:
-            case BY_KEYWORD:
-            case ASCENDING_KEYWORD:
-            case DESCENDING_KEYWORD:
-            case EQUALS_KEYWORD:
-            case TYPE_KEYWORD:
-                return true;
-            case RIGHT_DOUBLE_ARROW_TOKEN:
-                return isInMatchGuard;
-            case IDENTIFIER_TOKEN:
-                return isGroupOrCollectKeyword(nextToken);
-            default:
-                return isSimpleType(tokenKind);
-        }
+        return switch (tokenKind) {
+            case EOF_TOKEN,
+                 CLOSE_BRACE_TOKEN,
+                 OPEN_BRACE_TOKEN,
+                 CLOSE_PAREN_TOKEN,
+                 CLOSE_BRACKET_TOKEN,
+                 SEMICOLON_TOKEN,
+                 COMMA_TOKEN,
+                 PUBLIC_KEYWORD,
+                 CONST_KEYWORD,
+                 LISTENER_KEYWORD,
+                 RESOURCE_KEYWORD,
+                 EQUAL_TOKEN,
+                 DOCUMENTATION_STRING,
+                 AT_TOKEN,
+                 AS_KEYWORD,
+                 IN_KEYWORD,
+                 FROM_KEYWORD,
+                 WHERE_KEYWORD,
+                 LET_KEYWORD,
+                 SELECT_KEYWORD,
+                 DO_KEYWORD,
+                 COLON_TOKEN,
+                 ON_KEYWORD,
+                 CONFLICT_KEYWORD,
+                 LIMIT_KEYWORD,
+                 JOIN_KEYWORD,
+                 OUTER_KEYWORD,
+                 ORDER_KEYWORD,
+                 BY_KEYWORD,
+                 ASCENDING_KEYWORD,
+                 DESCENDING_KEYWORD,
+                 EQUALS_KEYWORD,
+                 TYPE_KEYWORD -> true;
+            case RIGHT_DOUBLE_ARROW_TOKEN -> isInMatchGuard;
+            case IDENTIFIER_TOKEN -> isGroupOrCollectKeyword(nextToken);
+            default -> isSimpleType(tokenKind);
+        };
     }
 
     /**
@@ -6090,30 +5958,18 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseBasicLiteral(STNode literalToken) {
-        SyntaxKind nodeKind;
-        switch (literalToken.kind) {
-            case NULL_KEYWORD:
-                nodeKind = SyntaxKind.NULL_LITERAL;
-                break;
-            case TRUE_KEYWORD:
-            case FALSE_KEYWORD:
-                nodeKind = SyntaxKind.BOOLEAN_LITERAL;
-                break;
-            case DECIMAL_INTEGER_LITERAL_TOKEN:
-            case DECIMAL_FLOATING_POINT_LITERAL_TOKEN:
-            case HEX_INTEGER_LITERAL_TOKEN:
-            case HEX_FLOATING_POINT_LITERAL_TOKEN:
-                nodeKind = SyntaxKind.NUMERIC_LITERAL;
-                break;
-            case STRING_LITERAL_TOKEN:
-                nodeKind = SyntaxKind.STRING_LITERAL;
-                break;
-            case ASTERISK_TOKEN:
-                nodeKind = SyntaxKind.ASTERISK_LITERAL;
-                break;
-            default:
-                nodeKind = literalToken.kind;
-        }
+        SyntaxKind nodeKind = switch (literalToken.kind) {
+            case NULL_KEYWORD -> SyntaxKind.NULL_LITERAL;
+            case TRUE_KEYWORD,
+                 FALSE_KEYWORD -> SyntaxKind.BOOLEAN_LITERAL;
+            case DECIMAL_INTEGER_LITERAL_TOKEN,
+                 DECIMAL_FLOATING_POINT_LITERAL_TOKEN,
+                 HEX_INTEGER_LITERAL_TOKEN,
+                 HEX_FLOATING_POINT_LITERAL_TOKEN -> SyntaxKind.NUMERIC_LITERAL;
+            case STRING_LITERAL_TOKEN -> SyntaxKind.STRING_LITERAL;
+            case ASTERISK_TOKEN -> SyntaxKind.ASTERISK_LITERAL;
+            default -> literalToken.kind;
+        };
         return STNodeFactory.createBasicLiteralNode(nodeKind, literalToken);
     }
 
@@ -6347,16 +6203,15 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseArgEnd() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_PAREN_TOKEN:
-                // null marks the end of args
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> parseComma();
+            // null marks the end of args
+            case CLOSE_PAREN_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.ARG_END);
-                return parseArgEnd();
-        }
+                yield parseArgEnd();
+            }
+        };
     }
 
     /**
@@ -6683,28 +6538,24 @@ public class BallerinaParser extends AbstractParser {
      */
     private boolean isObjectFieldStart() {
         STToken nextNextToken = getNextNextToken();
-        switch (nextNextToken.kind) {
-            case ERROR_KEYWORD: // error-binding-pattern not allowed in fields
-            case OPEN_BRACE_TOKEN: // mapping-binding-pattern not allowed in fields
-                return false;
-            case CLOSE_BRACE_TOKEN:
-                return true;
-            default:
-                return isModuleVarDeclStart(1);
-        }
+        return switch (nextNextToken.kind) {
+            case ERROR_KEYWORD, // error-binding-pattern not allowed in fields
+                 OPEN_BRACE_TOKEN // mapping-binding-pattern not allowed in fields
+                    -> false;
+            case CLOSE_BRACE_TOKEN -> true;
+            default -> isModuleVarDeclStart(1);
+        };
     }
 
     private boolean isObjectMethodStart(STToken token) {
-        switch (token.kind) {
-            case FUNCTION_KEYWORD:
-            case REMOTE_KEYWORD:
-            case RESOURCE_KEYWORD:
-            case ISOLATED_KEYWORD:
-            case TRANSACTIONAL_KEYWORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (token.kind) {
+            case FUNCTION_KEYWORD,
+                 REMOTE_KEYWORD,
+                 RESOURCE_KEYWORD,
+                 ISOLATED_KEYWORD,
+                 TRANSACTIONAL_KEYWORD -> true;
+            default -> false;
+        };
     }
     
     /**
@@ -6893,13 +6744,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndRelativeResourcePath(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case EOF_TOKEN:
-            case OPEN_PAREN_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case EOF_TOKEN, OPEN_PAREN_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode createResourcePathNodeList(List<STNode> pathElementList) {
@@ -6942,22 +6790,25 @@ public class BallerinaParser extends AbstractParser {
      */
     private STNode parseResourcePathSegment(boolean isFirstSegment) {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case IDENTIFIER_TOKEN:
+        return switch (nextToken.kind) {
+            case IDENTIFIER_TOKEN -> {
                 if (isFirstSegment && nextToken.isMissing() && isInvalidNodeStackEmpty() &&
                         getNextNextToken().kind == SyntaxKind.SLASH_TOKEN) {
                     // special case `[MISSING]/` to improve the error message for `/hello`
                     removeInsertedToken(); // to ignore current missing identifier diagnostic
-                    return SyntaxErrors.createMissingTokenWithDiagnostics(SyntaxKind.IDENTIFIER_TOKEN, 
+                    yield SyntaxErrors.createMissingTokenWithDiagnostics(SyntaxKind.IDENTIFIER_TOKEN,
                             DiagnosticErrorCode.ERROR_RESOURCE_PATH_CANNOT_BEGIN_WITH_SLASH);
                 }
-                return consume();
-            case OPEN_BRACKET_TOKEN:
-                return parseResourcePathParameter();
-            default:
+                // special case `[MISSING]/` to improve the error message for `/hello`
+                // to ignore current missing identifier diagnostic
+                yield consume();
+            }
+            case OPEN_BRACKET_TOKEN -> parseResourcePathParameter();
+            default -> {
                 recover(nextToken, ParserRuleContext.RESOURCE_PATH_SEGMENT);
-                return parseResourcePathSegment(isFirstSegment);
-        }
+                yield parseResourcePathSegment(isFirstSegment);
+            }
+        };
     }
 
     /**
@@ -6983,29 +6834,26 @@ public class BallerinaParser extends AbstractParser {
 
     private STNode parseOptionalPathParamName() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case IDENTIFIER_TOKEN:
-                return consume();
-            case CLOSE_BRACKET_TOKEN:
-                return STNodeFactory.createEmptyNode();
-            default:
+        return switch (nextToken.kind) {
+            case IDENTIFIER_TOKEN -> consume();
+            case CLOSE_BRACKET_TOKEN -> STNodeFactory.createEmptyNode();
+            default -> {
                 recover(nextToken, ParserRuleContext.OPTIONAL_PATH_PARAM_NAME);
-                return parseOptionalPathParamName();
-        }
+                yield parseOptionalPathParamName();
+            }
+        };
     }
     
     private STNode parseOptionalEllipsis() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case ELLIPSIS_TOKEN:
-                return consume();
-            case IDENTIFIER_TOKEN:
-            case CLOSE_BRACKET_TOKEN:    
-                return STNodeFactory.createEmptyNode();
-            default:
+        return switch (nextToken.kind) {
+            case ELLIPSIS_TOKEN -> consume();
+            case IDENTIFIER_TOKEN, CLOSE_BRACKET_TOKEN -> STNodeFactory.createEmptyNode();
+            default -> {
                 recover(nextToken, ParserRuleContext.PATH_PARAM_ELLIPSIS);
-                return parseOptionalEllipsis();
-        }
+                yield parseOptionalEllipsis();
+            }
+        };
     }
 
     /**
@@ -7015,17 +6863,15 @@ public class BallerinaParser extends AbstractParser {
      */
     private STNode parseRelativeResourcePathEnd() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case OPEN_PAREN_TOKEN:
-            case EOF_TOKEN:
-                // null represents the end of resource path.
-                return null;
-            case SLASH_TOKEN:
-                return consume();
-            default:
+        return switch (nextToken.kind) {
+            // null represents the end of resource path.
+            case OPEN_PAREN_TOKEN, EOF_TOKEN -> null;
+            case SLASH_TOKEN -> consume();
+            default -> {
                 recover(nextToken, ParserRuleContext.RELATIVE_RESOURCE_PATH_END);
-                return parseRelativeResourcePathEnd();
-        }
+                yield parseRelativeResourcePathEnd();
+            }
+        };
     }
 
     /**
@@ -7120,15 +6966,14 @@ public class BallerinaParser extends AbstractParser {
      */
     private STNode parseElseBody() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case IF_KEYWORD:
-                return parseIfElseBlock();
-            case OPEN_BRACE_TOKEN:
-                return parseBlockNode();
-            default:
+        return switch (nextToken.kind) {
+            case IF_KEYWORD -> parseIfElseBlock();
+            case OPEN_BRACE_TOKEN -> parseBlockNode();
+            default -> {
                 recover(peek(), ParserRuleContext.ELSE_BODY);
-                return parseElseBody();
-        }
+                yield parseElseBody();
+            }
+        };
     }
 
     /**
@@ -7385,14 +7230,10 @@ public class BallerinaParser extends AbstractParser {
     private STNode parseReturnStatementRhs(STNode returnKeyword) {
         STNode expr;
         STToken token = peek();
-        switch (token.kind) {
-            case SEMICOLON_TOKEN:
-                expr = STNodeFactory.createEmptyNode();
-                break;
-            default:
-                expr = parseActionOrExpression();
-                break;
-        }
+        expr = switch (token.kind) {
+            case SEMICOLON_TOKEN -> STNodeFactory.createEmptyNode();
+            default -> parseActionOrExpression();
+        };
 
         STNode semicolon = parseSemicolon();
         return STNodeFactory.createReturnStatementNode(returnKeyword, expr, semicolon);
@@ -7457,41 +7298,37 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseMappingFieldEnd() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_BRACE_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> parseComma();
+            case CLOSE_BRACE_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.MAPPING_FIELD_END);
-                return parseMappingFieldEnd();
-        }
+                yield parseMappingFieldEnd();
+            }
+        };
     }
 
     private boolean isEndOfMappingConstructor(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case IDENTIFIER_TOKEN:
-            case READONLY_KEYWORD:
-                return false;
-            case EOF_TOKEN:
-            case DOCUMENTATION_STRING:
-            case AT_TOKEN:
-            case CLOSE_BRACE_TOKEN:
-            case SEMICOLON_TOKEN:
-            case PUBLIC_KEYWORD:
-            case PRIVATE_KEYWORD:
-            case FUNCTION_KEYWORD:
-            case RETURNS_KEYWORD:
-            case SERVICE_KEYWORD:
-            case TYPE_KEYWORD:
-            case LISTENER_KEYWORD:
-            case CONST_KEYWORD:
-            case FINAL_KEYWORD:
-            case RESOURCE_KEYWORD:
-                return true;
-            default:
-                return isSimpleType(tokenKind);
-        }
+        return switch (tokenKind) {
+            case IDENTIFIER_TOKEN,
+                 READONLY_KEYWORD -> false;
+            case EOF_TOKEN,
+                 DOCUMENTATION_STRING,
+                 AT_TOKEN,
+                 CLOSE_BRACE_TOKEN,
+                 SEMICOLON_TOKEN,
+                 PUBLIC_KEYWORD,
+                 PRIVATE_KEYWORD,
+                 FUNCTION_KEYWORD,
+                 RETURNS_KEYWORD,
+                 SERVICE_KEYWORD,
+                 TYPE_KEYWORD,
+                 LISTENER_KEYWORD,
+                 CONST_KEYWORD,
+                 FINAL_KEYWORD,
+                 RESOURCE_KEYWORD -> true;
+            default -> isSimpleType(tokenKind);
+        };
     }
 
     /**
@@ -7533,15 +7370,14 @@ public class BallerinaParser extends AbstractParser {
 
     private STNode parseSpecificField(STNode readonlyKeyword) {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case STRING_LITERAL_TOKEN:
-                return parseQualifiedSpecificField(readonlyKeyword);
-            case IDENTIFIER_TOKEN:
-                return parseSpecificFieldWithOptionalValue(readonlyKeyword);
-            default:
+        return switch (nextToken.kind) {
+            case STRING_LITERAL_TOKEN -> parseQualifiedSpecificField(readonlyKeyword);
+            case IDENTIFIER_TOKEN -> parseSpecificFieldWithOptionalValue(readonlyKeyword);
+            default -> {
                 recover(peek(), ParserRuleContext.SPECIFIC_FIELD);
-                return parseSpecificField(readonlyKeyword);
-        }
+                yield parseSpecificField(readonlyKeyword);
+            }
+        };
     }
 
     private STNode parseQualifiedSpecificField(STNode readonlyKeyword) {
@@ -7950,13 +7786,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndAbsoluteResourcePath(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case EOF_TOKEN:
-            case ON_KEYWORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case EOF_TOKEN, ON_KEYWORD -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -8010,21 +7843,19 @@ public class BallerinaParser extends AbstractParser {
      * @return <code>true</code> if the token kind refers to a binary operator. <code>false</code> otherwise
      */
     static boolean isCompoundBinaryOperator(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case PLUS_TOKEN:
-            case MINUS_TOKEN:
-            case SLASH_TOKEN:
-            case ASTERISK_TOKEN:
-            case BITWISE_AND_TOKEN:
-            case BITWISE_XOR_TOKEN:
-            case PIPE_TOKEN:
-            case DOUBLE_LT_TOKEN:
-            case DOUBLE_GT_TOKEN:
-            case TRIPPLE_GT_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case PLUS_TOKEN,
+                 MINUS_TOKEN,
+                 SLASH_TOKEN,
+                 ASTERISK_TOKEN,
+                 BITWISE_AND_TOKEN,
+                 BITWISE_XOR_TOKEN,
+                 PIPE_TOKEN,
+                 DOUBLE_LT_TOKEN,
+                 DOUBLE_GT_TOKEN,
+                 TRIPPLE_GT_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private boolean isCompoundAssignment(SyntaxKind tokenKind) {
@@ -8084,26 +7915,23 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfListeners(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case OPEN_BRACE_TOKEN:
-            case EOF_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case OPEN_BRACE_TOKEN,
+                 EOF_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode parseListenersMemberEnd() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case OPEN_BRACE_TOKEN:
-                return null;
-            default:
+        return switch (nextToken.kind) {
+            case COMMA_TOKEN -> parseComma();
+            case OPEN_BRACE_TOKEN -> null;
+            default -> {
                 recover(nextToken, ParserRuleContext.LISTENERS_LIST_END);
-                return parseListenersMemberEnd();
-        }
+                yield parseListenersMemberEnd();
+            }
+        };
     }
 
     /**
@@ -8118,28 +7946,29 @@ public class BallerinaParser extends AbstractParser {
      */
     private boolean isServiceDeclStart(ParserRuleContext currentContext, int lookahead) {
         // Assume we always reach here after a peek()
-        switch (peek(lookahead + 1).kind) {
-            case IDENTIFIER_TOKEN:
+        return switch (peek(lookahead + 1).kind) {
+            case IDENTIFIER_TOKEN -> {
                 SyntaxKind tokenAfterIdentifier = peek(lookahead + 2).kind;
-                switch (tokenAfterIdentifier) {
-                    case ON_KEYWORD: // service foo on ...
-                    case OPEN_BRACE_TOKEN: // missing listeners--> service foo {
-                        return true;
-                    case EQUAL_TOKEN: // service foo = ...
-                    case SEMICOLON_TOKEN: // service foo;
-                    case QUESTION_MARK_TOKEN: // service foo?;
-                        return false;
-                    default:
-                        // If not any of above, this is not a valid syntax.
-                        return false;
-                }
-            case ON_KEYWORD:
-                // Next token sequence is similar to: `service on ...`.
-                // Then this is a service decl.
-                return true;
-            default:
-                return false;
-        }
+                yield switch (tokenAfterIdentifier) {
+                    case ON_KEYWORD,
+                         // service foo on ...
+                         OPEN_BRACE_TOKEN  // missing listeners--> service foo {
+                            -> true;
+                    case EQUAL_TOKEN,
+                         // service foo = ...
+                         SEMICOLON_TOKEN,
+                         // service foo;
+                         QUESTION_MARK_TOKEN // service foo?;
+                            -> false;
+                    // If not any of above, this is not a valid syntax.
+                    default -> false;
+                };
+            }
+            // Next token sequence is similar to: `service on ...`.
+            // Then this is a service decl.
+            case ON_KEYWORD -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -8426,15 +8255,10 @@ public class BallerinaParser extends AbstractParser {
      * @return <code>true</code> if the token kind refers to a unary operator. <code>false</code> otherwise
      */
     private boolean isUnaryOperator(SyntaxKind kind) {
-        switch (kind) {
-            case PLUS_TOKEN:
-            case MINUS_TOKEN:
-            case NEGATION_TOKEN:
-            case EXCLAMATION_MARK_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (kind) {
+            case PLUS_TOKEN, MINUS_TOKEN, NEGATION_TOKEN, EXCLAMATION_MARK_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -8523,20 +8347,18 @@ public class BallerinaParser extends AbstractParser {
      */
     private STNode parseArrayLength() {
         STToken token = peek();
-        switch (token.kind) {
-            case DECIMAL_INTEGER_LITERAL_TOKEN:
-            case HEX_INTEGER_LITERAL_TOKEN:
-            case ASTERISK_TOKEN:
-                return parseBasicLiteral();
-            case CLOSE_BRACKET_TOKEN:
-                return STNodeFactory.createEmptyNode();
+        return switch (token.kind) {
+            case DECIMAL_INTEGER_LITERAL_TOKEN,
+                 HEX_INTEGER_LITERAL_TOKEN,
+                 ASTERISK_TOKEN -> parseBasicLiteral();
+            case CLOSE_BRACKET_TOKEN -> STNodeFactory.createEmptyNode();
             // Parsing variable-reference-expr is same as parsing qualified identifier
-            case IDENTIFIER_TOKEN:
-                return parseQualifiedIdentifier(ParserRuleContext.ARRAY_LENGTH);
-            default:
+            case IDENTIFIER_TOKEN -> parseQualifiedIdentifier(ParserRuleContext.ARRAY_LENGTH);
+            default -> {
                 recover(token, ParserRuleContext.ARRAY_LENGTH);
-                return parseArrayLength();
-        }
+                yield parseArrayLength();
+            }
+        };
     }
 
     /**
@@ -8769,26 +8591,24 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isPossibleExpressionStatement(STNode expression) {
-        switch (expression.kind) {
-            case METHOD_CALL:
-            case FUNCTION_CALL:
-            case CHECK_EXPRESSION:
-            case REMOTE_METHOD_CALL_ACTION:
-            case CHECK_ACTION:
-            case BRACED_ACTION:
-            case START_ACTION:
-            case TRAP_ACTION:
-            case FLUSH_ACTION:
-            case ASYNC_SEND_ACTION:
-            case SYNC_SEND_ACTION:
-            case RECEIVE_ACTION:
-            case WAIT_ACTION:
-            case QUERY_ACTION:
-            case COMMIT_ACTION:
-                return true;
-            default:
-                return false;
-        }
+        return switch (expression.kind) {
+            case METHOD_CALL,
+                 FUNCTION_CALL,
+                 CHECK_EXPRESSION,
+                 REMOTE_METHOD_CALL_ACTION,
+                 CHECK_ACTION,
+                 BRACED_ACTION,
+                 START_ACTION,
+                 TRAP_ACTION,
+                 FLUSH_ACTION,
+                 ASYNC_SEND_ACTION,
+                 SYNC_SEND_ACTION,
+                 RECEIVE_ACTION,
+                 WAIT_ACTION,
+                 QUERY_ACTION,
+                 COMMIT_ACTION -> true;
+            default -> false;
+        };
     }
 
     private STNode getExpressionAsStatement(STNode expression) {
@@ -9048,15 +8868,14 @@ public class BallerinaParser extends AbstractParser {
     
     private STNode parseResourceAccessSegment() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case IDENTIFIER_TOKEN:
-                return consume();
-            case OPEN_BRACKET_TOKEN:
-                return parseComputedOrResourceAccessRestSegment(consume());
-            default:
+        return switch (nextToken.kind) {
+            case IDENTIFIER_TOKEN -> consume();
+            case OPEN_BRACKET_TOKEN -> parseComputedOrResourceAccessRestSegment(consume());
+            default -> {
                 recover(nextToken, ParserRuleContext.RESOURCE_ACCESS_PATH_SEGMENT);
-                return parseResourceAccessSegment();
-        }
+                yield parseResourceAccessSegment();
+            }
+        };
     }
 
     /**
@@ -9113,13 +8932,11 @@ public class BallerinaParser extends AbstractParser {
     }
     
     private boolean isEndOfResourceAccessPathSegments(STToken nextToken, boolean isRhsExpr, boolean isInMatchGuard) {
-        switch (nextToken.kind) {
-            case DOT_TOKEN:
-            case OPEN_PAREN_TOKEN:
-                return true;
-            default:
-                return isEndOfActionOrExpression(nextToken, isRhsExpr, isInMatchGuard);
-        }
+        return switch (nextToken.kind) {
+            case DOT_TOKEN,
+                 OPEN_PAREN_TOKEN -> true;
+            default -> isEndOfActionOrExpression(nextToken, isRhsExpr, isInMatchGuard);
+        };
     }
     
     private STNode parseRemoteMethodCallOrClientResourceAccessOrAsyncSendAction(STNode expression, boolean isRhsExpr,
@@ -9276,17 +9093,12 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private SyntaxKind getParameterizedTypeDescKind(STNode keywordToken) {
-        switch (keywordToken.kind) {
-            case TYPEDESC_KEYWORD:
-                return SyntaxKind.TYPEDESC_TYPE_DESC;
-            case FUTURE_KEYWORD:
-                return SyntaxKind.FUTURE_TYPE_DESC;
-            case XML_KEYWORD:
-                return SyntaxKind.XML_TYPE_DESC;
-            case ERROR_KEYWORD:
-            default:
-                return SyntaxKind.ERROR_TYPE_DESC;
-        }
+        return switch (keywordToken.kind) {
+            case TYPEDESC_KEYWORD -> SyntaxKind.TYPEDESC_TYPE_DESC;
+            case FUTURE_KEYWORD -> SyntaxKind.FUTURE_TYPE_DESC;
+            case XML_KEYWORD -> SyntaxKind.XML_TYPE_DESC;
+            default -> SyntaxKind.ERROR_TYPE_DESC;
+        };
     }
     
     /**
@@ -9589,26 +9401,22 @@ public class BallerinaParser extends AbstractParser {
      * @return Parsed node
      */
     private STNode parseAttachPointEnd() {
-        switch (peek().kind) {
-            case SEMICOLON_TOKEN:
-                // null represents the end of attach points.
-                return null;
-            case COMMA_TOKEN:
-                return consume();
-            default:
+        return switch (peek().kind) {
+            // null represents the end of attach points.
+            case SEMICOLON_TOKEN -> null;
+            case COMMA_TOKEN -> consume();
+            default -> {
                 recover(peek(), ParserRuleContext.ATTACH_POINT_END);
-                return parseAttachPointEnd();
-        }
+                yield parseAttachPointEnd();
+            }
+        };
     }
 
     private boolean isEndAnnotAttachPointList(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case EOF_TOKEN:
-            case SEMICOLON_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case EOF_TOKEN, SEMICOLON_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -9793,14 +9601,13 @@ public class BallerinaParser extends AbstractParser {
      */
     private STNode parseIdentAfterObjectIdent() {
         STToken token = peek();
-        switch (token.kind) {
-            case FUNCTION_KEYWORD:
-            case FIELD_KEYWORD:
-                return consume();
-            default:
+        return switch (token.kind) {
+            case FUNCTION_KEYWORD, FIELD_KEYWORD -> consume();
+            default -> {
                 recover(token, ParserRuleContext.IDENT_AFTER_OBJECT_IDENT);
-                return parseIdentAfterObjectIdent();
-        }
+                yield parseIdentAfterObjectIdent();
+            }
+        };
     }
 
     /**
@@ -9877,15 +9684,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isValidXMLNameSpaceURI(STNode expr) {
-        switch (expr.kind) {
-            case STRING_LITERAL:
-            case QUALIFIED_NAME_REFERENCE:
-            case SIMPLE_NAME_REFERENCE:
-                return true;
-            case IDENTIFIER_TOKEN:
-            default:
-                return false;
-        }
+        return switch (expr.kind) {
+            case STRING_LITERAL, QUALIFIED_NAME_REFERENCE, SIMPLE_NAME_REFERENCE -> true;
+            default -> false;
+        };
     }
 
     private STNode parseSimpleConstExpr() {
@@ -10199,57 +10001,50 @@ public class BallerinaParser extends AbstractParser {
      * @return <code>true</code> for simple type token in expression. <code>false</code> otherwise.
      */
     private boolean isSimpleTypeInExpression(SyntaxKind nodeKind) {
-        switch (nodeKind) {
-            case VAR_KEYWORD:
-            case READONLY_KEYWORD:
-                return false;
-            default:
-                return isSimpleType(nodeKind);
-        }
+        return switch (nodeKind) {
+            case VAR_KEYWORD, READONLY_KEYWORD -> false;
+            default -> isSimpleType(nodeKind);
+        };
     }
 
     static boolean isSimpleType(SyntaxKind nodeKind) {
-        switch (nodeKind) {
-            case INT_KEYWORD:
-            case FLOAT_KEYWORD:
-            case DECIMAL_KEYWORD:
-            case BOOLEAN_KEYWORD:
-            case STRING_KEYWORD:
-            case BYTE_KEYWORD:
-            case JSON_KEYWORD:
-            case HANDLE_KEYWORD:
-            case ANY_KEYWORD:
-            case ANYDATA_KEYWORD:
-            case NEVER_KEYWORD:
-            case VAR_KEYWORD:
-            case READONLY_KEYWORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nodeKind) {
+            case INT_KEYWORD,
+                 FLOAT_KEYWORD,
+                 DECIMAL_KEYWORD,
+                 BOOLEAN_KEYWORD,
+                 STRING_KEYWORD,
+                 BYTE_KEYWORD,
+                 JSON_KEYWORD,
+                 HANDLE_KEYWORD,
+                 ANY_KEYWORD,
+                 ANYDATA_KEYWORD,
+                 NEVER_KEYWORD,
+                 VAR_KEYWORD,
+                 READONLY_KEYWORD -> true;
+            default -> false;
+        };
     }
 
     static boolean isPredeclaredPrefix(SyntaxKind nodeKind) {
-        switch (nodeKind) {
-            case BOOLEAN_KEYWORD:
-            case DECIMAL_KEYWORD:
-            case ERROR_KEYWORD:
-            case FLOAT_KEYWORD:
-            case FUNCTION_KEYWORD:
-            case FUTURE_KEYWORD:
-            case INT_KEYWORD:
-            case MAP_KEYWORD:
-            case OBJECT_KEYWORD:
-            case STREAM_KEYWORD:
-            case STRING_KEYWORD:
-            case TABLE_KEYWORD:
-            case TRANSACTION_KEYWORD:
-            case TYPEDESC_KEYWORD:
-            case XML_KEYWORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nodeKind) {
+            case BOOLEAN_KEYWORD,
+                 DECIMAL_KEYWORD,
+                 ERROR_KEYWORD,
+                 FLOAT_KEYWORD,
+                 FUNCTION_KEYWORD,
+                 FUTURE_KEYWORD,
+                 INT_KEYWORD,
+                 MAP_KEYWORD,
+                 OBJECT_KEYWORD,
+                 STREAM_KEYWORD,
+                 STRING_KEYWORD,
+                 TABLE_KEYWORD,
+                 TRANSACTION_KEYWORD,
+                 TYPEDESC_KEYWORD,
+                 XML_KEYWORD -> true;
+            default -> false;
+        };
     }
 
     private boolean isQualifiedIdentifierPredeclaredPrefix(SyntaxKind nodeKind) {
@@ -10257,37 +10052,25 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private static SyntaxKind getBuiltinTypeSyntaxKind(SyntaxKind typeKeyword) {
-        switch (typeKeyword) {
-            case INT_KEYWORD:
-                return SyntaxKind.INT_TYPE_DESC;
-            case FLOAT_KEYWORD:
-                return SyntaxKind.FLOAT_TYPE_DESC;
-            case DECIMAL_KEYWORD:
-                return SyntaxKind.DECIMAL_TYPE_DESC;
-            case BOOLEAN_KEYWORD:
-                return SyntaxKind.BOOLEAN_TYPE_DESC;
-            case STRING_KEYWORD:
-                return SyntaxKind.STRING_TYPE_DESC;
-            case BYTE_KEYWORD:
-                return SyntaxKind.BYTE_TYPE_DESC;
-            case JSON_KEYWORD:
-                return SyntaxKind.JSON_TYPE_DESC;
-            case HANDLE_KEYWORD:
-                return SyntaxKind.HANDLE_TYPE_DESC;
-            case ANY_KEYWORD:
-                return SyntaxKind.ANY_TYPE_DESC;
-            case ANYDATA_KEYWORD:
-                return SyntaxKind.ANYDATA_TYPE_DESC;
-            case NEVER_KEYWORD:
-                return SyntaxKind.NEVER_TYPE_DESC;
-            case VAR_KEYWORD:
-                return SyntaxKind.VAR_TYPE_DESC;
-            case READONLY_KEYWORD:
-                return SyntaxKind.READONLY_TYPE_DESC;
-            default:
+        return switch (typeKeyword) {
+            case INT_KEYWORD -> SyntaxKind.INT_TYPE_DESC;
+            case FLOAT_KEYWORD -> SyntaxKind.FLOAT_TYPE_DESC;
+            case DECIMAL_KEYWORD -> SyntaxKind.DECIMAL_TYPE_DESC;
+            case BOOLEAN_KEYWORD -> SyntaxKind.BOOLEAN_TYPE_DESC;
+            case STRING_KEYWORD -> SyntaxKind.STRING_TYPE_DESC;
+            case BYTE_KEYWORD -> SyntaxKind.BYTE_TYPE_DESC;
+            case JSON_KEYWORD -> SyntaxKind.JSON_TYPE_DESC;
+            case HANDLE_KEYWORD -> SyntaxKind.HANDLE_TYPE_DESC;
+            case ANY_KEYWORD -> SyntaxKind.ANY_TYPE_DESC;
+            case ANYDATA_KEYWORD -> SyntaxKind.ANYDATA_TYPE_DESC;
+            case NEVER_KEYWORD -> SyntaxKind.NEVER_TYPE_DESC;
+            case VAR_KEYWORD -> SyntaxKind.VAR_TYPE_DESC;
+            case READONLY_KEYWORD -> SyntaxKind.READONLY_TYPE_DESC;
+            default -> {
                 assert false : typeKeyword + " is not a built-in type";
-                return SyntaxKind.TYPE_REFERENCE;
-        }
+                yield SyntaxKind.TYPE_REFERENCE;
+            }
+        };
     }
 
     /**
@@ -10487,26 +10270,22 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfListConstructor(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case EOF_TOKEN:
-            case CLOSE_BRACKET_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case EOF_TOKEN, CLOSE_BRACKET_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode parseListConstructorMemberEnd() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case COMMA_TOKEN:
-                return consume();
-            case CLOSE_BRACKET_TOKEN:
-                return null;
-            default:
+        return switch (nextToken.kind) {
+            case COMMA_TOKEN -> consume();
+            case CLOSE_BRACKET_TOKEN -> null;
+            default -> {
                 recover(nextToken, ParserRuleContext.LIST_CONSTRUCTOR_MEMBER_END);
-                return parseListConstructorMemberEnd();
-        }
+                yield parseListConstructorMemberEnd();
+            }
+        };
     }
 
     /**
@@ -10685,29 +10464,22 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfTableRowList(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case EOF_TOKEN:
-            case CLOSE_BRACKET_TOKEN:
-                return true;
-            case COMMA_TOKEN:
-            case OPEN_BRACE_TOKEN:
-                return false;
-            default:
-                return isEndOfMappingConstructor(tokenKind);
-        }
+        return switch (tokenKind) {
+            case EOF_TOKEN, CLOSE_BRACKET_TOKEN -> true;
+            case COMMA_TOKEN, OPEN_BRACE_TOKEN -> false;
+            default -> isEndOfMappingConstructor(tokenKind);
+        };
     }
 
     private STNode parseTableRowEnd() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_BRACKET_TOKEN:
-            case EOF_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> parseComma();
+            case CLOSE_BRACKET_TOKEN, EOF_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.TABLE_ROW_END);
-                return parseTableRowEnd();
-        }
+                yield parseTableRowEnd();
+            }
+        };
     }
 
     /**
@@ -10795,13 +10567,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfFieldNamesList(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case COMMA_TOKEN:
-            case IDENTIFIER_TOKEN:
-                return false;
-            default:
-                return true;
-        }
+        return switch (tokenKind) {
+            case COMMA_TOKEN, IDENTIFIER_TOKEN -> false;
+            default -> true;
+        };
     }
 
     /**
@@ -10956,15 +10725,11 @@ public class BallerinaParser extends AbstractParser {
 
     static boolean isEndOfLetVarDeclarations(STToken nextToken, STToken nextNextToken) {
         SyntaxKind tokenKind = nextToken.kind;
-        switch (tokenKind) {
-            case COMMA_TOKEN:
-            case AT_TOKEN:
-                return false;
-            case IN_KEYWORD:
-                return true;
-            default:
-                return isGroupOrCollectKeyword(nextToken) || !isTypeStartingToken(tokenKind, nextNextToken);
-        }
+        return switch (tokenKind) {
+            case COMMA_TOKEN, AT_TOKEN -> false;
+            case IN_KEYWORD -> true;
+            default -> isGroupOrCollectKeyword(nextToken) || !isTypeStartingToken(tokenKind, nextNextToken);
+        };
     }
 
     /**
@@ -11013,13 +10778,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfBacktickContent(SyntaxKind kind) {
-        switch (kind) {
-            case EOF_TOKEN:
-            case BACKTICK_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (kind) {
+            case EOF_TOKEN, BACKTICK_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode parseTemplateItem() {
@@ -11222,16 +10984,15 @@ public class BallerinaParser extends AbstractParser {
 
     private boolean isEndOfInterpolation() {
         SyntaxKind nextTokenKind = peek().kind;
-        switch (nextTokenKind) {
-            case EOF_TOKEN:
-            case BACKTICK_TOKEN:
-                return true;
-            default:
-                // Validate if the close brace is the end close brace of interpolation
+        return switch (nextTokenKind) {
+            case EOF_TOKEN, BACKTICK_TOKEN -> true;
+            default -> {
                 ParserMode currentLexerMode = this.tokenReader.getCurrentMode();
-                return nextTokenKind == SyntaxKind.CLOSE_BRACE_TOKEN && currentLexerMode != ParserMode.INTERPOLATION &&
+                // Validate if the close brace is the end close brace of interpolation
+                yield nextTokenKind == SyntaxKind.CLOSE_BRACE_TOKEN && currentLexerMode != ParserMode.INTERPOLATION &&
                         currentLexerMode != ParserMode.INTERPOLATION_BRACED_CONTENT;
-        }
+            }
+        };
     }
 
     /**
@@ -11330,15 +11091,14 @@ public class BallerinaParser extends AbstractParser {
      * @return Parsed node.
      */
     private STNode parseKeyConstraint(STNode keyKeywordToken) {
-        switch (peek().kind) {
-            case OPEN_PAREN_TOKEN:
-                return parseKeySpecifier(keyKeywordToken);
-            case LT_TOKEN:
-                return parseKeyTypeConstraint(keyKeywordToken);
-            default:
+        return switch (peek().kind) {
+            case OPEN_PAREN_TOKEN -> parseKeySpecifier(keyKeywordToken);
+            case LT_TOKEN -> parseKeyTypeConstraint(keyKeywordToken);
+            default -> {
                 recover(peek(), ParserRuleContext.KEY_CONSTRAINTS_RHS);
-                return parseKeyConstraint(keyKeywordToken);
-        }
+                yield parseKeyConstraint(keyKeywordToken);
+            }
+        };
     }
 
     /**
@@ -11438,13 +11198,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isRegularFuncQual(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case ISOLATED_KEYWORD:
-            case TRANSACTIONAL_KEYWORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case ISOLATED_KEYWORD, TRANSACTIONAL_KEYWORD -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -11625,36 +11382,33 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseImplicitAnonFuncParamEnd() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_PAREN_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> parseComma();
+            case CLOSE_PAREN_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.ANON_FUNC_PARAM_RHS);
-                return parseImplicitAnonFuncParamEnd();
-        }
+                yield parseImplicitAnonFuncParamEnd();
+            }
+        };
     }
 
     private boolean isEndOfAnonFuncParametersList(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case EOF_TOKEN:
-            case CLOSE_BRACE_TOKEN:
-            case CLOSE_PAREN_TOKEN:
-            case CLOSE_BRACKET_TOKEN:
-            case SEMICOLON_TOKEN:
-            case RETURNS_KEYWORD:
-            case TYPE_KEYWORD:
-            case LISTENER_KEYWORD:
-            case IF_KEYWORD:
-            case WHILE_KEYWORD:
-            case DO_KEYWORD:
-            case OPEN_BRACE_TOKEN:
-            case RIGHT_DOUBLE_ARROW_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case EOF_TOKEN,
+                 CLOSE_BRACE_TOKEN,
+                 CLOSE_PAREN_TOKEN,
+                 CLOSE_BRACKET_TOKEN,
+                 SEMICOLON_TOKEN,
+                 RETURNS_KEYWORD,
+                 TYPE_KEYWORD,
+                 LISTENER_KEYWORD,
+                 IF_KEYWORD,
+                 WHILE_KEYWORD,
+                 DO_KEYWORD,
+                 OPEN_BRACE_TOKEN,
+                 RIGHT_DOUBLE_ARROW_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -11762,43 +11516,38 @@ public class BallerinaParser extends AbstractParser {
 
     private STNode parseTupleMemberRhs() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_BRACKET_TOKEN:
-                return null;
-            default:
+        return switch (nextToken.kind) {
+            case COMMA_TOKEN -> parseComma();
+            case CLOSE_BRACKET_TOKEN -> null;
+            default -> {
                 recover(nextToken, ParserRuleContext.TUPLE_TYPE_MEMBER_RHS);
-                return parseTupleMemberRhs();
-        }
+                yield parseTupleMemberRhs();
+            }
+        };
     }
 
     private STNode parseTypeDescInTupleRhs() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case COMMA_TOKEN:
-            case CLOSE_BRACKET_TOKEN:
-                return null;
-            case ELLIPSIS_TOKEN:
-                return parseEllipsis();
-            default:
+        return switch (nextToken.kind) {
+            case COMMA_TOKEN, CLOSE_BRACKET_TOKEN -> null;
+            case ELLIPSIS_TOKEN -> parseEllipsis();
+            default -> {
                 recover(nextToken, ParserRuleContext.TYPE_DESC_IN_TUPLE_RHS);
-                return parseTypeDescInTupleRhs();
-        }
+                yield parseTypeDescInTupleRhs();
+            }
+        };
     }
 
     private boolean isEndOfTypeList(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case CLOSE_BRACKET_TOKEN:
-            case CLOSE_BRACE_TOKEN:
-            case CLOSE_PAREN_TOKEN:
-            case EOF_TOKEN:
-            case EQUAL_TOKEN:
-            case SEMICOLON_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextTokenKind) {
+            case CLOSE_BRACKET_TOKEN,
+                 CLOSE_BRACE_TOKEN,
+                 CLOSE_PAREN_TOKEN,
+                 EOF_TOKEN,
+                 EQUAL_TOKEN,
+                 SEMICOLON_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -11872,15 +11621,15 @@ public class BallerinaParser extends AbstractParser {
 
     private STNode parseTableConstructorOrQueryRhs(STNode tableKeyword, STNode keySpecifier, boolean isRhsExpr,
                                                    boolean allowActions) {
-        switch (peek().kind) {
-            case FROM_KEYWORD:
-                return parseQueryExprRhs(parseQueryConstructType(tableKeyword, keySpecifier), isRhsExpr, allowActions);
-            case OPEN_BRACKET_TOKEN:
-                return parseTableConstructorExprRhs(tableKeyword, keySpecifier);
-            default:
+        return switch (peek().kind) {
+            case FROM_KEYWORD ->
+                    parseQueryExprRhs(parseQueryConstructType(tableKeyword, keySpecifier), isRhsExpr, allowActions);
+            case OPEN_BRACKET_TOKEN -> parseTableConstructorExprRhs(tableKeyword, keySpecifier);
+            default -> {
                 recover(peek(), ParserRuleContext.TABLE_CONSTRUCTOR_OR_QUERY_RHS);
-                return parseTableConstructorOrQueryRhs(tableKeyword, keySpecifier, isRhsExpr, allowActions);
-        }
+                yield parseTableConstructorOrQueryRhs(tableKeyword, keySpecifier, isRhsExpr, allowActions);
+            }
+        };
     }
 
     /**
@@ -11994,24 +11743,21 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isValidIntermediateQueryStart(STToken token) {
-        switch (token.kind) {
-            case FROM_KEYWORD:
-            case WHERE_KEYWORD:
-            case LET_KEYWORD:
-            case SELECT_KEYWORD:
-            case JOIN_KEYWORD:
-            case OUTER_KEYWORD:
-            case ORDER_KEYWORD:
-            case BY_KEYWORD:
-            case ASCENDING_KEYWORD:
-            case DESCENDING_KEYWORD:
-            case LIMIT_KEYWORD:
-                return true;
-            case IDENTIFIER_TOKEN:
-                return isGroupOrCollectKeyword(token);
-            default:
-                return false;
-        }
+        return switch (token.kind) {
+            case FROM_KEYWORD,
+                 WHERE_KEYWORD,
+                 LET_KEYWORD,
+                 SELECT_KEYWORD,
+                 JOIN_KEYWORD,
+                 OUTER_KEYWORD,
+                 ORDER_KEYWORD,
+                 BY_KEYWORD,
+                 ASCENDING_KEYWORD,
+                 DESCENDING_KEYWORD,
+                 LIMIT_KEYWORD -> true;
+            case IDENTIFIER_TOKEN -> isGroupOrCollectKeyword(token);
+            default -> false;
+        };
     }
 
     private static boolean isGroupOrCollectKeyword(STToken nextToken) {
@@ -12135,31 +11881,29 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfIntermediateClause(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case CLOSE_BRACE_TOKEN:
-            case CLOSE_PAREN_TOKEN:
-            case CLOSE_BRACKET_TOKEN:
-            case OPEN_BRACE_TOKEN:
-            case SEMICOLON_TOKEN:
-            case PUBLIC_KEYWORD:
-            case FUNCTION_KEYWORD:
-            case EOF_TOKEN:
-            case RESOURCE_KEYWORD:
-            case LISTENER_KEYWORD:
-            case DOCUMENTATION_STRING:
-            case PRIVATE_KEYWORD:
-            case RETURNS_KEYWORD:
-            case SERVICE_KEYWORD:
-            case TYPE_KEYWORD:
-            case CONST_KEYWORD:
-            case FINAL_KEYWORD:
-            case DO_KEYWORD:
-            case ON_KEYWORD:
-            case CONFLICT_KEYWORD:
-                return true;
-            default:
-                return isValidExprRhsStart(tokenKind, SyntaxKind.NONE);
-        }
+        return switch (tokenKind) {
+            case CLOSE_BRACE_TOKEN,
+                 CLOSE_PAREN_TOKEN,
+                 CLOSE_BRACKET_TOKEN,
+                 OPEN_BRACE_TOKEN,
+                 SEMICOLON_TOKEN,
+                 PUBLIC_KEYWORD,
+                 FUNCTION_KEYWORD,
+                 EOF_TOKEN,
+                 RESOURCE_KEYWORD,
+                 LISTENER_KEYWORD,
+                 DOCUMENTATION_STRING,
+                 PRIVATE_KEYWORD,
+                 RETURNS_KEYWORD,
+                 SERVICE_KEYWORD,
+                 TYPE_KEYWORD,
+                 CONST_KEYWORD,
+                 FINAL_KEYWORD,
+                 DO_KEYWORD,
+                 ON_KEYWORD,
+                 CONFLICT_KEYWORD -> true;
+            default -> isValidExprRhsStart(tokenKind, SyntaxKind.NONE);
+        };
     }
 
     /**
@@ -12421,47 +12165,38 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfGroupByKeyListElement(STToken nextToken) {
-        switch (nextToken.kind) {
-            case COMMA_TOKEN:
-                return false;
-            case EOF_TOKEN:
-                return true;
-            default:
-                return isQueryClauseStartToken(nextToken);
-        }
+        return switch (nextToken.kind) {
+            case COMMA_TOKEN -> false;
+            case EOF_TOKEN -> true;
+            default -> isQueryClauseStartToken(nextToken);
+        };
     }
 
     private boolean isEndOfOrderKeys(STToken nextToken) {
-        switch (nextToken.kind) {
-            case COMMA_TOKEN:
-            case ASCENDING_KEYWORD:
-            case DESCENDING_KEYWORD:
-                return false;
-            case SEMICOLON_TOKEN:
-            case EOF_TOKEN:
-                return true;
-            default:
-                return isQueryClauseStartToken(nextToken);
-        }
+        return switch (nextToken.kind) {
+            case COMMA_TOKEN,
+                 ASCENDING_KEYWORD,
+                 DESCENDING_KEYWORD -> false;
+            case SEMICOLON_TOKEN,
+                 EOF_TOKEN -> true;
+            default -> isQueryClauseStartToken(nextToken);
+        };
     }
 
     private boolean isQueryClauseStartToken(STToken nextToken) {
-        switch (nextToken.kind) {
-            case SELECT_KEYWORD:
-            case LET_KEYWORD:
-            case WHERE_KEYWORD:
-            case OUTER_KEYWORD:
-            case JOIN_KEYWORD:
-            case ORDER_KEYWORD:
-            case DO_KEYWORD:
-            case FROM_KEYWORD:
-            case LIMIT_KEYWORD:
-                return true;
-            case IDENTIFIER_TOKEN:
-                return isGroupOrCollectKeyword(nextToken);
-            default:
-                return false;
-        }
+        return switch (nextToken.kind) {
+            case SELECT_KEYWORD,
+                 LET_KEYWORD,
+                 WHERE_KEYWORD,
+                 OUTER_KEYWORD,
+                 JOIN_KEYWORD,
+                 ORDER_KEYWORD,
+                 DO_KEYWORD,
+                 FROM_KEYWORD,
+                 LIMIT_KEYWORD -> true;
+            case IDENTIFIER_TOKEN -> isGroupOrCollectKeyword(nextToken);
+            default -> false;
+        };
     }
 
     private STNode parseGroupingKeyListMemberEnd() {
@@ -12548,14 +12283,10 @@ public class BallerinaParser extends AbstractParser {
 
         STNode orderDirection;
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case ASCENDING_KEYWORD:
-            case DESCENDING_KEYWORD:
-                orderDirection = consume();
-                break;
-            default:
-                orderDirection = STNodeFactory.createEmptyNode();
-        }
+        orderDirection = switch (nextToken.kind) {
+            case ASCENDING_KEYWORD, DESCENDING_KEYWORD -> consume();
+            default -> STNodeFactory.createEmptyNode();
+        };
 
         return STNodeFactory.createOrderKeyNode(expression, orderDirection);
     }
@@ -12758,20 +12489,22 @@ public class BallerinaParser extends AbstractParser {
         STNode closeParenToken = SyntaxErrors.createMissingTokenWithDiagnostics(SyntaxKind.CLOSE_PAREN_TOKEN,
                 DiagnosticErrorCode.ERROR_MISSING_CLOSE_PAREN_TOKEN);
 
-        switch (expr.kind) {
-            case FIELD_ACCESS:
+        return switch (expr.kind) {
+            case FIELD_ACCESS -> {
                 STFieldAccessExpressionNode fieldAccessExpr = (STFieldAccessExpressionNode) expr;
-                return STNodeFactory.createMethodCallExpressionNode(fieldAccessExpr.expression,
+                yield STNodeFactory.createMethodCallExpressionNode(fieldAccessExpr.expression,
                         fieldAccessExpr.dotToken, fieldAccessExpr.fieldName, openParenToken, arguments,
                         closeParenToken);
-            case ASYNC_SEND_ACTION:
+            }
+            case ASYNC_SEND_ACTION -> {
                 STAsyncSendActionNode asyncSendAction = (STAsyncSendActionNode) expr;
-                return STNodeFactory.createRemoteMethodCallActionNode(asyncSendAction.expression,
+                yield STNodeFactory.createRemoteMethodCallActionNode(asyncSendAction.expression,
                         asyncSendAction.rightArrowToken, asyncSendAction.peerWorker, openParenToken, arguments,
                         closeParenToken);
-            default: // QualifiedNameRef or SimpleNameRef
-                return STNodeFactory.createFunctionCallExpressionNode(expr, openParenToken, arguments, closeParenToken);
-        }
+            }
+            // QualifiedNameRef or SimpleNameRef
+            default -> STNodeFactory.createFunctionCallExpressionNode(expr, openParenToken, arguments, closeParenToken);
+        };
     }
 
     /**
@@ -12826,13 +12559,10 @@ public class BallerinaParser extends AbstractParser {
      */
     private STNode parseOptionalPeerWorkerName() {
         STToken token = peek();
-        switch (token.kind) {
-            case IDENTIFIER_TOKEN:
-            case FUNCTION_KEYWORD:
-                return STNodeFactory.createSimpleNameReferenceNode(consume());
-            default:
-                return STNodeFactory.createEmptyNode();
-        }
+        return switch (token.kind) {
+            case IDENTIFIER_TOKEN, FUNCTION_KEYWORD -> STNodeFactory.createSimpleNameReferenceNode(consume());
+            default -> STNodeFactory.createEmptyNode();
+        };
     }
 
     /**
@@ -12894,48 +12624,41 @@ public class BallerinaParser extends AbstractParser {
         STNode operator = parseUnaryOperator();
         STNode literal;
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case HEX_INTEGER_LITERAL_TOKEN:
-            case DECIMAL_FLOATING_POINT_LITERAL_TOKEN:
-            case HEX_FLOATING_POINT_LITERAL_TOKEN:
-                literal = parseBasicLiteral();
-                break;
-            default: // decimal integer literal
-                literal = parseDecimalIntLiteral(ParserRuleContext.DECIMAL_INTEGER_LITERAL_TOKEN);
-                literal = STNodeFactory.createBasicLiteralNode(SyntaxKind.NUMERIC_LITERAL, literal);
-        }
+        literal = switch (nextToken.kind) {
+            case HEX_INTEGER_LITERAL_TOKEN,
+                 DECIMAL_FLOATING_POINT_LITERAL_TOKEN,
+                 HEX_FLOATING_POINT_LITERAL_TOKEN -> parseBasicLiteral();
+            // decimal integer literal
+            default -> STNodeFactory.createBasicLiteralNode(SyntaxKind.NUMERIC_LITERAL,
+                    parseDecimalIntLiteral(ParserRuleContext.DECIMAL_INTEGER_LITERAL_TOKEN));
+        };
         return STNodeFactory.createUnaryExpressionNode(operator, literal);
     }
 
     private static boolean isSingletonTypeDescStart(SyntaxKind tokenKind, STToken nextNextToken) {
-        switch (tokenKind) {
-            case STRING_LITERAL_TOKEN:
-            case DECIMAL_INTEGER_LITERAL_TOKEN:
-            case HEX_INTEGER_LITERAL_TOKEN:
-            case DECIMAL_FLOATING_POINT_LITERAL_TOKEN:
-            case HEX_FLOATING_POINT_LITERAL_TOKEN:
-            case TRUE_KEYWORD:
-            case FALSE_KEYWORD:
-            case NULL_KEYWORD:
-                return true;
-            case PLUS_TOKEN:
-            case MINUS_TOKEN:
-                return isIntOrFloat(nextNextToken);
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case STRING_LITERAL_TOKEN,
+                 DECIMAL_INTEGER_LITERAL_TOKEN,
+                 HEX_INTEGER_LITERAL_TOKEN,
+                 DECIMAL_FLOATING_POINT_LITERAL_TOKEN,
+                 HEX_FLOATING_POINT_LITERAL_TOKEN,
+                 TRUE_KEYWORD,
+                 FALSE_KEYWORD,
+                 NULL_KEYWORD -> true;
+            case PLUS_TOKEN,
+                 MINUS_TOKEN -> isIntOrFloat(nextNextToken);
+            default -> false;
+        };
     }
 
     static boolean isIntOrFloat(STToken token) {
-        switch (token.kind) {
-            case DECIMAL_INTEGER_LITERAL_TOKEN:
-            case HEX_INTEGER_LITERAL_TOKEN:
-            case DECIMAL_FLOATING_POINT_LITERAL_TOKEN:
-            case HEX_FLOATING_POINT_LITERAL_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (token.kind) {
+            case DECIMAL_INTEGER_LITERAL_TOKEN,
+                 HEX_INTEGER_LITERAL_TOKEN,
+                 DECIMAL_FLOATING_POINT_LITERAL_TOKEN,
+                 HEX_FLOATING_POINT_LITERAL_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -13040,14 +12763,14 @@ public class BallerinaParser extends AbstractParser {
      */
     private STNode parsePeerWorkerName() {
         STToken token = peek();
-        switch (token.kind) {
-            case IDENTIFIER_TOKEN:
-            case FUNCTION_KEYWORD:
-                return STNodeFactory.createSimpleNameReferenceNode(consume());
-            default:
+        return switch (token.kind) {
+            case IDENTIFIER_TOKEN,
+                 FUNCTION_KEYWORD -> STNodeFactory.createSimpleNameReferenceNode(consume());
+            default -> {
                 recover(token, ParserRuleContext.PEER_WORKER_NAME);
-                return parsePeerWorkerName();
-        }
+                yield parsePeerWorkerName();
+            }
+        };
     }
 
     /**
@@ -13088,16 +12811,14 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseReceiveWorkers() {
-        switch (peek().kind) {
-            case FUNCTION_KEYWORD:
-            case IDENTIFIER_TOKEN:
-                return parseSingleOrAlternateReceiveWorkers();
-            case OPEN_BRACE_TOKEN:
-                return parseMultipleReceiveWorkers();
-            default:
+        return switch (peek().kind) {
+            case FUNCTION_KEYWORD, IDENTIFIER_TOKEN -> parseSingleOrAlternateReceiveWorkers();
+            case OPEN_BRACE_TOKEN -> parseMultipleReceiveWorkers();
+            default -> {
                 recover(peek(), ParserRuleContext.RECEIVE_WORKERS);
-                return parseReceiveWorkers();
-        }
+                yield parseReceiveWorkers();
+            }
+        };
     }
 
     private STNode parseSingleOrAlternateReceiveWorkers() {
@@ -13177,25 +12898,21 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfReceiveFields(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case EOF_TOKEN:
-            case CLOSE_BRACE_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextTokenKind) {
+            case EOF_TOKEN, CLOSE_BRACE_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode parseReceiveFieldEnd() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_BRACE_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> parseComma();
+            case CLOSE_BRACE_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.RECEIVE_FIELD_END);
-                return parseReceiveFieldEnd();
-        }
+                yield parseReceiveFieldEnd();
+            }
+        };
     }
 
     /**
@@ -13206,17 +12923,20 @@ public class BallerinaParser extends AbstractParser {
      * @return Receiver field node
      */
     private STNode parseReceiveField() {
-        switch (peek().kind) {
-            case FUNCTION_KEYWORD:
+        return switch (peek().kind) {
+            case FUNCTION_KEYWORD -> {
                 STNode functionKeyword = consume();
-                return STNodeFactory.createSimpleNameReferenceNode(functionKeyword);
-            case IDENTIFIER_TOKEN:
+                yield STNodeFactory.createSimpleNameReferenceNode(functionKeyword);
+            }
+            case IDENTIFIER_TOKEN -> {
                 STNode identifier = parseIdentifier(ParserRuleContext.RECEIVE_FIELD_NAME);
-                return createReceiveField(identifier);
-            default:
+                yield createReceiveField(identifier);
+            }
+            default -> {
                 recover(peek(), ParserRuleContext.RECEIVE_FIELD);
-                return parseReceiveField();
-        }
+                yield parseReceiveField();
+            }
+        };
     }
 
     private STNode createReceiveField(STNode identifier) {
@@ -13382,16 +13102,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfWaitFutureExprList(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case EOF_TOKEN:
-            case CLOSE_BRACE_TOKEN:
-            case SEMICOLON_TOKEN:
-            case OPEN_BRACE_TOKEN:
-                return true;
-            case PIPE_TOKEN:
-            default:
-                return false;
-        }
+        return switch (nextTokenKind) {
+            case EOF_TOKEN, CLOSE_BRACE_TOKEN, SEMICOLON_TOKEN, OPEN_BRACE_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode parseWaitFutureExpr() {
@@ -13474,25 +13188,21 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfWaitFields(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case EOF_TOKEN:
-            case CLOSE_BRACE_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextTokenKind) {
+            case EOF_TOKEN, CLOSE_BRACE_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode parseWaitFieldEnd() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_BRACE_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> parseComma();
+            case CLOSE_BRACE_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.WAIT_FIELD_END);
-                return parseWaitFieldEnd();
-        }
+                yield parseWaitFieldEnd();
+            }
+        };
     }
 
     /**
@@ -13855,15 +13565,10 @@ public class BallerinaParser extends AbstractParser {
      * @return Parsed enum member node.
      */
     private STNode parseEnumMember() {
-        STNode metadata;
-        switch (peek().kind) {
-            case DOCUMENTATION_STRING:
-            case AT_TOKEN:
-                metadata = parseMetaData();
-                break;
-            default:
-                metadata = STNodeFactory.createEmptyNode();
-        }
+        STNode metadata = switch (peek().kind) {
+            case DOCUMENTATION_STRING, AT_TOKEN -> parseMetaData();
+            default -> STNodeFactory.createEmptyNode();
+        };
 
         STNode identifierNode = parseIdentifier(ParserRuleContext.ENUM_MEMBER_NAME);
         return parseEnumMemberRhs(metadata, identifierNode);
@@ -13890,15 +13595,14 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseEnumMemberEnd() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_BRACE_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> parseComma();
+            case CLOSE_BRACE_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.ENUM_MEMBER_END);
-                return parseEnumMemberEnd();
-        }
+                yield parseEnumMemberEnd();
+            }
+        };
     }
 
     private STNode parseTransactionStmtOrVarDecl(STNode annots, List<STNode> qualifiers, STToken transactionKeyword) {
@@ -13990,19 +13694,16 @@ public class BallerinaParser extends AbstractParser {
 
     private STNode parseRetryKeywordRhs(STNode retryKeyword) {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case LT_TOKEN:
-                STNode typeParam = parseTypeParameter();
-                return parseRetryTypeParamRhs(retryKeyword, typeParam);
-            case OPEN_PAREN_TOKEN:
-            case OPEN_BRACE_TOKEN:
-            case TRANSACTION_KEYWORD:
-                typeParam = STNodeFactory.createEmptyNode();
-                return parseRetryTypeParamRhs(retryKeyword, typeParam);
-            default:
+        return switch (nextToken.kind) {
+            case LT_TOKEN -> parseRetryTypeParamRhs(retryKeyword, parseTypeParameter());
+            case OPEN_PAREN_TOKEN,
+                 OPEN_BRACE_TOKEN,
+                 TRANSACTION_KEYWORD -> parseRetryTypeParamRhs(retryKeyword, STNodeFactory.createEmptyNode());
+            default -> {
                 recover(peek(), ParserRuleContext.RETRY_KEYWORD_RHS);
-                return parseRetryKeywordRhs(retryKeyword);
-        }
+                yield parseRetryKeywordRhs(retryKeyword);
+            }
+        };
     }
 
     private STNode parseRetryTypeParamRhs(STNode retryKeyword, STNode typeParam) {
@@ -14027,15 +13728,14 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseRetryBody() {
-        switch (peek().kind) {
-            case OPEN_BRACE_TOKEN:
-                return parseBlockNode();
-            case TRANSACTION_KEYWORD:
-                return parseTransactionStatement(consume());
-            default:
+        return switch (peek().kind) {
+            case OPEN_BRACE_TOKEN -> parseBlockNode();
+            case TRANSACTION_KEYWORD -> parseTransactionStatement(consume());
+            default -> {
                 recover(peek(), ParserRuleContext.RETRY_BODY);
-                return parseRetryBody();
-        }
+                yield parseRetryBody();
+            }
+        };
     }
 
     /**
@@ -14058,15 +13758,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfRegularCompoundStmt(SyntaxKind nodeKind) {
-        switch (nodeKind) {
-            case CLOSE_BRACE_TOKEN:
-            case SEMICOLON_TOKEN:
-            case AT_TOKEN:
-            case EOF_TOKEN:
-                return true;
-            default:
-                return isStatementStartingToken(nodeKind);
-        }
+        return switch (nodeKind) {
+            case CLOSE_BRACE_TOKEN, SEMICOLON_TOKEN, AT_TOKEN, EOF_TOKEN -> true;
+            default -> isStatementStartingToken(nodeKind);
+        };
     }
 
     private boolean isStatementStartingToken(SyntaxKind nodeKind) {
@@ -14624,30 +14319,22 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfXMLNamePattern(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case GT_TOKEN:
-            case EOF_TOKEN:
-                return true;
-            case IDENTIFIER_TOKEN:
-            case ASTERISK_TOKEN:
-            case COLON_TOKEN:
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case GT_TOKEN, EOF_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode parseXMLNamePatternSeparator() {
         STToken token = peek();
-        switch (token.kind) {
-            case PIPE_TOKEN:
-                return consume();
-            case GT_TOKEN:
-            case EOF_TOKEN:
-                return null;
-            default:
+        return switch (token.kind) {
+            case PIPE_TOKEN -> consume();
+            case GT_TOKEN, EOF_TOKEN -> null;
+            default -> {
                 recover(token, ParserRuleContext.XML_NAME_PATTERN_RHS);
-                return parseXMLNamePatternSeparator();
-        }
+                yield parseXMLNamePatternSeparator();
+            }
+        };
     }
 
     /**
@@ -14825,14 +14512,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfMatchClauses(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case EOF_TOKEN:
-            case CLOSE_BRACE_TOKEN:
-            case TYPE_KEYWORD:
-                return true;
-            default:
-                return isEndOfStatements();
-        }
+        return switch (nextTokenKind) {
+            case EOF_TOKEN, CLOSE_BRACE_TOKEN, TYPE_KEYWORD -> true;
+            default -> isEndOfStatements();
+        };
     }
 
     /**
@@ -14919,14 +14602,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isEndOfMatchPattern(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case PIPE_TOKEN:
-            case IF_KEYWORD:
-            case RIGHT_DOUBLE_ARROW_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextTokenKind) {
+            case PIPE_TOKEN, IF_KEYWORD, RIGHT_DOUBLE_ARROW_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -14951,46 +14630,41 @@ public class BallerinaParser extends AbstractParser {
             return parseErrorMatchPatternOrConsPattern(typeRefOrConstExpr);
         }
 
-        switch (nextToken.kind) {
-            case OPEN_PAREN_TOKEN:
-            case NULL_KEYWORD:
-            case TRUE_KEYWORD:
-            case FALSE_KEYWORD:
-            case PLUS_TOKEN:
-            case MINUS_TOKEN:
-            case DECIMAL_INTEGER_LITERAL_TOKEN:
-            case HEX_INTEGER_LITERAL_TOKEN:
-            case DECIMAL_FLOATING_POINT_LITERAL_TOKEN:
-            case HEX_FLOATING_POINT_LITERAL_TOKEN:
-            case STRING_LITERAL_TOKEN:
-                return parseSimpleConstExpr();
-            case VAR_KEYWORD:
-                return parseVarTypedBindingPattern();
-            case OPEN_BRACKET_TOKEN:
-                return parseListMatchPattern();
-            case OPEN_BRACE_TOKEN:
-                return parseMappingMatchPattern();
-            case ERROR_KEYWORD:
-                return parseErrorMatchPattern();
-            default:
+        return switch (nextToken.kind) {
+            case OPEN_PAREN_TOKEN,
+                 NULL_KEYWORD,
+                 TRUE_KEYWORD,
+                 FALSE_KEYWORD,
+                 PLUS_TOKEN,
+                 MINUS_TOKEN,
+                 DECIMAL_INTEGER_LITERAL_TOKEN,
+                 HEX_INTEGER_LITERAL_TOKEN,
+                 DECIMAL_FLOATING_POINT_LITERAL_TOKEN,
+                 HEX_FLOATING_POINT_LITERAL_TOKEN,
+                 STRING_LITERAL_TOKEN -> parseSimpleConstExpr();
+            case VAR_KEYWORD -> parseVarTypedBindingPattern();
+            case OPEN_BRACKET_TOKEN -> parseListMatchPattern();
+            case OPEN_BRACE_TOKEN -> parseMappingMatchPattern();
+            case ERROR_KEYWORD -> parseErrorMatchPattern();
+            default -> {
                 recover(nextToken, ParserRuleContext.MATCH_PATTERN_START);
-                return parseMatchPattern();
-        }
+                yield parseMatchPattern();
+            }
+        };
     }
 
     private STNode parseMatchPatternListMemberRhs() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case PIPE_TOKEN:
-                return parsePipeToken();
-            case IF_KEYWORD:
-            case RIGHT_DOUBLE_ARROW_TOKEN:
-                // Returning null indicates the end of the match-patterns list
-                return null;
-            default:
+        return switch (nextToken.kind) {
+            case PIPE_TOKEN -> parsePipeToken();
+            // Returning null indicates the end of the match-patterns list
+            case IF_KEYWORD,
+                 RIGHT_DOUBLE_ARROW_TOKEN -> null;
+            default -> {
                 recover(nextToken, ParserRuleContext.MATCH_PATTERN_LIST_MEMBER_RHS);
-                return parseMatchPatternListMemberRhs();
-        }
+                yield parseMatchPatternListMemberRhs();
+            }
+        };
     }
 
     /**
@@ -15083,24 +14757,19 @@ public class BallerinaParser extends AbstractParser {
     }
 
     public boolean isEndOfListMatchPattern() {
-        switch (peek().kind) {
-            case CLOSE_BRACKET_TOKEN:
-            case EOF_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (peek().kind) {
+            case CLOSE_BRACKET_TOKEN, EOF_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode parseListMatchPatternMember() {
         STNode nextToken = peek();
-        switch (nextToken.kind) {
-            case ELLIPSIS_TOKEN:
-                return parseRestMatchPattern();
-            default:
-                // No need of recovery here
-                return parseMatchPattern();
-        }
+        return switch (nextToken.kind) {
+            case ELLIPSIS_TOKEN -> parseRestMatchPattern();
+            // No need of recovery here
+            default -> parseMatchPattern();
+        };
     }
 
     /**
@@ -15126,16 +14795,14 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseListMatchPatternMemberRhs() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_BRACKET_TOKEN:
-            case EOF_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> parseComma();
+            case CLOSE_BRACKET_TOKEN, EOF_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.LIST_MATCH_PATTERN_MEMBER_RHS);
-                return parseListMatchPatternMemberRhs();
-        }
+                yield parseListMatchPatternMemberRhs();
+            }
+        };
     }
 
     /**
@@ -15239,19 +14906,16 @@ public class BallerinaParser extends AbstractParser {
 
     private STNode parseFieldMatchPatternMember() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case IDENTIFIER_TOKEN:
-                return parseFieldMatchPattern();
-            case ELLIPSIS_TOKEN:
-                return parseRestMatchPattern();
-            case CLOSE_BRACE_TOKEN:
-            case EOF_TOKEN:
-                // null marks the end of field-match-patterns
-                return null;
-            default:
+        return switch (nextToken.kind) {
+            case IDENTIFIER_TOKEN -> parseFieldMatchPattern();
+            case ELLIPSIS_TOKEN -> parseRestMatchPattern();
+            // null marks the end of field-match-patterns
+            case CLOSE_BRACE_TOKEN, EOF_TOKEN -> null;
+            default -> {
                 recover(nextToken, ParserRuleContext.FIELD_MATCH_PATTERNS_START);
-                return parseFieldMatchPatternMember();
-        }
+                yield parseFieldMatchPatternMember();
+            }
+        };
     }
 
     /**
@@ -15270,26 +14934,21 @@ public class BallerinaParser extends AbstractParser {
     }
 
     public boolean isEndOfMappingMatchPattern() {
-        switch (peek().kind) {
-            case CLOSE_BRACE_TOKEN:
-            case EOF_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (peek().kind) {
+            case CLOSE_BRACE_TOKEN, EOF_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode parseFieldMatchPatternRhs() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_BRACE_TOKEN:
-            case EOF_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> parseComma();
+            case CLOSE_BRACE_TOKEN, EOF_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.FIELD_MATCH_PATTERN_MEMBER_RHS);
-                return parseFieldMatchPatternRhs();
-        }
+                yield parseFieldMatchPatternRhs();
+            }
+        };
     }
 
     private STNode parseErrorMatchPatternOrConsPattern(STNode typeRefOrConstExpr) {
@@ -15310,19 +14969,17 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isMatchPatternEnd(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case RIGHT_DOUBLE_ARROW_TOKEN:
-            case COMMA_TOKEN:
-            case CLOSE_BRACE_TOKEN:
-            case CLOSE_BRACKET_TOKEN:
-            case CLOSE_PAREN_TOKEN:
-            case PIPE_TOKEN:
-            case IF_KEYWORD:
-            case EOF_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case RIGHT_DOUBLE_ARROW_TOKEN,
+                 COMMA_TOKEN,
+                 CLOSE_BRACE_TOKEN,
+                 CLOSE_BRACKET_TOKEN,
+                 CLOSE_PAREN_TOKEN,
+                 PIPE_TOKEN,
+                 IF_KEYWORD,
+                 EOF_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -15419,35 +15076,28 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isSimpleMatchPattern(SyntaxKind matchPatternKind) {
-        switch (matchPatternKind) {
-            case IDENTIFIER_TOKEN:
-            case SIMPLE_NAME_REFERENCE:
-            case QUALIFIED_NAME_REFERENCE:
-            case NUMERIC_LITERAL:
-            case STRING_LITERAL:
-            case NULL_LITERAL:
-            case NIL_LITERAL:
-            case BOOLEAN_LITERAL:
-            case TYPED_BINDING_PATTERN:
-            case UNARY_EXPRESSION:
-                return true;
-            default:
-                return false;
-        }
+        return switch (matchPatternKind) {
+            case IDENTIFIER_TOKEN,
+                 SIMPLE_NAME_REFERENCE,
+                 QUALIFIED_NAME_REFERENCE,
+                 NUMERIC_LITERAL,
+                 STRING_LITERAL,
+                 NULL_LITERAL,
+                 NIL_LITERAL,
+                 BOOLEAN_LITERAL,
+                 TYPED_BINDING_PATTERN,
+                 UNARY_EXPRESSION -> true;
+            default -> false;
+        };
     }
 
     private boolean isValidSecondArgMatchPattern(SyntaxKind syntaxKind) {
-        switch (syntaxKind) {
-            case ERROR_MATCH_PATTERN:
-            case NAMED_ARG_MATCH_PATTERN:
-            case REST_MATCH_PATTERN:
-                return true;
-            default:
-                if (isSimpleMatchPattern(syntaxKind)) {
-                    return true;
-                }
-                return false;
-        }
+        return switch (syntaxKind) {
+            case ERROR_MATCH_PATTERN,
+                 NAMED_ARG_MATCH_PATTERN,
+                 REST_MATCH_PATTERN -> true;
+            default -> isSimpleMatchPattern(syntaxKind);
+        };
     }
 
     /**
@@ -15488,15 +15138,14 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseErrorArgListMatchPatternEnd(ParserRuleContext currentCtx) {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return consume();
-            case CLOSE_PAREN_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> consume();
+            case CLOSE_PAREN_TOKEN -> null;
+            default -> {
                 recover(peek(), currentCtx);
-                return parseErrorArgListMatchPatternEnd(currentCtx);
-        }
+                yield parseErrorArgListMatchPatternEnd(currentCtx);
+            }
+        };
     }
 
     private STNode parseErrorArgListMatchPattern(ParserRuleContext context) {
@@ -15564,17 +15213,17 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private DiagnosticErrorCode validateErrorFieldMatchPatternOrder(SyntaxKind prevArgKind, SyntaxKind currentArgKind) {
-        switch (currentArgKind) {
-            case NAMED_ARG_MATCH_PATTERN:
-            case REST_MATCH_PATTERN:
+        return switch (currentArgKind) {
+            case NAMED_ARG_MATCH_PATTERN,
+                 REST_MATCH_PATTERN -> {
                 // Nothing is allowed after a rest arg
                 if (prevArgKind == SyntaxKind.REST_MATCH_PATTERN) {
-                    return DiagnosticErrorCode.ERROR_REST_ARG_FOLLOWED_BY_ANOTHER_ARG;
+                    yield DiagnosticErrorCode.ERROR_REST_ARG_FOLLOWED_BY_ANOTHER_ARG;
                 }
-                return null;
-            default:
-                return DiagnosticErrorCode.ERROR_MATCH_PATTERN_NOT_ALLOWED;
-        }
+                yield null;
+            }
+            default -> DiagnosticErrorCode.ERROR_MATCH_PATTERN_NOT_ALLOWED;
+        };
     }
 
     /**
@@ -15946,17 +15595,15 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isExpression(SyntaxKind kind) {
-        switch (kind) {
-            case NUMERIC_LITERAL:
-            case STRING_LITERAL_TOKEN:
-            case NIL_LITERAL:
-            case NULL_LITERAL:
-            case BOOLEAN_LITERAL:
-                return true;
-            default:
-                return kind.compareTo(SyntaxKind.BINARY_EXPRESSION) >= 0 &&
-                        kind.compareTo(SyntaxKind.ERROR_CONSTRUCTOR) <= 0;
-        }
+        return switch (kind) {
+            case NUMERIC_LITERAL,
+                 STRING_LITERAL_TOKEN,
+                 NIL_LITERAL,
+                 NULL_LITERAL,
+                 BOOLEAN_LITERAL -> true;
+            default -> kind.compareTo(SyntaxKind.BINARY_EXPRESSION) >= 0 &&
+                    kind.compareTo(SyntaxKind.ERROR_CONSTRUCTOR) <= 0;
+        };
     }
 
     /**
@@ -16210,12 +15857,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isNumericLiteral(STNode node) {
-        switch (node.kind) {
-            case NUMERIC_LITERAL:
-                return true;
-            default:
-                return false;
-        }
+        return switch (node.kind) {
+            case NUMERIC_LITERAL -> true;
+            default -> false;
+        };
     }
 
     // ------------------------ Typed binding patterns ---------------------------
@@ -16271,19 +15916,16 @@ public class BallerinaParser extends AbstractParser {
      * @return binding-pattern node
      */
     private STNode parseBindingPattern() {
-        switch (peek().kind) {
-            case OPEN_BRACKET_TOKEN:
-                return parseListBindingPattern();
-            case IDENTIFIER_TOKEN:
-                return parseBindingPatternStartsWithIdentifier();
-            case OPEN_BRACE_TOKEN:
-                return parseMappingBindingPattern();
-            case ERROR_KEYWORD:
-                return parseErrorBindingPattern();
-            default:
+        return switch (peek().kind) {
+            case OPEN_BRACKET_TOKEN -> parseListBindingPattern();
+            case IDENTIFIER_TOKEN -> parseBindingPatternStartsWithIdentifier();
+            case OPEN_BRACE_TOKEN -> parseMappingBindingPattern();
+            case ERROR_KEYWORD -> parseErrorBindingPattern();
+            default -> {
                 recover(peek(), ParserRuleContext.BINDING_PATTERN);
-                return parseBindingPattern();
-        }
+                yield parseBindingPattern();
+            }
+        };
     }
 
     private STNode parseBindingPatternStartsWithIdentifier() {
@@ -16374,25 +16016,21 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseListBindingPatternMemberRhs() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_BRACKET_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> parseComma();
+            case CLOSE_BRACKET_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.LIST_BINDING_PATTERN_MEMBER_END);
-                return parseListBindingPatternMemberRhs();
-        }
+                yield parseListBindingPatternMemberRhs();
+            }
+        };
     }
 
     private boolean isEndOfListBindingPattern(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case CLOSE_BRACKET_TOKEN:
-            case EOF_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextTokenKind) {
+            case CLOSE_BRACKET_TOKEN, EOF_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -16408,18 +16046,17 @@ public class BallerinaParser extends AbstractParser {
      * @return List binding pattern member
      */
     private STNode parseListBindingPatternMember() {
-        switch (peek().kind) {
-            case ELLIPSIS_TOKEN:
-                return parseRestBindingPattern();
-            case OPEN_BRACKET_TOKEN:
-            case IDENTIFIER_TOKEN:
-            case OPEN_BRACE_TOKEN:
-            case ERROR_KEYWORD:
-                return parseBindingPattern();
-            default:
+        return switch (peek().kind) {
+            case ELLIPSIS_TOKEN -> parseRestBindingPattern();
+            case OPEN_BRACKET_TOKEN,
+                 IDENTIFIER_TOKEN,
+                 OPEN_BRACE_TOKEN,
+                 ERROR_KEYWORD -> parseBindingPattern();
+            default -> {
                 recover(peek(), ParserRuleContext.LIST_BINDING_PATTERN_MEMBER);
-                return parseListBindingPatternMember();
-        }
+                yield parseListBindingPatternMember();
+            }
+        };
     }
 
     /**
@@ -16544,25 +16181,22 @@ public class BallerinaParser extends AbstractParser {
      */
     private STNode parseMappingBindingPatternMember() {
         STToken token = peek();
-        switch (token.kind) {
-            case ELLIPSIS_TOKEN:
-                return parseRestBindingPattern();
-            default:
-                return parseFieldBindingPattern();
-        }
+        return switch (token.kind) {
+            case ELLIPSIS_TOKEN -> parseRestBindingPattern();
+            default -> parseFieldBindingPattern();
+        };
     }
 
     private STNode parseMappingBindingPatternEnd() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_BRACE_TOKEN:
-                return null;
-            default:
+        return switch (nextToken.kind) {
+            case COMMA_TOKEN -> parseComma();
+            case CLOSE_BRACE_TOKEN -> null;
+            default -> {
                 recover(nextToken, ParserRuleContext.MAPPING_BINDING_PATTERN_END);
-                return parseMappingBindingPatternEnd();
-        }
+                yield parseMappingBindingPatternEnd();
+            }
+        };
     }
 
     /**
@@ -16818,25 +16452,22 @@ public class BallerinaParser extends AbstractParser {
 
     private boolean isEndOfErrorFieldBindingPatterns() {
         SyntaxKind nextTokenKind = peek().kind;
-        switch (nextTokenKind) {
-            case CLOSE_PAREN_TOKEN:
-            case EOF_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextTokenKind) {
+            case CLOSE_PAREN_TOKEN,
+                 EOF_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode parseErrorArgsBindingPatternEnd(ParserRuleContext currentCtx) {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return consume();
-            case CLOSE_PAREN_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> consume();
+            case CLOSE_PAREN_TOKEN -> null;
+            default -> {
                 recover(peek(), currentCtx);
-                return parseErrorArgsBindingPatternEnd(currentCtx);
-        }
+                yield parseErrorArgsBindingPatternEnd(currentCtx);
+            }
+        };
     }
 
     private STNode parseErrorArgListBindingPattern(ParserRuleContext context, boolean isFirstArg) {
@@ -16880,22 +16511,17 @@ public class BallerinaParser extends AbstractParser {
 
     private DiagnosticErrorCode validateErrorFieldBindingPatternOrder(SyntaxKind prevArgKind,
                                                                       SyntaxKind currentArgKind) {
-        switch (currentArgKind) {
-            case NAMED_ARG_BINDING_PATTERN:
-            case REST_BINDING_PATTERN:
+        return switch (currentArgKind) {
+            case NAMED_ARG_BINDING_PATTERN,
+                 REST_BINDING_PATTERN -> {
                 // Nothing is allowed after a rest arg
                 if (prevArgKind == SyntaxKind.REST_BINDING_PATTERN) {
-                    return DiagnosticErrorCode.ERROR_REST_ARG_FOLLOWED_BY_ANOTHER_ARG;
+                    yield DiagnosticErrorCode.ERROR_REST_ARG_FOLLOWED_BY_ANOTHER_ARG;
                 }
-                return null;
-            case CAPTURE_BINDING_PATTERN:
-            case WILDCARD_BINDING_PATTERN:
-            case ERROR_BINDING_PATTERN:
-            case LIST_BINDING_PATTERN:
-            case MAPPING_BINDING_PATTERN:
-            default:
-                return DiagnosticErrorCode.ERROR_BINDING_PATTERN_NOT_ALLOWED;
-        }
+                yield null;
+            }
+            default -> DiagnosticErrorCode.ERROR_BINDING_PATTERN_NOT_ALLOWED;
+        };
     }
 
     // ------------------------ Typed binding patterns ---------------------------
@@ -17020,13 +16646,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isBracketedListEnd(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case EOF_TOKEN:
-            case CLOSE_BRACKET_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextTokenKind) {
+            case EOF_TOKEN, CLOSE_BRACKET_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -17102,15 +16725,14 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private STNode parseBracketedListMemberEnd() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return parseComma();
-            case CLOSE_BRACKET_TOKEN:
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> parseComma();
+            case CLOSE_BRACKET_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.BRACKETED_LIST_MEMBER_END);
-                return parseBracketedListMemberEnd();
-        }
+                yield parseBracketedListMemberEnd();
+            }
+        };
     }
 
     /**
@@ -17995,45 +17617,42 @@ public class BallerinaParser extends AbstractParser {
             return SyntaxKind.TUPLE_TYPE_DESC;
         }
 
-        switch (memberNode.kind) {
-            case WILDCARD_BINDING_PATTERN:
-            case CAPTURE_BINDING_PATTERN:
-            case LIST_BINDING_PATTERN:
-            case MAPPING_BINDING_PATTERN:
-            case ERROR_BINDING_PATTERN:
-                return SyntaxKind.LIST_BINDING_PATTERN;
-            case QUALIFIED_NAME_REFERENCE: // a qualified-name-ref can only be a type-ref
-                return SyntaxKind.TUPLE_TYPE_DESC;
-            case LIST_CONSTRUCTOR:
-            case MAPPING_CONSTRUCTOR:
-            case SPREAD_MEMBER:
-                return SyntaxKind.LIST_CONSTRUCTOR;
-            case MAPPING_BP_OR_MAPPING_CONSTRUCTOR:
-            case REST_BINDING_PATTERN:
+        return switch (memberNode.kind) {
+            case WILDCARD_BINDING_PATTERN,
+                 CAPTURE_BINDING_PATTERN,
+                 LIST_BINDING_PATTERN,
+                 MAPPING_BINDING_PATTERN,
+                 ERROR_BINDING_PATTERN -> SyntaxKind.LIST_BINDING_PATTERN;
+            // a qualified-name-ref can only be a type-ref
+            case QUALIFIED_NAME_REFERENCE -> SyntaxKind.TUPLE_TYPE_DESC;
+            case LIST_CONSTRUCTOR,
+                 MAPPING_CONSTRUCTOR,
+                 SPREAD_MEMBER -> SyntaxKind.LIST_CONSTRUCTOR;
+            case MAPPING_BP_OR_MAPPING_CONSTRUCTOR,
+                 REST_BINDING_PATTERN ->
                 // can be either list-bp or list-constructor. Cannot be a tuple-type-desc
-                return SyntaxKind.LIST_BP_OR_LIST_CONSTRUCTOR;
-            case SIMPLE_NAME_REFERENCE: // member is a simple type-ref/var-ref
-            case BRACKETED_LIST: // member is again ambiguous
-                return SyntaxKind.NONE;
-            case ERROR_CONSTRUCTOR:
+                    SyntaxKind.LIST_BP_OR_LIST_CONSTRUCTOR;
+            case SIMPLE_NAME_REFERENCE, // member is a simple type-ref/var-ref
+                 BRACKETED_LIST // member is again ambiguous
+                    -> SyntaxKind.NONE;
+            case ERROR_CONSTRUCTOR -> {
                 if (isPossibleErrorBindingPattern((STErrorConstructorExpressionNode) memberNode)) {
-                    return SyntaxKind.NONE;
+                    yield SyntaxKind.NONE;
                 }
-                return SyntaxKind.LIST_CONSTRUCTOR;
-            case INDEXED_EXPRESSION:
-                return SyntaxKind.TUPLE_TYPE_DESC_OR_LIST_CONST;
-            case MEMBER_TYPE_DESC:
-                return SyntaxKind.MEMBER_TYPE_DESC;
-            case REST_TYPE:
-                return SyntaxKind.REST_TYPE;
-            default:
+                yield SyntaxKind.LIST_CONSTRUCTOR;
+            }
+            case INDEXED_EXPRESSION -> SyntaxKind.TUPLE_TYPE_DESC_OR_LIST_CONST;
+            case MEMBER_TYPE_DESC -> SyntaxKind.MEMBER_TYPE_DESC;
+            case REST_TYPE -> SyntaxKind.REST_TYPE;
+            default -> {
                 if (isExpression(memberNode.kind) && !isAllBasicLiterals(memberNode) && !isAmbiguous(memberNode)) {
-                    return SyntaxKind.LIST_CONSTRUCTOR;
+                    yield SyntaxKind.LIST_CONSTRUCTOR;
                 }
+                yield SyntaxKind.NONE;
 
                 // can be any of the three.
-                return SyntaxKind.NONE;
-        }
+            }
+        };
     }
 
     private boolean isPossibleErrorBindingPattern(STErrorConstructorExpressionNode errorConstructor) {
@@ -18056,19 +17675,12 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isPosibleArgBindingPattern(STFunctionArgumentNode arg) {
-        switch (arg.kind) {
-            case POSITIONAL_ARG:
-                STNode expr = ((STPositionalArgumentNode) arg).expression;
-                return isPosibleBindingPattern(expr);
-            case NAMED_ARG:
-                expr = ((STNamedArgumentNode) arg).expression;
-                return isPosibleBindingPattern(expr);
-            case REST_ARG:
-                expr = ((STRestArgumentNode) arg).expression;
-                return expr.kind == SyntaxKind.SIMPLE_NAME_REFERENCE;
-            default:
-                return false;
-        }
+        return switch (arg.kind) {
+            case POSITIONAL_ARG -> isPosibleBindingPattern(((STPositionalArgumentNode) arg).expression);
+            case NAMED_ARG -> isPosibleBindingPattern(((STNamedArgumentNode) arg).expression);
+            case REST_ARG -> ((STRestArgumentNode) arg).expression.kind == SyntaxKind.SIMPLE_NAME_REFERENCE;
+            default -> false;
+        };
     }
 
     private boolean isPosibleBindingPattern(STNode node) {
@@ -18194,16 +17806,14 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isWildcardBP(STNode node) {
-        switch (node.kind) {
-            case SIMPLE_NAME_REFERENCE:
+        return switch (node.kind) {
+            case SIMPLE_NAME_REFERENCE -> {
                 STToken nameToken = (STToken) ((STSimpleNameReferenceNode) node).name;
-                return isUnderscoreToken(nameToken);
-            case IDENTIFIER_TOKEN:
-                return isUnderscoreToken((STToken) node);
-            default:
-                return false;
-
-        }
+                yield isUnderscoreToken(nameToken);
+            }
+            case IDENTIFIER_TOKEN -> isUnderscoreToken((STToken) node);
+            default -> false;
+        };
     }
 
     private boolean isUnderscoreToken(STToken token) {
@@ -18495,22 +18105,29 @@ public class BallerinaParser extends AbstractParser {
                     return STNodeFactory.createSpecificFieldNode(readonlyKeyword, identifier, colon, value);
                 }
 
-                switch (peek().kind) {
-                    case OPEN_BRACKET_TOKEN: // { foo:[
+                return switch (peek().kind) {
+                    // { foo:[
+                    case OPEN_BRACKET_TOKEN -> {
                         STNode bindingPatternOrExpr = parseListBindingPatternOrListConstructor();
-                        return getMappingField(identifier, colon, bindingPatternOrExpr);
-                    case OPEN_BRACE_TOKEN: // { foo:{
-                        bindingPatternOrExpr = parseMappingBindingPatterOrMappingConstructor();
-                        return getMappingField(identifier, colon, bindingPatternOrExpr);
-                    case ERROR_KEYWORD: // { foo: error
-                        bindingPatternOrExpr = parseErrorBindingPatternOrErrorConstructor();
-                        return getMappingField(identifier, colon, bindingPatternOrExpr);
-                    case IDENTIFIER_TOKEN: // { foo:bar
-                        return parseQualifiedIdentifierRhsInStmtStartBrace(identifier, colon);
-                    default:
+                        yield getMappingField(identifier, colon, bindingPatternOrExpr);
+                    }
+                    // { foo:{
+                    case OPEN_BRACE_TOKEN -> {
+                        STNode bindingPatternOrExpr = parseMappingBindingPatterOrMappingConstructor();
+                        yield getMappingField(identifier, colon, bindingPatternOrExpr);
+                    }
+                    // { foo: error
+                    case ERROR_KEYWORD -> {
+                        STNode bindingPatternOrExpr = parseErrorBindingPatternOrErrorConstructor();
+                        yield getMappingField(identifier, colon, bindingPatternOrExpr);
+                    }
+                    // { foo:bar
+                    case IDENTIFIER_TOKEN -> parseQualifiedIdentifierRhsInStmtStartBrace(identifier, colon);
+                    default -> {
                         STNode expr = parseExpression();
-                        return getMappingField(identifier, colon, expr);
-                }
+                        yield getMappingField(identifier, colon, expr);
+                    }
+                };
             default:
                 switchContext(ParserRuleContext.BLOCK_STMT);
                 if (!isEmpty(readonlyKeyword)) {
@@ -18603,21 +18220,19 @@ public class BallerinaParser extends AbstractParser {
                 }
 
                 // "{foo," and "{foo:bar," is ambiguous
-                switch (expr.kind) {
-                    case SIMPLE_NAME_REFERENCE:
-                    case LIST_BP_OR_LIST_CONSTRUCTOR:
-                    case MAPPING_BP_OR_MAPPING_CONSTRUCTOR:
-                        return SyntaxKind.MAPPING_BP_OR_MAPPING_CONSTRUCTOR;
-                    case ERROR_BINDING_PATTERN:
-                        return SyntaxKind.MAPPING_BINDING_PATTERN;
-                    case ERROR_CONSTRUCTOR:
+                return switch (expr.kind) {
+                    case SIMPLE_NAME_REFERENCE,
+                         LIST_BP_OR_LIST_CONSTRUCTOR,
+                         MAPPING_BP_OR_MAPPING_CONSTRUCTOR -> SyntaxKind.MAPPING_BP_OR_MAPPING_CONSTRUCTOR;
+                    case ERROR_BINDING_PATTERN -> SyntaxKind.MAPPING_BINDING_PATTERN;
+                    case ERROR_CONSTRUCTOR -> {
                         if (isPossibleErrorBindingPattern((STErrorConstructorExpressionNode) expr)) {
-                            return SyntaxKind.MAPPING_BP_OR_MAPPING_CONSTRUCTOR;
+                            yield SyntaxKind.MAPPING_BP_OR_MAPPING_CONSTRUCTOR;
                         }
-                        return SyntaxKind.MAPPING_CONSTRUCTOR;
-                    default:
-                        return SyntaxKind.MAPPING_CONSTRUCTOR;
-                }
+                        yield SyntaxKind.MAPPING_CONSTRUCTOR;
+                    }
+                    default -> SyntaxKind.MAPPING_CONSTRUCTOR;
+                };
             case SPREAD_FIELD:
             case COMPUTED_NAME_FIELD:
                 return SyntaxKind.MAPPING_CONSTRUCTOR;
@@ -18647,13 +18262,10 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isBracedListEnd(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case EOF_TOKEN:
-            case CLOSE_BRACE_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextTokenKind) {
+            case EOF_TOKEN, CLOSE_BRACE_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode parseMappingBindingPatternOrMappingConstructor(STNode openBrace, List<STNode> memberList) {
@@ -18741,21 +18353,14 @@ public class BallerinaParser extends AbstractParser {
 
     private STNode parseMappingFieldValue(STNode key, STNode colon) {
         // {foo: ...
-        STNode expr;
-        switch (peek().kind) {
-            case IDENTIFIER_TOKEN:
-                expr = parseExpression();
-                break;
-            case OPEN_BRACKET_TOKEN: // { foo:[
-                expr = parseListBindingPatternOrListConstructor();
-                break;
-            case OPEN_BRACE_TOKEN: // { foo:{
-                expr = parseMappingBindingPatterOrMappingConstructor();
-                break;
-            default:
-                expr = parseExpression();
-                break;
-        }
+        STNode expr = switch (peek().kind) {
+            case IDENTIFIER_TOKEN -> parseExpression();
+            // { foo:[
+            case OPEN_BRACKET_TOKEN -> parseListBindingPatternOrListConstructor();
+            // { foo:{
+            case OPEN_BRACE_TOKEN -> parseMappingBindingPatterOrMappingConstructor();
+            default -> parseExpression();
+        };
 
         if (isBindingPattern(expr.kind)) {
             key = STNodeFactory.createSimpleNameReferenceNode(key);
@@ -18767,16 +18372,14 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isBindingPattern(SyntaxKind kind) {
-        switch (kind) {
-            case FIELD_BINDING_PATTERN:
-            case MAPPING_BINDING_PATTERN:
-            case CAPTURE_BINDING_PATTERN:
-            case LIST_BINDING_PATTERN:
-            case WILDCARD_BINDING_PATTERN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (kind) {
+            case FIELD_BINDING_PATTERN,
+                 MAPPING_BINDING_PATTERN,
+                 CAPTURE_BINDING_PATTERN,
+                 LIST_BINDING_PATTERN,
+                 WILDCARD_BINDING_PATTERN -> true;
+            default -> false;
+        };
     }
 
     private SyntaxKind getTypeOfMappingBPOrMappingCons(STNode memberNode) {
@@ -18901,21 +18504,17 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private SyntaxKind getParsingNodeTypeOfListBPOrListCons(STNode memberNode) {
-        switch (memberNode.kind) {
-            case CAPTURE_BINDING_PATTERN:
-            case LIST_BINDING_PATTERN:
-            case MAPPING_BINDING_PATTERN:
-            case WILDCARD_BINDING_PATTERN:
-                return SyntaxKind.LIST_BINDING_PATTERN;
-            case SIMPLE_NAME_REFERENCE: // member is a simple type-ref/var-ref
-            case LIST_BP_OR_LIST_CONSTRUCTOR: // member is again ambiguous
-            case MAPPING_BP_OR_MAPPING_CONSTRUCTOR:
-            case REST_BINDING_PATTERN:
-                return SyntaxKind.LIST_BP_OR_LIST_CONSTRUCTOR;
-            case SPREAD_MEMBER:
-            default:
-                return SyntaxKind.LIST_CONSTRUCTOR;
-        }
+        return switch (memberNode.kind) {
+            case CAPTURE_BINDING_PATTERN,
+                 LIST_BINDING_PATTERN,
+                 MAPPING_BINDING_PATTERN,
+                 WILDCARD_BINDING_PATTERN -> SyntaxKind.LIST_BINDING_PATTERN;
+            case SIMPLE_NAME_REFERENCE, // member is a simple type-ref/var-ref
+                 LIST_BP_OR_LIST_CONSTRUCTOR, // member is again ambiguous
+                 MAPPING_BP_OR_MAPPING_CONSTRUCTOR,
+                 REST_BINDING_PATTERN -> SyntaxKind.LIST_BP_OR_LIST_CONSTRUCTOR;
+            default -> SyntaxKind.LIST_CONSTRUCTOR;
+        };
     }
 
     private STNode parseAsListConstructor(STNode openBracket, List<STNode> memberList, STNode member, boolean isRoot) {
@@ -19447,23 +19046,22 @@ public class BallerinaParser extends AbstractParser {
 
     private STNode getMappingField(STNode identifier, STNode colon, STNode bindingPatternOrExpr) {
         STNode simpleNameRef = STNodeFactory.createSimpleNameReferenceNode(identifier);
-        switch (bindingPatternOrExpr.kind) {
-            case LIST_BINDING_PATTERN:
-            case MAPPING_BINDING_PATTERN:
-                return STNodeFactory.createFieldBindingPatternFullNode(simpleNameRef, colon, bindingPatternOrExpr);
-            case LIST_CONSTRUCTOR:
-            case MAPPING_CONSTRUCTOR:
+        return switch (bindingPatternOrExpr.kind) {
+            case LIST_BINDING_PATTERN,
+                 MAPPING_BINDING_PATTERN ->
+                    STNodeFactory.createFieldBindingPatternFullNode(simpleNameRef, colon, bindingPatternOrExpr);
+            case LIST_CONSTRUCTOR,
+                 MAPPING_CONSTRUCTOR -> {
                 STNode readonlyKeyword = STNodeFactory.createEmptyNode();
-                return STNodeFactory
+                yield STNodeFactory
                         .createSpecificFieldNode(readonlyKeyword, identifier, colon, bindingPatternOrExpr);
-            case LIST_BP_OR_LIST_CONSTRUCTOR:
-            case MAPPING_BP_OR_MAPPING_CONSTRUCTOR:
-            default:
-                // If ambiguous, return an specific node, since it is used to represent any
-                // ambiguous mapping field
-                readonlyKeyword = STNodeFactory.createEmptyNode();
-                return STNodeFactory.createSpecificFieldNode(readonlyKeyword, identifier, colon, bindingPatternOrExpr);
-        }
+            }
+            // If ambiguous, return an specific node, since it is used to represent any  ambiguous mapping field
+            default -> {
+                STNode readonlyKeyword = STNodeFactory.createEmptyNode();
+                yield STNodeFactory.createSpecificFieldNode(readonlyKeyword, identifier, colon, bindingPatternOrExpr);
+            }
+        };
     }
 
     // ----------------------------------------- Error Recovery ----------------------------------------
@@ -19493,24 +19091,22 @@ public class BallerinaParser extends AbstractParser {
     }
 
     private boolean isBlockContext(ParserRuleContext ctx) {
-        switch (ctx) {
-            case FUNC_BODY_BLOCK:
-            case CLASS_MEMBER:
-            case OBJECT_CONSTRUCTOR_MEMBER:
-            case OBJECT_TYPE_MEMBER:
-            case BLOCK_STMT:
-            case MATCH_BODY:
-            case MAPPING_MATCH_PATTERN:
-            case MAPPING_BINDING_PATTERN:
-            case MAPPING_CONSTRUCTOR:
-            case FORK_STMT:
-            case MULTI_RECEIVE_WORKERS:
-            case MULTI_WAIT_FIELDS:
-            case MODULE_ENUM_DECLARATION:
-                return true;
-            default:
-                return false;
-        }
+        return switch (ctx) {
+            case FUNC_BODY_BLOCK,
+                 CLASS_MEMBER,
+                 OBJECT_CONSTRUCTOR_MEMBER,
+                 OBJECT_TYPE_MEMBER,
+                 BLOCK_STMT,
+                 MATCH_BODY,
+                 MAPPING_MATCH_PATTERN,
+                 MAPPING_BINDING_PATTERN,
+                 MAPPING_CONSTRUCTOR,
+                 FORK_STMT,
+                 MULTI_RECEIVE_WORKERS,
+                 MULTI_WAIT_FIELDS,
+                 MODULE_ENUM_DECLARATION -> true;
+            default -> false;
+        };
     }
 
     // ----------------------------------------- ~ End of Parser ~ ----------------------------------------

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParserErrorHandler.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParserErrorHandler.java
@@ -856,26 +856,24 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
 
     private boolean isEndOfObjectTypeNode(int nextLookahead) {
         STToken nextToken = this.tokenReader.peek(nextLookahead);
-        switch (nextToken.kind) {
-            case CLOSE_BRACE_TOKEN:
-            case EOF_TOKEN:
-            case CLOSE_BRACE_PIPE_TOKEN:
-            case TYPE_KEYWORD:
-            case SERVICE_KEYWORD:
-                return true;
-            default:
+        return switch (nextToken.kind) {
+            case CLOSE_BRACE_TOKEN,
+                 EOF_TOKEN,
+                 CLOSE_BRACE_PIPE_TOKEN,
+                 TYPE_KEYWORD,
+                 SERVICE_KEYWORD -> true;
+            default -> {
                 STToken nextNextToken = this.tokenReader.peek(nextLookahead + 1);
-                switch (nextNextToken.kind) {
-                    case CLOSE_BRACE_TOKEN:
-                    case EOF_TOKEN:
-                    case CLOSE_BRACE_PIPE_TOKEN:
-                    case TYPE_KEYWORD:
-                    case SERVICE_KEYWORD:
-                        return true;
-                    default:
-                        return false;
-                }
-        }
+                yield switch (nextNextToken.kind) {
+                    case CLOSE_BRACE_TOKEN,
+                         EOF_TOKEN,
+                         CLOSE_BRACE_PIPE_TOKEN,
+                         TYPE_KEYWORD,
+                         SERVICE_KEYWORD -> true;
+                    default -> false;
+                };
+            }
+        };
     }
 
     /**
@@ -1278,343 +1276,339 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
      * @return
      */
     private boolean isKeyword(ParserRuleContext currentCtx) {
-        switch (currentCtx) {
-            case EOF:
-            case PUBLIC_KEYWORD:
-            case PRIVATE_KEYWORD:
-            case FUNCTION_KEYWORD:
-            case NEW_KEYWORD:
-            case SELECT_KEYWORD:
-            case WHERE_KEYWORD:
-            case FROM_KEYWORD:
-            case ORDER_KEYWORD:
-            case GROUP_KEYWORD:
-            case BY_KEYWORD:
-            case START_KEYWORD:
-            case FLUSH_KEYWORD:
-            case DEFAULT_WORKER_NAME_IN_ASYNC_SEND:
-            case WAIT_KEYWORD:
-            case CHECKING_KEYWORD:
-            case FAIL_KEYWORD:
-            case DO_KEYWORD:
-            case TRANSACTION_KEYWORD:
-            case TRANSACTIONAL_KEYWORD:
-            case COMMIT_KEYWORD:
-            case RETRY_KEYWORD:
-            case ROLLBACK_KEYWORD:
-            case ENUM_KEYWORD:
-            case MATCH_KEYWORD:
-            case RETURNS_KEYWORD:
-            case EXTERNAL_KEYWORD:
-            case RECORD_KEYWORD:
-            case TYPE_KEYWORD:
-            case OBJECT_KEYWORD:
-            case ABSTRACT_KEYWORD:
-            case CLIENT_KEYWORD:
-            case IF_KEYWORD:
-            case ELSE_KEYWORD:
-            case WHILE_KEYWORD:
-            case PANIC_KEYWORD:
-            case AS_KEYWORD:
-            case LOCK_KEYWORD:
-            case IMPORT_KEYWORD:
-            case CONTINUE_KEYWORD:
-            case BREAK_KEYWORD:
-            case RETURN_KEYWORD:
-            case SERVICE_KEYWORD:
-            case ON_KEYWORD:
-            case LISTENER_KEYWORD:
-            case CONST_KEYWORD:
-            case FINAL_KEYWORD:
-            case TYPEOF_KEYWORD:
-            case IS_KEYWORD:
-            case NOT_IS_KEYWORD:
-            case NULL_KEYWORD:
-            case ANNOTATION_KEYWORD:
-            case SOURCE_KEYWORD:
-            case XMLNS_KEYWORD:
-            case WORKER_KEYWORD:
-            case FORK_KEYWORD:
-            case TRAP_KEYWORD:
-            case FOREACH_KEYWORD:
-            case IN_KEYWORD:
-            case TABLE_KEYWORD:
-            case KEY_KEYWORD:
-            case ERROR_KEYWORD:
-            case LET_KEYWORD:
-            case STREAM_KEYWORD:
-            case XML_KEYWORD:
-            case RE_KEYWORD:
-            case STRING_KEYWORD:
-            case BASE16_KEYWORD:
-            case BASE64_KEYWORD:
-            case DISTINCT_KEYWORD:
-            case CONFLICT_KEYWORD:
-            case LIMIT_KEYWORD:
-            case EQUALS_KEYWORD:
-            case JOIN_KEYWORD:
-            case OUTER_KEYWORD:
-            case CLASS_KEYWORD:
-            case MAP_KEYWORD:
-            case COLLECT_KEYWORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (currentCtx) {
+            case EOF,
+                 PUBLIC_KEYWORD,
+                 PRIVATE_KEYWORD,
+                 FUNCTION_KEYWORD,
+                 NEW_KEYWORD,
+                 SELECT_KEYWORD,
+                 WHERE_KEYWORD,
+                 FROM_KEYWORD,
+                 ORDER_KEYWORD,
+                 GROUP_KEYWORD,
+                 BY_KEYWORD,
+                 START_KEYWORD,
+                 FLUSH_KEYWORD,
+                 DEFAULT_WORKER_NAME_IN_ASYNC_SEND,
+                 WAIT_KEYWORD,
+                 CHECKING_KEYWORD,
+                 FAIL_KEYWORD,
+                 DO_KEYWORD,
+                 TRANSACTION_KEYWORD,
+                 TRANSACTIONAL_KEYWORD,
+                 COMMIT_KEYWORD,
+                 RETRY_KEYWORD,
+                 ROLLBACK_KEYWORD,
+                 ENUM_KEYWORD,
+                 MATCH_KEYWORD,
+                 RETURNS_KEYWORD,
+                 EXTERNAL_KEYWORD,
+                 RECORD_KEYWORD,
+                 TYPE_KEYWORD,
+                 OBJECT_KEYWORD,
+                 ABSTRACT_KEYWORD,
+                 CLIENT_KEYWORD,
+                 IF_KEYWORD,
+                 ELSE_KEYWORD,
+                 WHILE_KEYWORD,
+                 PANIC_KEYWORD,
+                 AS_KEYWORD,
+                 LOCK_KEYWORD,
+                 IMPORT_KEYWORD,
+                 CONTINUE_KEYWORD,
+                 BREAK_KEYWORD,
+                 RETURN_KEYWORD,
+                 SERVICE_KEYWORD,
+                 ON_KEYWORD,
+                 LISTENER_KEYWORD,
+                 CONST_KEYWORD,
+                 FINAL_KEYWORD,
+                 TYPEOF_KEYWORD,
+                 IS_KEYWORD,
+                 NOT_IS_KEYWORD,
+                 NULL_KEYWORD,
+                 ANNOTATION_KEYWORD,
+                 SOURCE_KEYWORD,
+                 XMLNS_KEYWORD,
+                 WORKER_KEYWORD,
+                 FORK_KEYWORD,
+                 TRAP_KEYWORD,
+                 FOREACH_KEYWORD,
+                 IN_KEYWORD,
+                 TABLE_KEYWORD,
+                 KEY_KEYWORD,
+                 ERROR_KEYWORD,
+                 LET_KEYWORD,
+                 STREAM_KEYWORD,
+                 XML_KEYWORD,
+                 RE_KEYWORD,
+                 STRING_KEYWORD,
+                 BASE16_KEYWORD,
+                 BASE64_KEYWORD,
+                 DISTINCT_KEYWORD,
+                 CONFLICT_KEYWORD,
+                 LIMIT_KEYWORD,
+                 EQUALS_KEYWORD,
+                 JOIN_KEYWORD,
+                 OUTER_KEYWORD,
+                 CLASS_KEYWORD,
+                 MAP_KEYWORD,
+                 COLLECT_KEYWORD -> true;
+            default -> false;
+        };
     }
 
     @Override
     protected boolean hasAlternativePaths(ParserRuleContext currentCtx) {
-        switch (currentCtx) {
-            case TOP_LEVEL_NODE:
-            case TOP_LEVEL_NODE_WITHOUT_MODIFIER:
-            case TOP_LEVEL_NODE_WITHOUT_METADATA:
-            case FUNC_OPTIONAL_RETURNS:
-            case FUNC_BODY_OR_TYPE_DESC_RHS:
-            case ANON_FUNC_BODY:
-            case FUNC_BODY:
-            case EXPRESSION:
-            case TERMINAL_EXPRESSION:
-            case VAR_DECL_STMT_RHS:
-            case EXPRESSION_RHS:
-            case VARIABLE_REF_RHS:
-            case STATEMENT:
-            case STATEMENT_WITHOUT_ANNOTS:
-            case PARAM_LIST:
-            case REQUIRED_PARAM_NAME_RHS:
-            case TYPE_NAME_OR_VAR_NAME:
-            case FIELD_DESCRIPTOR_RHS:
-            case FIELD_OR_REST_DESCIPTOR_RHS:
-            case RECORD_BODY_END:
-            case RECORD_BODY_START:
-            case TYPE_DESCRIPTOR:
-            case TYPE_DESC_WITHOUT_ISOLATED:
-            case RECORD_FIELD_OR_RECORD_END:
-            case RECORD_FIELD_START:
-            case RECORD_FIELD_WITHOUT_METADATA:
-            case ARG_START:
-            case ARG_START_OR_ARG_LIST_END:
-            case NAMED_OR_POSITIONAL_ARG_RHS:
-            case ARG_END:
-            case CLASS_MEMBER_OR_OBJECT_MEMBER_START:
-            case OBJECT_CONSTRUCTOR_MEMBER_START:
-            case CLASS_MEMBER_OR_OBJECT_MEMBER_WITHOUT_META:
-            case OBJECT_CONS_MEMBER_WITHOUT_META:
-            case OPTIONAL_FIELD_INITIALIZER:
-            case OBJECT_METHOD_START:
-            case OBJECT_FUNC_OR_FIELD:
-            case OBJECT_FUNC_OR_FIELD_WITHOUT_VISIBILITY:
-            case OBJECT_TYPE_START:
-            case OBJECT_CONSTRUCTOR_START:
-            case ELSE_BLOCK:
-            case ELSE_BODY:
-            case CALL_STMT_START:
-            case IMPORT_PREFIX_DECL:
-            case IMPORT_DECL_ORG_OR_MODULE_NAME_RHS:
-            case AFTER_IMPORT_MODULE_NAME:
-            case RETURN_STMT_RHS:
-            case ACCESS_EXPRESSION:
-            case FIRST_MAPPING_FIELD:
-            case MAPPING_FIELD:
-            case SPECIFIC_FIELD:
-            case SPECIFIC_FIELD_RHS:
-            case MAPPING_FIELD_END:
-            case OPTIONAL_ABSOLUTE_PATH:
-            case CONST_DECL_TYPE:
-            case CONST_DECL_RHS:
-            case ARRAY_LENGTH:
-            case PARAMETER_START:
-            case PARAMETER_START_WITHOUT_ANNOTATION:
-            case STMT_START_WITH_EXPR_RHS:
-            case EXPR_STMT_RHS:
-            case EXPRESSION_STATEMENT_START:
-            case ANNOT_DECL_OPTIONAL_TYPE:
-            case ANNOT_DECL_RHS:
-            case ANNOT_OPTIONAL_ATTACH_POINTS:
-            case ATTACH_POINT:
-            case ATTACH_POINT_IDENT:
-            case ATTACH_POINT_END:
-            case XML_NAMESPACE_PREFIX_DECL:
-            case CONSTANT_EXPRESSION_START:
-            case TYPE_DESC_RHS:
-            case LIST_CONSTRUCTOR_FIRST_MEMBER:
-            case LIST_CONSTRUCTOR_MEMBER:
-            case TYPE_CAST_PARAM:
-            case TYPE_CAST_PARAM_RHS:
-            case TABLE_KEYWORD_RHS:
-            case ROW_LIST_RHS:
-            case TABLE_ROW_END:
-            case KEY_SPECIFIER_RHS:
-            case TABLE_KEY_RHS:
-            case LET_VAR_DECL_START:
-            case ORDER_KEY_LIST_END:
-            case STREAM_TYPE_FIRST_PARAM_RHS:
-            case TEMPLATE_MEMBER:
-            case TEMPLATE_STRING_RHS:
-            case FUNCTION_KEYWORD_RHS:
-            case FUNC_TYPE_FUNC_KEYWORD_RHS_START:
-            case WORKER_NAME_RHS:
-            case BINDING_PATTERN:
-            case LIST_BINDING_PATTERNS_START:
-            case LIST_BINDING_PATTERN_MEMBER_END:
-            case FIELD_BINDING_PATTERN_END:
-            case LIST_BINDING_PATTERN_MEMBER:
-            case MAPPING_BINDING_PATTERN_END:
-            case MAPPING_BINDING_PATTERN_MEMBER:
-            case KEY_CONSTRAINTS_RHS:
-            case TABLE_TYPE_DESC_RHS:
-            case NEW_KEYWORD_RHS:
-            case TABLE_CONSTRUCTOR_OR_QUERY_START:
-            case TABLE_CONSTRUCTOR_OR_QUERY_RHS:
-            case QUERY_PIPELINE_RHS:
-            case BRACED_EXPR_OR_ANON_FUNC_PARAM_RHS:
-            case ANON_FUNC_PARAM_RHS:
-            case PARAM_END:
-            case ANNOTATION_REF_RHS:
-            case INFER_PARAM_END_OR_PARENTHESIS_END:
-            case TYPE_DESC_IN_TUPLE_RHS:
-            case TUPLE_TYPE_MEMBER_RHS:
-            case LIST_CONSTRUCTOR_MEMBER_END:
-            case NIL_OR_PARENTHESISED_TYPE_DESC_RHS:
-            case REMOTE_OR_RESOURCE_CALL_OR_ASYNC_SEND_RHS:
-            case REMOTE_CALL_OR_ASYNC_SEND_END:
-            case RECEIVE_WORKERS:
-            case RECEIVE_FIELD:
-            case RECEIVE_FIELD_END:
-            case WAIT_KEYWORD_RHS:
-            case WAIT_FIELD_NAME_RHS:
-            case WAIT_FIELD_END:
-            case WAIT_FUTURE_EXPR_END:
-            case OPTIONAL_PEER_WORKER:
-            case ENUM_MEMBER_START:
-            case ENUM_MEMBER_RHS:
-            case ENUM_MEMBER_END:
-            case MEMBER_ACCESS_KEY_EXPR_END:
-            case ROLLBACK_RHS:
-            case RETRY_KEYWORD_RHS:
-            case RETRY_TYPE_PARAM_RHS:
-            case RETRY_BODY:
-            case STMT_START_BRACKETED_LIST_MEMBER:
-            case STMT_START_BRACKETED_LIST_RHS:
-            case BINDING_PATTERN_OR_EXPR_RHS:
-            case BINDING_PATTERN_OR_VAR_REF_RHS:
-            case BRACKETED_LIST_RHS:
-            case BRACKETED_LIST_MEMBER:
-            case BRACKETED_LIST_MEMBER_END:
-            case TYPE_DESC_RHS_OR_BP_RHS:
-            case LIST_BINDING_MEMBER_OR_ARRAY_LENGTH:
-            case XML_NAVIGATE_EXPR:
-            case XML_NAME_PATTERN_RHS:
-            case XML_ATOMIC_NAME_PATTERN_START:
-            case XML_ATOMIC_NAME_IDENTIFIER_RHS:
-            case XML_STEP_START:
-            case FUNC_TYPE_DESC_RHS_OR_ANON_FUNC_BODY:
-            case OPTIONAL_MATCH_GUARD:
-            case MATCH_PATTERN_LIST_MEMBER_RHS:
-            case MATCH_PATTERN_START:
-            case LIST_MATCH_PATTERNS_START:
-            case LIST_MATCH_PATTERN_MEMBER:
-            case LIST_MATCH_PATTERN_MEMBER_RHS:
-            case ERROR_BINDING_PATTERN_ERROR_KEYWORD_RHS:
-            case ERROR_ARG_LIST_BINDING_PATTERN_START:
-            case ERROR_MESSAGE_BINDING_PATTERN_END:
-            case ERROR_MESSAGE_BINDING_PATTERN_RHS:
-            case ERROR_FIELD_BINDING_PATTERN:
-            case ERROR_FIELD_BINDING_PATTERN_END:
-            case FIELD_MATCH_PATTERNS_START:
-            case FIELD_MATCH_PATTERN_MEMBER:
-            case FIELD_MATCH_PATTERN_MEMBER_RHS:
-            case ERROR_MATCH_PATTERN_OR_CONST_PATTERN:
-            case ERROR_MATCH_PATTERN_ERROR_KEYWORD_RHS:
-            case ERROR_ARG_LIST_MATCH_PATTERN_START:
-            case ERROR_MESSAGE_MATCH_PATTERN_END:
-            case ERROR_MESSAGE_MATCH_PATTERN_RHS:
-            case ERROR_FIELD_MATCH_PATTERN:
-            case ERROR_FIELD_MATCH_PATTERN_RHS:
-            case NAMED_ARG_MATCH_PATTERN_RHS:
-            case EXTERNAL_FUNC_BODY_OPTIONAL_ANNOTS:
-            case LIST_BP_OR_LIST_CONSTRUCTOR_MEMBER:
-            case TUPLE_TYPE_DESC_OR_LIST_CONST_MEMBER:
-            case OBJECT_METHOD_WITHOUT_FIRST_QUALIFIER:
-            case OBJECT_METHOD_WITHOUT_SECOND_QUALIFIER:
-            case OBJECT_METHOD_WITHOUT_THIRD_QUALIFIER:
-            case JOIN_CLAUSE_START:
-            case INTERMEDIATE_CLAUSE_START:
-            case MAPPING_BP_OR_MAPPING_CONSTRUCTOR_MEMBER:
-            case TYPE_DESC_OR_EXPR_RHS:
-            case LISTENERS_LIST_END:
-            case REGULAR_COMPOUND_STMT_RHS:
-            case NAMED_WORKER_DECL_START:
-            case FUNC_TYPE_DESC_START:
-            case ANON_FUNC_EXPRESSION_START:
-            case MODULE_CLASS_DEFINITION_START:
-            case OBJECT_CONSTRUCTOR_TYPE_REF:
-            case OBJECT_FIELD_QUALIFIER:
-            case OPTIONAL_SERVICE_DECL_TYPE:
-            case SERVICE_IDENT_RHS:
-            case ABSOLUTE_RESOURCE_PATH_START:
-            case ABSOLUTE_RESOURCE_PATH_END:
-            case SERVICE_DECL_OR_VAR_DECL:
-            case OPTIONAL_RELATIVE_PATH:
-            case RELATIVE_RESOURCE_PATH_START:
-            case RELATIVE_RESOURCE_PATH_END:
-            case RESOURCE_PATH_SEGMENT:
-            case PATH_PARAM_OPTIONAL_ANNOTS:
-            case PATH_PARAM_ELLIPSIS:
-            case OPTIONAL_PATH_PARAM_NAME:
-            case OBJECT_CONS_WITHOUT_FIRST_QUALIFIER:
-            case OBJECT_TYPE_WITHOUT_FIRST_QUALIFIER:
-            case CONFIG_VAR_DECL_RHS:
-            case SERVICE_DECL_START:
-            case ERROR_CONSTRUCTOR_RHS:
-            case OPTIONAL_TYPE_PARAMETER:
-            case MAP_TYPE_OR_TYPE_REF:
-            case OBJECT_TYPE_OR_TYPE_REF:
-            case STREAM_TYPE_OR_TYPE_REF:
-            case TABLE_TYPE_OR_TYPE_REF:
-            case PARAMETERIZED_TYPE_OR_TYPE_REF:
-            case TYPE_DESC_RHS_OR_TYPE_REF:
-            case TRANSACTION_STMT_RHS_OR_TYPE_REF:
-            case TABLE_CONS_OR_QUERY_EXPR_OR_VAR_REF:
-            case QUERY_EXPR_OR_VAR_REF:
-            case ERROR_CONS_EXPR_OR_VAR_REF:
-            case QUALIFIED_IDENTIFIER:
-            case CLASS_DEF_WITHOUT_FIRST_QUALIFIER:
-            case CLASS_DEF_WITHOUT_SECOND_QUALIFIER:
-            case CLASS_DEF_WITHOUT_THIRD_QUALIFIER:
-            case FUNC_DEF_START:
-            case FUNC_DEF_WITHOUT_FIRST_QUALIFIER:
-            case FUNC_TYPE_DESC_START_WITHOUT_FIRST_QUAL:
-            case MODULE_VAR_DECL_START:
-            case MODULE_VAR_WITHOUT_FIRST_QUAL:
-            case MODULE_VAR_WITHOUT_SECOND_QUAL:
-            case FUNC_DEF_OR_TYPE_DESC_RHS:
-            case CLASS_DESCRIPTOR:
-            case EXPR_START_OR_INFERRED_TYPEDESC_DEFAULT_START:
-            case TYPE_CAST_PARAM_START_OR_INFERRED_TYPEDESC_DEFAULT_END:
-            case END_OF_PARAMS_OR_NEXT_PARAM_START:
-            case ASSIGNMENT_STMT_RHS:
-            case PARAM_START:
-            case PARAM_RHS:
-            case FUNC_TYPE_PARAM_RHS:
-            case ANNOTATION_DECL_START:
-            case ON_FAIL_OPTIONAL_BINDING_PATTERN:
-            case OPTIONAL_RESOURCE_ACCESS_PATH:
-            case RESOURCE_ACCESS_PATH_SEGMENT:
-            case COMPUTED_SEGMENT_OR_REST_SEGMENT:
-            case RESOURCE_ACCESS_SEGMENT_RHS:
-            case OPTIONAL_RESOURCE_ACCESS_METHOD:
-            case OPTIONAL_RESOURCE_ACCESS_ACTION_ARG_LIST:
-            case OPTIONAL_TOP_LEVEL_SEMICOLON:
-            case TUPLE_MEMBER:
-            case GROUPING_KEY_LIST_ELEMENT:
-            case GROUPING_KEY_LIST_ELEMENT_END:
-            case RESULT_CLAUSE:
-            case SINGLE_OR_ALTERNATE_WORKER_SEPARATOR:
-                return true;
-            default:
-                return false;
-        }
+        return switch (currentCtx) {
+            case TOP_LEVEL_NODE,
+                 TOP_LEVEL_NODE_WITHOUT_MODIFIER,
+                 TOP_LEVEL_NODE_WITHOUT_METADATA,
+                 FUNC_OPTIONAL_RETURNS,
+                 FUNC_BODY_OR_TYPE_DESC_RHS,
+                 ANON_FUNC_BODY,
+                 FUNC_BODY,
+                 EXPRESSION,
+                 TERMINAL_EXPRESSION,
+                 VAR_DECL_STMT_RHS,
+                 EXPRESSION_RHS,
+                 VARIABLE_REF_RHS,
+                 STATEMENT,
+                 STATEMENT_WITHOUT_ANNOTS,
+                 PARAM_LIST,
+                 REQUIRED_PARAM_NAME_RHS,
+                 TYPE_NAME_OR_VAR_NAME,
+                 FIELD_DESCRIPTOR_RHS,
+                 FIELD_OR_REST_DESCIPTOR_RHS,
+                 RECORD_BODY_END,
+                 RECORD_BODY_START,
+                 TYPE_DESCRIPTOR,
+                 TYPE_DESC_WITHOUT_ISOLATED,
+                 RECORD_FIELD_OR_RECORD_END,
+                 RECORD_FIELD_START,
+                 RECORD_FIELD_WITHOUT_METADATA,
+                 ARG_START,
+                 ARG_START_OR_ARG_LIST_END,
+                 NAMED_OR_POSITIONAL_ARG_RHS,
+                 ARG_END,
+                 CLASS_MEMBER_OR_OBJECT_MEMBER_START,
+                 OBJECT_CONSTRUCTOR_MEMBER_START,
+                 CLASS_MEMBER_OR_OBJECT_MEMBER_WITHOUT_META,
+                 OBJECT_CONS_MEMBER_WITHOUT_META,
+                 OPTIONAL_FIELD_INITIALIZER,
+                 OBJECT_METHOD_START,
+                 OBJECT_FUNC_OR_FIELD,
+                 OBJECT_FUNC_OR_FIELD_WITHOUT_VISIBILITY,
+                 OBJECT_TYPE_START,
+                 OBJECT_CONSTRUCTOR_START,
+                 ELSE_BLOCK,
+                 ELSE_BODY,
+                 CALL_STMT_START,
+                 IMPORT_PREFIX_DECL,
+                 IMPORT_DECL_ORG_OR_MODULE_NAME_RHS,
+                 AFTER_IMPORT_MODULE_NAME,
+                 RETURN_STMT_RHS,
+                 ACCESS_EXPRESSION,
+                 FIRST_MAPPING_FIELD,
+                 MAPPING_FIELD,
+                 SPECIFIC_FIELD,
+                 SPECIFIC_FIELD_RHS,
+                 MAPPING_FIELD_END,
+                 OPTIONAL_ABSOLUTE_PATH,
+                 CONST_DECL_TYPE,
+                 CONST_DECL_RHS,
+                 ARRAY_LENGTH,
+                 PARAMETER_START,
+                 PARAMETER_START_WITHOUT_ANNOTATION,
+                 STMT_START_WITH_EXPR_RHS,
+                 EXPR_STMT_RHS,
+                 EXPRESSION_STATEMENT_START,
+                 ANNOT_DECL_OPTIONAL_TYPE,
+                 ANNOT_DECL_RHS,
+                 ANNOT_OPTIONAL_ATTACH_POINTS,
+                 ATTACH_POINT,
+                 ATTACH_POINT_IDENT,
+                 ATTACH_POINT_END,
+                 XML_NAMESPACE_PREFIX_DECL,
+                 CONSTANT_EXPRESSION_START,
+                 TYPE_DESC_RHS,
+                 LIST_CONSTRUCTOR_FIRST_MEMBER,
+                 LIST_CONSTRUCTOR_MEMBER,
+                 TYPE_CAST_PARAM,
+                 TYPE_CAST_PARAM_RHS,
+                 TABLE_KEYWORD_RHS,
+                 ROW_LIST_RHS,
+                 TABLE_ROW_END,
+                 KEY_SPECIFIER_RHS,
+                 TABLE_KEY_RHS,
+                 LET_VAR_DECL_START,
+                 ORDER_KEY_LIST_END,
+                 STREAM_TYPE_FIRST_PARAM_RHS,
+                 TEMPLATE_MEMBER,
+                 TEMPLATE_STRING_RHS,
+                 FUNCTION_KEYWORD_RHS,
+                 FUNC_TYPE_FUNC_KEYWORD_RHS_START,
+                 WORKER_NAME_RHS,
+                 BINDING_PATTERN,
+                 LIST_BINDING_PATTERNS_START,
+                 LIST_BINDING_PATTERN_MEMBER_END,
+                 FIELD_BINDING_PATTERN_END,
+                 LIST_BINDING_PATTERN_MEMBER,
+                 MAPPING_BINDING_PATTERN_END,
+                 MAPPING_BINDING_PATTERN_MEMBER,
+                 KEY_CONSTRAINTS_RHS,
+                 TABLE_TYPE_DESC_RHS,
+                 NEW_KEYWORD_RHS,
+                 TABLE_CONSTRUCTOR_OR_QUERY_START,
+                 TABLE_CONSTRUCTOR_OR_QUERY_RHS,
+                 QUERY_PIPELINE_RHS,
+                 BRACED_EXPR_OR_ANON_FUNC_PARAM_RHS,
+                 ANON_FUNC_PARAM_RHS,
+                 PARAM_END,
+                 ANNOTATION_REF_RHS,
+                 INFER_PARAM_END_OR_PARENTHESIS_END,
+                 TYPE_DESC_IN_TUPLE_RHS,
+                 TUPLE_TYPE_MEMBER_RHS,
+                 LIST_CONSTRUCTOR_MEMBER_END,
+                 NIL_OR_PARENTHESISED_TYPE_DESC_RHS,
+                 REMOTE_OR_RESOURCE_CALL_OR_ASYNC_SEND_RHS,
+                 REMOTE_CALL_OR_ASYNC_SEND_END,
+                 RECEIVE_WORKERS,
+                 RECEIVE_FIELD,
+                 RECEIVE_FIELD_END,
+                 WAIT_KEYWORD_RHS,
+                 WAIT_FIELD_NAME_RHS,
+                 WAIT_FIELD_END,
+                 WAIT_FUTURE_EXPR_END,
+                 OPTIONAL_PEER_WORKER,
+                 ENUM_MEMBER_START,
+                 ENUM_MEMBER_RHS,
+                 ENUM_MEMBER_END,
+                 MEMBER_ACCESS_KEY_EXPR_END,
+                 ROLLBACK_RHS,
+                 RETRY_KEYWORD_RHS,
+                 RETRY_TYPE_PARAM_RHS,
+                 RETRY_BODY,
+                 STMT_START_BRACKETED_LIST_MEMBER,
+                 STMT_START_BRACKETED_LIST_RHS,
+                 BINDING_PATTERN_OR_EXPR_RHS,
+                 BINDING_PATTERN_OR_VAR_REF_RHS,
+                 BRACKETED_LIST_RHS,
+                 BRACKETED_LIST_MEMBER,
+                 BRACKETED_LIST_MEMBER_END,
+                 TYPE_DESC_RHS_OR_BP_RHS,
+                 LIST_BINDING_MEMBER_OR_ARRAY_LENGTH,
+                 XML_NAVIGATE_EXPR,
+                 XML_NAME_PATTERN_RHS,
+                 XML_ATOMIC_NAME_PATTERN_START,
+                 XML_ATOMIC_NAME_IDENTIFIER_RHS,
+                 XML_STEP_START,
+                 FUNC_TYPE_DESC_RHS_OR_ANON_FUNC_BODY,
+                 OPTIONAL_MATCH_GUARD,
+                 MATCH_PATTERN_LIST_MEMBER_RHS,
+                 MATCH_PATTERN_START,
+                 LIST_MATCH_PATTERNS_START,
+                 LIST_MATCH_PATTERN_MEMBER,
+                 LIST_MATCH_PATTERN_MEMBER_RHS,
+                 ERROR_BINDING_PATTERN_ERROR_KEYWORD_RHS,
+                 ERROR_ARG_LIST_BINDING_PATTERN_START,
+                 ERROR_MESSAGE_BINDING_PATTERN_END,
+                 ERROR_MESSAGE_BINDING_PATTERN_RHS,
+                 ERROR_FIELD_BINDING_PATTERN,
+                 ERROR_FIELD_BINDING_PATTERN_END,
+                 FIELD_MATCH_PATTERNS_START,
+                 FIELD_MATCH_PATTERN_MEMBER,
+                 FIELD_MATCH_PATTERN_MEMBER_RHS,
+                 ERROR_MATCH_PATTERN_OR_CONST_PATTERN,
+                 ERROR_MATCH_PATTERN_ERROR_KEYWORD_RHS,
+                 ERROR_ARG_LIST_MATCH_PATTERN_START,
+                 ERROR_MESSAGE_MATCH_PATTERN_END,
+                 ERROR_MESSAGE_MATCH_PATTERN_RHS,
+                 ERROR_FIELD_MATCH_PATTERN,
+                 ERROR_FIELD_MATCH_PATTERN_RHS,
+                 NAMED_ARG_MATCH_PATTERN_RHS,
+                 EXTERNAL_FUNC_BODY_OPTIONAL_ANNOTS,
+                 LIST_BP_OR_LIST_CONSTRUCTOR_MEMBER,
+                 TUPLE_TYPE_DESC_OR_LIST_CONST_MEMBER,
+                 OBJECT_METHOD_WITHOUT_FIRST_QUALIFIER,
+                 OBJECT_METHOD_WITHOUT_SECOND_QUALIFIER,
+                 OBJECT_METHOD_WITHOUT_THIRD_QUALIFIER,
+                 JOIN_CLAUSE_START,
+                 INTERMEDIATE_CLAUSE_START,
+                 MAPPING_BP_OR_MAPPING_CONSTRUCTOR_MEMBER,
+                 TYPE_DESC_OR_EXPR_RHS,
+                 LISTENERS_LIST_END,
+                 REGULAR_COMPOUND_STMT_RHS,
+                 NAMED_WORKER_DECL_START,
+                 FUNC_TYPE_DESC_START,
+                 ANON_FUNC_EXPRESSION_START,
+                 MODULE_CLASS_DEFINITION_START,
+                 OBJECT_CONSTRUCTOR_TYPE_REF,
+                 OBJECT_FIELD_QUALIFIER,
+                 OPTIONAL_SERVICE_DECL_TYPE,
+                 SERVICE_IDENT_RHS,
+                 ABSOLUTE_RESOURCE_PATH_START,
+                 ABSOLUTE_RESOURCE_PATH_END,
+                 SERVICE_DECL_OR_VAR_DECL,
+                 OPTIONAL_RELATIVE_PATH,
+                 RELATIVE_RESOURCE_PATH_START,
+                 RELATIVE_RESOURCE_PATH_END,
+                 RESOURCE_PATH_SEGMENT,
+                 PATH_PARAM_OPTIONAL_ANNOTS,
+                 PATH_PARAM_ELLIPSIS,
+                 OPTIONAL_PATH_PARAM_NAME,
+                 OBJECT_CONS_WITHOUT_FIRST_QUALIFIER,
+                 OBJECT_TYPE_WITHOUT_FIRST_QUALIFIER,
+                 CONFIG_VAR_DECL_RHS,
+                 SERVICE_DECL_START,
+                 ERROR_CONSTRUCTOR_RHS,
+                 OPTIONAL_TYPE_PARAMETER,
+                 MAP_TYPE_OR_TYPE_REF,
+                 OBJECT_TYPE_OR_TYPE_REF,
+                 STREAM_TYPE_OR_TYPE_REF,
+                 TABLE_TYPE_OR_TYPE_REF,
+                 PARAMETERIZED_TYPE_OR_TYPE_REF,
+                 TYPE_DESC_RHS_OR_TYPE_REF,
+                 TRANSACTION_STMT_RHS_OR_TYPE_REF,
+                 TABLE_CONS_OR_QUERY_EXPR_OR_VAR_REF,
+                 QUERY_EXPR_OR_VAR_REF,
+                 ERROR_CONS_EXPR_OR_VAR_REF,
+                 QUALIFIED_IDENTIFIER,
+                 CLASS_DEF_WITHOUT_FIRST_QUALIFIER,
+                 CLASS_DEF_WITHOUT_SECOND_QUALIFIER,
+                 CLASS_DEF_WITHOUT_THIRD_QUALIFIER,
+                 FUNC_DEF_START,
+                 FUNC_DEF_WITHOUT_FIRST_QUALIFIER,
+                 FUNC_TYPE_DESC_START_WITHOUT_FIRST_QUAL,
+                 MODULE_VAR_DECL_START,
+                 MODULE_VAR_WITHOUT_FIRST_QUAL,
+                 MODULE_VAR_WITHOUT_SECOND_QUAL,
+                 FUNC_DEF_OR_TYPE_DESC_RHS,
+                 CLASS_DESCRIPTOR,
+                 EXPR_START_OR_INFERRED_TYPEDESC_DEFAULT_START,
+                 TYPE_CAST_PARAM_START_OR_INFERRED_TYPEDESC_DEFAULT_END,
+                 END_OF_PARAMS_OR_NEXT_PARAM_START,
+                 ASSIGNMENT_STMT_RHS,
+                 PARAM_START,
+                 PARAM_RHS,
+                 FUNC_TYPE_PARAM_RHS,
+                 ANNOTATION_DECL_START,
+                 ON_FAIL_OPTIONAL_BINDING_PATTERN,
+                 OPTIONAL_RESOURCE_ACCESS_PATH,
+                 RESOURCE_ACCESS_PATH_SEGMENT,
+                 COMPUTED_SEGMENT_OR_REST_SEGMENT,
+                 RESOURCE_ACCESS_SEGMENT_RHS,
+                 OPTIONAL_RESOURCE_ACCESS_METHOD,
+                 OPTIONAL_RESOURCE_ACCESS_ACTION_ARG_LIST,
+                 OPTIONAL_TOP_LEVEL_SEMICOLON,
+                 TUPLE_MEMBER,
+                 GROUPING_KEY_LIST_ELEMENT,
+                 GROUPING_KEY_LIST_ELEMENT_END,
+                 RESULT_CLAUSE,
+                 SINGLE_OR_ALTERNATE_WORKER_SEPARATOR -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -1624,466 +1618,256 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
      * @return shortest alternative path
      */
     protected ParserRuleContext getShortestAlternative(ParserRuleContext currentCtx) {
-        switch (currentCtx) {
-            case TOP_LEVEL_NODE:
-            case TOP_LEVEL_NODE_WITHOUT_MODIFIER:
-            case TOP_LEVEL_NODE_WITHOUT_METADATA:
-                return ParserRuleContext.EOF;
-            case FUNC_OPTIONAL_RETURNS:
-                return ParserRuleContext.RETURNS_KEYWORD;
-            case FUNC_BODY_OR_TYPE_DESC_RHS:
-                return ParserRuleContext.FUNC_BODY;
-            case ANON_FUNC_BODY:
-                return ParserRuleContext.EXPLICIT_ANON_FUNC_EXPR_BODY_START;
-            case FUNC_BODY:
-                return ParserRuleContext.FUNC_BODY_BLOCK;
-            case EXPRESSION:
-            case TERMINAL_EXPRESSION:
-                return ParserRuleContext.VARIABLE_REF;
-            case VAR_DECL_STMT_RHS:
-                return ParserRuleContext.SEMICOLON;
-            case EXPRESSION_RHS:
-            case VARIABLE_REF_RHS:
-                return ParserRuleContext.BINARY_OPERATOR;
-            case STATEMENT:
-            case STATEMENT_WITHOUT_ANNOTS:
-                return ParserRuleContext.VAR_DECL_STMT;
-            case PARAM_LIST:
-                return ParserRuleContext.CLOSE_PARENTHESIS;
-            case REQUIRED_PARAM_NAME_RHS:
-                return ParserRuleContext.PARAM_END;
-            case TYPE_NAME_OR_VAR_NAME:
-                return ParserRuleContext.VARIABLE_NAME;
-            case FIELD_DESCRIPTOR_RHS:
-                return ParserRuleContext.SEMICOLON;
-            case FIELD_OR_REST_DESCIPTOR_RHS:
-                return ParserRuleContext.VARIABLE_NAME;
-            case RECORD_BODY_END:
-                return ParserRuleContext.CLOSE_BRACE;
-            case RECORD_BODY_START:
-                return ParserRuleContext.OPEN_BRACE;
-            case TYPE_DESCRIPTOR:
-                return ParserRuleContext.SIMPLE_TYPE_DESC_IDENTIFIER;
-            case TYPE_DESC_WITHOUT_ISOLATED:
-                return ParserRuleContext.FUNC_TYPE_DESC;
-            case RECORD_FIELD_OR_RECORD_END:
-                return ParserRuleContext.RECORD_BODY_END;
-            case RECORD_FIELD_START:
-            case RECORD_FIELD_WITHOUT_METADATA:
-                return ParserRuleContext.TYPE_DESC_IN_RECORD_FIELD;
-            case ARG_START:
-                return ParserRuleContext.EXPRESSION;
-            case ARG_START_OR_ARG_LIST_END:
-                return ParserRuleContext.ARG_LIST_END;
-            case NAMED_OR_POSITIONAL_ARG_RHS:
-                return ParserRuleContext.ARG_END;
-            case ARG_END:
-                return ParserRuleContext.ARG_LIST_END;
-            case CLASS_MEMBER_OR_OBJECT_MEMBER_START:
-            case OBJECT_CONSTRUCTOR_MEMBER_START:
-            case CLASS_MEMBER_OR_OBJECT_MEMBER_WITHOUT_META:
-            case OBJECT_CONS_MEMBER_WITHOUT_META:
-                return ParserRuleContext.CLOSE_BRACE;
-            case OPTIONAL_FIELD_INITIALIZER:
-                return ParserRuleContext.SEMICOLON;
-            case ON_FAIL_OPTIONAL_BINDING_PATTERN:
-                return ParserRuleContext.BLOCK_STMT;
-            case OBJECT_METHOD_START:
-                return ParserRuleContext.FUNC_DEF_OR_FUNC_TYPE;
-            case OBJECT_FUNC_OR_FIELD:
-                return ParserRuleContext.OBJECT_FUNC_OR_FIELD_WITHOUT_VISIBILITY;
-            case OBJECT_FUNC_OR_FIELD_WITHOUT_VISIBILITY:
-                return ParserRuleContext.OBJECT_FIELD_START;
-            case OBJECT_TYPE_START:
-            case OBJECT_CONSTRUCTOR_START:
-                return ParserRuleContext.OBJECT_KEYWORD;
-            case ELSE_BLOCK:
-                return ParserRuleContext.STATEMENT;
-            case ELSE_BODY:
-                return ParserRuleContext.OPEN_BRACE;
-            case CALL_STMT_START:
-                return ParserRuleContext.VARIABLE_REF;
-            case IMPORT_PREFIX_DECL:
-                return ParserRuleContext.SEMICOLON;
-            case IMPORT_DECL_ORG_OR_MODULE_NAME_RHS:
-                return ParserRuleContext.AFTER_IMPORT_MODULE_NAME;
-            case AFTER_IMPORT_MODULE_NAME:
-            case RETURN_STMT_RHS:
-                return ParserRuleContext.SEMICOLON;
-            case ACCESS_EXPRESSION:
-                return ParserRuleContext.VARIABLE_REF;
-            case FIRST_MAPPING_FIELD:
-                return ParserRuleContext.CLOSE_BRACE;
-            case MAPPING_FIELD:
-                return ParserRuleContext.SPECIFIC_FIELD;
-            case SPECIFIC_FIELD:
-                return ParserRuleContext.MAPPING_FIELD_NAME;
-            case SPECIFIC_FIELD_RHS:
-                return ParserRuleContext.MAPPING_FIELD_END;
-            case MAPPING_FIELD_END:
-                return ParserRuleContext.CLOSE_BRACE;
-            case OPTIONAL_ABSOLUTE_PATH:
-                return ParserRuleContext.ON_KEYWORD;
-            case CONST_DECL_TYPE:
-                return ParserRuleContext.VARIABLE_NAME;
-            case CONST_DECL_RHS:
-                return ParserRuleContext.ASSIGN_OP;
-            case ARRAY_LENGTH:
-                return ParserRuleContext.CLOSE_BRACKET;
-            case PARAMETER_START:
-                return ParserRuleContext.PARAMETER_START_WITHOUT_ANNOTATION;
-            case PARAMETER_START_WITHOUT_ANNOTATION:
-                return ParserRuleContext.TYPE_DESC_IN_PARAM;
-            case STMT_START_WITH_EXPR_RHS:
-            case EXPR_STMT_RHS:
-                return ParserRuleContext.SEMICOLON;
-            case EXPRESSION_STATEMENT_START:
-                return ParserRuleContext.VARIABLE_REF;
-            case ANNOT_DECL_OPTIONAL_TYPE:
-                return ParserRuleContext.ANNOTATION_TAG;
-            case ANNOT_DECL_RHS:
-            case ANNOT_OPTIONAL_ATTACH_POINTS:
-                return ParserRuleContext.SEMICOLON;
-            case ATTACH_POINT:
-                return ParserRuleContext.ATTACH_POINT_IDENT;
-            case ATTACH_POINT_IDENT:
-                return ParserRuleContext.SINGLE_KEYWORD_ATTACH_POINT_IDENT;
-            case ATTACH_POINT_END:
-            case BINDING_PATTERN_OR_VAR_REF_RHS:
-                return ParserRuleContext.SEMICOLON;
-            case XML_NAMESPACE_PREFIX_DECL:
-                return ParserRuleContext.SEMICOLON;
-            case CONSTANT_EXPRESSION_START:
-                return ParserRuleContext.VARIABLE_REF;
-            case TYPE_DESC_RHS:
-                return ParserRuleContext.END_OF_TYPE_DESC;
-            case LIST_CONSTRUCTOR_FIRST_MEMBER:
-                return ParserRuleContext.CLOSE_BRACKET;
-            case LIST_CONSTRUCTOR_MEMBER:
-                return ParserRuleContext.EXPRESSION;
-            case TYPE_CAST_PARAM:
-            case TYPE_CAST_PARAM_RHS:
-                return ParserRuleContext.TYPE_DESC_IN_ANGLE_BRACKETS;
-            case TABLE_KEYWORD_RHS:
-                return ParserRuleContext.TABLE_CONSTRUCTOR;
-            case ROW_LIST_RHS:
-            case TABLE_ROW_END:
-                return ParserRuleContext.CLOSE_BRACKET;
-            case KEY_SPECIFIER_RHS:
-            case TABLE_KEY_RHS:
-                return ParserRuleContext.CLOSE_PARENTHESIS;
-            case LET_VAR_DECL_START:
-                return ParserRuleContext.TYPE_DESC_IN_TYPE_BINDING_PATTERN;
-            case ORDER_KEY_LIST_END:
-                return ParserRuleContext.ORDER_CLAUSE_END;
-            case GROUPING_KEY_LIST_ELEMENT_END:
-                return ParserRuleContext.GROUP_BY_CLAUSE_END;
-            case GROUPING_KEY_LIST_ELEMENT:
-                return ParserRuleContext.VARIABLE_NAME;
-            case STREAM_TYPE_FIRST_PARAM_RHS:
-                return ParserRuleContext.GT;
-            case TEMPLATE_MEMBER:
-            case TEMPLATE_STRING_RHS:
-                return ParserRuleContext.TEMPLATE_END;
-            case FUNCTION_KEYWORD_RHS:
-                return ParserRuleContext.FUNC_TYPE_FUNC_KEYWORD_RHS;
-            case FUNC_TYPE_FUNC_KEYWORD_RHS_START:
-                return ParserRuleContext.FUNC_TYPE_DESC_END;
-            case WORKER_NAME_RHS:
-                return ParserRuleContext.BLOCK_STMT;
-            case BINDING_PATTERN:
-                return ParserRuleContext.BINDING_PATTERN_STARTING_IDENTIFIER;
-            case LIST_BINDING_PATTERNS_START:
-            case LIST_BINDING_PATTERN_MEMBER_END:
-                return ParserRuleContext.CLOSE_BRACKET;
-            case FIELD_BINDING_PATTERN_END:
-                return ParserRuleContext.CLOSE_BRACE;
-            case LIST_BINDING_PATTERN_MEMBER:
-                return ParserRuleContext.BINDING_PATTERN;
-            case MAPPING_BINDING_PATTERN_END:
-                return ParserRuleContext.CLOSE_BRACE;
-            case MAPPING_BINDING_PATTERN_MEMBER:
-                return ParserRuleContext.FIELD_BINDING_PATTERN;
-            case KEY_CONSTRAINTS_RHS:
-                return ParserRuleContext.OPEN_PARENTHESIS;
-            case TABLE_TYPE_DESC_RHS:
-                return ParserRuleContext.TYPE_DESC_RHS;
-            case NEW_KEYWORD_RHS:
-                return ParserRuleContext.EXPRESSION_RHS;
-            case TABLE_CONSTRUCTOR_OR_QUERY_START:
-                return ParserRuleContext.TABLE_KEYWORD;
-            case TABLE_CONSTRUCTOR_OR_QUERY_RHS:
-                return ParserRuleContext.TABLE_CONSTRUCTOR;
-            case QUERY_PIPELINE_RHS:
-                return ParserRuleContext.QUERY_EXPRESSION_RHS;
-            case BRACED_EXPR_OR_ANON_FUNC_PARAM_RHS:
-            case ANON_FUNC_PARAM_RHS:
-                return ParserRuleContext.CLOSE_PARENTHESIS;
-            case PARAM_END:
-                return ParserRuleContext.CLOSE_PARENTHESIS;
-            case ANNOTATION_REF_RHS:
-                return ParserRuleContext.ANNOTATION_END;
-            case INFER_PARAM_END_OR_PARENTHESIS_END:
-                return ParserRuleContext.CLOSE_PARENTHESIS;
-            case TYPE_DESC_IN_TUPLE_RHS:
-                return ParserRuleContext.CLOSE_BRACKET;
-            case TUPLE_TYPE_MEMBER_RHS:
-                return ParserRuleContext.CLOSE_BRACKET;
-            case LIST_CONSTRUCTOR_MEMBER_END:
-                return ParserRuleContext.CLOSE_BRACKET;
-            case NIL_OR_PARENTHESISED_TYPE_DESC_RHS:
-                return ParserRuleContext.CLOSE_PARENTHESIS;
-            case REMOTE_OR_RESOURCE_CALL_OR_ASYNC_SEND_RHS:
-                return ParserRuleContext.PEER_WORKER_NAME;
-            case REMOTE_CALL_OR_ASYNC_SEND_END:
-                return ParserRuleContext.SEMICOLON;
-            case RECEIVE_WORKERS:
-            case RECEIVE_FIELD:
-                return ParserRuleContext.PEER_WORKER_NAME;
-            case RECEIVE_FIELD_END:
-                return ParserRuleContext.CLOSE_BRACE;
-            case WAIT_KEYWORD_RHS:
-                return ParserRuleContext.MULTI_WAIT_FIELDS;
-            case WAIT_FIELD_NAME_RHS:
-                return ParserRuleContext.WAIT_FIELD_END;
-            case WAIT_FIELD_END:
-                return ParserRuleContext.CLOSE_BRACE;
-            case WAIT_FUTURE_EXPR_END:
-                return ParserRuleContext.ALTERNATE_WAIT_EXPR_LIST_END;
-            case OPTIONAL_PEER_WORKER:
-                return ParserRuleContext.EXPRESSION_RHS;
-            case ENUM_MEMBER_START:
-                return ParserRuleContext.ENUM_MEMBER_NAME;
-            case ENUM_MEMBER_RHS:
-                return ParserRuleContext.ENUM_MEMBER_END;
-            case ENUM_MEMBER_END:
-                return ParserRuleContext.CLOSE_BRACE;
-            case MEMBER_ACCESS_KEY_EXPR_END:
-                return ParserRuleContext.CLOSE_BRACKET;
-            case ROLLBACK_RHS:
-                return ParserRuleContext.SEMICOLON;
-            case RETRY_KEYWORD_RHS:
-                return ParserRuleContext.RETRY_TYPE_PARAM_RHS;
-            case RETRY_TYPE_PARAM_RHS:
-                return ParserRuleContext.RETRY_BODY;
-            case RETRY_BODY:
-                return ParserRuleContext.BLOCK_STMT;
-            case STMT_START_BRACKETED_LIST_MEMBER:
-                return ParserRuleContext.TYPE_DESCRIPTOR;
-            case STMT_START_BRACKETED_LIST_RHS:
-                return ParserRuleContext.VARIABLE_NAME;
-            case BINDING_PATTERN_OR_EXPR_RHS:
-            case BRACKETED_LIST_RHS:
-                return ParserRuleContext.TYPE_DESC_RHS_OR_BP_RHS;
-            case BRACKETED_LIST_MEMBER:
-                return ParserRuleContext.EXPRESSION;
-            case BRACKETED_LIST_MEMBER_END:
-                return ParserRuleContext.CLOSE_BRACKET;
-            case TYPE_DESC_RHS_OR_BP_RHS:
-                return ParserRuleContext.TYPE_DESC_RHS_IN_TYPED_BP;
-            case LIST_BINDING_MEMBER_OR_ARRAY_LENGTH:
-                return ParserRuleContext.BINDING_PATTERN;
-            case XML_NAVIGATE_EXPR:
-                return ParserRuleContext.XML_FILTER_EXPR;
-            case XML_NAME_PATTERN_RHS:
-                return ParserRuleContext.GT;
-            case XML_ATOMIC_NAME_PATTERN_START:
-                return ParserRuleContext.XML_ATOMIC_NAME_IDENTIFIER;
-            case XML_ATOMIC_NAME_IDENTIFIER_RHS:
-                return ParserRuleContext.IDENTIFIER;
-            case XML_STEP_START:
-                return ParserRuleContext.SLASH_ASTERISK_TOKEN;
-            case FUNC_TYPE_DESC_RHS_OR_ANON_FUNC_BODY:
-                return ParserRuleContext.ANON_FUNC_BODY;
-            case OPTIONAL_MATCH_GUARD:
-                return ParserRuleContext.RIGHT_DOUBLE_ARROW;
-            case MATCH_PATTERN_LIST_MEMBER_RHS:
-                return ParserRuleContext.MATCH_PATTERN_END;
-            case MATCH_PATTERN_START:
-                return ParserRuleContext.CONSTANT_EXPRESSION;
-            case LIST_MATCH_PATTERNS_START:
-                return ParserRuleContext.CLOSE_BRACKET;
-            case LIST_MATCH_PATTERN_MEMBER:
-                return ParserRuleContext.MATCH_PATTERN_START;
-            case LIST_MATCH_PATTERN_MEMBER_RHS:
-                return ParserRuleContext.CLOSE_BRACKET;
-            case ERROR_BINDING_PATTERN_ERROR_KEYWORD_RHS:
-                return ParserRuleContext.OPEN_PARENTHESIS;
-            case ERROR_ARG_LIST_BINDING_PATTERN_START:
-            case ERROR_MESSAGE_BINDING_PATTERN_END:
-                return ParserRuleContext.CLOSE_PARENTHESIS;
-            case ERROR_MESSAGE_BINDING_PATTERN_RHS:
-                return ParserRuleContext.ERROR_CAUSE_SIMPLE_BINDING_PATTERN;
-            case ERROR_FIELD_BINDING_PATTERN:
-                return ParserRuleContext.NAMED_ARG_BINDING_PATTERN;
-            case ERROR_FIELD_BINDING_PATTERN_END:
-                return ParserRuleContext.CLOSE_PARENTHESIS;
-            case FIELD_MATCH_PATTERNS_START:
-                return ParserRuleContext.CLOSE_BRACE;
-            case FIELD_MATCH_PATTERN_MEMBER:
-                return ParserRuleContext.VARIABLE_NAME;
-            case FIELD_MATCH_PATTERN_MEMBER_RHS:
-                return ParserRuleContext.CLOSE_BRACE;
-            case ERROR_MATCH_PATTERN_OR_CONST_PATTERN:
-                return ParserRuleContext.MATCH_PATTERN_RHS;
-            case ERROR_MATCH_PATTERN_ERROR_KEYWORD_RHS:
-                return ParserRuleContext.OPEN_PARENTHESIS;
-            case ERROR_ARG_LIST_MATCH_PATTERN_START:
-            case ERROR_MESSAGE_MATCH_PATTERN_END:
-                return ParserRuleContext.CLOSE_PARENTHESIS;
-            case ERROR_MESSAGE_MATCH_PATTERN_RHS:
-                return ParserRuleContext.ERROR_CAUSE_MATCH_PATTERN;
-            case ERROR_FIELD_MATCH_PATTERN:
-                return ParserRuleContext.NAMED_ARG_MATCH_PATTERN;
-            case ERROR_FIELD_MATCH_PATTERN_RHS:
-                return ParserRuleContext.CLOSE_PARENTHESIS;
-            case NAMED_ARG_MATCH_PATTERN_RHS:
-                return ParserRuleContext.NAMED_ARG_MATCH_PATTERN;
-            case EXTERNAL_FUNC_BODY_OPTIONAL_ANNOTS:
-                return ParserRuleContext.EXTERNAL_KEYWORD;
-            case LIST_BP_OR_LIST_CONSTRUCTOR_MEMBER:
-                return ParserRuleContext.LIST_BINDING_PATTERN_MEMBER;
-            case TUPLE_TYPE_DESC_OR_LIST_CONST_MEMBER:
-                return ParserRuleContext.TYPE_DESCRIPTOR;
-            case OBJECT_METHOD_WITHOUT_FIRST_QUALIFIER:
-            case OBJECT_METHOD_WITHOUT_SECOND_QUALIFIER:
-            case OBJECT_METHOD_WITHOUT_THIRD_QUALIFIER:
-            case FUNC_DEF:
-                return ParserRuleContext.FUNC_DEF_OR_FUNC_TYPE;
-            case JOIN_CLAUSE_START:
-                return ParserRuleContext.JOIN_KEYWORD;
-            case INTERMEDIATE_CLAUSE_START:
-                return ParserRuleContext.WHERE_CLAUSE;
-            case MAPPING_BP_OR_MAPPING_CONSTRUCTOR_MEMBER:
-                return ParserRuleContext.MAPPING_BINDING_PATTERN_MEMBER;
-            case TYPE_DESC_OR_EXPR_RHS:
-                return ParserRuleContext.TYPE_DESC_RHS_OR_BP_RHS;
-            case LISTENERS_LIST_END:
-                return ParserRuleContext.OBJECT_CONSTRUCTOR_BLOCK;
-            case REGULAR_COMPOUND_STMT_RHS:
-                return ParserRuleContext.STATEMENT;
-            case NAMED_WORKER_DECL_START:
-                return ParserRuleContext.WORKER_KEYWORD;
-            case FUNC_TYPE_DESC_START:
-            case FUNC_DEF_START:
-            case ANON_FUNC_EXPRESSION_START:
-                return ParserRuleContext.FUNCTION_KEYWORD;
-            case MODULE_CLASS_DEFINITION_START:
-                return ParserRuleContext.CLASS_KEYWORD;
-            case OBJECT_CONSTRUCTOR_TYPE_REF:
-                return ParserRuleContext.OPEN_BRACE;
-            case OBJECT_FIELD_QUALIFIER:
-                return ParserRuleContext.TYPE_DESC_BEFORE_IDENTIFIER;
-            case OPTIONAL_SERVICE_DECL_TYPE:
-                return ParserRuleContext.OPTIONAL_ABSOLUTE_PATH;
-            case SERVICE_IDENT_RHS:
-                return ParserRuleContext.ATTACH_POINT_END;
-            case ABSOLUTE_RESOURCE_PATH_START:
-                return ParserRuleContext.ABSOLUTE_PATH_SINGLE_SLASH;
-            case ABSOLUTE_RESOURCE_PATH_END:
-                return ParserRuleContext.SERVICE_DECL_RHS;
-            case SERVICE_DECL_OR_VAR_DECL:
-                return ParserRuleContext.SERVICE_VAR_DECL_RHS;
-            case OPTIONAL_RELATIVE_PATH:
-                return ParserRuleContext.OPEN_PARENTHESIS;
-            case RELATIVE_RESOURCE_PATH_START:
-                return ParserRuleContext.DOT;
-            case RELATIVE_RESOURCE_PATH_END:
-                return ParserRuleContext.RESOURCE_ACCESSOR_DEF_OR_DECL_RHS;
-            case RESOURCE_PATH_SEGMENT:
-                return ParserRuleContext.PATH_SEGMENT_IDENT;
-            case PATH_PARAM_OPTIONAL_ANNOTS:
-                return ParserRuleContext.TYPE_DESC_IN_PATH_PARAM;
-            case PATH_PARAM_ELLIPSIS:
-            case OPTIONAL_PATH_PARAM_NAME:
-                return ParserRuleContext.CLOSE_BRACKET;
-            case OBJECT_CONS_WITHOUT_FIRST_QUALIFIER:
-            case OBJECT_TYPE_WITHOUT_FIRST_QUALIFIER:
-                return ParserRuleContext.OBJECT_KEYWORD;
-            case CONFIG_VAR_DECL_RHS:
-                return ParserRuleContext.EXPRESSION;
-            case SERVICE_DECL_START:
-                return ParserRuleContext.SERVICE_KEYWORD;
-            case ERROR_CONSTRUCTOR_RHS:
-                return ParserRuleContext.ARG_LIST_OPEN_PAREN;
-            case OPTIONAL_TYPE_PARAMETER:
-                return ParserRuleContext.TYPE_DESC_RHS;
-            case MAP_TYPE_OR_TYPE_REF:
-                return ParserRuleContext.LT;
-            case OBJECT_TYPE_OR_TYPE_REF:
-                return ParserRuleContext.OBJECT_TYPE_OBJECT_KEYWORD_RHS;
-            case STREAM_TYPE_OR_TYPE_REF:
-                return ParserRuleContext.LT;
-            case TABLE_TYPE_OR_TYPE_REF:
-                return ParserRuleContext.ROW_TYPE_PARAM;
-            case PARAMETERIZED_TYPE_OR_TYPE_REF:
-                return ParserRuleContext.OPTIONAL_TYPE_PARAMETER;
-            case TYPE_DESC_RHS_OR_TYPE_REF:
-                return ParserRuleContext.TYPE_DESC_RHS;
-            case TRANSACTION_STMT_RHS_OR_TYPE_REF:
-                return ParserRuleContext.TRANSACTION_STMT_TRANSACTION_KEYWORD_RHS;
-            case TABLE_CONS_OR_QUERY_EXPR_OR_VAR_REF:
-                return ParserRuleContext.EXPRESSION_START_TABLE_KEYWORD_RHS;
-            case QUERY_EXPR_OR_VAR_REF:
-                return ParserRuleContext.QUERY_CONSTRUCT_TYPE_RHS;
-            case ERROR_CONS_EXPR_OR_VAR_REF:
-                return ParserRuleContext.ERROR_CONS_ERROR_KEYWORD_RHS;
-            case QUALIFIED_IDENTIFIER:
-                return ParserRuleContext.QUALIFIED_IDENTIFIER_START_IDENTIFIER;
-            case CLASS_DEF_WITHOUT_FIRST_QUALIFIER:
-            case CLASS_DEF_WITHOUT_SECOND_QUALIFIER:
-            case CLASS_DEF_WITHOUT_THIRD_QUALIFIER:
-                return ParserRuleContext.CLASS_KEYWORD;
-            case FUNC_DEF_WITHOUT_FIRST_QUALIFIER:
-                return ParserRuleContext.FUNC_DEF_OR_FUNC_TYPE;
-            case FUNC_TYPE_DESC_START_WITHOUT_FIRST_QUAL:
-                return ParserRuleContext.FUNCTION_KEYWORD;
-            case MODULE_VAR_DECL_START:
-            case MODULE_VAR_WITHOUT_FIRST_QUAL:
-            case MODULE_VAR_WITHOUT_SECOND_QUAL:
-                return ParserRuleContext.VAR_DECL_STMT;
-            case FUNC_DEF_OR_TYPE_DESC_RHS:
-                return ParserRuleContext.SEMICOLON;
-            case CLASS_DESCRIPTOR:
-                return ParserRuleContext.TYPE_REFERENCE;
-            case EXPR_START_OR_INFERRED_TYPEDESC_DEFAULT_START:
-                return ParserRuleContext.EXPRESSION;
-            case TYPE_CAST_PARAM_START_OR_INFERRED_TYPEDESC_DEFAULT_END:
-                return ParserRuleContext.INFERRED_TYPEDESC_DEFAULT_END_GT;
-            case END_OF_PARAMS_OR_NEXT_PARAM_START:
-                return ParserRuleContext.CLOSE_PARENTHESIS;
-            case ASSIGNMENT_STMT_RHS:
-                return ParserRuleContext.ASSIGN_OP;
-            case PARAM_START:
-                return ParserRuleContext.TYPE_DESC_IN_PARAM;
-            case PARAM_RHS:
-                return ParserRuleContext.VARIABLE_NAME;
-            case FUNC_TYPE_PARAM_RHS:
-                return ParserRuleContext.PARAM_END;
-            case ANNOTATION_DECL_START:
-                return ParserRuleContext.ANNOTATION_KEYWORD;
-            case OPTIONAL_RESOURCE_ACCESS_PATH:
-            case RESOURCE_ACCESS_SEGMENT_RHS:
-                return ParserRuleContext.OPTIONAL_RESOURCE_ACCESS_METHOD;
-            case RESOURCE_ACCESS_PATH_SEGMENT:
-                return ParserRuleContext.IDENTIFIER;
-            case COMPUTED_SEGMENT_OR_REST_SEGMENT:
-                return ParserRuleContext.EXPRESSION;
-            case OPTIONAL_RESOURCE_ACCESS_METHOD:
-                return ParserRuleContext.OPTIONAL_RESOURCE_ACCESS_ACTION_ARG_LIST;
-            case OPTIONAL_RESOURCE_ACCESS_ACTION_ARG_LIST:
-                return ParserRuleContext.ACTION_END;
-            case OPTIONAL_TOP_LEVEL_SEMICOLON:
-                return ParserRuleContext.TOP_LEVEL_NODE;
-            case TUPLE_MEMBER:
-                return ParserRuleContext.TYPE_DESC_IN_TUPLE;
-            case RESULT_CLAUSE:
-                return ParserRuleContext.SELECT_CLAUSE;
-            case SINGLE_OR_ALTERNATE_WORKER_SEPARATOR:
-                return ParserRuleContext.SINGLE_OR_ALTERNATE_WORKER_END;
-            default:
-                throw new IllegalStateException("Alternative path entry not found");
-        }
+        return switch (currentCtx) {
+            case TOP_LEVEL_NODE,
+                 TOP_LEVEL_NODE_WITHOUT_MODIFIER,
+                 TOP_LEVEL_NODE_WITHOUT_METADATA -> ParserRuleContext.EOF;
+            case FUNC_OPTIONAL_RETURNS -> ParserRuleContext.RETURNS_KEYWORD;
+            case FUNC_BODY_OR_TYPE_DESC_RHS -> ParserRuleContext.FUNC_BODY;
+            case ANON_FUNC_BODY -> ParserRuleContext.EXPLICIT_ANON_FUNC_EXPR_BODY_START;
+            case FUNC_BODY -> ParserRuleContext.FUNC_BODY_BLOCK;
+            case EXPRESSION,
+                 TERMINAL_EXPRESSION -> ParserRuleContext.VARIABLE_REF;
+            case VAR_DECL_STMT_RHS -> ParserRuleContext.SEMICOLON;
+            case EXPRESSION_RHS,
+                 VARIABLE_REF_RHS -> ParserRuleContext.BINARY_OPERATOR;
+            case STATEMENT,
+                 STATEMENT_WITHOUT_ANNOTS -> ParserRuleContext.VAR_DECL_STMT;
+            case PARAM_LIST -> ParserRuleContext.CLOSE_PARENTHESIS;
+            case REQUIRED_PARAM_NAME_RHS -> ParserRuleContext.PARAM_END;
+            case TYPE_NAME_OR_VAR_NAME -> ParserRuleContext.VARIABLE_NAME;
+            case FIELD_DESCRIPTOR_RHS -> ParserRuleContext.SEMICOLON;
+            case FIELD_OR_REST_DESCIPTOR_RHS -> ParserRuleContext.VARIABLE_NAME;
+            case RECORD_BODY_END -> ParserRuleContext.CLOSE_BRACE;
+            case RECORD_BODY_START -> ParserRuleContext.OPEN_BRACE;
+            case TYPE_DESCRIPTOR -> ParserRuleContext.SIMPLE_TYPE_DESC_IDENTIFIER;
+            case TYPE_DESC_WITHOUT_ISOLATED -> ParserRuleContext.FUNC_TYPE_DESC;
+            case RECORD_FIELD_OR_RECORD_END -> ParserRuleContext.RECORD_BODY_END;
+            case RECORD_FIELD_START,
+                 RECORD_FIELD_WITHOUT_METADATA -> ParserRuleContext.TYPE_DESC_IN_RECORD_FIELD;
+            case ARG_START -> ParserRuleContext.EXPRESSION;
+            case ARG_START_OR_ARG_LIST_END -> ParserRuleContext.ARG_LIST_END;
+            case NAMED_OR_POSITIONAL_ARG_RHS -> ParserRuleContext.ARG_END;
+            case ARG_END -> ParserRuleContext.ARG_LIST_END;
+            case CLASS_MEMBER_OR_OBJECT_MEMBER_START,
+                 OBJECT_CONSTRUCTOR_MEMBER_START,
+                 CLASS_MEMBER_OR_OBJECT_MEMBER_WITHOUT_META,
+                 OBJECT_CONS_MEMBER_WITHOUT_META -> ParserRuleContext.CLOSE_BRACE;
+            case OPTIONAL_FIELD_INITIALIZER -> ParserRuleContext.SEMICOLON;
+            case ON_FAIL_OPTIONAL_BINDING_PATTERN -> ParserRuleContext.BLOCK_STMT;
+            case OBJECT_METHOD_START -> ParserRuleContext.FUNC_DEF_OR_FUNC_TYPE;
+            case OBJECT_FUNC_OR_FIELD -> ParserRuleContext.OBJECT_FUNC_OR_FIELD_WITHOUT_VISIBILITY;
+            case OBJECT_FUNC_OR_FIELD_WITHOUT_VISIBILITY -> ParserRuleContext.OBJECT_FIELD_START;
+            case OBJECT_TYPE_START,
+                 OBJECT_CONSTRUCTOR_START -> ParserRuleContext.OBJECT_KEYWORD;
+            case ELSE_BLOCK -> ParserRuleContext.STATEMENT;
+            case ELSE_BODY -> ParserRuleContext.OPEN_BRACE;
+            case CALL_STMT_START -> ParserRuleContext.VARIABLE_REF;
+            case IMPORT_PREFIX_DECL -> ParserRuleContext.SEMICOLON;
+            case IMPORT_DECL_ORG_OR_MODULE_NAME_RHS -> ParserRuleContext.AFTER_IMPORT_MODULE_NAME;
+            case AFTER_IMPORT_MODULE_NAME,
+                 RETURN_STMT_RHS -> ParserRuleContext.SEMICOLON;
+            case ACCESS_EXPRESSION -> ParserRuleContext.VARIABLE_REF;
+            case FIRST_MAPPING_FIELD -> ParserRuleContext.CLOSE_BRACE;
+            case MAPPING_FIELD -> ParserRuleContext.SPECIFIC_FIELD;
+            case SPECIFIC_FIELD -> ParserRuleContext.MAPPING_FIELD_NAME;
+            case SPECIFIC_FIELD_RHS -> ParserRuleContext.MAPPING_FIELD_END;
+            case MAPPING_FIELD_END -> ParserRuleContext.CLOSE_BRACE;
+            case OPTIONAL_ABSOLUTE_PATH -> ParserRuleContext.ON_KEYWORD;
+            case CONST_DECL_TYPE -> ParserRuleContext.VARIABLE_NAME;
+            case CONST_DECL_RHS -> ParserRuleContext.ASSIGN_OP;
+            case ARRAY_LENGTH -> ParserRuleContext.CLOSE_BRACKET;
+            case PARAMETER_START -> ParserRuleContext.PARAMETER_START_WITHOUT_ANNOTATION;
+            case PARAMETER_START_WITHOUT_ANNOTATION -> ParserRuleContext.TYPE_DESC_IN_PARAM;
+            case STMT_START_WITH_EXPR_RHS,
+                 EXPR_STMT_RHS -> ParserRuleContext.SEMICOLON;
+            case EXPRESSION_STATEMENT_START -> ParserRuleContext.VARIABLE_REF;
+            case ANNOT_DECL_OPTIONAL_TYPE -> ParserRuleContext.ANNOTATION_TAG;
+            case ANNOT_DECL_RHS,
+                 ANNOT_OPTIONAL_ATTACH_POINTS -> ParserRuleContext.SEMICOLON;
+            case ATTACH_POINT -> ParserRuleContext.ATTACH_POINT_IDENT;
+            case ATTACH_POINT_IDENT -> ParserRuleContext.SINGLE_KEYWORD_ATTACH_POINT_IDENT;
+            case ATTACH_POINT_END,
+                 BINDING_PATTERN_OR_VAR_REF_RHS -> ParserRuleContext.SEMICOLON;
+            case XML_NAMESPACE_PREFIX_DECL -> ParserRuleContext.SEMICOLON;
+            case CONSTANT_EXPRESSION_START -> ParserRuleContext.VARIABLE_REF;
+            case TYPE_DESC_RHS -> ParserRuleContext.END_OF_TYPE_DESC;
+            case LIST_CONSTRUCTOR_FIRST_MEMBER -> ParserRuleContext.CLOSE_BRACKET;
+            case LIST_CONSTRUCTOR_MEMBER -> ParserRuleContext.EXPRESSION;
+            case TYPE_CAST_PARAM,
+                 TYPE_CAST_PARAM_RHS -> ParserRuleContext.TYPE_DESC_IN_ANGLE_BRACKETS;
+            case TABLE_KEYWORD_RHS -> ParserRuleContext.TABLE_CONSTRUCTOR;
+            case ROW_LIST_RHS,
+                 TABLE_ROW_END -> ParserRuleContext.CLOSE_BRACKET;
+            case KEY_SPECIFIER_RHS,
+                 TABLE_KEY_RHS -> ParserRuleContext.CLOSE_PARENTHESIS;
+            case LET_VAR_DECL_START -> ParserRuleContext.TYPE_DESC_IN_TYPE_BINDING_PATTERN;
+            case ORDER_KEY_LIST_END -> ParserRuleContext.ORDER_CLAUSE_END;
+            case GROUPING_KEY_LIST_ELEMENT_END -> ParserRuleContext.GROUP_BY_CLAUSE_END;
+            case GROUPING_KEY_LIST_ELEMENT -> ParserRuleContext.VARIABLE_NAME;
+            case STREAM_TYPE_FIRST_PARAM_RHS -> ParserRuleContext.GT;
+            case TEMPLATE_MEMBER,
+                 TEMPLATE_STRING_RHS -> ParserRuleContext.TEMPLATE_END;
+            case FUNCTION_KEYWORD_RHS -> ParserRuleContext.FUNC_TYPE_FUNC_KEYWORD_RHS;
+            case FUNC_TYPE_FUNC_KEYWORD_RHS_START -> ParserRuleContext.FUNC_TYPE_DESC_END;
+            case WORKER_NAME_RHS -> ParserRuleContext.BLOCK_STMT;
+            case BINDING_PATTERN -> ParserRuleContext.BINDING_PATTERN_STARTING_IDENTIFIER;
+            case LIST_BINDING_PATTERNS_START,
+                 LIST_BINDING_PATTERN_MEMBER_END -> ParserRuleContext.CLOSE_BRACKET;
+            case FIELD_BINDING_PATTERN_END -> ParserRuleContext.CLOSE_BRACE;
+            case LIST_BINDING_PATTERN_MEMBER -> ParserRuleContext.BINDING_PATTERN;
+            case MAPPING_BINDING_PATTERN_END -> ParserRuleContext.CLOSE_BRACE;
+            case MAPPING_BINDING_PATTERN_MEMBER -> ParserRuleContext.FIELD_BINDING_PATTERN;
+            case KEY_CONSTRAINTS_RHS -> ParserRuleContext.OPEN_PARENTHESIS;
+            case TABLE_TYPE_DESC_RHS -> ParserRuleContext.TYPE_DESC_RHS;
+            case NEW_KEYWORD_RHS -> ParserRuleContext.EXPRESSION_RHS;
+            case TABLE_CONSTRUCTOR_OR_QUERY_START -> ParserRuleContext.TABLE_KEYWORD;
+            case TABLE_CONSTRUCTOR_OR_QUERY_RHS -> ParserRuleContext.TABLE_CONSTRUCTOR;
+            case QUERY_PIPELINE_RHS -> ParserRuleContext.QUERY_EXPRESSION_RHS;
+            case BRACED_EXPR_OR_ANON_FUNC_PARAM_RHS,
+                 ANON_FUNC_PARAM_RHS -> ParserRuleContext.CLOSE_PARENTHESIS;
+            case PARAM_END -> ParserRuleContext.CLOSE_PARENTHESIS;
+            case ANNOTATION_REF_RHS -> ParserRuleContext.ANNOTATION_END;
+            case INFER_PARAM_END_OR_PARENTHESIS_END -> ParserRuleContext.CLOSE_PARENTHESIS;
+            case TYPE_DESC_IN_TUPLE_RHS -> ParserRuleContext.CLOSE_BRACKET;
+            case TUPLE_TYPE_MEMBER_RHS -> ParserRuleContext.CLOSE_BRACKET;
+            case LIST_CONSTRUCTOR_MEMBER_END -> ParserRuleContext.CLOSE_BRACKET;
+            case NIL_OR_PARENTHESISED_TYPE_DESC_RHS -> ParserRuleContext.CLOSE_PARENTHESIS;
+            case REMOTE_OR_RESOURCE_CALL_OR_ASYNC_SEND_RHS -> ParserRuleContext.PEER_WORKER_NAME;
+            case REMOTE_CALL_OR_ASYNC_SEND_END -> ParserRuleContext.SEMICOLON;
+            case RECEIVE_WORKERS,
+                 RECEIVE_FIELD -> ParserRuleContext.PEER_WORKER_NAME;
+            case RECEIVE_FIELD_END -> ParserRuleContext.CLOSE_BRACE;
+            case WAIT_KEYWORD_RHS -> ParserRuleContext.MULTI_WAIT_FIELDS;
+            case WAIT_FIELD_NAME_RHS -> ParserRuleContext.WAIT_FIELD_END;
+            case WAIT_FIELD_END -> ParserRuleContext.CLOSE_BRACE;
+            case WAIT_FUTURE_EXPR_END -> ParserRuleContext.ALTERNATE_WAIT_EXPR_LIST_END;
+            case OPTIONAL_PEER_WORKER -> ParserRuleContext.EXPRESSION_RHS;
+            case ENUM_MEMBER_START -> ParserRuleContext.ENUM_MEMBER_NAME;
+            case ENUM_MEMBER_RHS -> ParserRuleContext.ENUM_MEMBER_END;
+            case ENUM_MEMBER_END -> ParserRuleContext.CLOSE_BRACE;
+            case MEMBER_ACCESS_KEY_EXPR_END -> ParserRuleContext.CLOSE_BRACKET;
+            case ROLLBACK_RHS -> ParserRuleContext.SEMICOLON;
+            case RETRY_KEYWORD_RHS -> ParserRuleContext.RETRY_TYPE_PARAM_RHS;
+            case RETRY_TYPE_PARAM_RHS -> ParserRuleContext.RETRY_BODY;
+            case RETRY_BODY -> ParserRuleContext.BLOCK_STMT;
+            case STMT_START_BRACKETED_LIST_MEMBER -> ParserRuleContext.TYPE_DESCRIPTOR;
+            case STMT_START_BRACKETED_LIST_RHS -> ParserRuleContext.VARIABLE_NAME;
+            case BINDING_PATTERN_OR_EXPR_RHS,
+                 BRACKETED_LIST_RHS -> ParserRuleContext.TYPE_DESC_RHS_OR_BP_RHS;
+            case BRACKETED_LIST_MEMBER -> ParserRuleContext.EXPRESSION;
+            case BRACKETED_LIST_MEMBER_END -> ParserRuleContext.CLOSE_BRACKET;
+            case TYPE_DESC_RHS_OR_BP_RHS -> ParserRuleContext.TYPE_DESC_RHS_IN_TYPED_BP;
+            case LIST_BINDING_MEMBER_OR_ARRAY_LENGTH -> ParserRuleContext.BINDING_PATTERN;
+            case XML_NAVIGATE_EXPR -> ParserRuleContext.XML_FILTER_EXPR;
+            case XML_NAME_PATTERN_RHS -> ParserRuleContext.GT;
+            case XML_ATOMIC_NAME_PATTERN_START -> ParserRuleContext.XML_ATOMIC_NAME_IDENTIFIER;
+            case XML_ATOMIC_NAME_IDENTIFIER_RHS -> ParserRuleContext.IDENTIFIER;
+            case XML_STEP_START -> ParserRuleContext.SLASH_ASTERISK_TOKEN;
+            case FUNC_TYPE_DESC_RHS_OR_ANON_FUNC_BODY -> ParserRuleContext.ANON_FUNC_BODY;
+            case OPTIONAL_MATCH_GUARD -> ParserRuleContext.RIGHT_DOUBLE_ARROW;
+            case MATCH_PATTERN_LIST_MEMBER_RHS -> ParserRuleContext.MATCH_PATTERN_END;
+            case MATCH_PATTERN_START -> ParserRuleContext.CONSTANT_EXPRESSION;
+            case LIST_MATCH_PATTERNS_START -> ParserRuleContext.CLOSE_BRACKET;
+            case LIST_MATCH_PATTERN_MEMBER -> ParserRuleContext.MATCH_PATTERN_START;
+            case LIST_MATCH_PATTERN_MEMBER_RHS -> ParserRuleContext.CLOSE_BRACKET;
+            case ERROR_BINDING_PATTERN_ERROR_KEYWORD_RHS -> ParserRuleContext.OPEN_PARENTHESIS;
+            case ERROR_ARG_LIST_BINDING_PATTERN_START,
+                 ERROR_MESSAGE_BINDING_PATTERN_END -> ParserRuleContext.CLOSE_PARENTHESIS;
+            case ERROR_MESSAGE_BINDING_PATTERN_RHS -> ParserRuleContext.ERROR_CAUSE_SIMPLE_BINDING_PATTERN;
+            case ERROR_FIELD_BINDING_PATTERN -> ParserRuleContext.NAMED_ARG_BINDING_PATTERN;
+            case ERROR_FIELD_BINDING_PATTERN_END -> ParserRuleContext.CLOSE_PARENTHESIS;
+            case FIELD_MATCH_PATTERNS_START -> ParserRuleContext.CLOSE_BRACE;
+            case FIELD_MATCH_PATTERN_MEMBER -> ParserRuleContext.VARIABLE_NAME;
+            case FIELD_MATCH_PATTERN_MEMBER_RHS -> ParserRuleContext.CLOSE_BRACE;
+            case ERROR_MATCH_PATTERN_OR_CONST_PATTERN -> ParserRuleContext.MATCH_PATTERN_RHS;
+            case ERROR_MATCH_PATTERN_ERROR_KEYWORD_RHS -> ParserRuleContext.OPEN_PARENTHESIS;
+            case ERROR_ARG_LIST_MATCH_PATTERN_START,
+                 ERROR_MESSAGE_MATCH_PATTERN_END -> ParserRuleContext.CLOSE_PARENTHESIS;
+            case ERROR_MESSAGE_MATCH_PATTERN_RHS -> ParserRuleContext.ERROR_CAUSE_MATCH_PATTERN;
+            case ERROR_FIELD_MATCH_PATTERN -> ParserRuleContext.NAMED_ARG_MATCH_PATTERN;
+            case ERROR_FIELD_MATCH_PATTERN_RHS -> ParserRuleContext.CLOSE_PARENTHESIS;
+            case NAMED_ARG_MATCH_PATTERN_RHS -> ParserRuleContext.NAMED_ARG_MATCH_PATTERN;
+            case EXTERNAL_FUNC_BODY_OPTIONAL_ANNOTS -> ParserRuleContext.EXTERNAL_KEYWORD;
+            case LIST_BP_OR_LIST_CONSTRUCTOR_MEMBER -> ParserRuleContext.LIST_BINDING_PATTERN_MEMBER;
+            case TUPLE_TYPE_DESC_OR_LIST_CONST_MEMBER -> ParserRuleContext.TYPE_DESCRIPTOR;
+            case OBJECT_METHOD_WITHOUT_FIRST_QUALIFIER,
+                 OBJECT_METHOD_WITHOUT_SECOND_QUALIFIER,
+                 OBJECT_METHOD_WITHOUT_THIRD_QUALIFIER,
+                 FUNC_DEF -> ParserRuleContext.FUNC_DEF_OR_FUNC_TYPE;
+            case JOIN_CLAUSE_START -> ParserRuleContext.JOIN_KEYWORD;
+            case INTERMEDIATE_CLAUSE_START -> ParserRuleContext.WHERE_CLAUSE;
+            case MAPPING_BP_OR_MAPPING_CONSTRUCTOR_MEMBER -> ParserRuleContext.MAPPING_BINDING_PATTERN_MEMBER;
+            case TYPE_DESC_OR_EXPR_RHS -> ParserRuleContext.TYPE_DESC_RHS_OR_BP_RHS;
+            case LISTENERS_LIST_END -> ParserRuleContext.OBJECT_CONSTRUCTOR_BLOCK;
+            case REGULAR_COMPOUND_STMT_RHS -> ParserRuleContext.STATEMENT;
+            case NAMED_WORKER_DECL_START -> ParserRuleContext.WORKER_KEYWORD;
+            case FUNC_TYPE_DESC_START,
+                 FUNC_DEF_START,
+                 ANON_FUNC_EXPRESSION_START -> ParserRuleContext.FUNCTION_KEYWORD;
+            case MODULE_CLASS_DEFINITION_START -> ParserRuleContext.CLASS_KEYWORD;
+            case OBJECT_CONSTRUCTOR_TYPE_REF -> ParserRuleContext.OPEN_BRACE;
+            case OBJECT_FIELD_QUALIFIER -> ParserRuleContext.TYPE_DESC_BEFORE_IDENTIFIER;
+            case OPTIONAL_SERVICE_DECL_TYPE -> ParserRuleContext.OPTIONAL_ABSOLUTE_PATH;
+            case SERVICE_IDENT_RHS -> ParserRuleContext.ATTACH_POINT_END;
+            case ABSOLUTE_RESOURCE_PATH_START -> ParserRuleContext.ABSOLUTE_PATH_SINGLE_SLASH;
+            case ABSOLUTE_RESOURCE_PATH_END -> ParserRuleContext.SERVICE_DECL_RHS;
+            case SERVICE_DECL_OR_VAR_DECL -> ParserRuleContext.SERVICE_VAR_DECL_RHS;
+            case OPTIONAL_RELATIVE_PATH -> ParserRuleContext.OPEN_PARENTHESIS;
+            case RELATIVE_RESOURCE_PATH_START -> ParserRuleContext.DOT;
+            case RELATIVE_RESOURCE_PATH_END -> ParserRuleContext.RESOURCE_ACCESSOR_DEF_OR_DECL_RHS;
+            case RESOURCE_PATH_SEGMENT -> ParserRuleContext.PATH_SEGMENT_IDENT;
+            case PATH_PARAM_OPTIONAL_ANNOTS -> ParserRuleContext.TYPE_DESC_IN_PATH_PARAM;
+            case PATH_PARAM_ELLIPSIS,
+                 OPTIONAL_PATH_PARAM_NAME -> ParserRuleContext.CLOSE_BRACKET;
+            case OBJECT_CONS_WITHOUT_FIRST_QUALIFIER,
+                 OBJECT_TYPE_WITHOUT_FIRST_QUALIFIER -> ParserRuleContext.OBJECT_KEYWORD;
+            case CONFIG_VAR_DECL_RHS -> ParserRuleContext.EXPRESSION;
+            case SERVICE_DECL_START -> ParserRuleContext.SERVICE_KEYWORD;
+            case ERROR_CONSTRUCTOR_RHS -> ParserRuleContext.ARG_LIST_OPEN_PAREN;
+            case OPTIONAL_TYPE_PARAMETER -> ParserRuleContext.TYPE_DESC_RHS;
+            case MAP_TYPE_OR_TYPE_REF -> ParserRuleContext.LT;
+            case OBJECT_TYPE_OR_TYPE_REF -> ParserRuleContext.OBJECT_TYPE_OBJECT_KEYWORD_RHS;
+            case STREAM_TYPE_OR_TYPE_REF -> ParserRuleContext.LT;
+            case TABLE_TYPE_OR_TYPE_REF -> ParserRuleContext.ROW_TYPE_PARAM;
+            case PARAMETERIZED_TYPE_OR_TYPE_REF -> ParserRuleContext.OPTIONAL_TYPE_PARAMETER;
+            case TYPE_DESC_RHS_OR_TYPE_REF -> ParserRuleContext.TYPE_DESC_RHS;
+            case TRANSACTION_STMT_RHS_OR_TYPE_REF -> ParserRuleContext.TRANSACTION_STMT_TRANSACTION_KEYWORD_RHS;
+            case TABLE_CONS_OR_QUERY_EXPR_OR_VAR_REF -> ParserRuleContext.EXPRESSION_START_TABLE_KEYWORD_RHS;
+            case QUERY_EXPR_OR_VAR_REF -> ParserRuleContext.QUERY_CONSTRUCT_TYPE_RHS;
+            case ERROR_CONS_EXPR_OR_VAR_REF -> ParserRuleContext.ERROR_CONS_ERROR_KEYWORD_RHS;
+            case QUALIFIED_IDENTIFIER -> ParserRuleContext.QUALIFIED_IDENTIFIER_START_IDENTIFIER;
+            case CLASS_DEF_WITHOUT_FIRST_QUALIFIER,
+                 CLASS_DEF_WITHOUT_SECOND_QUALIFIER,
+                 CLASS_DEF_WITHOUT_THIRD_QUALIFIER -> ParserRuleContext.CLASS_KEYWORD;
+            case FUNC_DEF_WITHOUT_FIRST_QUALIFIER -> ParserRuleContext.FUNC_DEF_OR_FUNC_TYPE;
+            case FUNC_TYPE_DESC_START_WITHOUT_FIRST_QUAL -> ParserRuleContext.FUNCTION_KEYWORD;
+            case MODULE_VAR_DECL_START,
+                 MODULE_VAR_WITHOUT_FIRST_QUAL,
+                 MODULE_VAR_WITHOUT_SECOND_QUAL -> ParserRuleContext.VAR_DECL_STMT;
+            case FUNC_DEF_OR_TYPE_DESC_RHS -> ParserRuleContext.SEMICOLON;
+            case CLASS_DESCRIPTOR -> ParserRuleContext.TYPE_REFERENCE;
+            case EXPR_START_OR_INFERRED_TYPEDESC_DEFAULT_START -> ParserRuleContext.EXPRESSION;
+            case TYPE_CAST_PARAM_START_OR_INFERRED_TYPEDESC_DEFAULT_END ->
+                    ParserRuleContext.INFERRED_TYPEDESC_DEFAULT_END_GT;
+            case END_OF_PARAMS_OR_NEXT_PARAM_START -> ParserRuleContext.CLOSE_PARENTHESIS;
+            case ASSIGNMENT_STMT_RHS -> ParserRuleContext.ASSIGN_OP;
+            case PARAM_START -> ParserRuleContext.TYPE_DESC_IN_PARAM;
+            case PARAM_RHS -> ParserRuleContext.VARIABLE_NAME;
+            case FUNC_TYPE_PARAM_RHS -> ParserRuleContext.PARAM_END;
+            case ANNOTATION_DECL_START -> ParserRuleContext.ANNOTATION_KEYWORD;
+            case OPTIONAL_RESOURCE_ACCESS_PATH,
+                 RESOURCE_ACCESS_SEGMENT_RHS -> ParserRuleContext.OPTIONAL_RESOURCE_ACCESS_METHOD;
+            case RESOURCE_ACCESS_PATH_SEGMENT -> ParserRuleContext.IDENTIFIER;
+            case COMPUTED_SEGMENT_OR_REST_SEGMENT -> ParserRuleContext.EXPRESSION;
+            case OPTIONAL_RESOURCE_ACCESS_METHOD -> ParserRuleContext.OPTIONAL_RESOURCE_ACCESS_ACTION_ARG_LIST;
+            case OPTIONAL_RESOURCE_ACCESS_ACTION_ARG_LIST -> ParserRuleContext.ACTION_END;
+            case OPTIONAL_TOP_LEVEL_SEMICOLON -> ParserRuleContext.TOP_LEVEL_NODE;
+            case TUPLE_MEMBER -> ParserRuleContext.TYPE_DESC_IN_TUPLE;
+            case RESULT_CLAUSE -> ParserRuleContext.SELECT_CLAUSE;
+            case SINGLE_OR_ALTERNATE_WORKER_SEPARATOR -> ParserRuleContext.SINGLE_OR_ALTERNATE_WORKER_END;
+            default -> throw new IllegalStateException("Alternative path entry not found");
+        };
     }
 
     private Result seekMatchInAlternativePaths(ParserRuleContext currentCtx, int lookahead, int currentDepth,
@@ -2908,20 +2692,12 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
 
         ParserRuleContext nextContext;
         STToken nextNextToken = this.tokenReader.peek(lookahead + 1);
-        switch (nextNextToken.kind) {
-            case OPEN_PAREN_TOKEN:
-                nextContext = ParserRuleContext.OPEN_PARENTHESIS;
-                break;
-            case DOT_TOKEN:
-                nextContext = ParserRuleContext.DOT;
-                break;
-            case OPEN_BRACKET_TOKEN:
-                nextContext = ParserRuleContext.MEMBER_ACCESS_KEY_EXPR;
-                break;
-            default:
-                nextContext = getNextRuleForExpr();
-                break;
-        }
+        nextContext = switch (nextNextToken.kind) {
+            case OPEN_PAREN_TOKEN -> ParserRuleContext.OPEN_PARENTHESIS;
+            case DOT_TOKEN -> ParserRuleContext.DOT;
+            case OPEN_BRACKET_TOKEN -> ParserRuleContext.MEMBER_ACCESS_KEY_EXPR;
+            default -> getNextRuleForExpr();
+        };
 
         currentMatches++;
         lookahead++;
@@ -3075,14 +2851,10 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
         } else if (parentCtx == ParserRuleContext.SELECT_CLAUSE ||
                 parentCtx == ParserRuleContext.COLLECT_CLAUSE) {
             STToken nextToken = this.tokenReader.peek(lookahead);
-            switch (nextToken.kind) {
-                case ON_KEYWORD:
-                case CONFLICT_KEYWORD:
-                    nextContext = ParserRuleContext.ON_CONFLICT_CLAUSE;
-                    break;
-                default:
-                    nextContext = ParserRuleContext.QUERY_EXPRESSION_END;
-            }
+            nextContext = switch (nextToken.kind) {
+                case ON_KEYWORD, CONFLICT_KEYWORD -> ParserRuleContext.ON_CONFLICT_CLAUSE;
+                default -> ParserRuleContext.QUERY_EXPRESSION_END;
+            };
         } else if (parentCtx == ParserRuleContext.JOIN_CLAUSE) {
             nextContext = ParserRuleContext.ON_CLAUSE;
         } else if (parentCtx == ParserRuleContext.ON_CLAUSE) {
@@ -3231,42 +3003,34 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
                 return ParserRuleContext.RECORD_FIELD_OR_RECORD_END;
             case ELLIPSIS:
                 parentCtx = getParentContext();
-                switch (parentCtx) {
-                    case MAPPING_CONSTRUCTOR:
-                    case LIST_CONSTRUCTOR:
-                    case ARG_LIST:
-                        return ParserRuleContext.EXPRESSION;
-                    case STMT_START_BRACKETED_LIST:
-                    case BRACKETED_LIST:
-                    case TUPLE_MEMBERS:
-                        return ParserRuleContext.CLOSE_BRACKET;
-                    case REST_MATCH_PATTERN:
-                        return ParserRuleContext.VAR_KEYWORD;
-                    case RELATIVE_RESOURCE_PATH:
-                        return ParserRuleContext.OPTIONAL_PATH_PARAM_NAME;
-                    case CLIENT_RESOURCE_ACCESS_ACTION:
-                        return ParserRuleContext.EXPRESSION;
-                    default:
-                        return ParserRuleContext.VARIABLE_NAME;
-                }
+                return switch (parentCtx) {
+                    case MAPPING_CONSTRUCTOR,
+                         LIST_CONSTRUCTOR,
+                         ARG_LIST -> ParserRuleContext.EXPRESSION;
+                    case STMT_START_BRACKETED_LIST,
+                         BRACKETED_LIST,
+                         TUPLE_MEMBERS -> ParserRuleContext.CLOSE_BRACKET;
+                    case REST_MATCH_PATTERN -> ParserRuleContext.VAR_KEYWORD;
+                    case RELATIVE_RESOURCE_PATH -> ParserRuleContext.OPTIONAL_PATH_PARAM_NAME;
+                    case CLIENT_RESOURCE_ACCESS_ACTION -> ParserRuleContext.EXPRESSION;
+                    default -> ParserRuleContext.VARIABLE_NAME;
+                };
             case QUESTION_MARK:
                 return getNextRuleForQuestionMark();
             case RECORD_TYPE_DESCRIPTOR:
                 return ParserRuleContext.RECORD_KEYWORD;
             case ASTERISK:
                 parentCtx = getParentContext();
-                switch (parentCtx) {
-                    case ARRAY_TYPE_DESCRIPTOR:
-                        return ParserRuleContext.CLOSE_BRACKET;
-                    case XML_ATOMIC_NAME_PATTERN:
+                return switch (parentCtx) {
+                    case ARRAY_TYPE_DESCRIPTOR -> ParserRuleContext.CLOSE_BRACKET;
+                    case XML_ATOMIC_NAME_PATTERN -> {
                         endContext();
-                        return ParserRuleContext.XML_NAME_PATTERN_RHS;
-                    case REQUIRED_PARAM:
-                    case DEFAULTABLE_PARAM:
-                        return ParserRuleContext.TYPE_DESC_IN_PARAM;
-                    default:
-                        return ParserRuleContext.TYPE_REFERENCE_IN_TYPE_INCLUSION;
-                }
+                        yield ParserRuleContext.XML_NAME_PATTERN_RHS;
+                    }
+                    case REQUIRED_PARAM,
+                         DEFAULTABLE_PARAM -> ParserRuleContext.TYPE_DESC_IN_PARAM;
+                    default -> ParserRuleContext.TYPE_REFERENCE_IN_TYPE_INCLUSION;
+                };
             case TYPE_NAME:
                 return ParserRuleContext.TYPE_DESC_IN_TYPE_DEF;
             case OBJECT_TYPE_DESCRIPTOR:
@@ -4412,74 +4176,57 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
     }
 
     private boolean isInMatchPatternCtx(ParserRuleContext context) {
-        switch (context) {
-            case MATCH_PATTERN:
-            case LIST_MATCH_PATTERN:
-            case MAPPING_MATCH_PATTERN:
-            case ERROR_MATCH_PATTERN:
-            case NAMED_ARG_MATCH_PATTERN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (context) {
+            case MATCH_PATTERN,
+                 LIST_MATCH_PATTERN,
+                 MAPPING_MATCH_PATTERN,
+                 ERROR_MATCH_PATTERN,
+                 NAMED_ARG_MATCH_PATTERN -> true;
+            default -> false;
+        };
     }
 
     private ParserRuleContext getNextRuleForOpenBrace() {
         ParserRuleContext parentCtx = getParentContext();
-        switch (parentCtx) {
-            case OBJECT_TYPE_DESCRIPTOR:
-                return ParserRuleContext.OBJECT_TYPE_MEMBER;
-            case MODULE_CLASS_DEFINITION:
-                return ParserRuleContext.CLASS_MEMBER;
-            case OBJECT_CONSTRUCTOR:
-            case SERVICE_DECL:
-                return ParserRuleContext.OBJECT_CONSTRUCTOR_MEMBER;
-            case RECORD_TYPE_DESCRIPTOR:
-                return ParserRuleContext.RECORD_FIELD;
-            case MAPPING_CONSTRUCTOR:
-                return ParserRuleContext.FIRST_MAPPING_FIELD;
-            case FORK_STMT:
-                return ParserRuleContext.NAMED_WORKER_DECL;
-            case MULTI_RECEIVE_WORKERS:
-                return ParserRuleContext.RECEIVE_FIELD;
-            case MULTI_WAIT_FIELDS:
-                return ParserRuleContext.WAIT_FIELD_NAME;
-            case MODULE_ENUM_DECLARATION:
-                return ParserRuleContext.ENUM_MEMBER_LIST;
-            case MAPPING_BINDING_PATTERN:
-                return ParserRuleContext.MAPPING_BINDING_PATTERN_MEMBER;
-            case MAPPING_MATCH_PATTERN:
-                return ParserRuleContext.FIELD_MATCH_PATTERNS_START;
-            case MATCH_BODY:
-                return ParserRuleContext.MATCH_PATTERN;
-            default:
-                return ParserRuleContext.STATEMENT;
-        }
+        return switch (parentCtx) {
+            case OBJECT_TYPE_DESCRIPTOR -> ParserRuleContext.OBJECT_TYPE_MEMBER;
+            case MODULE_CLASS_DEFINITION -> ParserRuleContext.CLASS_MEMBER;
+            case OBJECT_CONSTRUCTOR,
+                 SERVICE_DECL -> ParserRuleContext.OBJECT_CONSTRUCTOR_MEMBER;
+            case RECORD_TYPE_DESCRIPTOR -> ParserRuleContext.RECORD_FIELD;
+            case MAPPING_CONSTRUCTOR -> ParserRuleContext.FIRST_MAPPING_FIELD;
+            case FORK_STMT -> ParserRuleContext.NAMED_WORKER_DECL;
+            case MULTI_RECEIVE_WORKERS -> ParserRuleContext.RECEIVE_FIELD;
+            case MULTI_WAIT_FIELDS -> ParserRuleContext.WAIT_FIELD_NAME;
+            case MODULE_ENUM_DECLARATION -> ParserRuleContext.ENUM_MEMBER_LIST;
+            case MAPPING_BINDING_PATTERN -> ParserRuleContext.MAPPING_BINDING_PATTERN_MEMBER;
+            case MAPPING_MATCH_PATTERN -> ParserRuleContext.FIELD_MATCH_PATTERNS_START;
+            case MATCH_BODY -> ParserRuleContext.MATCH_PATTERN;
+            default -> ParserRuleContext.STATEMENT;
+        };
     }
 
     private boolean isExpressionContext(ParserRuleContext ctx) {
-        switch (ctx) {
-            case LISTENERS_LIST:
-            case MAPPING_CONSTRUCTOR:
-            case COMPUTED_FIELD_NAME:
-            case LIST_CONSTRUCTOR:
-            case INTERPOLATION:
-            case ARG_LIST:
-            case LET_EXPR_LET_VAR_DECL:
-            case LET_CLAUSE_LET_VAR_DECL:
-            case TABLE_CONSTRUCTOR:
-            case QUERY_EXPRESSION:
-            case TABLE_CONSTRUCTOR_OR_QUERY_EXPRESSION:
-            case ORDER_KEY_LIST:
-            case GROUP_BY_CLAUSE:
-            case SELECT_CLAUSE:
-            case COLLECT_CLAUSE:
-            case JOIN_CLAUSE:
-            case ON_CONFLICT_CLAUSE:
-                return true;
-            default:
-                return false;
-        }
+        return switch (ctx) {
+            case LISTENERS_LIST,
+                 MAPPING_CONSTRUCTOR,
+                 COMPUTED_FIELD_NAME,
+                 LIST_CONSTRUCTOR,
+                 INTERPOLATION,
+                 ARG_LIST,
+                 LET_EXPR_LET_VAR_DECL,
+                 LET_CLAUSE_LET_VAR_DECL,
+                 TABLE_CONSTRUCTOR,
+                 QUERY_EXPRESSION,
+                 TABLE_CONSTRUCTOR_OR_QUERY_EXPRESSION,
+                 ORDER_KEY_LIST,
+                 GROUP_BY_CLAUSE,
+                 SELECT_CLAUSE,
+                 COLLECT_CLAUSE,
+                 JOIN_CLAUSE,
+                 ON_CONFLICT_CLAUSE -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -4511,70 +4258,47 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
      */
     private ParserRuleContext getNextRuleForComma() {
         ParserRuleContext parentCtx = getParentContext();
-        switch (parentCtx) {
-            case PARAM_LIST:
-            case REQUIRED_PARAM:
-            case DEFAULTABLE_PARAM:
-            case REST_PARAM:
+        return switch (parentCtx) {
+            case PARAM_LIST,
+                 REQUIRED_PARAM,
+                 DEFAULTABLE_PARAM,
+                 REST_PARAM -> {
                 endContext();
-                return parentCtx;
-            case ARG_LIST:
-                return ParserRuleContext.ARG_START;
-            case MAPPING_CONSTRUCTOR:
-                return ParserRuleContext.MAPPING_FIELD;
-            case LIST_CONSTRUCTOR:
-                return ParserRuleContext.LIST_CONSTRUCTOR_MEMBER;
-            case LISTENERS_LIST:
-            case ORDER_KEY_LIST:
-                return ParserRuleContext.EXPRESSION;
-            case GROUP_BY_CLAUSE:
-                return ParserRuleContext.GROUPING_KEY_LIST_ELEMENT;
-            case ANNOT_ATTACH_POINTS_LIST:
-                return ParserRuleContext.ATTACH_POINT;
-            case TABLE_CONSTRUCTOR:
-                return ParserRuleContext.MAPPING_CONSTRUCTOR;
-            case KEY_SPECIFIER:
-                return ParserRuleContext.VARIABLE_NAME;
-            case LET_EXPR_LET_VAR_DECL:
-            case LET_CLAUSE_LET_VAR_DECL:
-                return ParserRuleContext.LET_VAR_DECL_START;
-            case TYPE_DESC_IN_STREAM_TYPE_DESC:
-                return ParserRuleContext.TYPE_DESCRIPTOR;
-            case BRACED_EXPR_OR_ANON_FUNC_PARAMS:
-                return ParserRuleContext.IMPLICIT_ANON_FUNC_PARAM;
-            case TUPLE_MEMBERS:
-                return ParserRuleContext.TUPLE_MEMBER;
-            case LIST_BINDING_PATTERN:
-                return ParserRuleContext.LIST_BINDING_PATTERN_MEMBER;
-            case MAPPING_BINDING_PATTERN:
-            case MAPPING_BP_OR_MAPPING_CONSTRUCTOR:
-                return ParserRuleContext.MAPPING_BINDING_PATTERN_MEMBER;
-            case MULTI_RECEIVE_WORKERS:
-                return ParserRuleContext.RECEIVE_FIELD;
-            case MULTI_WAIT_FIELDS:
-                return ParserRuleContext.WAIT_FIELD_NAME;
-            case ENUM_MEMBER_LIST:
-                return ParserRuleContext.ENUM_MEMBER_START;
-            case MEMBER_ACCESS_KEY_EXPR:
-                return ParserRuleContext.MEMBER_ACCESS_KEY_EXPR_END;
-            case STMT_START_BRACKETED_LIST:
-                return ParserRuleContext.STMT_START_BRACKETED_LIST_MEMBER;
-            case BRACKETED_LIST:
-                return ParserRuleContext.BRACKETED_LIST_MEMBER;
-            case LIST_MATCH_PATTERN:
-                return ParserRuleContext.LIST_MATCH_PATTERN_MEMBER;
-            case ERROR_BINDING_PATTERN:
-                return ParserRuleContext.ERROR_FIELD_BINDING_PATTERN;
-            case MAPPING_MATCH_PATTERN:
-                return ParserRuleContext.FIELD_MATCH_PATTERN_MEMBER;
-            case ERROR_MATCH_PATTERN:
-                return ParserRuleContext.ERROR_FIELD_MATCH_PATTERN;
-            case NAMED_ARG_MATCH_PATTERN:
+                yield parentCtx;
+            }
+            case ARG_LIST -> ParserRuleContext.ARG_START;
+            case MAPPING_CONSTRUCTOR -> ParserRuleContext.MAPPING_FIELD;
+            case LIST_CONSTRUCTOR -> ParserRuleContext.LIST_CONSTRUCTOR_MEMBER;
+            case LISTENERS_LIST,
+                 ORDER_KEY_LIST -> ParserRuleContext.EXPRESSION;
+            case GROUP_BY_CLAUSE -> ParserRuleContext.GROUPING_KEY_LIST_ELEMENT;
+            case ANNOT_ATTACH_POINTS_LIST -> ParserRuleContext.ATTACH_POINT;
+            case TABLE_CONSTRUCTOR -> ParserRuleContext.MAPPING_CONSTRUCTOR;
+            case KEY_SPECIFIER -> ParserRuleContext.VARIABLE_NAME;
+            case LET_EXPR_LET_VAR_DECL,
+                 LET_CLAUSE_LET_VAR_DECL -> ParserRuleContext.LET_VAR_DECL_START;
+            case TYPE_DESC_IN_STREAM_TYPE_DESC -> ParserRuleContext.TYPE_DESCRIPTOR;
+            case BRACED_EXPR_OR_ANON_FUNC_PARAMS -> ParserRuleContext.IMPLICIT_ANON_FUNC_PARAM;
+            case TUPLE_MEMBERS -> ParserRuleContext.TUPLE_MEMBER;
+            case LIST_BINDING_PATTERN -> ParserRuleContext.LIST_BINDING_PATTERN_MEMBER;
+            case MAPPING_BINDING_PATTERN,
+                 MAPPING_BP_OR_MAPPING_CONSTRUCTOR -> ParserRuleContext.MAPPING_BINDING_PATTERN_MEMBER;
+            case MULTI_RECEIVE_WORKERS -> ParserRuleContext.RECEIVE_FIELD;
+            case MULTI_WAIT_FIELDS -> ParserRuleContext.WAIT_FIELD_NAME;
+            case ENUM_MEMBER_LIST -> ParserRuleContext.ENUM_MEMBER_START;
+            case MEMBER_ACCESS_KEY_EXPR -> ParserRuleContext.MEMBER_ACCESS_KEY_EXPR_END;
+            case STMT_START_BRACKETED_LIST -> ParserRuleContext.STMT_START_BRACKETED_LIST_MEMBER;
+            case BRACKETED_LIST -> ParserRuleContext.BRACKETED_LIST_MEMBER;
+            case LIST_MATCH_PATTERN -> ParserRuleContext.LIST_MATCH_PATTERN_MEMBER;
+            case ERROR_BINDING_PATTERN -> ParserRuleContext.ERROR_FIELD_BINDING_PATTERN;
+            case MAPPING_MATCH_PATTERN -> ParserRuleContext.FIELD_MATCH_PATTERN_MEMBER;
+            case ERROR_MATCH_PATTERN -> ParserRuleContext.ERROR_FIELD_MATCH_PATTERN;
+            case NAMED_ARG_MATCH_PATTERN -> {
                 endContext();
-                return ParserRuleContext.NAMED_ARG_MATCH_PATTERN_RHS;
-            default:
-                throw new IllegalStateException("getNextRuleForComma found: " + parentCtx);
-        }
+                yield ParserRuleContext.NAMED_ARG_MATCH_PATTERN_RHS;
+            }
+            default -> throw new IllegalStateException("getNextRuleForComma found: " + parentCtx);
+        };
     }
 
     /**
@@ -4706,29 +4430,27 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
     }
 
     private boolean isInTypeDescContext() {
-        switch (getParentContext()) {
-            case TYPE_DESC_IN_ANNOTATION_DECL:
-            case TYPE_DESC_BEFORE_IDENTIFIER:
-            case TYPE_DESC_BEFORE_IDENTIFIER_IN_GROUPING_KEY:
-            case TYPE_DESC_IN_RECORD_FIELD:
-            case TYPE_DESC_IN_PARAM:
-            case TYPE_DESC_IN_TYPE_BINDING_PATTERN:
-            case TYPE_DESC_IN_TYPE_DEF:
-            case TYPE_DESC_IN_ANGLE_BRACKETS:
-            case TYPE_DESC_IN_RETURN_TYPE_DESC:
-            case TYPE_DESC_IN_EXPRESSION:
-            case TYPE_DESC_IN_STREAM_TYPE_DESC:
-            case TYPE_DESC_IN_PARENTHESIS:
-            case TYPE_DESC_IN_TUPLE:
-            case TYPE_DESC_IN_SERVICE:
-            case TYPE_DESC_IN_PATH_PARAM:
-            case STMT_START_BRACKETED_LIST:
-            case BRACKETED_LIST:
-            case TYPE_REFERENCE_IN_TYPE_INCLUSION:
-                return true;
-            default:
-                return false;
-        }
+        return switch (getParentContext()) {
+            case TYPE_DESC_IN_ANNOTATION_DECL,
+                 TYPE_DESC_BEFORE_IDENTIFIER,
+                 TYPE_DESC_BEFORE_IDENTIFIER_IN_GROUPING_KEY,
+                 TYPE_DESC_IN_RECORD_FIELD,
+                 TYPE_DESC_IN_PARAM,
+                 TYPE_DESC_IN_TYPE_BINDING_PATTERN,
+                 TYPE_DESC_IN_TYPE_DEF,
+                 TYPE_DESC_IN_ANGLE_BRACKETS,
+                 TYPE_DESC_IN_RETURN_TYPE_DESC,
+                 TYPE_DESC_IN_EXPRESSION,
+                 TYPE_DESC_IN_STREAM_TYPE_DESC,
+                 TYPE_DESC_IN_PARENTHESIS,
+                 TYPE_DESC_IN_TUPLE,
+                 TYPE_DESC_IN_SERVICE,
+                 TYPE_DESC_IN_PATH_PARAM,
+                 STMT_START_BRACKETED_LIST,
+                 BRACKETED_LIST,
+                 TYPE_REFERENCE_IN_TYPE_INCLUSION -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -4738,37 +4460,34 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
      */
     private ParserRuleContext getNextRuleForEqualOp() {
         ParserRuleContext parentCtx = getParentContext();
-        switch (parentCtx) {
-            case EXTERNAL_FUNC_BODY:
-                return ParserRuleContext.EXTERNAL_FUNC_BODY_OPTIONAL_ANNOTS;
-            case REQUIRED_PARAM:
-            case DEFAULTABLE_PARAM:
-                return ParserRuleContext.EXPR_START_OR_INFERRED_TYPEDESC_DEFAULT_START;
-            case RECORD_FIELD:
-            case ARG_LIST:
-            case OBJECT_CONSTRUCTOR_MEMBER:
-            case CLASS_MEMBER:
-            case OBJECT_TYPE_MEMBER:
-            case LISTENER_DECL:
-            case CONSTANT_DECL:
-            case LET_EXPR_LET_VAR_DECL:
-            case LET_CLAUSE_LET_VAR_DECL:
-            case ENUM_MEMBER_LIST:
-            case GROUP_BY_CLAUSE:
-                return ParserRuleContext.EXPRESSION;
-            case FUNC_DEF_OR_FUNC_TYPE:
+        return switch (parentCtx) {
+            case EXTERNAL_FUNC_BODY -> ParserRuleContext.EXTERNAL_FUNC_BODY_OPTIONAL_ANNOTS;
+            case REQUIRED_PARAM,
+                 DEFAULTABLE_PARAM -> ParserRuleContext.EXPR_START_OR_INFERRED_TYPEDESC_DEFAULT_START;
+            case RECORD_FIELD,
+                 ARG_LIST,
+                 OBJECT_CONSTRUCTOR_MEMBER,
+                 CLASS_MEMBER,
+                 OBJECT_TYPE_MEMBER,
+                 LISTENER_DECL,
+                 CONSTANT_DECL,
+                 LET_EXPR_LET_VAR_DECL,
+                 LET_CLAUSE_LET_VAR_DECL,
+                 ENUM_MEMBER_LIST,
+                 GROUP_BY_CLAUSE -> ParserRuleContext.EXPRESSION;
+            case FUNC_DEF_OR_FUNC_TYPE -> {
                 switchContext(ParserRuleContext.VAR_DECL_STMT);
-                return ParserRuleContext.EXPRESSION;
-            case NAMED_ARG_MATCH_PATTERN:
-                return ParserRuleContext.MATCH_PATTERN;
-            case ERROR_BINDING_PATTERN:
-                return ParserRuleContext.BINDING_PATTERN;
-            default:
+                yield ParserRuleContext.EXPRESSION;
+            }
+            case NAMED_ARG_MATCH_PATTERN -> ParserRuleContext.MATCH_PATTERN;
+            case ERROR_BINDING_PATTERN -> ParserRuleContext.BINDING_PATTERN;
+            default -> {
                 if (isStatement(parentCtx)) {
-                    return ParserRuleContext.EXPRESSION;
+                    yield ParserRuleContext.EXPRESSION;
                 }
                 throw new IllegalStateException("getNextRuleForEqualOp found: " + parentCtx);
-        }
+            }
+        };
     }
 
     /**
@@ -4840,12 +4559,10 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
                         parentCtx = getParentContext();
                         if (parentCtx == ParserRuleContext.FORK_STMT) {
                             nextToken = this.tokenReader.peek(nextLookahead);
-                            switch (nextToken.kind) {
-                                case CLOSE_BRACE_TOKEN:
-                                    return ParserRuleContext.CLOSE_BRACE;
-                                default:
-                                    return ParserRuleContext.REGULAR_COMPOUND_STMT_RHS;
-                            }
+                            return switch (nextToken.kind) {
+                                case CLOSE_BRACE_TOKEN -> ParserRuleContext.CLOSE_BRACE;
+                                default -> ParserRuleContext.REGULAR_COMPOUND_STMT_RHS;
+                            };
                         } else {
                             return ParserRuleContext.REGULAR_COMPOUND_STMT_RHS;
                         }
@@ -4907,24 +4624,22 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
     private ParserRuleContext getNextRuleForCloseBraceInFuncBody() {
         ParserRuleContext parentCtx;
         parentCtx = getParentContext();
-        switch (parentCtx) {
-            case OBJECT_CONSTRUCTOR_MEMBER:
-                return ParserRuleContext.OBJECT_CONSTRUCTOR_MEMBER_START;
-            case CLASS_MEMBER:
-            case OBJECT_TYPE_MEMBER:
-                return ParserRuleContext.CLASS_MEMBER_OR_OBJECT_MEMBER_START;
-            case COMP_UNIT:
-                return ParserRuleContext.OPTIONAL_TOP_LEVEL_SEMICOLON;
-            case FUNC_DEF:
-            case FUNC_DEF_OR_FUNC_TYPE:
+        return switch (parentCtx) {
+            case OBJECT_CONSTRUCTOR_MEMBER -> ParserRuleContext.OBJECT_CONSTRUCTOR_MEMBER_START;
+            case CLASS_MEMBER,
+                 OBJECT_TYPE_MEMBER -> ParserRuleContext.CLASS_MEMBER_OR_OBJECT_MEMBER_START;
+            case COMP_UNIT -> ParserRuleContext.OPTIONAL_TOP_LEVEL_SEMICOLON;
+            case FUNC_DEF,
+                 FUNC_DEF_OR_FUNC_TYPE -> {
                 endContext(); // end func-def
-                return getNextRuleForCloseBraceInFuncBody();
-            case ANON_FUNC_EXPRESSION:
-            default:
+                yield getNextRuleForCloseBraceInFuncBody();
+            }
+            default -> {
                 // Anonynous func
                 endContext(); // end anon-func
-                return ParserRuleContext.EXPRESSION_RHS;
-        }
+                yield ParserRuleContext.EXPRESSION_RHS;
+            }
+        };
     }
 
     private ParserRuleContext getNextRuleForAnnotationEnd(int nextLookahead) {
@@ -4937,45 +4652,34 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
 
         endContext(); // end annotations
         parentCtx = getParentContext();
-        switch (parentCtx) {
-            case COMP_UNIT:
-                return ParserRuleContext.TOP_LEVEL_NODE_WITHOUT_METADATA;
-            case FUNC_DEF:
-            case FUNC_TYPE_DESC:
-            case FUNC_DEF_OR_FUNC_TYPE:
-            case ANON_FUNC_EXPRESSION:
-            case FUNC_TYPE_DESC_OR_ANON_FUNC:
-                return ParserRuleContext.TYPE_DESC_IN_RETURN_TYPE_DESC;
-            case LET_EXPR_LET_VAR_DECL:
-            case LET_CLAUSE_LET_VAR_DECL:
-                return ParserRuleContext.TYPE_DESC_IN_TYPE_BINDING_PATTERN;
-            case RECORD_FIELD:
-                return ParserRuleContext.RECORD_FIELD_WITHOUT_METADATA;
-            case OBJECT_CONSTRUCTOR_MEMBER:
-                return ParserRuleContext.OBJECT_CONS_MEMBER_WITHOUT_META;
-            case CLASS_MEMBER:
-            case OBJECT_TYPE_MEMBER:
-                return ParserRuleContext.CLASS_MEMBER_OR_OBJECT_MEMBER_WITHOUT_META;
-            case FUNC_BODY_BLOCK:
-                return ParserRuleContext.STATEMENT_WITHOUT_ANNOTS;
-            case EXTERNAL_FUNC_BODY:
-                return ParserRuleContext.EXTERNAL_KEYWORD;
-            case TYPE_CAST:
-                return ParserRuleContext.TYPE_CAST_PARAM_RHS;
-            case ENUM_MEMBER_LIST:
-                return ParserRuleContext.ENUM_MEMBER_NAME;
-            case RELATIVE_RESOURCE_PATH:
-                return ParserRuleContext.TYPE_DESC_IN_PATH_PARAM;
-            case TUPLE_MEMBERS:
-                return ParserRuleContext.TUPLE_MEMBER;
-            default:
+        return switch (parentCtx) {
+            case COMP_UNIT -> ParserRuleContext.TOP_LEVEL_NODE_WITHOUT_METADATA;
+            case FUNC_DEF,
+                 FUNC_TYPE_DESC,
+                 FUNC_DEF_OR_FUNC_TYPE,
+                 ANON_FUNC_EXPRESSION,
+                 FUNC_TYPE_DESC_OR_ANON_FUNC -> ParserRuleContext.TYPE_DESC_IN_RETURN_TYPE_DESC;
+            case LET_EXPR_LET_VAR_DECL,
+                 LET_CLAUSE_LET_VAR_DECL -> ParserRuleContext.TYPE_DESC_IN_TYPE_BINDING_PATTERN;
+            case RECORD_FIELD -> ParserRuleContext.RECORD_FIELD_WITHOUT_METADATA;
+            case OBJECT_CONSTRUCTOR_MEMBER -> ParserRuleContext.OBJECT_CONS_MEMBER_WITHOUT_META;
+            case CLASS_MEMBER,
+                 OBJECT_TYPE_MEMBER -> ParserRuleContext.CLASS_MEMBER_OR_OBJECT_MEMBER_WITHOUT_META;
+            case FUNC_BODY_BLOCK -> ParserRuleContext.STATEMENT_WITHOUT_ANNOTS;
+            case EXTERNAL_FUNC_BODY -> ParserRuleContext.EXTERNAL_KEYWORD;
+            case TYPE_CAST -> ParserRuleContext.TYPE_CAST_PARAM_RHS;
+            case ENUM_MEMBER_LIST -> ParserRuleContext.ENUM_MEMBER_NAME;
+            case RELATIVE_RESOURCE_PATH -> ParserRuleContext.TYPE_DESC_IN_PATH_PARAM;
+            case TUPLE_MEMBERS -> ParserRuleContext.TUPLE_MEMBER;
+            default -> {
                 if (isParameter(parentCtx)) {
-                    return ParserRuleContext.TYPE_DESC_IN_PARAM;
+                    yield ParserRuleContext.TYPE_DESC_IN_PARAM;
                 }
 
                 // everything else, treat as an annotation in an expression
-                return ParserRuleContext.EXPRESSION;
-        }
+                yield ParserRuleContext.EXPRESSION;
+            }
+        };
     }
 
     /**
@@ -5163,16 +4867,12 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
 
     private ParserRuleContext getNextRuleForDot() {
         ParserRuleContext parentCtx = getParentContext();
-        switch (parentCtx) {
-            case IMPORT_DECL:
-                return ParserRuleContext.IMPORT_MODULE_NAME;
-            case RELATIVE_RESOURCE_PATH:
-                return ParserRuleContext.RESOURCE_ACCESSOR_DEF_OR_DECL_RHS;
-            case CLIENT_RESOURCE_ACCESS_ACTION:
-                return ParserRuleContext.METHOD_NAME;
-            default:
-                return ParserRuleContext.FIELD_ACCESS_IDENTIFIER;
-        }
+        return switch (parentCtx) {
+            case IMPORT_DECL -> ParserRuleContext.IMPORT_MODULE_NAME;
+            case RELATIVE_RESOURCE_PATH -> ParserRuleContext.RESOURCE_ACCESSOR_DEF_OR_DECL_RHS;
+            case CLIENT_RESOURCE_ACCESS_ACTION -> ParserRuleContext.METHOD_NAME;
+            default -> ParserRuleContext.FIELD_ACCESS_IDENTIFIER;
+        };
     }
 
     /**
@@ -5182,15 +4882,14 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
      */
     private ParserRuleContext getNextRuleForQuestionMark() {
         ParserRuleContext parentCtx = getParentContext();
-        switch (parentCtx) {
-            case OPTIONAL_TYPE_DESCRIPTOR:
+        return switch (parentCtx) {
+            case OPTIONAL_TYPE_DESCRIPTOR -> {
                 endContext();
-                return ParserRuleContext.TYPE_DESC_RHS;
-            case CONDITIONAL_EXPRESSION:
-                return ParserRuleContext.EXPRESSION;
-            default:
-                return ParserRuleContext.SEMICOLON;
-        }
+                yield ParserRuleContext.TYPE_DESC_RHS;
+            }
+            case CONDITIONAL_EXPRESSION -> ParserRuleContext.EXPRESSION;
+            default -> ParserRuleContext.SEMICOLON;
+        };
     }
 
     /**
@@ -5200,27 +4899,21 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
      */
     private ParserRuleContext getNextRuleForOpenBracket() {
         ParserRuleContext parentCtx = getParentContext();
-        switch (parentCtx) {
-            case ARRAY_TYPE_DESCRIPTOR:
-                return ParserRuleContext.ARRAY_LENGTH;
-            case LIST_CONSTRUCTOR:
-                return ParserRuleContext.LIST_CONSTRUCTOR_FIRST_MEMBER;
-            case TABLE_CONSTRUCTOR:
-                return ParserRuleContext.ROW_LIST_RHS;
-            case LIST_BINDING_PATTERN:
-                return ParserRuleContext.LIST_BINDING_PATTERNS_START;
-            case LIST_MATCH_PATTERN:
-                return ParserRuleContext.LIST_MATCH_PATTERNS_START;
-            case RELATIVE_RESOURCE_PATH:
-                return ParserRuleContext.PATH_PARAM_OPTIONAL_ANNOTS;
-            case CLIENT_RESOURCE_ACCESS_ACTION:
-                return ParserRuleContext.COMPUTED_SEGMENT_OR_REST_SEGMENT;
-            default:
+        return switch (parentCtx) {
+            case ARRAY_TYPE_DESCRIPTOR -> ParserRuleContext.ARRAY_LENGTH;
+            case LIST_CONSTRUCTOR -> ParserRuleContext.LIST_CONSTRUCTOR_FIRST_MEMBER;
+            case TABLE_CONSTRUCTOR -> ParserRuleContext.ROW_LIST_RHS;
+            case LIST_BINDING_PATTERN -> ParserRuleContext.LIST_BINDING_PATTERNS_START;
+            case LIST_MATCH_PATTERN -> ParserRuleContext.LIST_MATCH_PATTERNS_START;
+            case RELATIVE_RESOURCE_PATH -> ParserRuleContext.PATH_PARAM_OPTIONAL_ANNOTS;
+            case CLIENT_RESOURCE_ACCESS_ACTION -> ParserRuleContext.COMPUTED_SEGMENT_OR_REST_SEGMENT;
+            default -> {
                 if (isInTypeDescContext()) {
-                    return ParserRuleContext.TUPLE_MEMBERS;
+                    yield ParserRuleContext.TUPLE_MEMBERS;
                 }
-                return ParserRuleContext.EXPRESSION;
-        }
+                yield ParserRuleContext.EXPRESSION;
+            }
+        };
     }
 
     /**
@@ -5280,14 +4973,13 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
      */
     private ParserRuleContext getNextRuleForDecimalIntegerLiteral() {
         ParserRuleContext parentCtx = getParentContext();
-        switch (parentCtx) {
-            case CONSTANT_EXPRESSION:
+        return switch (parentCtx) {
+            case CONSTANT_EXPRESSION -> {
                 endContext();
-                return getNextRuleForConstExpr();
-            case ARRAY_TYPE_DESCRIPTOR:
-            default:
-                return ParserRuleContext.CLOSE_BRACKET;
-        }
+                yield getNextRuleForConstExpr();
+            }
+            default -> ParserRuleContext.CLOSE_BRACKET;
+        };
     }
 
     private ParserRuleContext getNextRuleForExpr() {
@@ -5316,25 +5008,23 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
 
     private ParserRuleContext getNextRuleForConstExpr() {
         ParserRuleContext parentCtx = getParentContext();
-        switch (parentCtx) {
-            case XML_NAMESPACE_DECLARATION:
-                return ParserRuleContext.XML_NAMESPACE_PREFIX_DECL;
-            default:
+        return switch (parentCtx) {
+            case XML_NAMESPACE_DECLARATION -> ParserRuleContext.XML_NAMESPACE_PREFIX_DECL;
+            default -> {
                 if (isInTypeDescContext()) {
-                    return ParserRuleContext.TYPE_DESC_RHS;
+                    yield ParserRuleContext.TYPE_DESC_RHS;
                 }
-                return getNextRuleForMatchPattern();
-        }
+                yield getNextRuleForMatchPattern();
+            }
+        };
     }
 
     private ParserRuleContext getNextRuleForLt() {
         ParserRuleContext parentCtx = getParentContext();
-        switch (parentCtx) {
-            case TYPE_CAST:
-                return ParserRuleContext.TYPE_CAST_PARAM;
-            default:
-                return ParserRuleContext.TYPE_DESC_IN_ANGLE_BRACKETS;
-        }
+        return switch (parentCtx) {
+            case TYPE_CAST -> ParserRuleContext.TYPE_CAST_PARAM;
+            default -> ParserRuleContext.TYPE_DESC_IN_ANGLE_BRACKETS;
+        };
     }
 
     private ParserRuleContext getNextRuleForGt() {
@@ -5504,49 +5194,40 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
     private ParserRuleContext getNextRuleForColon() {
         ParserRuleContext parentCtx;
         parentCtx = getParentContext();
-        switch (parentCtx) {
-            case MAPPING_CONSTRUCTOR:
-                return ParserRuleContext.EXPRESSION;
-            case MULTI_RECEIVE_WORKERS:
-                return ParserRuleContext.PEER_WORKER_NAME;
-            case MULTI_WAIT_FIELDS:
-                return ParserRuleContext.EXPRESSION;
-            case CONDITIONAL_EXPRESSION:
+        return switch (parentCtx) {
+            case MAPPING_CONSTRUCTOR -> ParserRuleContext.EXPRESSION;
+            case MULTI_RECEIVE_WORKERS -> ParserRuleContext.PEER_WORKER_NAME;
+            case MULTI_WAIT_FIELDS -> ParserRuleContext.EXPRESSION;
+            case CONDITIONAL_EXPRESSION -> {
                 endContext(); // end conditional-expr
-                return ParserRuleContext.EXPRESSION;
-            case MAPPING_BINDING_PATTERN:
-            case MAPPING_BP_OR_MAPPING_CONSTRUCTOR:
-                return ParserRuleContext.VARIABLE_NAME;
-            case FIELD_BINDING_PATTERN:
+                yield ParserRuleContext.EXPRESSION;
+            }
+            case MAPPING_BINDING_PATTERN,
+                 MAPPING_BP_OR_MAPPING_CONSTRUCTOR -> ParserRuleContext.VARIABLE_NAME;
+            case FIELD_BINDING_PATTERN -> {
                 endContext();
-                return ParserRuleContext.VARIABLE_NAME;
-            case XML_ATOMIC_NAME_PATTERN:
-                return ParserRuleContext.XML_ATOMIC_NAME_IDENTIFIER_RHS;
-            case MAPPING_MATCH_PATTERN:
-                return ParserRuleContext.MATCH_PATTERN;
-            default:
-                return ParserRuleContext.IDENTIFIER;
-        }
+                yield ParserRuleContext.VARIABLE_NAME;
+            }
+            case XML_ATOMIC_NAME_PATTERN -> ParserRuleContext.XML_ATOMIC_NAME_IDENTIFIER_RHS;
+            case MAPPING_MATCH_PATTERN -> ParserRuleContext.MATCH_PATTERN;
+            default -> ParserRuleContext.IDENTIFIER;
+        };
     }
 
     private ParserRuleContext getNextRuleForMatchPattern() {
         ParserRuleContext parentCtx = getParentContext();
-        switch (parentCtx) {
-            case LIST_MATCH_PATTERN:
-                return ParserRuleContext.LIST_MATCH_PATTERN_MEMBER_RHS;
-            case MAPPING_MATCH_PATTERN:
-                return ParserRuleContext.FIELD_MATCH_PATTERN_MEMBER_RHS;
-            case MATCH_PATTERN:
-                return ParserRuleContext.MATCH_PATTERN_LIST_MEMBER_RHS;
-            case ERROR_MATCH_PATTERN:
-            case NAMED_ARG_MATCH_PATTERN:
-                return ParserRuleContext.ERROR_FIELD_MATCH_PATTERN_RHS;
-            case ERROR_ARG_LIST_MATCH_PATTERN_FIRST_ARG:
+        return switch (parentCtx) {
+            case LIST_MATCH_PATTERN -> ParserRuleContext.LIST_MATCH_PATTERN_MEMBER_RHS;
+            case MAPPING_MATCH_PATTERN -> ParserRuleContext.FIELD_MATCH_PATTERN_MEMBER_RHS;
+            case MATCH_PATTERN -> ParserRuleContext.MATCH_PATTERN_LIST_MEMBER_RHS;
+            case ERROR_MATCH_PATTERN,
+                 NAMED_ARG_MATCH_PATTERN -> ParserRuleContext.ERROR_FIELD_MATCH_PATTERN_RHS;
+            case ERROR_ARG_LIST_MATCH_PATTERN_FIRST_ARG -> {
                 endContext();
-                return ParserRuleContext.ERROR_MESSAGE_MATCH_PATTERN_END;
-            default:
-                return ParserRuleContext.OPTIONAL_MATCH_GUARD;
-        }
+                yield ParserRuleContext.ERROR_MESSAGE_MATCH_PATTERN_END;
+            }
+            default -> ParserRuleContext.OPTIONAL_MATCH_GUARD;
+        };
     }
 
     /**
@@ -5556,24 +5237,22 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
      */
     private ParserRuleContext getNextRuleForTypeReference() {
         ParserRuleContext parentCtx = getParentContext();
-        switch (parentCtx) {
-            case ERROR_CONSTRUCTOR:
-                return ParserRuleContext.ARG_LIST_OPEN_PAREN;
-            case OBJECT_CONSTRUCTOR:
-                return ParserRuleContext.OPEN_BRACE;
-            case ERROR_MATCH_PATTERN:
-            case ERROR_BINDING_PATTERN:
-                return ParserRuleContext.OPEN_PARENTHESIS;
-            case CLASS_DESCRIPTOR_IN_NEW_EXPR:
+        return switch (parentCtx) {
+            case ERROR_CONSTRUCTOR -> ParserRuleContext.ARG_LIST_OPEN_PAREN;
+            case OBJECT_CONSTRUCTOR -> ParserRuleContext.OPEN_BRACE;
+            case ERROR_MATCH_PATTERN,
+                 ERROR_BINDING_PATTERN -> ParserRuleContext.OPEN_PARENTHESIS;
+            case CLASS_DESCRIPTOR_IN_NEW_EXPR -> {
                 endContext();
-                return ParserRuleContext.ARG_LIST_OPEN_PAREN;
-            default:
+                yield ParserRuleContext.ARG_LIST_OPEN_PAREN;
+            }
+            default -> {
                 if (isInTypeDescContext()) {
-                    return ParserRuleContext.TYPE_DESC_RHS;
+                    yield ParserRuleContext.TYPE_DESC_RHS;
                 }
-
                 throw new IllegalStateException("getNextRuleForTypeReference found: " + parentCtx);
-        }
+            }
+        };
     }
 
     /**
@@ -5587,16 +5266,13 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
         }
 
         ParserRuleContext parentCtx = getParentContext();
-        switch (parentCtx) {
-            case ERROR_MATCH_PATTERN:
-                return ParserRuleContext.ERROR_MATCH_PATTERN_ERROR_KEYWORD_RHS;
-            case ERROR_BINDING_PATTERN:
-                return ParserRuleContext.ERROR_BINDING_PATTERN_ERROR_KEYWORD_RHS;
-            case ERROR_CONSTRUCTOR:
-                return ParserRuleContext.ERROR_CONSTRUCTOR_RHS;
-        }
+        return switch (parentCtx) {
+            case ERROR_MATCH_PATTERN -> ParserRuleContext.ERROR_MATCH_PATTERN_ERROR_KEYWORD_RHS;
+            case ERROR_BINDING_PATTERN -> ParserRuleContext.ERROR_BINDING_PATTERN_ERROR_KEYWORD_RHS;
+            case ERROR_CONSTRUCTOR -> ParserRuleContext.ERROR_CONSTRUCTOR_RHS;
+            default -> ParserRuleContext.ARG_LIST_OPEN_PAREN;
+        };
 
-        return ParserRuleContext.ARG_LIST_OPEN_PAREN;
     }
 
     /**
@@ -5632,14 +5308,11 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
 
     private ParserRuleContext getNextRuleForAction() {
         ParserRuleContext parentCtx = getParentContext();
-        switch (parentCtx) {
-            case MATCH_STMT:
-                return ParserRuleContext.MATCH_BODY;
-            case FOREACH_STMT:
-                return ParserRuleContext.BLOCK_STMT;
-            default:
-                return ParserRuleContext.SEMICOLON;
-        }
+        return switch (parentCtx) {
+            case MATCH_STMT -> ParserRuleContext.MATCH_BODY;
+            case FOREACH_STMT -> ParserRuleContext.BLOCK_STMT;
+            default -> ParserRuleContext.SEMICOLON;
+        };
     }
 
     /**
@@ -5649,36 +5322,34 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
      * @return <code>true</code> if the given context is a statement. <code>false</code> otherwise
      */
     private boolean isStatement(ParserRuleContext parentCtx) {
-        switch (parentCtx) {
-            case STATEMENT:
-            case STATEMENT_WITHOUT_ANNOTS:
-            case VAR_DECL_STMT:
-            case ASSIGNMENT_STMT:
-            case ASSIGNMENT_OR_VAR_DECL_STMT:
-            case IF_BLOCK:
-            case BLOCK_STMT:
-            case WHILE_BLOCK:
-            case DO_BLOCK:
-            case CALL_STMT:
-            case PANIC_STMT:
-            case CONTINUE_STATEMENT:
-            case BREAK_STATEMENT:
-            case RETURN_STMT:
-            case FAIL_STATEMENT:
-            case LOCAL_TYPE_DEFINITION_STMT:
-            case EXPRESSION_STATEMENT:
-            case LOCK_STMT:
-            case FORK_STMT:
-            case FOREACH_STMT:
-            case TRANSACTION_STMT:
-            case RETRY_STMT:
-            case ROLLBACK_STMT:
-            case AMBIGUOUS_STMT:
-            case MATCH_STMT:
-                return true;
-            default:
-                return false;
-        }
+        return switch (parentCtx) {
+            case STATEMENT,
+                 STATEMENT_WITHOUT_ANNOTS,
+                 VAR_DECL_STMT,
+                 ASSIGNMENT_STMT,
+                 ASSIGNMENT_OR_VAR_DECL_STMT,
+                 IF_BLOCK,
+                 BLOCK_STMT,
+                 WHILE_BLOCK,
+                 DO_BLOCK,
+                 CALL_STMT,
+                 PANIC_STMT,
+                 CONTINUE_STATEMENT,
+                 BREAK_STATEMENT,
+                 RETURN_STMT,
+                 FAIL_STATEMENT,
+                 LOCAL_TYPE_DEFINITION_STMT,
+                 EXPRESSION_STATEMENT,
+                 LOCK_STMT,
+                 FORK_STMT,
+                 FOREACH_STMT,
+                 TRANSACTION_STMT,
+                 RETRY_STMT,
+                 ROLLBACK_STMT,
+                 AMBIGUOUS_STMT,
+                 MATCH_STMT -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -5688,51 +5359,43 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
      * @return <code>true</code> if the given token refers to a binary operator. <code>false</code> otherwise
      */
     private boolean isBinaryOperator(STToken token) {
-        switch (token.kind) {
-            case PLUS_TOKEN:
-            case MINUS_TOKEN:
-            case SLASH_TOKEN:
-            case ASTERISK_TOKEN:
-            case GT_TOKEN:
-            case LT_TOKEN:
-            case DOUBLE_EQUAL_TOKEN:
-            case TRIPPLE_EQUAL_TOKEN:
-            case LT_EQUAL_TOKEN:
-            case GT_EQUAL_TOKEN:
-            case NOT_EQUAL_TOKEN:
-            case NOT_DOUBLE_EQUAL_TOKEN:
-            case BITWISE_AND_TOKEN:
-            case BITWISE_XOR_TOKEN:
-            case PIPE_TOKEN:
-            case LOGICAL_AND_TOKEN:
-            case LOGICAL_OR_TOKEN:
-            case DOUBLE_LT_TOKEN:
-            case DOUBLE_GT_TOKEN:
-            case TRIPPLE_GT_TOKEN:
-            case ELLIPSIS_TOKEN:
-            case DOUBLE_DOT_LT_TOKEN:
-            case ELVIS_TOKEN:
-                return true;
+        return switch (token.kind) {
+            case PLUS_TOKEN,
+                 MINUS_TOKEN,
+                 SLASH_TOKEN,
+                 ASTERISK_TOKEN,
+                 GT_TOKEN,
+                 LT_TOKEN,
+                 DOUBLE_EQUAL_TOKEN,
+                 TRIPPLE_EQUAL_TOKEN,
+                 LT_EQUAL_TOKEN,
+                 GT_EQUAL_TOKEN,
+                 NOT_EQUAL_TOKEN,
+                 NOT_DOUBLE_EQUAL_TOKEN,
+                 BITWISE_AND_TOKEN,
+                 BITWISE_XOR_TOKEN,
+                 PIPE_TOKEN,
+                 LOGICAL_AND_TOKEN,
+                 LOGICAL_OR_TOKEN,
+                 DOUBLE_LT_TOKEN,
+                 DOUBLE_GT_TOKEN,
+                 TRIPPLE_GT_TOKEN,
+                 ELLIPSIS_TOKEN,
+                 DOUBLE_DOT_LT_TOKEN,
+                 ELVIS_TOKEN -> true;
 
             // Treat these also as binary operators.
-            case RIGHT_ARROW_TOKEN:
-            case RIGHT_DOUBLE_ARROW_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+            case RIGHT_ARROW_TOKEN,
+                 RIGHT_DOUBLE_ARROW_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private boolean isParameter(ParserRuleContext ctx) {
-        switch (ctx) {
-            case REQUIRED_PARAM:
-            case DEFAULTABLE_PARAM:
-            case REST_PARAM:
-            case PARAM_LIST:
-                return true;
-            default:
-                return false;
-        }
+        return switch (ctx) {
+            case REQUIRED_PARAM, DEFAULTABLE_PARAM, REST_PARAM, PARAM_LIST -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -5769,428 +5432,276 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
      */
     @Override
     protected SyntaxKind getExpectedTokenKind(ParserRuleContext ctx) {
-        switch (ctx) {
-            case EXTERNAL_FUNC_BODY:
-                return SyntaxKind.EQUAL_TOKEN;
-            case FUNC_BODY_BLOCK:
-                return SyntaxKind.OPEN_BRACE_TOKEN;
-            case FUNC_DEF:
-            case FUNC_DEF_OR_FUNC_TYPE:
-            case FUNC_TYPE_DESC:
-            case FUNC_TYPE_DESC_OR_ANON_FUNC:
-                return SyntaxKind.FUNCTION_KEYWORD;
-            case SIMPLE_TYPE_DESCRIPTOR:
-                return SyntaxKind.ANY_KEYWORD;
-            case REQUIRED_PARAM:
-            case VAR_DECL_STMT:
-            case ASSIGNMENT_OR_VAR_DECL_STMT:
-            case DEFAULTABLE_PARAM:
-            case REST_PARAM:
-            case TYPE_NAME:
-            case TYPE_REFERENCE_IN_TYPE_INCLUSION:
-            case TYPE_REFERENCE:
-            case SIMPLE_TYPE_DESC_IDENTIFIER:
-            case FIELD_ACCESS_IDENTIFIER:
-            case FUNC_NAME:
-            case CLASS_NAME:
-            case VARIABLE_NAME:
-            case IMPORT_MODULE_NAME:
-            case IMPORT_ORG_OR_MODULE_NAME:
-            case IMPORT_PREFIX:
-            case VARIABLE_REF:
-            case BASIC_LITERAL: // return var-ref for any kind of terminal expression
-            case IDENTIFIER:
-            case QUALIFIED_IDENTIFIER_START_IDENTIFIER:
-            case NAMESPACE_PREFIX:
-            case IMPLICIT_ANON_FUNC_PARAM:
-            case METHOD_NAME:
-            case PEER_WORKER_NAME:
-            case RECEIVE_FIELD_NAME:
-            case WAIT_FIELD_NAME:
-            case FIELD_BINDING_PATTERN_NAME:
-            case XML_ATOMIC_NAME_IDENTIFIER:
-            case MAPPING_FIELD_NAME:
-            case WORKER_NAME:
-            case NAMED_WORKERS:
-            case ANNOTATION_TAG:
-            case AFTER_PARAMETER_TYPE:
-            case MODULE_ENUM_NAME:
-            case ENUM_MEMBER_NAME:
-            case TYPED_BINDING_PATTERN_TYPE_RHS:
-            case ASSIGNMENT_STMT:
-            case EXPRESSION:
-            case TERMINAL_EXPRESSION:
-            case XML_NAME:
-            case ACCESS_EXPRESSION:
-            case BINDING_PATTERN_STARTING_IDENTIFIER:
-            case COMPUTED_FIELD_NAME:
-            case SIMPLE_BINDING_PATTERN:
-            case ERROR_FIELD_BINDING_PATTERN:
-            case ERROR_CAUSE_SIMPLE_BINDING_PATTERN:
-            case PATH_SEGMENT_IDENT:
-            case TYPE_DESCRIPTOR:
-            case NAMED_ARG_BINDING_PATTERN:
-                return SyntaxKind.IDENTIFIER_TOKEN;
-            case DECIMAL_INTEGER_LITERAL_TOKEN:
-            case SIGNED_INT_OR_FLOAT_RHS:
-                return SyntaxKind.DECIMAL_INTEGER_LITERAL_TOKEN;
-            case STRING_LITERAL_TOKEN:
-                return SyntaxKind.STRING_LITERAL_TOKEN;
-            case OPTIONAL_TYPE_DESCRIPTOR:
-                return SyntaxKind.OPTIONAL_TYPE_DESC;
-            case ARRAY_TYPE_DESCRIPTOR:
-                return SyntaxKind.ARRAY_TYPE_DESC;
-            case HEX_INTEGER_LITERAL_TOKEN:
-                return SyntaxKind.HEX_INTEGER_LITERAL_TOKEN;
-            case OBJECT_FIELD_RHS:
-                return SyntaxKind.SEMICOLON_TOKEN;
-            case DECIMAL_FLOATING_POINT_LITERAL_TOKEN:
-                return SyntaxKind.DECIMAL_FLOATING_POINT_LITERAL_TOKEN;
-            case HEX_FLOATING_POINT_LITERAL_TOKEN:
-                return SyntaxKind.HEX_FLOATING_POINT_LITERAL_TOKEN;
-            case STATEMENT:
-            case STATEMENT_WITHOUT_ANNOTS:
-                return SyntaxKind.CLOSE_BRACE_TOKEN;
-            case ERROR_MATCH_PATTERN:
-            case NIL_LITERAL:
-                return SyntaxKind.OPEN_PAREN_TOKEN;
-            default:
-                return getExpectedSeperatorTokenKind(ctx);
-        }
+        return switch (ctx) {
+            case EXTERNAL_FUNC_BODY -> SyntaxKind.EQUAL_TOKEN;
+            case FUNC_BODY_BLOCK -> SyntaxKind.OPEN_BRACE_TOKEN;
+            case FUNC_DEF,
+                 FUNC_DEF_OR_FUNC_TYPE,
+                 FUNC_TYPE_DESC,
+                 FUNC_TYPE_DESC_OR_ANON_FUNC -> SyntaxKind.FUNCTION_KEYWORD;
+            case SIMPLE_TYPE_DESCRIPTOR -> SyntaxKind.ANY_KEYWORD;
+            case REQUIRED_PARAM,
+                 VAR_DECL_STMT,
+                 ASSIGNMENT_OR_VAR_DECL_STMT,
+                 DEFAULTABLE_PARAM,
+                 REST_PARAM,
+                 TYPE_NAME,
+                 TYPE_REFERENCE_IN_TYPE_INCLUSION,
+                 TYPE_REFERENCE,
+                 SIMPLE_TYPE_DESC_IDENTIFIER,
+                 FIELD_ACCESS_IDENTIFIER,
+                 FUNC_NAME,
+                 CLASS_NAME,
+                 VARIABLE_NAME,
+                 IMPORT_MODULE_NAME,
+                 IMPORT_ORG_OR_MODULE_NAME,
+                 IMPORT_PREFIX,
+                 VARIABLE_REF,
+                 BASIC_LITERAL, // return var-ref for any kind of terminal expression
+                 IDENTIFIER,
+                 QUALIFIED_IDENTIFIER_START_IDENTIFIER,
+                 NAMESPACE_PREFIX,
+                 IMPLICIT_ANON_FUNC_PARAM,
+                 METHOD_NAME,
+                 PEER_WORKER_NAME,
+                 RECEIVE_FIELD_NAME,
+                 WAIT_FIELD_NAME,
+                 FIELD_BINDING_PATTERN_NAME,
+                 XML_ATOMIC_NAME_IDENTIFIER,
+                 MAPPING_FIELD_NAME,
+                 WORKER_NAME,
+                 NAMED_WORKERS,
+                 ANNOTATION_TAG,
+                 AFTER_PARAMETER_TYPE,
+                 MODULE_ENUM_NAME,
+                 ENUM_MEMBER_NAME,
+                 TYPED_BINDING_PATTERN_TYPE_RHS,
+                 ASSIGNMENT_STMT,
+                 EXPRESSION,
+                 TERMINAL_EXPRESSION,
+                 XML_NAME,
+                 ACCESS_EXPRESSION,
+                 BINDING_PATTERN_STARTING_IDENTIFIER,
+                 COMPUTED_FIELD_NAME,
+                 SIMPLE_BINDING_PATTERN,
+                 ERROR_FIELD_BINDING_PATTERN,
+                 ERROR_CAUSE_SIMPLE_BINDING_PATTERN,
+                 PATH_SEGMENT_IDENT,
+                 TYPE_DESCRIPTOR,
+                 NAMED_ARG_BINDING_PATTERN -> SyntaxKind.IDENTIFIER_TOKEN;
+            case DECIMAL_INTEGER_LITERAL_TOKEN,
+                 SIGNED_INT_OR_FLOAT_RHS -> SyntaxKind.DECIMAL_INTEGER_LITERAL_TOKEN;
+            case STRING_LITERAL_TOKEN -> SyntaxKind.STRING_LITERAL_TOKEN;
+            case OPTIONAL_TYPE_DESCRIPTOR -> SyntaxKind.OPTIONAL_TYPE_DESC;
+            case ARRAY_TYPE_DESCRIPTOR -> SyntaxKind.ARRAY_TYPE_DESC;
+            case HEX_INTEGER_LITERAL_TOKEN -> SyntaxKind.HEX_INTEGER_LITERAL_TOKEN;
+            case OBJECT_FIELD_RHS -> SyntaxKind.SEMICOLON_TOKEN;
+            case DECIMAL_FLOATING_POINT_LITERAL_TOKEN -> SyntaxKind.DECIMAL_FLOATING_POINT_LITERAL_TOKEN;
+            case HEX_FLOATING_POINT_LITERAL_TOKEN -> SyntaxKind.HEX_FLOATING_POINT_LITERAL_TOKEN;
+            case STATEMENT,
+                 STATEMENT_WITHOUT_ANNOTS -> SyntaxKind.CLOSE_BRACE_TOKEN;
+            case ERROR_MATCH_PATTERN,
+                 NIL_LITERAL -> SyntaxKind.OPEN_PAREN_TOKEN;
+            default -> getExpectedSeperatorTokenKind(ctx);
+        };
     }
 
     protected SyntaxKind getExpectedSeperatorTokenKind(ParserRuleContext ctx) {
-        switch (ctx) {
-            case BITWISE_AND_OPERATOR:
-                return SyntaxKind.BITWISE_AND_TOKEN;
-            case EQUAL_OR_RIGHT_ARROW:
-                return SyntaxKind.EQUAL_TOKEN;
-            case EOF:
-                return SyntaxKind.EOF_TOKEN;
-            case ASSIGN_OP:
-                return SyntaxKind.EQUAL_TOKEN;
-            case BINARY_OPERATOR:
-                return SyntaxKind.PLUS_TOKEN;
-            case CLOSE_BRACE:
-                return SyntaxKind.CLOSE_BRACE_TOKEN;
-            case CLOSE_PARENTHESIS:
-            case ARG_LIST_CLOSE_PAREN:
-                return SyntaxKind.CLOSE_PAREN_TOKEN;
-            case COMMA:
-            case ERROR_MESSAGE_BINDING_PATTERN_END_COMMA:
-            case ERROR_MESSAGE_MATCH_PATTERN_END_COMMA:
-                return SyntaxKind.COMMA_TOKEN;
-            case OPEN_BRACE:
-                return SyntaxKind.OPEN_BRACE_TOKEN;
-            case OPEN_PARENTHESIS:
-            case ARG_LIST_OPEN_PAREN:
-            case PARENTHESISED_TYPE_DESC_START:
-                return SyntaxKind.OPEN_PAREN_TOKEN;
-            case SEMICOLON:
-                return SyntaxKind.SEMICOLON_TOKEN;
-            case ASTERISK:
-                return SyntaxKind.ASTERISK_TOKEN;
-            case CLOSED_RECORD_BODY_END:
-                return SyntaxKind.CLOSE_BRACE_PIPE_TOKEN;
-            case CLOSED_RECORD_BODY_START:
-                return SyntaxKind.OPEN_BRACE_PIPE_TOKEN;
-            case ELLIPSIS:
-                return SyntaxKind.ELLIPSIS_TOKEN;
-            case QUESTION_MARK:
-                return SyntaxKind.QUESTION_MARK_TOKEN;
-            case CLOSE_BRACKET:
-                return SyntaxKind.CLOSE_BRACKET_TOKEN;
-            case DOT:
-            case METHOD_CALL_DOT:
-                return SyntaxKind.DOT_TOKEN;
-            case OPEN_BRACKET:
-            case TUPLE_TYPE_DESC_START:
-                return SyntaxKind.OPEN_BRACKET_TOKEN;
-            case SLASH:
-            case ABSOLUTE_PATH_SINGLE_SLASH:
-            case RESOURCE_METHOD_CALL_SLASH_TOKEN:
-                return SyntaxKind.SLASH_TOKEN;
-            case COLON:
-            case TYPE_REF_COLON:
-            case VAR_REF_COLON:
-                return SyntaxKind.COLON_TOKEN;
-            case UNARY_OPERATOR:
-            case COMPOUND_BINARY_OPERATOR:
-            case UNARY_EXPRESSION:
-            case EXPRESSION_RHS:
-                return SyntaxKind.PLUS_TOKEN;
-            case AT:
-                return SyntaxKind.AT_TOKEN;
-            case RIGHT_ARROW:
-                return SyntaxKind.RIGHT_ARROW_TOKEN;
-            case GT:
-            case INFERRED_TYPEDESC_DEFAULT_END_GT:
-                return SyntaxKind.GT_TOKEN;
-            case LT:
-            case STREAM_TYPE_PARAM_START_TOKEN:
-            case INFERRED_TYPEDESC_DEFAULT_START_LT:
-                return SyntaxKind.LT_TOKEN;
-            case SYNC_SEND_TOKEN:
-                return SyntaxKind.SYNC_SEND_TOKEN;
-            case ANNOT_CHAINING_TOKEN:
-                return SyntaxKind.ANNOT_CHAINING_TOKEN;
-            case OPTIONAL_CHAINING_TOKEN:
-                return SyntaxKind.OPTIONAL_CHAINING_TOKEN;
-            case DOT_LT_TOKEN:
-                return SyntaxKind.DOT_LT_TOKEN;
-            case SLASH_LT_TOKEN:
-                return SyntaxKind.SLASH_LT_TOKEN;
-            case DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN:
-                return SyntaxKind.DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN;
-            case SLASH_ASTERISK_TOKEN:
-                return SyntaxKind.SLASH_ASTERISK_TOKEN;
-            case PLUS_TOKEN:
-                return SyntaxKind.PLUS_TOKEN;
-            case MINUS_TOKEN:
-                return SyntaxKind.MINUS_TOKEN;
-            case LEFT_ARROW_TOKEN:
-                return SyntaxKind.LEFT_ARROW_TOKEN;
-            case TEMPLATE_END:
-            case TEMPLATE_START:
-                return SyntaxKind.BACKTICK_TOKEN;
-            case LT_TOKEN:
-                return SyntaxKind.LT_TOKEN;
-            case GT_TOKEN:
-                return SyntaxKind.GT_TOKEN;
-            case INTERPOLATION_START_TOKEN:
-                return SyntaxKind.INTERPOLATION_START_TOKEN;
-            case EXPR_FUNC_BODY_START:
-            case RIGHT_DOUBLE_ARROW:
-                return SyntaxKind.RIGHT_DOUBLE_ARROW_TOKEN;
-            default:
-                return getExpectedKeywordKind(ctx);
-        }
+        return switch (ctx) {
+            case BITWISE_AND_OPERATOR -> SyntaxKind.BITWISE_AND_TOKEN;
+            case EQUAL_OR_RIGHT_ARROW,
+                 ASSIGN_OP -> SyntaxKind.EQUAL_TOKEN;
+            case EOF -> SyntaxKind.EOF_TOKEN;
+            case BINARY_OPERATOR -> SyntaxKind.PLUS_TOKEN;
+            case CLOSE_BRACE -> SyntaxKind.CLOSE_BRACE_TOKEN;
+            case CLOSE_PARENTHESIS,
+                 ARG_LIST_CLOSE_PAREN -> SyntaxKind.CLOSE_PAREN_TOKEN;
+            case COMMA,
+                 ERROR_MESSAGE_BINDING_PATTERN_END_COMMA,
+                 ERROR_MESSAGE_MATCH_PATTERN_END_COMMA -> SyntaxKind.COMMA_TOKEN;
+            case OPEN_BRACE -> SyntaxKind.OPEN_BRACE_TOKEN;
+            case OPEN_PARENTHESIS,
+                 ARG_LIST_OPEN_PAREN,
+                 PARENTHESISED_TYPE_DESC_START -> SyntaxKind.OPEN_PAREN_TOKEN;
+            case SEMICOLON -> SyntaxKind.SEMICOLON_TOKEN;
+            case ASTERISK -> SyntaxKind.ASTERISK_TOKEN;
+            case CLOSED_RECORD_BODY_END -> SyntaxKind.CLOSE_BRACE_PIPE_TOKEN;
+            case CLOSED_RECORD_BODY_START -> SyntaxKind.OPEN_BRACE_PIPE_TOKEN;
+            case ELLIPSIS -> SyntaxKind.ELLIPSIS_TOKEN;
+            case QUESTION_MARK -> SyntaxKind.QUESTION_MARK_TOKEN;
+            case CLOSE_BRACKET -> SyntaxKind.CLOSE_BRACKET_TOKEN;
+            case DOT,
+                 METHOD_CALL_DOT -> SyntaxKind.DOT_TOKEN;
+            case OPEN_BRACKET,
+                 TUPLE_TYPE_DESC_START -> SyntaxKind.OPEN_BRACKET_TOKEN;
+            case SLASH,
+                 ABSOLUTE_PATH_SINGLE_SLASH,
+                 RESOURCE_METHOD_CALL_SLASH_TOKEN -> SyntaxKind.SLASH_TOKEN;
+            case COLON,
+                 TYPE_REF_COLON,
+                 VAR_REF_COLON -> SyntaxKind.COLON_TOKEN;
+            case UNARY_OPERATOR,
+                 COMPOUND_BINARY_OPERATOR,
+                 UNARY_EXPRESSION,
+                 EXPRESSION_RHS -> SyntaxKind.PLUS_TOKEN;
+            case AT -> SyntaxKind.AT_TOKEN;
+            case RIGHT_ARROW -> SyntaxKind.RIGHT_ARROW_TOKEN;
+            case GT,
+                 INFERRED_TYPEDESC_DEFAULT_END_GT -> SyntaxKind.GT_TOKEN;
+            case LT,
+                 STREAM_TYPE_PARAM_START_TOKEN,
+                 INFERRED_TYPEDESC_DEFAULT_START_LT -> SyntaxKind.LT_TOKEN;
+            case SYNC_SEND_TOKEN -> SyntaxKind.SYNC_SEND_TOKEN;
+            case ANNOT_CHAINING_TOKEN -> SyntaxKind.ANNOT_CHAINING_TOKEN;
+            case OPTIONAL_CHAINING_TOKEN -> SyntaxKind.OPTIONAL_CHAINING_TOKEN;
+            case DOT_LT_TOKEN -> SyntaxKind.DOT_LT_TOKEN;
+            case SLASH_LT_TOKEN -> SyntaxKind.SLASH_LT_TOKEN;
+            case DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN -> SyntaxKind.DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN;
+            case SLASH_ASTERISK_TOKEN -> SyntaxKind.SLASH_ASTERISK_TOKEN;
+            case PLUS_TOKEN -> SyntaxKind.PLUS_TOKEN;
+            case MINUS_TOKEN -> SyntaxKind.MINUS_TOKEN;
+            case LEFT_ARROW_TOKEN -> SyntaxKind.LEFT_ARROW_TOKEN;
+            case TEMPLATE_END,
+                 TEMPLATE_START -> SyntaxKind.BACKTICK_TOKEN;
+            case LT_TOKEN -> SyntaxKind.LT_TOKEN;
+            case GT_TOKEN -> SyntaxKind.GT_TOKEN;
+            case INTERPOLATION_START_TOKEN -> SyntaxKind.INTERPOLATION_START_TOKEN;
+            case EXPR_FUNC_BODY_START,
+                 RIGHT_DOUBLE_ARROW -> SyntaxKind.RIGHT_DOUBLE_ARROW_TOKEN;
+            default -> getExpectedKeywordKind(ctx);
+        };
     }
 
     protected SyntaxKind getExpectedKeywordKind(ParserRuleContext ctx) {
-        switch (ctx) {
-            case EXTERNAL_KEYWORD:
-                return SyntaxKind.EXTERNAL_KEYWORD;
-            case FUNCTION_KEYWORD:
-                return SyntaxKind.FUNCTION_KEYWORD;
-            case RETURNS_KEYWORD:
-                return SyntaxKind.RETURNS_KEYWORD;
-            case PUBLIC_KEYWORD:
-                return SyntaxKind.PUBLIC_KEYWORD;
-            case RECORD_FIELD:
-            case RECORD_KEYWORD:
-                return SyntaxKind.RECORD_KEYWORD;
-            case TYPE_KEYWORD:
-                return SyntaxKind.TYPE_KEYWORD;
-            case OBJECT_KEYWORD:
-            case OBJECT_IDENT:
-            case OBJECT_TYPE_DESCRIPTOR:
-                return SyntaxKind.OBJECT_KEYWORD;
-            case PRIVATE_KEYWORD:
-                return SyntaxKind.PRIVATE_KEYWORD;
-            case REMOTE_IDENT:
-                return SyntaxKind.REMOTE_KEYWORD;
-            case ABSTRACT_KEYWORD:
-                return SyntaxKind.ABSTRACT_KEYWORD;
-            case CLIENT_KEYWORD:
-                return SyntaxKind.CLIENT_KEYWORD;
-            case IF_KEYWORD:
-                return SyntaxKind.IF_KEYWORD;
-            case ELSE_KEYWORD:
-                return SyntaxKind.ELSE_KEYWORD;
-            case WHILE_KEYWORD:
-                return SyntaxKind.WHILE_KEYWORD;
-            case CHECKING_KEYWORD:
-                return SyntaxKind.CHECK_KEYWORD;
-            case FAIL_KEYWORD:
-                return SyntaxKind.FAIL_KEYWORD;
-            case AS_KEYWORD:
-                return SyntaxKind.AS_KEYWORD;
-            case BOOLEAN_LITERAL:
-                return SyntaxKind.TRUE_KEYWORD;
-            case IMPORT_KEYWORD:
-                return SyntaxKind.IMPORT_KEYWORD;
-            case ON_KEYWORD:
-                return SyntaxKind.ON_KEYWORD;
-            case PANIC_KEYWORD:
-                return SyntaxKind.PANIC_KEYWORD;
-            case RETURN_KEYWORD:
-                return SyntaxKind.RETURN_KEYWORD;
-            case SERVICE_KEYWORD:
-            case SERVICE_IDENT:
-                return SyntaxKind.SERVICE_KEYWORD;
-            case BREAK_KEYWORD:
-                return SyntaxKind.BREAK_KEYWORD;
-            case LISTENER_KEYWORD:
-                return SyntaxKind.LISTENER_KEYWORD;
-            case CONTINUE_KEYWORD:
-                return SyntaxKind.CONTINUE_KEYWORD;
-            case CONST_KEYWORD:
-                return SyntaxKind.CONST_KEYWORD;
-            case FINAL_KEYWORD:
-                return SyntaxKind.FINAL_KEYWORD;
-            case IS_KEYWORD:
-                return SyntaxKind.IS_KEYWORD;
-            case TYPEOF_KEYWORD:
-                return SyntaxKind.TYPEOF_KEYWORD;
-            case MAP_KEYWORD:
-            case MAP_TYPE_DESCRIPTOR:
-                return SyntaxKind.MAP_KEYWORD;
-            case PARAMETERIZED_TYPE:
-                return SyntaxKind.ERROR_KEYWORD;
-            case NULL_KEYWORD:
-                return SyntaxKind.NULL_KEYWORD;
-            case LOCK_KEYWORD:
-                return SyntaxKind.LOCK_KEYWORD;
-            case ANNOTATION_KEYWORD:
-                return SyntaxKind.ANNOTATION_KEYWORD;
-            case SINGLE_KEYWORD_ATTACH_POINT_IDENT:
-                return SyntaxKind.TYPE_KEYWORD;
-            case IDENT_AFTER_OBJECT_IDENT:
-                return SyntaxKind.FUNCTION_KEYWORD;
-            case FIELD_IDENT:
-                return SyntaxKind.FIELD_KEYWORD;
-            case FUNCTION_IDENT:
-                return SyntaxKind.FUNCTION_KEYWORD;
-            case RECORD_IDENT:
-                return SyntaxKind.RECORD_KEYWORD;
-            case XMLNS_KEYWORD:
-            case XML_NAMESPACE_DECLARATION:
-                return SyntaxKind.XMLNS_KEYWORD;
-            case SOURCE_KEYWORD:
-                return SyntaxKind.SOURCE_KEYWORD;
-            case START_KEYWORD:
-                return SyntaxKind.START_KEYWORD;
-            case FLUSH_KEYWORD:
-                return SyntaxKind.FLUSH_KEYWORD;
-            case OPTIONAL_PEER_WORKER:
-            case DEFAULT_WORKER_NAME_IN_ASYNC_SEND:
-                return SyntaxKind.FUNCTION_KEYWORD;
-            case WAIT_KEYWORD:
-                return SyntaxKind.WAIT_KEYWORD;
-            case TRANSACTION_KEYWORD:
-                return SyntaxKind.TRANSACTION_KEYWORD;
-            case TRANSACTIONAL_KEYWORD:
-                return SyntaxKind.TRANSACTIONAL_KEYWORD;
-            case COMMIT_KEYWORD:
-                return SyntaxKind.COMMIT_KEYWORD;
-            case RETRY_KEYWORD:
-                return SyntaxKind.RETRY_KEYWORD;
-            case ROLLBACK_KEYWORD:
-                return SyntaxKind.ROLLBACK_KEYWORD;
-            case ENUM_KEYWORD:
-                return SyntaxKind.ENUM_KEYWORD;
-            case MATCH_KEYWORD:
-                return SyntaxKind.MATCH_KEYWORD;
-            case NEW_KEYWORD:
-                return SyntaxKind.NEW_KEYWORD;
-            case FORK_KEYWORD:
-                return SyntaxKind.FORK_KEYWORD;
-            case NAMED_WORKER_DECL:
-            case WORKER_KEYWORD:
-                return SyntaxKind.WORKER_KEYWORD;
-            case TRAP_KEYWORD:
-                return SyntaxKind.TRAP_KEYWORD;
-            case FOREACH_KEYWORD:
-                return SyntaxKind.FOREACH_KEYWORD;
-            case IN_KEYWORD:
-                return SyntaxKind.IN_KEYWORD;
-            case PIPE:
-            case UNION_OR_INTERSECTION_TOKEN:
-                return SyntaxKind.PIPE_TOKEN;
-            case TABLE_KEYWORD:
-                return SyntaxKind.TABLE_KEYWORD;
-            case KEY_KEYWORD:
-                return SyntaxKind.KEY_KEYWORD;
-            case ERROR_KEYWORD:
-            case ERROR_BINDING_PATTERN:
-                return SyntaxKind.ERROR_KEYWORD;
-            case STREAM_KEYWORD:
-                return SyntaxKind.STREAM_KEYWORD;
-            case LET_KEYWORD:
-                return SyntaxKind.LET_KEYWORD;
-            case XML_KEYWORD:
-                return SyntaxKind.XML_KEYWORD;
-            case RE_KEYWORD:
-                return SyntaxKind.RE_KEYWORD;
-            case STRING_KEYWORD:
-                return SyntaxKind.STRING_KEYWORD;
-            case BASE16_KEYWORD:
-                return SyntaxKind.BASE16_KEYWORD;
-            case BASE64_KEYWORD:
-                return SyntaxKind.BASE64_KEYWORD;
-            case SELECT_KEYWORD:
-                return SyntaxKind.SELECT_KEYWORD;
-            case WHERE_KEYWORD:
-                return SyntaxKind.WHERE_KEYWORD;
-            case FROM_KEYWORD:
-                return SyntaxKind.FROM_KEYWORD;
-            case ORDER_KEYWORD:
-                return SyntaxKind.ORDER_KEYWORD;
-            case GROUP_KEYWORD:
-                return SyntaxKind.GROUP_KEYWORD;
-            case BY_KEYWORD:
-                return SyntaxKind.BY_KEYWORD;
-            case ORDER_DIRECTION:
-                return SyntaxKind.ASCENDING_KEYWORD;
-            case DO_KEYWORD:
-                return SyntaxKind.DO_KEYWORD;
-            case DISTINCT_KEYWORD:
-                return SyntaxKind.DISTINCT_KEYWORD;
-            case VAR_KEYWORD:
-                return SyntaxKind.VAR_KEYWORD;
-            case CONFLICT_KEYWORD:
-                return SyntaxKind.CONFLICT_KEYWORD;
-            case LIMIT_KEYWORD:
-                return SyntaxKind.LIMIT_KEYWORD;
-            case EQUALS_KEYWORD:
-                return SyntaxKind.EQUALS_KEYWORD;
-            case JOIN_KEYWORD:
-                return SyntaxKind.JOIN_KEYWORD;
-            case OUTER_KEYWORD:
-                return SyntaxKind.OUTER_KEYWORD;
-            case CLASS_KEYWORD:
-                return SyntaxKind.CLASS_KEYWORD;
-            case COLLECT_KEYWORD:
-                return SyntaxKind.COLLECT_KEYWORD;
-            default:
-                return getExpectedQualifierKind(ctx);
-        }
+        return switch (ctx) {
+            case EXTERNAL_KEYWORD -> SyntaxKind.EXTERNAL_KEYWORD;
+            case FUNCTION_KEYWORD,
+                 IDENT_AFTER_OBJECT_IDENT,
+                 FUNCTION_IDENT,
+                 OPTIONAL_PEER_WORKER,
+                 DEFAULT_WORKER_NAME_IN_ASYNC_SEND -> SyntaxKind.FUNCTION_KEYWORD;
+            case RETURNS_KEYWORD -> SyntaxKind.RETURNS_KEYWORD;
+            case PUBLIC_KEYWORD -> SyntaxKind.PUBLIC_KEYWORD;
+            case RECORD_FIELD,
+                 RECORD_KEYWORD,
+                 RECORD_IDENT -> SyntaxKind.RECORD_KEYWORD;
+            case TYPE_KEYWORD,
+                 SINGLE_KEYWORD_ATTACH_POINT_IDENT -> SyntaxKind.TYPE_KEYWORD;
+            case OBJECT_KEYWORD,
+                 OBJECT_IDENT,
+                 OBJECT_TYPE_DESCRIPTOR -> SyntaxKind.OBJECT_KEYWORD;
+            case PRIVATE_KEYWORD -> SyntaxKind.PRIVATE_KEYWORD;
+            case REMOTE_IDENT -> SyntaxKind.REMOTE_KEYWORD;
+            case ABSTRACT_KEYWORD -> SyntaxKind.ABSTRACT_KEYWORD;
+            case CLIENT_KEYWORD -> SyntaxKind.CLIENT_KEYWORD;
+            case IF_KEYWORD -> SyntaxKind.IF_KEYWORD;
+            case ELSE_KEYWORD -> SyntaxKind.ELSE_KEYWORD;
+            case WHILE_KEYWORD -> SyntaxKind.WHILE_KEYWORD;
+            case CHECKING_KEYWORD -> SyntaxKind.CHECK_KEYWORD;
+            case FAIL_KEYWORD -> SyntaxKind.FAIL_KEYWORD;
+            case AS_KEYWORD -> SyntaxKind.AS_KEYWORD;
+            case BOOLEAN_LITERAL -> SyntaxKind.TRUE_KEYWORD;
+            case IMPORT_KEYWORD -> SyntaxKind.IMPORT_KEYWORD;
+            case ON_KEYWORD -> SyntaxKind.ON_KEYWORD;
+            case PANIC_KEYWORD -> SyntaxKind.PANIC_KEYWORD;
+            case RETURN_KEYWORD -> SyntaxKind.RETURN_KEYWORD;
+            case SERVICE_KEYWORD,
+                 SERVICE_IDENT -> SyntaxKind.SERVICE_KEYWORD;
+            case BREAK_KEYWORD -> SyntaxKind.BREAK_KEYWORD;
+            case LISTENER_KEYWORD -> SyntaxKind.LISTENER_KEYWORD;
+            case CONTINUE_KEYWORD -> SyntaxKind.CONTINUE_KEYWORD;
+            case CONST_KEYWORD -> SyntaxKind.CONST_KEYWORD;
+            case FINAL_KEYWORD -> SyntaxKind.FINAL_KEYWORD;
+            case IS_KEYWORD -> SyntaxKind.IS_KEYWORD;
+            case TYPEOF_KEYWORD -> SyntaxKind.TYPEOF_KEYWORD;
+            case MAP_KEYWORD,
+                 MAP_TYPE_DESCRIPTOR -> SyntaxKind.MAP_KEYWORD;
+            case PARAMETERIZED_TYPE,
+                 ERROR_KEYWORD,
+                 ERROR_BINDING_PATTERN -> SyntaxKind.ERROR_KEYWORD;
+            case NULL_KEYWORD -> SyntaxKind.NULL_KEYWORD;
+            case LOCK_KEYWORD -> SyntaxKind.LOCK_KEYWORD;
+            case ANNOTATION_KEYWORD -> SyntaxKind.ANNOTATION_KEYWORD;
+            case FIELD_IDENT -> SyntaxKind.FIELD_KEYWORD;
+            case XMLNS_KEYWORD,
+                 XML_NAMESPACE_DECLARATION -> SyntaxKind.XMLNS_KEYWORD;
+            case SOURCE_KEYWORD -> SyntaxKind.SOURCE_KEYWORD;
+            case START_KEYWORD -> SyntaxKind.START_KEYWORD;
+            case FLUSH_KEYWORD -> SyntaxKind.FLUSH_KEYWORD;
+            case WAIT_KEYWORD -> SyntaxKind.WAIT_KEYWORD;
+            case TRANSACTION_KEYWORD -> SyntaxKind.TRANSACTION_KEYWORD;
+            case TRANSACTIONAL_KEYWORD -> SyntaxKind.TRANSACTIONAL_KEYWORD;
+            case COMMIT_KEYWORD -> SyntaxKind.COMMIT_KEYWORD;
+            case RETRY_KEYWORD -> SyntaxKind.RETRY_KEYWORD;
+            case ROLLBACK_KEYWORD -> SyntaxKind.ROLLBACK_KEYWORD;
+            case ENUM_KEYWORD -> SyntaxKind.ENUM_KEYWORD;
+            case MATCH_KEYWORD -> SyntaxKind.MATCH_KEYWORD;
+            case NEW_KEYWORD -> SyntaxKind.NEW_KEYWORD;
+            case FORK_KEYWORD -> SyntaxKind.FORK_KEYWORD;
+            case NAMED_WORKER_DECL,
+                 WORKER_KEYWORD -> SyntaxKind.WORKER_KEYWORD;
+            case TRAP_KEYWORD -> SyntaxKind.TRAP_KEYWORD;
+            case FOREACH_KEYWORD -> SyntaxKind.FOREACH_KEYWORD;
+            case IN_KEYWORD -> SyntaxKind.IN_KEYWORD;
+            case PIPE,
+                 UNION_OR_INTERSECTION_TOKEN -> SyntaxKind.PIPE_TOKEN;
+            case TABLE_KEYWORD -> SyntaxKind.TABLE_KEYWORD;
+            case KEY_KEYWORD -> SyntaxKind.KEY_KEYWORD;
+            case STREAM_KEYWORD -> SyntaxKind.STREAM_KEYWORD;
+            case LET_KEYWORD -> SyntaxKind.LET_KEYWORD;
+            case XML_KEYWORD -> SyntaxKind.XML_KEYWORD;
+            case RE_KEYWORD -> SyntaxKind.RE_KEYWORD;
+            case STRING_KEYWORD -> SyntaxKind.STRING_KEYWORD;
+            case BASE16_KEYWORD -> SyntaxKind.BASE16_KEYWORD;
+            case BASE64_KEYWORD -> SyntaxKind.BASE64_KEYWORD;
+            case SELECT_KEYWORD -> SyntaxKind.SELECT_KEYWORD;
+            case WHERE_KEYWORD -> SyntaxKind.WHERE_KEYWORD;
+            case FROM_KEYWORD -> SyntaxKind.FROM_KEYWORD;
+            case ORDER_KEYWORD -> SyntaxKind.ORDER_KEYWORD;
+            case GROUP_KEYWORD -> SyntaxKind.GROUP_KEYWORD;
+            case BY_KEYWORD -> SyntaxKind.BY_KEYWORD;
+            case ORDER_DIRECTION -> SyntaxKind.ASCENDING_KEYWORD;
+            case DO_KEYWORD -> SyntaxKind.DO_KEYWORD;
+            case DISTINCT_KEYWORD -> SyntaxKind.DISTINCT_KEYWORD;
+            case VAR_KEYWORD -> SyntaxKind.VAR_KEYWORD;
+            case CONFLICT_KEYWORD -> SyntaxKind.CONFLICT_KEYWORD;
+            case LIMIT_KEYWORD -> SyntaxKind.LIMIT_KEYWORD;
+            case EQUALS_KEYWORD -> SyntaxKind.EQUALS_KEYWORD;
+            case JOIN_KEYWORD -> SyntaxKind.JOIN_KEYWORD;
+            case OUTER_KEYWORD -> SyntaxKind.OUTER_KEYWORD;
+            case CLASS_KEYWORD -> SyntaxKind.CLASS_KEYWORD;
+            case COLLECT_KEYWORD -> SyntaxKind.COLLECT_KEYWORD;
+            default -> getExpectedQualifierKind(ctx);
+        };
     }
 
     protected SyntaxKind getExpectedQualifierKind(ParserRuleContext ctx) {
         // Ideally, optimal solution should not be an INSERT action on qualifiers.
         // Therefore, qualifier ctxs are pointed to the end of qualifier parsing token to exit early.
-        switch (ctx) {
-            case FIRST_OBJECT_CONS_QUALIFIER:
-            case SECOND_OBJECT_CONS_QUALIFIER:
-            case FIRST_OBJECT_TYPE_QUALIFIER:
-            case SECOND_OBJECT_TYPE_QUALIFIER:
-                return SyntaxKind.OBJECT_KEYWORD;
-            case FIRST_CLASS_TYPE_QUALIFIER:
-            case SECOND_CLASS_TYPE_QUALIFIER:
-            case THIRD_CLASS_TYPE_QUALIFIER:
-            case FOURTH_CLASS_TYPE_QUALIFIER:
-                return SyntaxKind.CLASS_KEYWORD;
-            case FUNC_DEF_FIRST_QUALIFIER:
-            case FUNC_DEF_SECOND_QUALIFIER:
-            case FUNC_TYPE_FIRST_QUALIFIER:
-            case FUNC_TYPE_SECOND_QUALIFIER:
-            case OBJECT_METHOD_FIRST_QUALIFIER:
-            case OBJECT_METHOD_SECOND_QUALIFIER:
-            case OBJECT_METHOD_THIRD_QUALIFIER:
-            case OBJECT_METHOD_FOURTH_QUALIFIER:
-                return SyntaxKind.FUNCTION_KEYWORD;
-            case MODULE_VAR_FIRST_QUAL:
-            case MODULE_VAR_SECOND_QUAL:
-            case MODULE_VAR_THIRD_QUAL:
-            case OBJECT_MEMBER_VISIBILITY_QUAL:
-                return SyntaxKind.IDENTIFIER_TOKEN;
-            case SERVICE_DECL_QUALIFIER:
-                return SyntaxKind.SERVICE_KEYWORD;
-            default:
-                return SyntaxKind.NONE;
-        }
+        return switch (ctx) {
+            case FIRST_OBJECT_CONS_QUALIFIER,
+                 SECOND_OBJECT_CONS_QUALIFIER,
+                 FIRST_OBJECT_TYPE_QUALIFIER,
+                 SECOND_OBJECT_TYPE_QUALIFIER -> SyntaxKind.OBJECT_KEYWORD;
+            case FIRST_CLASS_TYPE_QUALIFIER,
+                 SECOND_CLASS_TYPE_QUALIFIER,
+                 THIRD_CLASS_TYPE_QUALIFIER,
+                 FOURTH_CLASS_TYPE_QUALIFIER -> SyntaxKind.CLASS_KEYWORD;
+            case FUNC_DEF_FIRST_QUALIFIER,
+                 FUNC_DEF_SECOND_QUALIFIER,
+                 FUNC_TYPE_FIRST_QUALIFIER,
+                 FUNC_TYPE_SECOND_QUALIFIER,
+                 OBJECT_METHOD_FIRST_QUALIFIER,
+                 OBJECT_METHOD_SECOND_QUALIFIER,
+                 OBJECT_METHOD_THIRD_QUALIFIER,
+                 OBJECT_METHOD_FOURTH_QUALIFIER -> SyntaxKind.FUNCTION_KEYWORD;
+            case MODULE_VAR_FIRST_QUAL,
+                 MODULE_VAR_SECOND_QUAL,
+                 MODULE_VAR_THIRD_QUAL,
+                 OBJECT_MEMBER_VISIBILITY_QUAL -> SyntaxKind.IDENTIFIER_TOKEN;
+            case SERVICE_DECL_QUALIFIER -> SyntaxKind.SERVICE_KEYWORD;
+            default -> SyntaxKind.NONE;
+        };
     }
 
     /**
@@ -6200,19 +5711,17 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
      * @return <code>true</code> if the given token kind belongs to a basic literal.<code>false</code> otherwise
      */
     private boolean isBasicLiteral(SyntaxKind kind) {
-        switch (kind) {
-            case DECIMAL_INTEGER_LITERAL_TOKEN:
-            case HEX_INTEGER_LITERAL_TOKEN:
-            case STRING_LITERAL_TOKEN:
-            case TRUE_KEYWORD:
-            case FALSE_KEYWORD:
-            case NULL_KEYWORD:
-            case DECIMAL_FLOATING_POINT_LITERAL_TOKEN:
-            case HEX_FLOATING_POINT_LITERAL_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (kind) {
+            case DECIMAL_INTEGER_LITERAL_TOKEN,
+                 HEX_INTEGER_LITERAL_TOKEN,
+                 STRING_LITERAL_TOKEN,
+                 TRUE_KEYWORD,
+                 FALSE_KEYWORD,
+                 NULL_KEYWORD,
+                 DECIMAL_FLOATING_POINT_LITERAL_TOKEN,
+                 HEX_FLOATING_POINT_LITERAL_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -6222,34 +5731,30 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
      * @return <code>true</code> if the given token refers to a unary operator. <code>false</code> otherwise
      */
     private boolean isUnaryOperator(STToken token) {
-        switch (token.kind) {
-            case PLUS_TOKEN:
-            case MINUS_TOKEN:
-            case NEGATION_TOKEN:
-            case EXCLAMATION_MARK_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (token.kind) {
+            case PLUS_TOKEN,
+                 MINUS_TOKEN,
+                 NEGATION_TOKEN,
+                 EXCLAMATION_MARK_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private boolean isSingleKeywordAttachPointIdent(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case ANNOTATION_KEYWORD:
-            case EXTERNAL_KEYWORD:
-            case VAR_KEYWORD:
-            case CONST_KEYWORD:
-            case LISTENER_KEYWORD:
-            case WORKER_KEYWORD:
-            case TYPE_KEYWORD:
-            case FUNCTION_KEYWORD:
-            case PARAMETER_KEYWORD:
-            case RETURN_KEYWORD:
-            case FIELD_KEYWORD:
-            case CLASS_KEYWORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tokenKind) {
+            case ANNOTATION_KEYWORD,
+                 EXTERNAL_KEYWORD,
+                 VAR_KEYWORD,
+                 CONST_KEYWORD,
+                 LISTENER_KEYWORD,
+                 WORKER_KEYWORD,
+                 TYPE_KEYWORD,
+                 FUNCTION_KEYWORD,
+                 PARAMETER_KEYWORD,
+                 RETURN_KEYWORD,
+                 FIELD_KEYWORD,
+                 CLASS_KEYWORD -> true;
+            default -> false;
+        };
     }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/DocumentationLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/DocumentationLexer.java
@@ -63,46 +63,34 @@ public class DocumentationLexer extends AbstractLexer {
      */
     @Override
     public STToken nextToken() {
-        STToken token;
-        switch (this.mode) {
-            case DOC_LINE_START_HASH:
+        STToken token = switch (this.mode) {
+            case DOC_LINE_START_HASH -> {
                 processLeadingTrivia();
-                token = readDocLineStartHashToken();
-                break;
-            case DOC_LINE_DIFFERENTIATOR:
+                yield readDocLineStartHashToken();
+            }
+            case DOC_LINE_DIFFERENTIATOR -> {
                 processLeadingTrivia();
-                token = readDocLineDifferentiatorToken();
-                break;
-            case DOC_INTERNAL:
-                token = readDocInternalToken();
-                break;
-            case DOC_PARAMETER:
+                yield readDocLineDifferentiatorToken();
+            }
+            case DOC_INTERNAL -> readDocInternalToken();
+            case DOC_PARAMETER -> {
                 processLeadingTrivia();
-                token = readDocParameterToken();
-                break;
-            case DOC_REFERENCE_TYPE:
+                yield readDocParameterToken();
+            }
+            case DOC_REFERENCE_TYPE -> {
                 processLeadingTrivia();
-                token = readDocReferenceTypeToken();
-                break;
-            case DOC_SINGLE_BACKTICK_CONTENT:
-                token = readSingleBacktickContentToken();
-                break;
-            case DOC_DOUBLE_BACKTICK_CONTENT:
-                token = readCodeContent(2);
-                break;
-            case DOC_TRIPLE_BACKTICK_CONTENT:
-                token = readCodeContent(3);
-                break;
-            case DOC_CODE_REF_END:
-                token = readCodeReferenceEndToken();
-                break;
-            case DOC_CODE_LINE_START_HASH:
+                yield readDocReferenceTypeToken();
+            }
+            case DOC_SINGLE_BACKTICK_CONTENT -> readSingleBacktickContentToken();
+            case DOC_DOUBLE_BACKTICK_CONTENT -> readCodeContent(2);
+            case DOC_TRIPLE_BACKTICK_CONTENT -> readCodeContent(3);
+            case DOC_CODE_REF_END -> readCodeReferenceEndToken();
+            case DOC_CODE_LINE_START_HASH -> {
                 processLeadingTrivia();
-                token = readCodeLineStartHashToken();
-                break;
-            default:
-                token = null;
-        }
+                yield readCodeLineStartHashToken();
+            }
+            default -> null;
+        };
 
         // Can we improve this logic by creating the token with diagnostics then and there?
         return cloneWithDiagnostics(token);
@@ -134,13 +122,10 @@ public class DocumentationLexer extends AbstractLexer {
      * Check whether a given char is a possible identifier start.
      */
     private boolean isPossibleIdentifierStart(int startChar) {
-        switch (startChar) {
-            case LexerTerminals.SINGLE_QUOTE:
-            case LexerTerminals.BACKSLASH:
-                return true;
-            default:
-                return isIdentifierInitialChar(startChar);
-        }
+        return switch (startChar) {
+            case LexerTerminals.SINGLE_QUOTE, LexerTerminals.BACKSLASH -> true;
+            default -> isIdentifierInitialChar(startChar);
+        };
     }
 
     /**
@@ -753,29 +738,21 @@ public class DocumentationLexer extends AbstractLexer {
 
     private STToken processReferenceType() {
         String tokenText = getLexeme();
-        switch (tokenText) {
-            case LexerTerminals.TYPE:
-                return getDocSyntaxToken(SyntaxKind.TYPE_DOC_REFERENCE_TOKEN);
-            case LexerTerminals.SERVICE:
-                return getDocSyntaxToken(SyntaxKind.SERVICE_DOC_REFERENCE_TOKEN);
-            case LexerTerminals.VARIABLE:
-                return getDocSyntaxToken(SyntaxKind.VARIABLE_DOC_REFERENCE_TOKEN);
-            case LexerTerminals.VAR:
-                return getDocSyntaxToken(SyntaxKind.VAR_DOC_REFERENCE_TOKEN);
-            case LexerTerminals.ANNOTATION:
-                return getDocSyntaxToken(SyntaxKind.ANNOTATION_DOC_REFERENCE_TOKEN);
-            case LexerTerminals.MODULE:
-                return getDocSyntaxToken(SyntaxKind.MODULE_DOC_REFERENCE_TOKEN);
-            case LexerTerminals.FUNCTION:
-                return getDocSyntaxToken(SyntaxKind.FUNCTION_DOC_REFERENCE_TOKEN);
-            case LexerTerminals.PARAMETER:
-                return getDocSyntaxToken(SyntaxKind.PARAMETER_DOC_REFERENCE_TOKEN);
-            case LexerTerminals.CONST:
-                return getDocSyntaxToken(SyntaxKind.CONST_DOC_REFERENCE_TOKEN);
-            default:
+        return switch (tokenText) {
+            case LexerTerminals.TYPE -> getDocSyntaxToken(SyntaxKind.TYPE_DOC_REFERENCE_TOKEN);
+            case LexerTerminals.SERVICE -> getDocSyntaxToken(SyntaxKind.SERVICE_DOC_REFERENCE_TOKEN);
+            case LexerTerminals.VARIABLE -> getDocSyntaxToken(SyntaxKind.VARIABLE_DOC_REFERENCE_TOKEN);
+            case LexerTerminals.VAR -> getDocSyntaxToken(SyntaxKind.VAR_DOC_REFERENCE_TOKEN);
+            case LexerTerminals.ANNOTATION -> getDocSyntaxToken(SyntaxKind.ANNOTATION_DOC_REFERENCE_TOKEN);
+            case LexerTerminals.MODULE -> getDocSyntaxToken(SyntaxKind.MODULE_DOC_REFERENCE_TOKEN);
+            case LexerTerminals.FUNCTION -> getDocSyntaxToken(SyntaxKind.FUNCTION_DOC_REFERENCE_TOKEN);
+            case LexerTerminals.PARAMETER -> getDocSyntaxToken(SyntaxKind.PARAMETER_DOC_REFERENCE_TOKEN);
+            case LexerTerminals.CONST -> getDocSyntaxToken(SyntaxKind.CONST_DOC_REFERENCE_TOKEN);
+            default -> {
                 assert false : "Invalid reference type";
-                return getDocSyntaxToken(SyntaxKind.EOF_TOKEN);
-        }
+                yield getDocSyntaxToken(SyntaxKind.EOF_TOKEN);
+            }
+        };
     }
 
     /*

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/DocumentationParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/DocumentationParser.java
@@ -91,17 +91,12 @@ public class DocumentationParser extends AbstractParser {
     private STNode parseSingleDocumentationLine() {
         STNode hashToken = consume();
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case PLUS_TOKEN:
-                return parseParameterDocumentationLine(hashToken);
-            case DEPRECATION_LITERAL:
-                return parseDeprecationDocumentationLine(hashToken);
-            case TRIPLE_BACKTICK_TOKEN:
-            case DOUBLE_BACKTICK_TOKEN:
-                return parseCodeBlockOrInlineCodeRef(hashToken);
-            default:
-                return parseDocumentationLine(hashToken);
-        }
+        return switch (nextToken.kind) {
+            case PLUS_TOKEN -> parseParameterDocumentationLine(hashToken);
+            case DEPRECATION_LITERAL -> parseDeprecationDocumentationLine(hashToken);
+            case TRIPLE_BACKTICK_TOKEN, DOUBLE_BACKTICK_TOKEN -> parseCodeBlockOrInlineCodeRef(hashToken);
+            default -> parseDocumentationLine(hashToken);
+        };
     }
 
     /**
@@ -128,16 +123,11 @@ public class DocumentationParser extends AbstractParser {
     }
 
     private boolean isInlineCodeRef(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case HASH_TOKEN:
-                return getNextNextToken().kind == SyntaxKind.DOCUMENTATION_DESCRIPTION;
-            case CODE_CONTENT:
-                return getNextNextToken().kind != SyntaxKind.HASH_TOKEN;
-            case DOUBLE_BACKTICK_TOKEN:
-            case TRIPLE_BACKTICK_TOKEN:
-            default:
-                return true;
-        }
+        return switch (nextTokenKind) {
+            case HASH_TOKEN -> getNextNextToken().kind == SyntaxKind.DOCUMENTATION_DESCRIPTION;
+            case CODE_CONTENT -> getNextNextToken().kind != SyntaxKind.HASH_TOKEN;
+            default -> true;
+        };
     }
 
     /**
@@ -408,13 +398,12 @@ public class DocumentationParser extends AbstractParser {
         STNode nextToken = peek();
         if (nextToken.kind == SyntaxKind.HASH_TOKEN) {
             STNode nextNextToken = getNextNextToken();
-            switch (nextNextToken.kind) {
-                case CODE_CONTENT:
-                case HASH_TOKEN: // case where code line description is empty
-                    return false;
-                default:
-                    return true;
-            }
+            return switch (nextNextToken.kind) {
+                case CODE_CONTENT,
+                     // case where code line description is empty
+                     HASH_TOKEN -> false;
+                default -> true;
+            };
         }
 
         return true;
@@ -478,22 +467,14 @@ public class DocumentationParser extends AbstractParser {
     private boolean isBallerinaNameRefTokenSequence(ReferenceGenre refGenre) {
         boolean hasMatch;
         Lookahead lookahead = new Lookahead();
-        switch (refGenre) {
-            case SPECIAL_KEY:
-                // Look for x, m:x match
-                hasMatch = hasQualifiedIdentifier(lookahead);
-                break;
-            case FUNCTION_KEY:
-                // Look for x, m:x, x(), m:x(), T.y(), m:T.y() match
-                hasMatch = hasBacktickExpr(lookahead, true);
-                break;
-            case NO_KEY:
-                // Look for x(), m:x(), T.y(), m:T.y() match
-                hasMatch = hasBacktickExpr(lookahead, false);
-                break;
-            default:
-                throw new IllegalStateException("Unsupported backtick reference genre");
-        }
+        hasMatch = switch (refGenre) {
+            // Look for x, m:x match
+            case SPECIAL_KEY -> hasQualifiedIdentifier(lookahead);
+            // Look for x, m:x, x(), m:x(), T.y(), m:T.y() match
+            case FUNCTION_KEY -> hasBacktickExpr(lookahead, true);
+            // Look for x(), m:x(), T.y(), m:T.y() match
+            case NO_KEY -> hasBacktickExpr(lookahead, false);
+        };
 
         return hasMatch && peek(lookahead.offset).kind == SyntaxKind.BACKTICK_TOKEN;
     }
@@ -568,20 +549,18 @@ public class DocumentationParser extends AbstractParser {
     }
 
     private boolean isDocumentReferenceType(SyntaxKind kind) {
-        switch (kind) {
-            case TYPE_DOC_REFERENCE_TOKEN:
-            case SERVICE_DOC_REFERENCE_TOKEN:
-            case VARIABLE_DOC_REFERENCE_TOKEN:
-            case VAR_DOC_REFERENCE_TOKEN:
-            case ANNOTATION_DOC_REFERENCE_TOKEN:
-            case MODULE_DOC_REFERENCE_TOKEN:
-            case FUNCTION_DOC_REFERENCE_TOKEN:
-            case PARAMETER_DOC_REFERENCE_TOKEN:
-            case CONST_DOC_REFERENCE_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (kind) {
+            case TYPE_DOC_REFERENCE_TOKEN,
+                 SERVICE_DOC_REFERENCE_TOKEN,
+                 VARIABLE_DOC_REFERENCE_TOKEN,
+                 VAR_DOC_REFERENCE_TOKEN,
+                 ANNOTATION_DOC_REFERENCE_TOKEN,
+                 MODULE_DOC_REFERENCE_TOKEN,
+                 FUNCTION_DOC_REFERENCE_TOKEN,
+                 PARAMETER_DOC_REFERENCE_TOKEN,
+                 CONST_DOC_REFERENCE_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -610,21 +589,19 @@ public class DocumentationParser extends AbstractParser {
     }
 
     private boolean isEndOfIntermediateDocumentation(SyntaxKind kind) {
-        switch (kind) {
-            case DOCUMENTATION_DESCRIPTION:
-            case PLUS_TOKEN:
-            case PARAMETER_NAME:
-            case MINUS_TOKEN:
-            case BACKTICK_TOKEN:
-            case DOUBLE_BACKTICK_TOKEN:
-            case TRIPLE_BACKTICK_TOKEN:
-            case CODE_CONTENT:
-            case RETURN_KEYWORD:
-            case DEPRECATION_LITERAL:
-                return false;
-            default:
-                return !isDocumentReferenceType(kind);
-        }
+        return switch (kind) {
+            case DOCUMENTATION_DESCRIPTION,
+                 PLUS_TOKEN,
+                 PARAMETER_NAME,
+                 MINUS_TOKEN,
+                 BACKTICK_TOKEN,
+                 DOUBLE_BACKTICK_TOKEN,
+                 TRIPLE_BACKTICK_TOKEN,
+                 CODE_CONTENT,
+                 RETURN_KEYWORD,
+                 DEPRECATION_LITERAL -> false;
+            default -> !isDocumentReferenceType(kind);
+        };
     }
 
     /**
@@ -710,17 +687,15 @@ public class DocumentationParser extends AbstractParser {
     }
 
     private boolean isBacktickExprToken(SyntaxKind kind) {
-        switch (kind) {
-            case DOT_TOKEN:
-            case COLON_TOKEN:
-            case OPEN_PAREN_TOKEN:
-            case CLOSE_PAREN_TOKEN:
-            case IDENTIFIER_TOKEN:
-            case CODE_CONTENT:
-                return true;
-            default:
-                return false;
-        }
+        return switch (kind) {
+            case DOT_TOKEN,
+                 COLON_TOKEN,
+                 OPEN_PAREN_TOKEN,
+                 CLOSE_PAREN_TOKEN,
+                 IDENTIFIER_TOKEN,
+                 CODE_CONTENT -> true;
+            default -> false;
+        };
     }
 
     private STNode parseNameReferenceContent() {
@@ -742,18 +717,16 @@ public class DocumentationParser extends AbstractParser {
         STNode referenceName = parseQualifiedIdentifier(identifier);
 
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case BACKTICK_TOKEN:
-                return referenceName;
-            case DOT_TOKEN:
+        return switch (nextToken.kind) {
+            case BACKTICK_TOKEN -> referenceName;
+            case DOT_TOKEN -> {
                 STNode dotToken = consume();
-                return parseMethodCall(referenceName, dotToken);
-            case OPEN_PAREN_TOKEN:
-                return parseFuncCall(referenceName);
-            default:
-                // Since we have validated the token sequence beforehand, code should not reach here.
-                throw new IllegalStateException("Unsupported token kind");
-        }
+                yield parseMethodCall(referenceName, dotToken);
+            }
+            case OPEN_PAREN_TOKEN -> parseFuncCall(referenceName);
+            // Since we have validated the token sequence beforehand, code should not reach here.
+            default -> throw new IllegalStateException("Unsupported token kind");
+        };
     }
 
     /**

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/RegExpLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/RegExpLexer.java
@@ -101,56 +101,49 @@ public class RegExpLexer extends AbstractLexer {
 
         // ReSequence has zero or more ReTerm.
         this.reader.advance();
-        switch (nextChar) {
-            case LexerTerminals.BITWISE_XOR:
-                return getRegExpSyntaxToken(SyntaxKind.BITWISE_XOR_TOKEN);
-            case LexerTerminals.DOLLAR:
+        return switch (nextChar) {
+            case LexerTerminals.BITWISE_XOR -> getRegExpSyntaxToken(SyntaxKind.BITWISE_XOR_TOKEN);
+            case LexerTerminals.DOLLAR -> {
                 if (this.mode != ParserMode.RE_CHAR_CLASS && peek() == LexerTerminals.OPEN_BRACE) {
                     // Start interpolation mode.
                     startMode(ParserMode.INTERPOLATION);
                     this.reader.advance();
-                    return getRegExpSyntaxToken(SyntaxKind.INTERPOLATION_START_TOKEN);
+                    yield getRegExpSyntaxToken(SyntaxKind.INTERPOLATION_START_TOKEN);
                 }
-                return getRegExpSyntaxToken(SyntaxKind.DOLLAR_TOKEN);
-            case LexerTerminals.DOT:
-                return getRegExpSyntaxToken(SyntaxKind.DOT_TOKEN);
-            case LexerTerminals.ASTERISK:
-                return getRegExpSyntaxToken(SyntaxKind.ASTERISK_TOKEN);
-            case LexerTerminals.PLUS:
-                return getRegExpSyntaxToken(SyntaxKind.PLUS_TOKEN);
-            case LexerTerminals.QUESTION_MARK:
-                return getRegExpSyntaxToken(SyntaxKind.QUESTION_MARK_TOKEN);
-            case LexerTerminals.BACKSLASH:
-                return processReEscape();
+                yield getRegExpSyntaxToken(SyntaxKind.DOLLAR_TOKEN);
+                // Start interpolation mode.
+            }
+            case LexerTerminals.DOT -> getRegExpSyntaxToken(SyntaxKind.DOT_TOKEN);
+            case LexerTerminals.ASTERISK -> getRegExpSyntaxToken(SyntaxKind.ASTERISK_TOKEN);
+            case LexerTerminals.PLUS -> getRegExpSyntaxToken(SyntaxKind.PLUS_TOKEN);
+            case LexerTerminals.QUESTION_MARK -> getRegExpSyntaxToken(SyntaxKind.QUESTION_MARK_TOKEN);
+            case LexerTerminals.BACKSLASH -> processReEscape();
             // Start parsing ReSyntaxChar character class [[^] [ReCharSet]].
-            case LexerTerminals.OPEN_BRACKET:
+            case LexerTerminals.OPEN_BRACKET -> {
                 if (this.mode != ParserMode.RE_QUOTE_ESCAPE) {
                     startMode(ParserMode.RE_CHAR_CLASS);
                 }
-
-                return getRegExpSyntaxToken(SyntaxKind.OPEN_BRACKET_TOKEN);
-            case LexerTerminals.CLOSE_BRACKET:
+                yield getRegExpSyntaxToken(SyntaxKind.OPEN_BRACKET_TOKEN);
+            }
+            case LexerTerminals.CLOSE_BRACKET -> {
                 if (this.mode == ParserMode.RE_CHAR_CLASS) {
                     endMode();
                 }
-                return getRegExpSyntaxToken(SyntaxKind.CLOSE_BRACKET_TOKEN);
-            case LexerTerminals.OPEN_BRACE:
-                return getRegExpSyntaxToken(SyntaxKind.OPEN_BRACE_TOKEN);
-            case LexerTerminals.CLOSE_BRACE:
-                return getRegExpSyntaxToken(SyntaxKind.CLOSE_BRACE_TOKEN);
+                yield getRegExpSyntaxToken(SyntaxKind.CLOSE_BRACKET_TOKEN);
+            }
+            case LexerTerminals.OPEN_BRACE -> getRegExpSyntaxToken(SyntaxKind.OPEN_BRACE_TOKEN);
+            case LexerTerminals.CLOSE_BRACE -> getRegExpSyntaxToken(SyntaxKind.CLOSE_BRACE_TOKEN);
             // Start parsing capturing group ([? ReFlagsOnOff :] ReDisjunction).
-            case LexerTerminals.OPEN_PARANTHESIS:
-                return getRegExpSyntaxToken(SyntaxKind.OPEN_PAREN_TOKEN);
-            case LexerTerminals.CLOSE_PARANTHESIS:
-                return getRegExpSyntaxToken(SyntaxKind.CLOSE_PAREN_TOKEN);
-            case LexerTerminals.COMMA:
-                return getRegExpSyntaxToken(SyntaxKind.COMMA_TOKEN);
-            default:
+            case LexerTerminals.OPEN_PARANTHESIS -> getRegExpSyntaxToken(SyntaxKind.OPEN_PAREN_TOKEN);
+            case LexerTerminals.CLOSE_PARANTHESIS -> getRegExpSyntaxToken(SyntaxKind.CLOSE_PAREN_TOKEN);
+            case LexerTerminals.COMMA -> getRegExpSyntaxToken(SyntaxKind.COMMA_TOKEN);
+            default -> {
                 if (isDigit(nextChar)) {
-                    return getRegExpText(SyntaxKind.DIGIT);
+                    yield getRegExpText(SyntaxKind.DIGIT);
                 }
-                return getRegExpText(SyntaxKind.RE_LITERAL_CHAR);
-        }
+                yield getRegExpText(SyntaxKind.RE_LITERAL_CHAR);
+            }
+        };
     }
 
     private STToken processReEscape() {
@@ -482,17 +475,10 @@ public class RegExpLexer extends AbstractLexer {
      * @return <code>true</code>, if the character is ReSimpleCharClassCode. <code>false</code> otherwise.
      */
     protected static boolean isReSimpleCharClassCode(int c) {
-        switch (c) {
-            case 'd':
-            case 'D':
-            case 's':
-            case 'S':
-            case 'w':
-            case 'W':
-                return true;
-            default:
-                return false;
-        }
+        return switch (c) {
+            case 'd', 'D', 's', 'S', 'w', 'W' -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -506,14 +492,10 @@ public class RegExpLexer extends AbstractLexer {
      * @return <code>true</code>, if the character is ReCharSetLiteralChar. <code>false</code> otherwise.
      */
     protected static boolean isReCharSetLiteralChar(int c) {
-        switch (c) {
-            case '\\':
-            case ']':
-            case '-':
-                return false;
-            default:
-                return true;
-        }
+        return switch (c) {
+            case '\\', ']', '-' -> false;
+            default -> true;
+        };
     }
 
     /**
@@ -531,14 +513,9 @@ public class RegExpLexer extends AbstractLexer {
      * @return <code>true</code>, if the character is ReFlag. <code>false</code> otherwise.
      */
     protected static boolean isReFlag(int c) {
-        switch (c) {
-            case 'm':
-            case 's':
-            case 'i':
-            case 'x':
-                return true;
-            default:
-                return false;
-        }
+        return switch (c) {
+            case 'm', 's', 'i', 'x' -> true;
+            default -> false;
+        };
     }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/RegExpParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/RegExpParser.java
@@ -96,36 +96,25 @@ public class RegExpParser extends AbstractParser {
             return parseReAssertion();
         }
 
-        STNode reAtom;
-        switch (nextToken.kind) {
-            case RE_LITERAL_CHAR:
-            case RE_NUMERIC_ESCAPE:
-            case RE_CONTROL_ESCAPE:
-            case COMMA_TOKEN:
-            case DOT_TOKEN:
-            case DIGIT:
-                reAtom = parseChars();
-                break;
-            case BACK_SLASH_TOKEN:
-                reAtom = parseReEscape();
-                break;
-            case OPEN_BRACKET_TOKEN:
-                reAtom = parseCharacterClass();
-                break;
-            case OPEN_PAREN_TOKEN:
-                reAtom = parseCapturingGroup();
-                break;
-            case INTERPOLATION_START_TOKEN:
-                reAtom = parseInterpolation();
-                break;
-            default:
+        STNode reAtom = switch (nextToken.kind) {
+            case RE_LITERAL_CHAR,
+                 RE_NUMERIC_ESCAPE,
+                 RE_CONTROL_ESCAPE,
+                 COMMA_TOKEN,
+                 DOT_TOKEN,
+                 DIGIT -> parseChars();
+            case BACK_SLASH_TOKEN -> parseReEscape();
+            case OPEN_BRACKET_TOKEN -> parseCharacterClass();
+            case OPEN_PAREN_TOKEN -> parseCapturingGroup();
+            case INTERPOLATION_START_TOKEN -> parseInterpolation();
+            default -> {
                 // Here the token is a syntax char, which is invalid. A syntax char should have a backslash prior
                 // to the token.
                 STNode missingBackSlash =
                         SyntaxErrors.createMissingRegExpTokenWithDiagnostics(SyntaxKind.BACK_SLASH_TOKEN);
-                reAtom = SyntaxErrors.cloneWithTrailingInvalidNodeMinutiae(missingBackSlash, consume());
-                break;
-        }
+                yield SyntaxErrors.cloneWithTrailingInvalidNodeMinutiae(missingBackSlash, consume());
+            }
+        };
 
         nextToken = peek();
         STNode quantifier = parseOptionalQuantifier(nextToken.kind);
@@ -138,15 +127,10 @@ public class RegExpParser extends AbstractParser {
     }
 
     private STNode parseOptionalQuantifier(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case PLUS_TOKEN:
-            case ASTERISK_TOKEN:
-            case QUESTION_MARK_TOKEN:
-            case OPEN_BRACE_TOKEN:
-                return parseReQuantifier();
-            default:
-                return null;
-        }
+        return switch (tokenKind) {
+            case PLUS_TOKEN, ASTERISK_TOKEN, QUESTION_MARK_TOKEN, OPEN_BRACE_TOKEN -> parseReQuantifier();
+            default -> null;
+        };
     }
 
     /**
@@ -304,17 +288,10 @@ public class RegExpParser extends AbstractParser {
         if (token.kind != SyntaxKind.RE_LITERAL_CHAR) {
             return false;
         }
-        switch (token.text()) {
-            case "d":
-            case "D":
-            case "s":
-            case "S":
-            case "w":
-            case "W":
-                return true;
-            default:
-                return false;
-        }
+        return switch (token.text()) {
+            case "d", "D", "s", "S", "w", "W" -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -445,24 +422,17 @@ public class RegExpParser extends AbstractParser {
     }
 
     private boolean isReCharSetLiteralChar(String tokenText) {
-        switch (tokenText) {
-            case "\\":
-            case "-":
-            case "]":
-                return false;
-            default:
-                return true;
-        }
+        return switch (tokenText) {
+            case "\\", "-", "]" -> false;
+            default -> true;
+        };
     }
 
     private boolean isCharacterClassEnd(SyntaxKind kind) {
-        switch (kind) {
-            case EOF_TOKEN:
-            case CLOSE_BRACKET_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (kind) {
+            case EOF_TOKEN, CLOSE_BRACKET_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -550,15 +520,11 @@ public class RegExpParser extends AbstractParser {
     }
 
     private boolean isEndOfDigits(SyntaxKind kind, boolean isLeastDigits) {
-        switch (kind) {
-            case CLOSE_BRACE_TOKEN:
-            case EOF_TOKEN:
-                return true;
-            case COMMA_TOKEN:
-                return isLeastDigits;
-            default:
-                return false;
-        }
+        return switch (kind) {
+            case CLOSE_BRACE_TOKEN, EOF_TOKEN -> true;
+            case COMMA_TOKEN -> isLeastDigits;
+            default -> false;
+        };
     }
 
     /**
@@ -637,15 +603,10 @@ public class RegExpParser extends AbstractParser {
         if (nextToken.kind != SyntaxKind.RE_LITERAL_CHAR) {
             return false;
         }
-        switch (nextToken.text()) {
-            case "m":
-            case "s":
-            case "i":
-            case "x":
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextToken.text()) {
+            case "m", "s", "i", "x" -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -749,24 +710,17 @@ public class RegExpParser extends AbstractParser {
     }
 
     private boolean isEndOfReDisjunction(SyntaxKind kind, boolean inCapturingGroup) {
-        switch (kind) {
-            case EOF_TOKEN:
-            case BACKTICK_TOKEN:
-                return true;
-            default:
-                return kind == SyntaxKind.CLOSE_PAREN_TOKEN && inCapturingGroup;
-        }
+        return switch (kind) {
+            case EOF_TOKEN, BACKTICK_TOKEN -> true;
+            default -> kind == SyntaxKind.CLOSE_PAREN_TOKEN && inCapturingGroup;
+        };
     }
 
     private boolean isEndOfReSequence(SyntaxKind kind, boolean inCapturingGroup) {
-        switch (kind) {
-            case EOF_TOKEN:
-            case BACKTICK_TOKEN:
-            case PIPE_TOKEN:
-                return true;
-            default:
-                return kind == SyntaxKind.CLOSE_PAREN_TOKEN && inCapturingGroup;
-        }
+        return switch (kind) {
+            case EOF_TOKEN, BACKTICK_TOKEN, PIPE_TOKEN -> true;
+            default -> kind == SyntaxKind.CLOSE_PAREN_TOKEN && inCapturingGroup;
+        };
     }
 
     private STNode getToken(STToken token, SyntaxKind syntaxKind) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/SyntaxErrors.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/SyntaxErrors.java
@@ -98,484 +98,322 @@ public class SyntaxErrors {
     }
 
     private static DiagnosticCode getErrorCode(ParserRuleContext currentCtx) {
-        switch (currentCtx) {
-            case EXTERNAL_FUNC_BODY:
-                return DiagnosticErrorCode.ERROR_MISSING_EQUAL_TOKEN;
-            case FUNC_BODY_BLOCK:
-                return DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACE_TOKEN;
-            case FUNC_DEF:
-            case FUNC_DEF_OR_FUNC_TYPE:
-            case FUNC_TYPE_DESC:
-            case FUNC_TYPE_DESC_OR_ANON_FUNC:
-            case IDENT_AFTER_OBJECT_IDENT:
-            case FUNC_DEF_FIRST_QUALIFIER:
-            case FUNC_DEF_SECOND_QUALIFIER:
-            case FUNC_TYPE_FIRST_QUALIFIER:
-            case FUNC_TYPE_SECOND_QUALIFIER:
-            case OBJECT_METHOD_FIRST_QUALIFIER:
-            case OBJECT_METHOD_SECOND_QUALIFIER:
-            case OBJECT_METHOD_THIRD_QUALIFIER:
-            case OBJECT_METHOD_FOURTH_QUALIFIER:
-                return DiagnosticErrorCode.ERROR_MISSING_FUNCTION_KEYWORD;
-            case SINGLE_KEYWORD_ATTACH_POINT_IDENT:
-                return DiagnosticErrorCode.ERROR_MISSING_ATTACH_POINT_NAME;
-            case SIMPLE_TYPE_DESCRIPTOR:
-                return DiagnosticErrorCode.ERROR_MISSING_BUILTIN_TYPE;
-            case REQUIRED_PARAM:
-            case VAR_DECL_STMT:
-            case ASSIGNMENT_OR_VAR_DECL_STMT:
-            case DEFAULTABLE_PARAM:
-            case REST_PARAM:
-            case TYPE_DESCRIPTOR:
-            case OPTIONAL_TYPE_DESCRIPTOR:
-            case ARRAY_TYPE_DESCRIPTOR:
-            case SIMPLE_TYPE_DESC_IDENTIFIER:
-                return DiagnosticErrorCode.ERROR_MISSING_TYPE_DESC;
-            case TYPE_REFERENCE:
-                return DiagnosticErrorCode.ERROR_MISSING_TYPE_REFERENCE;
-            case TYPE_NAME:
-            case TYPE_REFERENCE_IN_TYPE_INCLUSION:
-            case FIELD_ACCESS_IDENTIFIER:
-            case CLASS_NAME:
-            case FUNC_NAME:
-            case VARIABLE_NAME:
-            case IMPORT_MODULE_NAME:
-            case IMPORT_ORG_OR_MODULE_NAME:
-            case IMPORT_PREFIX:
-            case VARIABLE_REF:
-            case BASIC_LITERAL: // return var-ref for any kind of terminal expression
-            case IDENTIFIER:
-            case QUALIFIED_IDENTIFIER_START_IDENTIFIER:
-            case NAMESPACE_PREFIX:
-            case IMPLICIT_ANON_FUNC_PARAM:
-            case METHOD_NAME:
-            case PEER_WORKER_NAME:
-            case RECEIVE_FIELD_NAME:
-            case WAIT_FIELD_NAME:
-            case FIELD_BINDING_PATTERN_NAME:
-            case XML_ATOMIC_NAME_IDENTIFIER:
-            case MAPPING_FIELD_NAME:
-            case WORKER_NAME:
-            case NAMED_WORKERS:
-            case ANNOTATION_TAG:
-            case AFTER_PARAMETER_TYPE:
-            case MODULE_ENUM_NAME:
-            case ENUM_MEMBER_NAME:
-            case TYPED_BINDING_PATTERN_TYPE_RHS:
-            case ASSIGNMENT_STMT:
-            case XML_NAME:
-            case ACCESS_EXPRESSION:
-            case BINDING_PATTERN_STARTING_IDENTIFIER:
-            case COMPUTED_FIELD_NAME:
-            case SIMPLE_BINDING_PATTERN:
-            case ERROR_FIELD_BINDING_PATTERN:
-            case ERROR_CAUSE_SIMPLE_BINDING_PATTERN:
-            case PATH_SEGMENT_IDENT:
-            case NAMED_ARG_BINDING_PATTERN:
-            case MODULE_VAR_FIRST_QUAL:
-            case MODULE_VAR_SECOND_QUAL:
-            case MODULE_VAR_THIRD_QUAL:
-            case OBJECT_MEMBER_VISIBILITY_QUAL:
-                return DiagnosticErrorCode.ERROR_MISSING_IDENTIFIER;
-            case EXPRESSION:
-            case TERMINAL_EXPRESSION:
-                return DiagnosticErrorCode.ERROR_MISSING_EXPRESSION;
-            case STRING_LITERAL_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_STRING_LITERAL;
-            case DECIMAL_INTEGER_LITERAL_TOKEN:
-            case SIGNED_INT_OR_FLOAT_RHS:
-                return DiagnosticErrorCode.ERROR_MISSING_DECIMAL_INTEGER_LITERAL;
-            case HEX_INTEGER_LITERAL_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_HEX_INTEGER_LITERAL;
-            case OBJECT_FIELD_RHS:
-            case BINDING_PATTERN_OR_VAR_REF_RHS:
-                return DiagnosticErrorCode.ERROR_MISSING_SEMICOLON_TOKEN;
-            case NIL_LITERAL:
-            case ERROR_MATCH_PATTERN:
-                return DiagnosticErrorCode.ERROR_MISSING_ERROR_KEYWORD;
-            case DECIMAL_FLOATING_POINT_LITERAL_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_DECIMAL_FLOATING_POINT_LITERAL;
-            case HEX_FLOATING_POINT_LITERAL_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_HEX_FLOATING_POINT_LITERAL;
-            case STATEMENT:
-            case STATEMENT_WITHOUT_ANNOTS:
-                return DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACE_TOKEN;
-            case XML_COMMENT_CONTENT:
-            case XML_PI_DATA:
-                return DiagnosticErrorCode.ERROR_MISSING_XML_TEXT_CONTENT;
-            default:
-                return getSeperatorTokenErrorCode(currentCtx);
-        }
+        return switch (currentCtx) {
+            case EXTERNAL_FUNC_BODY -> DiagnosticErrorCode.ERROR_MISSING_EQUAL_TOKEN;
+            case FUNC_BODY_BLOCK -> DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACE_TOKEN;
+            case FUNC_DEF,
+                 FUNC_DEF_OR_FUNC_TYPE,
+                 FUNC_TYPE_DESC,
+                 FUNC_TYPE_DESC_OR_ANON_FUNC,
+                 IDENT_AFTER_OBJECT_IDENT,
+                 FUNC_DEF_FIRST_QUALIFIER,
+                 FUNC_DEF_SECOND_QUALIFIER,
+                 FUNC_TYPE_FIRST_QUALIFIER,
+                 FUNC_TYPE_SECOND_QUALIFIER,
+                 OBJECT_METHOD_FIRST_QUALIFIER,
+                 OBJECT_METHOD_SECOND_QUALIFIER,
+                 OBJECT_METHOD_THIRD_QUALIFIER,
+                 OBJECT_METHOD_FOURTH_QUALIFIER -> DiagnosticErrorCode.ERROR_MISSING_FUNCTION_KEYWORD;
+            case SINGLE_KEYWORD_ATTACH_POINT_IDENT -> DiagnosticErrorCode.ERROR_MISSING_ATTACH_POINT_NAME;
+            case SIMPLE_TYPE_DESCRIPTOR -> DiagnosticErrorCode.ERROR_MISSING_BUILTIN_TYPE;
+            case REQUIRED_PARAM,
+                 VAR_DECL_STMT,
+                 ASSIGNMENT_OR_VAR_DECL_STMT,
+                 DEFAULTABLE_PARAM,
+                 REST_PARAM,
+                 TYPE_DESCRIPTOR,
+                 OPTIONAL_TYPE_DESCRIPTOR,
+                 ARRAY_TYPE_DESCRIPTOR,
+                 SIMPLE_TYPE_DESC_IDENTIFIER -> DiagnosticErrorCode.ERROR_MISSING_TYPE_DESC;
+            // return var-ref for any kind of terminal expression
+            case TYPE_REFERENCE -> DiagnosticErrorCode.ERROR_MISSING_TYPE_REFERENCE;
+            case TYPE_NAME,
+                 TYPE_REFERENCE_IN_TYPE_INCLUSION,
+                 FIELD_ACCESS_IDENTIFIER,
+                 CLASS_NAME,
+                 FUNC_NAME,
+                 VARIABLE_NAME,
+                 IMPORT_MODULE_NAME,
+                 IMPORT_ORG_OR_MODULE_NAME,
+                 IMPORT_PREFIX,
+                 VARIABLE_REF,
+                 BASIC_LITERAL,
+                 IDENTIFIER,
+                 QUALIFIED_IDENTIFIER_START_IDENTIFIER,
+                 NAMESPACE_PREFIX,
+                 IMPLICIT_ANON_FUNC_PARAM,
+                 METHOD_NAME,
+                 PEER_WORKER_NAME,
+                 RECEIVE_FIELD_NAME,
+                 WAIT_FIELD_NAME,
+                 FIELD_BINDING_PATTERN_NAME,
+                 XML_ATOMIC_NAME_IDENTIFIER,
+                 MAPPING_FIELD_NAME,
+                 WORKER_NAME,
+                 NAMED_WORKERS,
+                 ANNOTATION_TAG,
+                 AFTER_PARAMETER_TYPE,
+                 MODULE_ENUM_NAME,
+                 ENUM_MEMBER_NAME,
+                 TYPED_BINDING_PATTERN_TYPE_RHS,
+                 ASSIGNMENT_STMT,
+                 XML_NAME,
+                 ACCESS_EXPRESSION,
+                 BINDING_PATTERN_STARTING_IDENTIFIER,
+                 COMPUTED_FIELD_NAME,
+                 SIMPLE_BINDING_PATTERN,
+                 ERROR_FIELD_BINDING_PATTERN,
+                 ERROR_CAUSE_SIMPLE_BINDING_PATTERN,
+                 PATH_SEGMENT_IDENT,
+                 NAMED_ARG_BINDING_PATTERN,
+                 MODULE_VAR_FIRST_QUAL,
+                 MODULE_VAR_SECOND_QUAL,
+                 MODULE_VAR_THIRD_QUAL,
+                 OBJECT_MEMBER_VISIBILITY_QUAL -> DiagnosticErrorCode.ERROR_MISSING_IDENTIFIER;
+            case EXPRESSION,
+                 TERMINAL_EXPRESSION -> DiagnosticErrorCode.ERROR_MISSING_EXPRESSION;
+            case STRING_LITERAL_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_STRING_LITERAL;
+            case DECIMAL_INTEGER_LITERAL_TOKEN,
+                 SIGNED_INT_OR_FLOAT_RHS -> DiagnosticErrorCode.ERROR_MISSING_DECIMAL_INTEGER_LITERAL;
+            case HEX_INTEGER_LITERAL_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_HEX_INTEGER_LITERAL;
+            case OBJECT_FIELD_RHS,
+                 BINDING_PATTERN_OR_VAR_REF_RHS -> DiagnosticErrorCode.ERROR_MISSING_SEMICOLON_TOKEN;
+            case NIL_LITERAL,
+                 ERROR_MATCH_PATTERN -> DiagnosticErrorCode.ERROR_MISSING_ERROR_KEYWORD;
+            case DECIMAL_FLOATING_POINT_LITERAL_TOKEN ->
+                    DiagnosticErrorCode.ERROR_MISSING_DECIMAL_FLOATING_POINT_LITERAL;
+            case HEX_FLOATING_POINT_LITERAL_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_HEX_FLOATING_POINT_LITERAL;
+            case STATEMENT,
+                 STATEMENT_WITHOUT_ANNOTS -> DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACE_TOKEN;
+            case XML_COMMENT_CONTENT,
+                 XML_PI_DATA -> DiagnosticErrorCode.ERROR_MISSING_XML_TEXT_CONTENT;
+            default -> getSeperatorTokenErrorCode(currentCtx);
+        };
     }
 
     private static DiagnosticCode getSeperatorTokenErrorCode(ParserRuleContext ctx) {
-        switch (ctx) {
-            case BITWISE_AND_OPERATOR:
-                return DiagnosticErrorCode.ERROR_MISSING_BITWISE_AND_TOKEN;
-            case EQUAL_OR_RIGHT_ARROW:
-            case ASSIGN_OP:
-                return DiagnosticErrorCode.ERROR_MISSING_EQUAL_TOKEN;
-            case BINARY_OPERATOR:
-            case UNARY_OPERATOR:
-            case COMPOUND_BINARY_OPERATOR:
-            case UNARY_EXPRESSION:
-            case EXPRESSION_RHS:
-            case PLUS_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_BINARY_OPERATOR;
-            case CLOSE_BRACE:
-                return DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACE_TOKEN;
-            case CLOSE_PARENTHESIS:
-            case ARG_LIST_CLOSE_PAREN:
-                return DiagnosticErrorCode.ERROR_MISSING_CLOSE_PAREN_TOKEN;
-            case COMMA:
-            case ERROR_MESSAGE_BINDING_PATTERN_END_COMMA:
-            case ERROR_MESSAGE_MATCH_PATTERN_END_COMMA:
-                return DiagnosticErrorCode.ERROR_MISSING_COMMA_TOKEN;
-            case OPEN_BRACE:
-                return DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACE_TOKEN;
-            case OPEN_PARENTHESIS:
-            case ARG_LIST_OPEN_PAREN:
-            case PARENTHESISED_TYPE_DESC_START:
-                return DiagnosticErrorCode.ERROR_MISSING_OPEN_PAREN_TOKEN;
-            case SEMICOLON:
-            case OBJECT_FIELD_RHS:
-                return DiagnosticErrorCode.ERROR_MISSING_SEMICOLON_TOKEN;
-            case ASTERISK:
-                return DiagnosticErrorCode.ERROR_MISSING_ASTERISK_TOKEN;
-            case CLOSED_RECORD_BODY_END:
-                return DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACE_PIPE_TOKEN;
-            case CLOSED_RECORD_BODY_START:
-                return DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACE_PIPE_TOKEN;
-            case ELLIPSIS:
-                return DiagnosticErrorCode.ERROR_MISSING_ELLIPSIS_TOKEN;
-            case QUESTION_MARK:
-                return DiagnosticErrorCode.ERROR_MISSING_QUESTION_MARK_TOKEN;
-            case CLOSE_BRACKET:
-                return DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACKET_TOKEN;
-            case DOT:
-            case METHOD_CALL_DOT:
-                return DiagnosticErrorCode.ERROR_MISSING_DOT_TOKEN;
-            case OPEN_BRACKET:
-            case TUPLE_TYPE_DESC_START:
-                return DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACKET_TOKEN;
-            case SLASH:
-            case ABSOLUTE_PATH_SINGLE_SLASH:
-            case RESOURCE_METHOD_CALL_SLASH_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_SLASH_TOKEN;
-            case COLON:
-            case VAR_REF_COLON:
-            case TYPE_REF_COLON:
-                return DiagnosticErrorCode.ERROR_MISSING_COLON_TOKEN;
-            case AT:
-                return DiagnosticErrorCode.ERROR_MISSING_AT_TOKEN;
-            case RIGHT_ARROW:
-                return DiagnosticErrorCode.ERROR_MISSING_RIGHT_ARROW_TOKEN;
-            case GT:
-            case GT_TOKEN:
-            case XML_START_OR_EMPTY_TAG_END:
-            case XML_ATTRIBUTES:
-            case INFERRED_TYPEDESC_DEFAULT_END_GT:
-                return DiagnosticErrorCode.ERROR_MISSING_GT_TOKEN;
-            case LT:
-            case LT_TOKEN:
-            case XML_START_OR_EMPTY_TAG:
-            case XML_END_TAG:
-            case INFERRED_TYPEDESC_DEFAULT_START_LT:
-            case STREAM_TYPE_PARAM_START_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_LT_TOKEN;
-            case SYNC_SEND_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_SYNC_SEND_TOKEN;
-            case ANNOT_CHAINING_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_ANNOT_CHAINING_TOKEN;
-            case OPTIONAL_CHAINING_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_OPTIONAL_CHAINING_TOKEN;
-            case DOT_LT_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_DOT_LT_TOKEN;
-            case SLASH_LT_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_SLASH_LT_TOKEN;
-            case DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN;
-            case SLASH_ASTERISK_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_SLASH_ASTERISK_TOKEN;
-            case MINUS_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_MINUS_TOKEN;
-            case LEFT_ARROW_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_LEFT_ARROW_TOKEN;
-            case TEMPLATE_END:
-            case TEMPLATE_START:
-            case XML_CONTENT:
-            case XML_TEXT:
-                return DiagnosticErrorCode.ERROR_MISSING_BACKTICK_TOKEN;
-            case XML_COMMENT_START:
-                return DiagnosticErrorCode.ERROR_MISSING_XML_COMMENT_START_TOKEN;
-            case XML_COMMENT_END:
-                return DiagnosticErrorCode.ERROR_MISSING_XML_COMMENT_END_TOKEN;
-            case XML_PI:
-            case XML_PI_START:
-                return DiagnosticErrorCode.ERROR_MISSING_XML_PI_START_TOKEN;
-            case XML_PI_END:
-                return DiagnosticErrorCode.ERROR_MISSING_XML_PI_END_TOKEN;
-            case XML_QUOTE_END:
-            case XML_QUOTE_START:
-                return DiagnosticErrorCode.ERROR_MISSING_DOUBLE_QUOTE_TOKEN;
-            case INTERPOLATION_START_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_INTERPOLATION_START_TOKEN;
-            case EXPR_FUNC_BODY_START:
-            case RIGHT_DOUBLE_ARROW:
-                return DiagnosticErrorCode.ERROR_MISSING_RIGHT_DOUBLE_ARROW_TOKEN;
-            case XML_CDATA_END:
-                return DiagnosticErrorCode.ERROR_MISSING_XML_CDATA_END_TOKEN;
-            default:
-                return getKeywordErrorCode(ctx);
-        }
+        return switch (ctx) {
+            case BITWISE_AND_OPERATOR -> DiagnosticErrorCode.ERROR_MISSING_BITWISE_AND_TOKEN;
+            case EQUAL_OR_RIGHT_ARROW,
+                 ASSIGN_OP -> DiagnosticErrorCode.ERROR_MISSING_EQUAL_TOKEN;
+            case BINARY_OPERATOR,
+                 UNARY_OPERATOR,
+                 COMPOUND_BINARY_OPERATOR,
+                 UNARY_EXPRESSION,
+                 EXPRESSION_RHS,
+                 PLUS_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_BINARY_OPERATOR;
+            case CLOSE_BRACE -> DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACE_TOKEN;
+            case CLOSE_PARENTHESIS,
+                 ARG_LIST_CLOSE_PAREN -> DiagnosticErrorCode.ERROR_MISSING_CLOSE_PAREN_TOKEN;
+            case COMMA,
+                 ERROR_MESSAGE_BINDING_PATTERN_END_COMMA,
+                 ERROR_MESSAGE_MATCH_PATTERN_END_COMMA -> DiagnosticErrorCode.ERROR_MISSING_COMMA_TOKEN;
+            case OPEN_BRACE -> DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACE_TOKEN;
+            case OPEN_PARENTHESIS,
+                 ARG_LIST_OPEN_PAREN,
+                 PARENTHESISED_TYPE_DESC_START -> DiagnosticErrorCode.ERROR_MISSING_OPEN_PAREN_TOKEN;
+            case SEMICOLON,
+                 OBJECT_FIELD_RHS -> DiagnosticErrorCode.ERROR_MISSING_SEMICOLON_TOKEN;
+            case ASTERISK -> DiagnosticErrorCode.ERROR_MISSING_ASTERISK_TOKEN;
+            case CLOSED_RECORD_BODY_END -> DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACE_PIPE_TOKEN;
+            case CLOSED_RECORD_BODY_START -> DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACE_PIPE_TOKEN;
+            case ELLIPSIS -> DiagnosticErrorCode.ERROR_MISSING_ELLIPSIS_TOKEN;
+            case QUESTION_MARK -> DiagnosticErrorCode.ERROR_MISSING_QUESTION_MARK_TOKEN;
+            case CLOSE_BRACKET -> DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACKET_TOKEN;
+            case DOT,
+                 METHOD_CALL_DOT -> DiagnosticErrorCode.ERROR_MISSING_DOT_TOKEN;
+            case OPEN_BRACKET,
+                 TUPLE_TYPE_DESC_START -> DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACKET_TOKEN;
+            case SLASH,
+                 ABSOLUTE_PATH_SINGLE_SLASH,
+                 RESOURCE_METHOD_CALL_SLASH_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_SLASH_TOKEN;
+            case COLON,
+                 VAR_REF_COLON,
+                 TYPE_REF_COLON -> DiagnosticErrorCode.ERROR_MISSING_COLON_TOKEN;
+            case AT -> DiagnosticErrorCode.ERROR_MISSING_AT_TOKEN;
+            case RIGHT_ARROW -> DiagnosticErrorCode.ERROR_MISSING_RIGHT_ARROW_TOKEN;
+            case GT,
+                 GT_TOKEN,
+                 XML_START_OR_EMPTY_TAG_END,
+                 XML_ATTRIBUTES,
+                 INFERRED_TYPEDESC_DEFAULT_END_GT -> DiagnosticErrorCode.ERROR_MISSING_GT_TOKEN;
+            case LT,
+                 LT_TOKEN,
+                 XML_START_OR_EMPTY_TAG,
+                 XML_END_TAG,
+                 INFERRED_TYPEDESC_DEFAULT_START_LT,
+                 STREAM_TYPE_PARAM_START_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_LT_TOKEN;
+            case SYNC_SEND_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_SYNC_SEND_TOKEN;
+            case ANNOT_CHAINING_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_ANNOT_CHAINING_TOKEN;
+            case OPTIONAL_CHAINING_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_OPTIONAL_CHAINING_TOKEN;
+            case DOT_LT_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_DOT_LT_TOKEN;
+            case SLASH_LT_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_SLASH_LT_TOKEN;
+            case DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN ->
+                    DiagnosticErrorCode.ERROR_MISSING_DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN;
+            case SLASH_ASTERISK_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_SLASH_ASTERISK_TOKEN;
+            case MINUS_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_MINUS_TOKEN;
+            case LEFT_ARROW_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_LEFT_ARROW_TOKEN;
+            case TEMPLATE_END,
+                 TEMPLATE_START,
+                 XML_CONTENT,
+                 XML_TEXT -> DiagnosticErrorCode.ERROR_MISSING_BACKTICK_TOKEN;
+            case XML_COMMENT_START -> DiagnosticErrorCode.ERROR_MISSING_XML_COMMENT_START_TOKEN;
+            case XML_COMMENT_END -> DiagnosticErrorCode.ERROR_MISSING_XML_COMMENT_END_TOKEN;
+            case XML_PI,
+                 XML_PI_START -> DiagnosticErrorCode.ERROR_MISSING_XML_PI_START_TOKEN;
+            case XML_PI_END -> DiagnosticErrorCode.ERROR_MISSING_XML_PI_END_TOKEN;
+            case XML_QUOTE_END,
+                 XML_QUOTE_START -> DiagnosticErrorCode.ERROR_MISSING_DOUBLE_QUOTE_TOKEN;
+            case INTERPOLATION_START_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_INTERPOLATION_START_TOKEN;
+            case EXPR_FUNC_BODY_START,
+                 RIGHT_DOUBLE_ARROW -> DiagnosticErrorCode.ERROR_MISSING_RIGHT_DOUBLE_ARROW_TOKEN;
+            case XML_CDATA_END -> DiagnosticErrorCode.ERROR_MISSING_XML_CDATA_END_TOKEN;
+            default -> getKeywordErrorCode(ctx);
+        };
     }
 
     private static DiagnosticCode getKeywordErrorCode(ParserRuleContext ctx) {
-        switch (ctx) {
-            case PUBLIC_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_PUBLIC_KEYWORD;
-            case PRIVATE_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_PRIVATE_KEYWORD;
-            case ABSTRACT_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_ABSTRACT_KEYWORD;
-            case CLIENT_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_CLIENT_KEYWORD;
-            case IMPORT_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_IMPORT_KEYWORD;
-            case FUNCTION_KEYWORD:
-            case FUNCTION_IDENT:
-            case OPTIONAL_PEER_WORKER:
-            case DEFAULT_WORKER_NAME_IN_ASYNC_SEND:
-                return DiagnosticErrorCode.ERROR_MISSING_FUNCTION_KEYWORD;
-            case CONST_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_CONST_KEYWORD;
-            case LISTENER_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_LISTENER_KEYWORD;
-            case SERVICE_KEYWORD:
-            case SERVICE_IDENT:
-            case SERVICE_DECL_QUALIFIER:
-                return DiagnosticErrorCode.ERROR_MISSING_SERVICE_KEYWORD;
-            case XMLNS_KEYWORD:
-            case XML_NAMESPACE_DECLARATION:
-                return DiagnosticErrorCode.ERROR_MISSING_XMLNS_KEYWORD;
-            case ANNOTATION_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_ANNOTATION_KEYWORD;
-            case TYPE_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_TYPE_KEYWORD;
-            case RECORD_KEYWORD:
-            case RECORD_FIELD:
-            case RECORD_IDENT:
-                return DiagnosticErrorCode.ERROR_MISSING_RECORD_KEYWORD;
-            case OBJECT_KEYWORD:
-            case OBJECT_IDENT:
-            case OBJECT_TYPE_DESCRIPTOR:
-            case FIRST_OBJECT_CONS_QUALIFIER:
-            case SECOND_OBJECT_CONS_QUALIFIER:
-            case FIRST_OBJECT_TYPE_QUALIFIER:
-            case SECOND_OBJECT_TYPE_QUALIFIER:
-                return DiagnosticErrorCode.ERROR_MISSING_OBJECT_KEYWORD;
-            case AS_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_AS_KEYWORD;
-            case ON_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_ON_KEYWORD;
-            case FINAL_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_FINAL_KEYWORD;
-            case SOURCE_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_SOURCE_KEYWORD;
-            case WORKER_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_WORKER_KEYWORD;
-            case FIELD_IDENT:
-                return DiagnosticErrorCode.ERROR_MISSING_FIELD_KEYWORD;
-            case RETURNS_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_RETURNS_KEYWORD;
-            case RETURN_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_RETURN_KEYWORD;
-            case EXTERNAL_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_EXTERNAL_KEYWORD;
-            case BOOLEAN_LITERAL:
-                return DiagnosticErrorCode.ERROR_MISSING_TRUE_KEYWORD;
-            case IF_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_IF_KEYWORD;
-            case ELSE_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_ELSE_KEYWORD;
-            case WHILE_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_WHILE_KEYWORD;
-            case CHECKING_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_CHECK_KEYWORD;
-            case PANIC_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_PANIC_KEYWORD;
-            case CONTINUE_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_CONTINUE_KEYWORD;
-            case BREAK_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_BREAK_KEYWORD;
-            case TYPEOF_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_TYPEOF_KEYWORD;
-            case IS_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_IS_KEYWORD;
-            case NULL_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_NULL_KEYWORD;
-            case LOCK_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_LOCK_KEYWORD;
-            case FORK_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_FORK_KEYWORD;
-            case TRAP_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_TRAP_KEYWORD;
-            case IN_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_IN_KEYWORD;
-            case FOREACH_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_FOREACH_KEYWORD;
-            case TABLE_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_TABLE_KEYWORD;
-            case KEY_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_KEY_KEYWORD;
-            case LET_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_LET_KEYWORD;
-            case NEW_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_NEW_KEYWORD;
-            case FROM_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_FROM_KEYWORD;
-            case WHERE_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_WHERE_KEYWORD;
-            case SELECT_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_SELECT_KEYWORD;
-            case START_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_START_KEYWORD;
-            case FLUSH_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_FLUSH_KEYWORD;
-            case WAIT_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_WAIT_KEYWORD;
-            case DO_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_DO_KEYWORD;
-            case TRANSACTION_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_TRANSACTION_KEYWORD;
-            case TRANSACTIONAL_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_TRANSACTIONAL_KEYWORD;
-            case COMMIT_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_COMMIT_KEYWORD;
-            case ROLLBACK_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_ROLLBACK_KEYWORD;
-            case RETRY_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_RETRY_KEYWORD;
-            case ENUM_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_ENUM_KEYWORD;
-            case BASE16_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_BASE16_KEYWORD;
-            case BASE64_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_BASE64_KEYWORD;
-            case MATCH_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_MATCH_KEYWORD;
-            case CONFLICT_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_CONFLICT_KEYWORD;
-            case LIMIT_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_LIMIT_KEYWORD;
-            case ORDER_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_ORDER_KEYWORD;
-            case BY_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_BY_KEYWORD;
-            case GROUP_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_GROUP_KEYWORD;
-            case ORDER_DIRECTION:
-                return DiagnosticErrorCode.ERROR_MISSING_ASCENDING_KEYWORD;
-            case JOIN_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_JOIN_KEYWORD;
-            case OUTER_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_OUTER_KEYWORD;
-            case FAIL_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_FAIL_KEYWORD;
-            case PIPE:
-            case UNION_OR_INTERSECTION_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_PIPE_TOKEN;
-            case EQUALS_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_EQUALS_KEYWORD;
-            case REMOTE_IDENT:
-                return DiagnosticErrorCode.ERROR_MISSING_REMOTE_KEYWORD;
+        return switch (ctx) {
+            case PUBLIC_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_PUBLIC_KEYWORD;
+            case PRIVATE_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_PRIVATE_KEYWORD;
+            case ABSTRACT_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_ABSTRACT_KEYWORD;
+            case CLIENT_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_CLIENT_KEYWORD;
+            case IMPORT_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_IMPORT_KEYWORD;
+            case FUNCTION_KEYWORD,
+                 FUNCTION_IDENT,
+                 OPTIONAL_PEER_WORKER,
+                 DEFAULT_WORKER_NAME_IN_ASYNC_SEND -> DiagnosticErrorCode.ERROR_MISSING_FUNCTION_KEYWORD;
+            case CONST_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_CONST_KEYWORD;
+            case LISTENER_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_LISTENER_KEYWORD;
+            case SERVICE_KEYWORD,
+                 SERVICE_IDENT,
+                 SERVICE_DECL_QUALIFIER -> DiagnosticErrorCode.ERROR_MISSING_SERVICE_KEYWORD;
+            case XMLNS_KEYWORD,
+                 XML_NAMESPACE_DECLARATION -> DiagnosticErrorCode.ERROR_MISSING_XMLNS_KEYWORD;
+            case ANNOTATION_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_ANNOTATION_KEYWORD;
+            case TYPE_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_TYPE_KEYWORD;
+            case RECORD_KEYWORD,
+                 RECORD_FIELD,
+                 RECORD_IDENT -> DiagnosticErrorCode.ERROR_MISSING_RECORD_KEYWORD;
+            case OBJECT_KEYWORD,
+                 OBJECT_IDENT,
+                 OBJECT_TYPE_DESCRIPTOR,
+                 FIRST_OBJECT_CONS_QUALIFIER,
+                 SECOND_OBJECT_CONS_QUALIFIER,
+                 FIRST_OBJECT_TYPE_QUALIFIER,
+                 SECOND_OBJECT_TYPE_QUALIFIER -> DiagnosticErrorCode.ERROR_MISSING_OBJECT_KEYWORD;
+            case AS_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_AS_KEYWORD;
+            case ON_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_ON_KEYWORD;
+            case FINAL_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_FINAL_KEYWORD;
+            case SOURCE_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_SOURCE_KEYWORD;
+            case WORKER_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_WORKER_KEYWORD;
+            case FIELD_IDENT -> DiagnosticErrorCode.ERROR_MISSING_FIELD_KEYWORD;
+            case RETURNS_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_RETURNS_KEYWORD;
+            case RETURN_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_RETURN_KEYWORD;
+            case EXTERNAL_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_EXTERNAL_KEYWORD;
+            case BOOLEAN_LITERAL -> DiagnosticErrorCode.ERROR_MISSING_TRUE_KEYWORD;
+            case IF_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_IF_KEYWORD;
+            case ELSE_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_ELSE_KEYWORD;
+            case WHILE_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_WHILE_KEYWORD;
+            case CHECKING_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_CHECK_KEYWORD;
+            case PANIC_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_PANIC_KEYWORD;
+            case CONTINUE_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_CONTINUE_KEYWORD;
+            case BREAK_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_BREAK_KEYWORD;
+            case TYPEOF_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_TYPEOF_KEYWORD;
+            case IS_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_IS_KEYWORD;
+            case NULL_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_NULL_KEYWORD;
+            case LOCK_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_LOCK_KEYWORD;
+            case FORK_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_FORK_KEYWORD;
+            case TRAP_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_TRAP_KEYWORD;
+            case IN_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_IN_KEYWORD;
+            case FOREACH_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_FOREACH_KEYWORD;
+            case TABLE_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_TABLE_KEYWORD;
+            case KEY_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_KEY_KEYWORD;
+            case LET_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_LET_KEYWORD;
+            case NEW_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_NEW_KEYWORD;
+            case FROM_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_FROM_KEYWORD;
+            case WHERE_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_WHERE_KEYWORD;
+            case SELECT_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_SELECT_KEYWORD;
+            case START_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_START_KEYWORD;
+            case FLUSH_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_FLUSH_KEYWORD;
+            case WAIT_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_WAIT_KEYWORD;
+            case DO_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_DO_KEYWORD;
+            case TRANSACTION_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_TRANSACTION_KEYWORD;
+            case TRANSACTIONAL_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_TRANSACTIONAL_KEYWORD;
+            case COMMIT_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_COMMIT_KEYWORD;
+            case ROLLBACK_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_ROLLBACK_KEYWORD;
+            case RETRY_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_RETRY_KEYWORD;
+            case ENUM_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_ENUM_KEYWORD;
+            case BASE16_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_BASE16_KEYWORD;
+            case BASE64_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_BASE64_KEYWORD;
+            case MATCH_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_MATCH_KEYWORD;
+            case CONFLICT_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_CONFLICT_KEYWORD;
+            case LIMIT_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_LIMIT_KEYWORD;
+            case ORDER_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_ORDER_KEYWORD;
+            case BY_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_BY_KEYWORD;
+            case GROUP_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_GROUP_KEYWORD;
+            case ORDER_DIRECTION -> DiagnosticErrorCode.ERROR_MISSING_ASCENDING_KEYWORD;
+            case JOIN_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_JOIN_KEYWORD;
+            case OUTER_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_OUTER_KEYWORD;
+            case FAIL_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_FAIL_KEYWORD;
+            case PIPE,
+                 UNION_OR_INTERSECTION_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_PIPE_TOKEN;
+            case EQUALS_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_EQUALS_KEYWORD;
+            case REMOTE_IDENT -> DiagnosticErrorCode.ERROR_MISSING_REMOTE_KEYWORD;
 
             // Type keywords
-            case STRING_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_STRING_KEYWORD;
-            case XML_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_XML_KEYWORD;
-            case RE_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_RE_KEYWORD;
-            case VAR_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_VAR_KEYWORD;
-            case MAP_KEYWORD:
-            case NAMED_WORKER_DECL:
-            case MAP_TYPE_DESCRIPTOR:
-                return DiagnosticErrorCode.ERROR_MISSING_MAP_KEYWORD;
-            case ERROR_KEYWORD:
-            case ERROR_BINDING_PATTERN:
-            case PARAMETERIZED_TYPE:
-                return DiagnosticErrorCode.ERROR_MISSING_ERROR_KEYWORD;
-            case STREAM_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_STREAM_KEYWORD;
-            case READONLY_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_READONLY_KEYWORD;
-            case DISTINCT_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_DISTINCT_KEYWORD;
-            case CLASS_KEYWORD:
-            case FIRST_CLASS_TYPE_QUALIFIER:
-            case SECOND_CLASS_TYPE_QUALIFIER:
-            case THIRD_CLASS_TYPE_QUALIFIER:
-            case FOURTH_CLASS_TYPE_QUALIFIER:
-                return DiagnosticErrorCode.ERROR_MISSING_CLASS_KEYWORD;
-            case COLLECT_KEYWORD:
-                return DiagnosticErrorCode.ERROR_MISSING_COLLECT_KEYWORD;
-            default:
-                return DiagnosticErrorCode.ERROR_SYNTAX_ERROR;
-        }
+            case STRING_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_STRING_KEYWORD;
+            case XML_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_XML_KEYWORD;
+            case RE_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_RE_KEYWORD;
+            case VAR_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_VAR_KEYWORD;
+            case MAP_KEYWORD,
+                 NAMED_WORKER_DECL,
+                 MAP_TYPE_DESCRIPTOR -> DiagnosticErrorCode.ERROR_MISSING_MAP_KEYWORD;
+            case ERROR_KEYWORD,
+                 ERROR_BINDING_PATTERN,
+                 PARAMETERIZED_TYPE -> DiagnosticErrorCode.ERROR_MISSING_ERROR_KEYWORD;
+            case STREAM_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_STREAM_KEYWORD;
+            case READONLY_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_READONLY_KEYWORD;
+            case DISTINCT_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_DISTINCT_KEYWORD;
+            case CLASS_KEYWORD,
+                 FIRST_CLASS_TYPE_QUALIFIER,
+                 SECOND_CLASS_TYPE_QUALIFIER,
+                 THIRD_CLASS_TYPE_QUALIFIER,
+                 FOURTH_CLASS_TYPE_QUALIFIER -> DiagnosticErrorCode.ERROR_MISSING_CLASS_KEYWORD;
+            case COLLECT_KEYWORD -> DiagnosticErrorCode.ERROR_MISSING_COLLECT_KEYWORD;
+            default -> DiagnosticErrorCode.ERROR_SYNTAX_ERROR;
+        };
     }
 
     private static DiagnosticCode getDocWarningCode(SyntaxKind expectedKind) {
-        switch (expectedKind) {
-            case HASH_TOKEN:
-                return DiagnosticWarningCode.WARNING_MISSING_HASH_TOKEN;
-            case BACKTICK_TOKEN:
-                return DiagnosticWarningCode.WARNING_MISSING_SINGLE_BACKTICK_TOKEN;
-            case DOUBLE_BACKTICK_TOKEN:
-                return DiagnosticWarningCode.WARNING_MISSING_DOUBLE_BACKTICK_TOKEN;
-            case TRIPLE_BACKTICK_TOKEN:
-                return DiagnosticWarningCode.WARNING_MISSING_TRIPLE_BACKTICK_TOKEN;
-            case IDENTIFIER_TOKEN:
-                return DiagnosticWarningCode.WARNING_MISSING_IDENTIFIER_TOKEN;
-            case OPEN_PAREN_TOKEN:
-                return DiagnosticWarningCode.WARNING_MISSING_OPEN_PAREN_TOKEN;
-            case CLOSE_PAREN_TOKEN:
-                return DiagnosticWarningCode.WARNING_MISSING_CLOSE_PAREN_TOKEN;
-            case MINUS_TOKEN:
-                return DiagnosticWarningCode.WARNING_MISSING_HYPHEN_TOKEN;
-            case PARAMETER_NAME:
-                return DiagnosticWarningCode.WARNING_MISSING_PARAMETER_NAME;
-            case CODE_CONTENT:
-                return DiagnosticWarningCode.WARNING_MISSING_CODE_REFERENCE;
-            default:
-                return DiagnosticWarningCode.WARNING_SYNTAX_WARNING;
-        }
+        return switch (expectedKind) {
+            case HASH_TOKEN -> DiagnosticWarningCode.WARNING_MISSING_HASH_TOKEN;
+            case BACKTICK_TOKEN -> DiagnosticWarningCode.WARNING_MISSING_SINGLE_BACKTICK_TOKEN;
+            case DOUBLE_BACKTICK_TOKEN -> DiagnosticWarningCode.WARNING_MISSING_DOUBLE_BACKTICK_TOKEN;
+            case TRIPLE_BACKTICK_TOKEN -> DiagnosticWarningCode.WARNING_MISSING_TRIPLE_BACKTICK_TOKEN;
+            case IDENTIFIER_TOKEN -> DiagnosticWarningCode.WARNING_MISSING_IDENTIFIER_TOKEN;
+            case OPEN_PAREN_TOKEN -> DiagnosticWarningCode.WARNING_MISSING_OPEN_PAREN_TOKEN;
+            case CLOSE_PAREN_TOKEN -> DiagnosticWarningCode.WARNING_MISSING_CLOSE_PAREN_TOKEN;
+            case MINUS_TOKEN -> DiagnosticWarningCode.WARNING_MISSING_HYPHEN_TOKEN;
+            case PARAMETER_NAME -> DiagnosticWarningCode.WARNING_MISSING_PARAMETER_NAME;
+            case CODE_CONTENT -> DiagnosticWarningCode.WARNING_MISSING_CODE_REFERENCE;
+            default -> DiagnosticWarningCode.WARNING_SYNTAX_WARNING;
+        };
     }
 
     private static DiagnosticCode getRegExpErrorCode(SyntaxKind expectedKind) {
-        switch (expectedKind) {
-            case CLOSE_PAREN_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_CLOSE_PAREN_TOKEN;
-            case CLOSE_BRACKET_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACKET_TOKEN;
-            case OPEN_BRACE_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACE_TOKEN;
-            case CLOSE_BRACE_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACE_TOKEN;
-            case COLON_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_COLON_TOKEN;
-            case RE_UNICODE_PROPERTY_VALUE:
-                return DiagnosticErrorCode.ERROR_MISSING_RE_UNICODE_PROPERTY_VALUE;
-            case DIGIT:
-                return DiagnosticErrorCode.ERROR_MISSING_RE_QUANTIFIER_DIGIT;
-            case BITWISE_XOR_TOKEN:
-                return DiagnosticErrorCode.ERROR_INVALID_RE_SYNTAX_CHAR;
-            case BACK_SLASH_TOKEN:
-                return DiagnosticErrorCode.ERROR_MISSING_BACKSLASH;
-            default:
-                return DiagnosticErrorCode.ERROR_SYNTAX_ERROR;
-        }
+        return switch (expectedKind) {
+            case CLOSE_PAREN_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_CLOSE_PAREN_TOKEN;
+            case CLOSE_BRACKET_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACKET_TOKEN;
+            case OPEN_BRACE_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACE_TOKEN;
+            case CLOSE_BRACE_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACE_TOKEN;
+            case COLON_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_COLON_TOKEN;
+            case RE_UNICODE_PROPERTY_VALUE -> DiagnosticErrorCode.ERROR_MISSING_RE_UNICODE_PROPERTY_VALUE;
+            case DIGIT -> DiagnosticErrorCode.ERROR_MISSING_RE_QUANTIFIER_DIGIT;
+            case BITWISE_XOR_TOKEN -> DiagnosticErrorCode.ERROR_INVALID_RE_SYNTAX_CHAR;
+            case BACK_SLASH_TOKEN -> DiagnosticErrorCode.ERROR_MISSING_BACKSLASH;
+            default -> DiagnosticErrorCode.ERROR_SYNTAX_ERROR;
+        };
     }
 
     /**

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/XMLLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/XMLLexer.java
@@ -45,53 +45,37 @@ public class XMLLexer extends AbstractLexer {
      */
     @Override
     public STToken nextToken() {
-        STToken token;
-        switch (this.mode) {
-            case XML_CONTENT:
-                token = readTokenInXMLContent();
-                break;
-            case XML_ELEMENT_START_TAG:
+        STToken token = switch (this.mode) {
+            case XML_CONTENT -> readTokenInXMLContent();
+            case XML_ELEMENT_START_TAG -> {
                 processLeadingXMLTrivia();
-                token = readTokenInXMLElement(true);
-                break;
-            case XML_ELEMENT_END_TAG:
+                yield readTokenInXMLElement(true);
+            }
+            case XML_ELEMENT_END_TAG -> {
                 processLeadingXMLTrivia();
-                token = readTokenInXMLElement(false);
-                break;
-            case XML_TEXT:
-                // XML text have no trivia. Whitespace is part of the text.
-                token = readTokenInXMLText();
-                break;
-            case INTERPOLATION:
-                token = readTokenInInterpolation();
-                break;
-            case XML_ATTRIBUTES:
+                yield readTokenInXMLElement(false);
+            }
+            // XML text have no trivia. Whitespace is part of the text.
+            case XML_TEXT -> readTokenInXMLText();
+            case INTERPOLATION -> readTokenInInterpolation();
+            case XML_ATTRIBUTES -> {
                 processLeadingXMLTrivia();
-                token = readTokenInXMLAttributes(true);
-                break;
-            case XML_COMMENT:
-                token = readTokenInXMLCommentOrCDATA(false);
-                break;
-            case XML_PI:
+                yield readTokenInXMLAttributes(true);
+            }
+            case XML_COMMENT -> readTokenInXMLCommentOrCDATA(false);
+            case XML_PI -> {
                 processLeadingXMLTrivia();
-                token = readTokenInXMLPI();
-                break;
-            case XML_PI_DATA:
+                yield readTokenInXMLPI();
+            }
+            case XML_PI_DATA -> {
                 processLeadingXMLTrivia();
-                token = readTokenInXMLPIData();
-                break;
-            case XML_SINGLE_QUOTED_STRING:
-                token = processXMLSingleQuotedString();
-                break;
-            case XML_DOUBLE_QUOTED_STRING:
-                token = processXMLDoubleQuotedString();
-                break;
-            case XML_CDATA_SECTION:
-                token = readTokenInXMLCommentOrCDATA(true);
-                break;
-            default:
-                token = null;
-        }
+                yield readTokenInXMLPIData();
+            }
+            case XML_SINGLE_QUOTED_STRING -> processXMLSingleQuotedString();
+            case XML_DOUBLE_QUOTED_STRING -> processXMLDoubleQuotedString();
+            case XML_CDATA_SECTION -> readTokenInXMLCommentOrCDATA(true);
+            default -> null;
+        };
 
         // Can we improve this logic by creating the token with diagnostics then and there?
         return cloneWithDiagnostics(token);

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/XMLParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/XMLParser.java
@@ -76,17 +76,16 @@ public class XMLParser extends AbstractParser {
      * @return <code>true</code> if this is the end of the back-tick literal. <code>false</code> otherwise
      */
     private boolean isEndOfXMLContent(SyntaxKind kind, boolean isInXMLElement) {
-        switch (kind) {
-            case EOF_TOKEN:
-            case BACKTICK_TOKEN:
-                return true;
-            case LT_TOKEN:
+        return switch (kind) {
+            case EOF_TOKEN,
+                 BACKTICK_TOKEN -> true;
+            case LT_TOKEN -> {
                 STToken nextNextToken = getNextNextToken();
-                return isInXMLElement &&
+                yield isInXMLElement &&
                         (nextNextToken.kind == SyntaxKind.SLASH_TOKEN || nextNextToken.kind == SyntaxKind.LT_TOKEN);
-            default:
-                return false;
-        }
+            }
+            default -> false;
+        };
     }
 
     /**
@@ -104,20 +103,14 @@ public class XMLParser extends AbstractParser {
      */
     private STNode parseXMLContentItem() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case LT_TOKEN:
-                return parseXMLElement();
-            case XML_COMMENT_START_TOKEN:
-                return parseXMLComment();
-            case XML_PI_START_TOKEN:
-                return parseXMLPI();
-            case INTERPOLATION_START_TOKEN:
-                return parseInterpolation();
-            case XML_CDATA_START_TOKEN:
-                return parseXMLCdataSection();
-            default:
-                return parseXMLText();
-        }
+        return switch (nextToken.kind) {
+            case LT_TOKEN -> parseXMLElement();
+            case XML_COMMENT_START_TOKEN -> parseXMLComment();
+            case XML_PI_START_TOKEN -> parseXMLPI();
+            case INTERPOLATION_START_TOKEN -> parseInterpolation();
+            case XML_CDATA_START_TOKEN -> parseXMLCdataSection();
+            default -> parseXMLText();
+        };
     }
 
     /**
@@ -338,19 +331,17 @@ public class XMLParser extends AbstractParser {
      * @return <code>true</code> if this is the end of the XML attributes. <code>false</code> otherwise
      */
     private boolean isEndOfXMLAttributes(SyntaxKind kind) {
-        switch (kind) {
-            case EOF_TOKEN:
-            case BACKTICK_TOKEN:
-            case GT_TOKEN:
-            case LT_TOKEN:
-            case SLASH_TOKEN:
-            case XML_COMMENT_START_TOKEN:
-            case XML_PI_START_TOKEN:
-            case XML_CDATA_START_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (kind) {
+            case EOF_TOKEN,
+                 BACKTICK_TOKEN,
+                 GT_TOKEN,
+                 LT_TOKEN,
+                 SLASH_TOKEN,
+                 XML_COMMENT_START_TOKEN,
+                 XML_PI_START_TOKEN,
+                 XML_CDATA_START_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -432,18 +423,17 @@ public class XMLParser extends AbstractParser {
     }
 
     private boolean isEndOfXMLAttributeValue(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case EOF_TOKEN:
-            case BACKTICK_TOKEN:
-            case LT_TOKEN:
-            case GT_TOKEN:
-            case DOUBLE_QUOTE_TOKEN:
-            case SINGLE_QUOTE_TOKEN:
-            case IDENTIFIER_TOKEN: // Lexer will return identifier if the start quote is missing    
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextTokenKind) {
+            case EOF_TOKEN,
+                 BACKTICK_TOKEN,
+                 LT_TOKEN,
+                 GT_TOKEN,
+                 DOUBLE_QUOTE_TOKEN,
+                 SINGLE_QUOTE_TOKEN,
+                 IDENTIFIER_TOKEN -> // Lexer will return identifier if the start quote is missing
+                    true;
+            default -> false;
+        };
     }
 
     /**
@@ -459,16 +449,16 @@ public class XMLParser extends AbstractParser {
      */
     private STNode parseXMLText() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case INTERPOLATION_START_TOKEN:
-            case EOF_TOKEN:
-            case BACKTICK_TOKEN:
-            case LT_TOKEN:
-                return null;
-            default:
+        return switch (nextToken.kind) {
+            case INTERPOLATION_START_TOKEN,
+                 EOF_TOKEN,
+                 BACKTICK_TOKEN,
+                 LT_TOKEN -> null;
+            default -> {
                 STNode content = parseCharData();
-                return STNodeFactory.createXMLTextNode(content);
-        }
+                yield STNodeFactory.createXMLTextNode(content);
+            }
+        };
     }
 
     /**
@@ -540,16 +530,14 @@ public class XMLParser extends AbstractParser {
     }
 
     private boolean isEndOfXMLComment(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case EOF_TOKEN:
-            case BACKTICK_TOKEN:
-            case LT_TOKEN:
-            case GT_TOKEN:
-            case XML_COMMENT_END_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextTokenKind) {
+            case EOF_TOKEN,
+                 BACKTICK_TOKEN,
+                 LT_TOKEN,
+                 GT_TOKEN,
+                 XML_COMMENT_END_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -583,14 +571,12 @@ public class XMLParser extends AbstractParser {
     }
 
     private boolean isEndOfXMLCdata(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case EOF_TOKEN:
-            case BACKTICK_TOKEN:
-            case XML_CDATA_END_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextTokenKind) {
+            case EOF_TOKEN,
+                 BACKTICK_TOKEN,
+                 XML_CDATA_END_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -670,16 +656,14 @@ public class XMLParser extends AbstractParser {
     }
 
     private boolean isEndOfXMLPI(SyntaxKind nextTokenKind) {
-        switch (nextTokenKind) {
-            case EOF_TOKEN:
-            case BACKTICK_TOKEN:
-            case LT_TOKEN:
-            case GT_TOKEN:
-            case XML_PI_END_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (nextTokenKind) {
+            case EOF_TOKEN,
+                 BACKTICK_TOKEN,
+                 LT_TOKEN,
+                 GT_TOKEN,
+                 XML_PI_END_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -689,14 +673,11 @@ public class XMLParser extends AbstractParser {
      */
     private STNode parseXMLCharacterSet() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case XML_TEXT_CONTENT:
-                return consume();
-            case INTERPOLATION_START_TOKEN:
-                return parseInterpolation();
-            default:
-                throw new IllegalStateException();
-        }
+        return switch (nextToken.kind) {
+            case XML_TEXT_CONTENT -> consume();
+            case INTERPOLATION_START_TOKEN -> parseInterpolation();
+            default -> throw new IllegalStateException();
+        };
     }
 
     private Solution recover(STToken token, ParserRuleContext currentCtx) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/XMLParserErrorHandler.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/XMLParserErrorHandler.java
@@ -54,17 +54,15 @@ public class XMLParserErrorHandler extends AbstractParserErrorHandler {
 
     @Override
     protected boolean hasAlternativePaths(ParserRuleContext currentCtx) {
-        switch (currentCtx) {
-            case XML_CONTENT:
-            case XML_ATTRIBUTES:
-            case XML_START_OR_EMPTY_TAG_END:
-            case XML_ATTRIBUTE_VALUE_ITEM:
-            case XML_PI_TARGET_RHS:
-            case XML_OPTIONAL_CDATA_CONTENT:
-                return true;
-            default:
-                return false;
-        }
+        return switch (currentCtx) {
+            case XML_CONTENT,
+                 XML_ATTRIBUTES,
+                 XML_START_OR_EMPTY_TAG_END,
+                 XML_ATTRIBUTE_VALUE_ITEM,
+                 XML_PI_TARGET_RHS,
+                 XML_OPTIONAL_CDATA_CONTENT -> true;
+            default -> false;
+        };
     }
 
     @Override
@@ -167,29 +165,15 @@ public class XMLParserErrorHandler extends AbstractParserErrorHandler {
 
     private Result seekMatchInAlternativePaths(ParserRuleContext currentCtx, int lookahead, int currentDepth,
                                                int matchingRulesCount, boolean isEntryPoint) {
-        ParserRuleContext[] alternativeRules;
-        switch (currentCtx) {
-            case XML_CONTENT:
-                alternativeRules = XML_CONTENT;
-                break;
-            case XML_ATTRIBUTES:
-                alternativeRules = XML_ATTRIBUTES;
-                break;
-            case XML_START_OR_EMPTY_TAG_END:
-                alternativeRules = XML_START_OR_EMPTY_TAG_END;
-                break;
-            case XML_ATTRIBUTE_VALUE_ITEM:
-                alternativeRules = XML_ATTRIBUTE_VALUE_ITEM;
-                break;
-            case XML_PI_TARGET_RHS:
-                alternativeRules = XML_PI_TARGET_RHS;
-                break;
-            case XML_OPTIONAL_CDATA_CONTENT:
-                alternativeRules = XML_OPTIONAL_CDATA_CONTENT;
-                break;
-            default:
-                throw new IllegalStateException("seekMatchInExprRelatedAlternativePaths found: " + currentCtx);
-        }
+        ParserRuleContext[] alternativeRules = switch (currentCtx) {
+            case XML_CONTENT -> XML_CONTENT;
+            case XML_ATTRIBUTES -> XML_ATTRIBUTES;
+            case XML_START_OR_EMPTY_TAG_END -> XML_START_OR_EMPTY_TAG_END;
+            case XML_ATTRIBUTE_VALUE_ITEM -> XML_ATTRIBUTE_VALUE_ITEM;
+            case XML_PI_TARGET_RHS -> XML_PI_TARGET_RHS;
+            case XML_OPTIONAL_CDATA_CONTENT -> XML_OPTIONAL_CDATA_CONTENT;
+            default -> throw new IllegalStateException("seekMatchInExprRelatedAlternativePaths found: " + currentCtx);
+        };
 
         return seekInAlternativesPaths(lookahead, currentDepth, matchingRulesCount, alternativeRules, isEntryPoint);
     }
@@ -213,45 +197,35 @@ public class XMLParserErrorHandler extends AbstractParserErrorHandler {
                 return ParserRuleContext.LT_TOKEN;
             case LT_TOKEN:
                 ParserRuleContext parentCtx = getParentContext();
-                switch (parentCtx) {
-                    case XML_START_OR_EMPTY_TAG:
-                        return ParserRuleContext.XML_NAME;
-                    case XML_END_TAG:
-                        return ParserRuleContext.SLASH;
-                    default:
-                        throw new IllegalStateException(" < cannot exist in: " + parentCtx);
-                }
+                return switch (parentCtx) {
+                    case XML_START_OR_EMPTY_TAG -> ParserRuleContext.XML_NAME;
+                    case XML_END_TAG -> ParserRuleContext.SLASH;
+                    default -> throw new IllegalStateException(" < cannot exist in: " + parentCtx);
+                };
             case GT_TOKEN:
             case XML_PI_END:
                 endContext();
                 return ParserRuleContext.XML_CONTENT;
             case XML_NAME:
                 parentCtx = getParentContext();
-                switch (parentCtx) {
-                    case XML_START_OR_EMPTY_TAG:
-                        return ParserRuleContext.XML_ATTRIBUTES;
-                    case XML_END_TAG:
-                        return ParserRuleContext.GT_TOKEN;
-                    case XML_ATTRIBUTES:
-                        return ParserRuleContext.ASSIGN_OP;
-                    case XML_PI:
-                        return ParserRuleContext.XML_PI_TARGET_RHS;
-                    default:
-                        throw new IllegalStateException("XML name cannot exist in: " + parentCtx);
-                }
+                return switch (parentCtx) {
+                    case XML_START_OR_EMPTY_TAG -> ParserRuleContext.XML_ATTRIBUTES;
+                    case XML_END_TAG -> ParserRuleContext.GT_TOKEN;
+                    case XML_ATTRIBUTES -> ParserRuleContext.ASSIGN_OP;
+                    case XML_PI -> ParserRuleContext.XML_PI_TARGET_RHS;
+                    default -> throw new IllegalStateException("XML name cannot exist in: " + parentCtx);
+                };
             case SLASH:
                 parentCtx = getParentContext();
-                switch (parentCtx) {
-                    case XML_ATTRIBUTES:
+                return switch (parentCtx) {
+                    case XML_ATTRIBUTES -> {
                         endContext();
-                        return ParserRuleContext.GT_TOKEN;
-                    case XML_START_OR_EMPTY_TAG:
-                        return ParserRuleContext.GT_TOKEN;
-                    case XML_END_TAG:
-                        return ParserRuleContext.XML_NAME;
-                    default:
-                        throw new IllegalStateException("slash cannot exist in: " + parentCtx);
-                }
+                        yield ParserRuleContext.GT_TOKEN;
+                    }
+                    case XML_START_OR_EMPTY_TAG -> ParserRuleContext.GT_TOKEN;
+                    case XML_END_TAG -> ParserRuleContext.XML_NAME;
+                    default -> throw new IllegalStateException("slash cannot exist in: " + parentCtx);
+                };
             case ASSIGN_OP:
                 return ParserRuleContext.XML_QUOTE_START;
             case XML_ATTRIBUTE:
@@ -293,47 +267,30 @@ public class XMLParserErrorHandler extends AbstractParserErrorHandler {
 
     @Override
     protected SyntaxKind getExpectedTokenKind(ParserRuleContext context) {
-        switch (context) {
-            case LT_TOKEN:
-            case XML_START_OR_EMPTY_TAG:
-            case XML_END_TAG:
-                return SyntaxKind.LT_TOKEN;
-            case GT_TOKEN:
-                return SyntaxKind.GT_TOKEN;
-            case SLASH:
-                return SyntaxKind.SLASH_TOKEN;
-            case XML_KEYWORD:
-                return SyntaxKind.XML_KEYWORD;
-            case XML_NAME:
-                return SyntaxKind.IDENTIFIER_TOKEN;
-            case ASSIGN_OP:
-                return SyntaxKind.EQUAL_TOKEN;
-            case XML_START_OR_EMPTY_TAG_END:
-            case XML_ATTRIBUTES:
-                return SyntaxKind.GT_TOKEN;
-            case XML_CONTENT:
-            case XML_TEXT:
-                return SyntaxKind.BACKTICK_TOKEN;
-            case XML_COMMENT_START:
-                return SyntaxKind.XML_COMMENT_START_TOKEN;
-            case XML_COMMENT_CONTENT:
-                return SyntaxKind.XML_TEXT_CONTENT;
-            case XML_COMMENT_END:
-                return SyntaxKind.XML_COMMENT_END_TOKEN;
-            case XML_PI:
-            case XML_PI_START:
-                return SyntaxKind.XML_PI_START_TOKEN;
-            case XML_PI_END:
-                return SyntaxKind.XML_PI_END_TOKEN;
-            case XML_PI_DATA:
-                return SyntaxKind.XML_TEXT_CONTENT;
-            case XML_QUOTE_END:
-            case XML_QUOTE_START:
-                return SyntaxKind.DOUBLE_QUOTE_TOKEN;
-            case XML_CDATA_END:
-                return SyntaxKind.XML_CDATA_END_TOKEN;
-            default:
-                return SyntaxKind.NONE;
-        }
+        return switch (context) {
+            case LT_TOKEN,
+                 XML_START_OR_EMPTY_TAG,
+                 XML_END_TAG -> SyntaxKind.LT_TOKEN;
+            case GT_TOKEN -> SyntaxKind.GT_TOKEN;
+            case SLASH -> SyntaxKind.SLASH_TOKEN;
+            case XML_KEYWORD -> SyntaxKind.XML_KEYWORD;
+            case XML_NAME -> SyntaxKind.IDENTIFIER_TOKEN;
+            case ASSIGN_OP -> SyntaxKind.EQUAL_TOKEN;
+            case XML_START_OR_EMPTY_TAG_END,
+                 XML_ATTRIBUTES -> SyntaxKind.GT_TOKEN;
+            case XML_CONTENT,
+                 XML_TEXT -> SyntaxKind.BACKTICK_TOKEN;
+            case XML_COMMENT_START -> SyntaxKind.XML_COMMENT_START_TOKEN;
+            case XML_COMMENT_CONTENT -> SyntaxKind.XML_TEXT_CONTENT;
+            case XML_COMMENT_END -> SyntaxKind.XML_COMMENT_END_TOKEN;
+            case XML_PI,
+                 XML_PI_START -> SyntaxKind.XML_PI_START_TOKEN;
+            case XML_PI_END -> SyntaxKind.XML_PI_END_TOKEN;
+            case XML_PI_DATA -> SyntaxKind.XML_TEXT_CONTENT;
+            case XML_QUOTE_END,
+                 XML_QUOTE_START -> SyntaxKind.DOUBLE_QUOTE_TOKEN;
+            case XML_CDATA_END -> SyntaxKind.XML_CDATA_END_TOKEN;
+            default -> SyntaxKind.NONE;
+        };
     }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/incremental/HybridNodes.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/incremental/HybridNodes.java
@@ -41,14 +41,11 @@ class HybridNodes {
      */
     static HybridNode nextNode(HybridNode prevNode, HybridNode.Kind kind) {
         HybridNode.State state = prevNode.state().cloneState();
-        switch (kind) {
-            case TOKEN:
-                return nextToken(state);
-            case SUBTREE:
-                return nextSubtree(state);
-            default:
-                throw new UnsupportedOperationException("Unsupported HybridNode.Kind: " + kind);
-        }
+        return switch (kind) {
+            case TOKEN -> nextToken(state);
+            case SUBTREE -> nextSubtree(state);
+            default -> throw new UnsupportedOperationException("Unsupported HybridNode.Kind: " + kind);
+        };
     }
 
     private static HybridNode nextSubtree(HybridNode.State state) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STMissingToken.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STMissingToken.java
@@ -61,12 +61,10 @@ public class STMissingToken extends STToken {
 
     @Override
     public Node createFacade(int position, NonTerminalNode parent) {
-        switch (kind) {
-            case IDENTIFIER_TOKEN:
-                return new IdentifierToken(this, position, parent);
-            default:
-                return new Token(this, position, parent);
-        }
+        return switch (kind) {
+            case IDENTIFIER_TOKEN -> new IdentifierToken(this, position, parent);
+            default -> new Token(this, position, parent);
+        };
     }
 
     @Override

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/utils/ConditionalExprResolver.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/utils/ConditionalExprResolver.java
@@ -78,20 +78,10 @@ public class ConditionalExprResolver {
      * @return <code>true</code> if modulePrefixIdentifier text is Valid Simple NameRef
      */
     private static boolean isValidSimpleNameRef(STToken modulePrefixIdentifier) {
-        switch (modulePrefixIdentifier.text()) {
-            case ERROR:
-            case FUTURE:
-            case MAP:
-            case OBJECT:
-            case STREAM:
-            case TABLE:
-            case TRANSACTION:
-            case TYPEDESC:
-            case XML:
-                return false;
-            default:
-                return true;
-        }
+        return switch (modulePrefixIdentifier.text()) {
+            case ERROR, FUTURE, MAP, OBJECT, STREAM, TABLE, TRANSACTION, TYPEDESC, XML -> false;
+            default -> true;
+        };
     }
 
     /**

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/ParserTestUtils.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/ParserTestUtils.java
@@ -333,15 +333,10 @@ public class ParserTestUtils {
     }
 
     public static boolean isTrivia(SyntaxKind syntaxKind) {
-        switch (syntaxKind) {
-            case WHITESPACE_MINUTIAE:
-            case END_OF_LINE_MINUTIAE:
-            case COMMENT_MINUTIAE:
-            case INVALID_NODE_MINUTIAE:
-                return true;
-            default:
-                return false;
-        }
+        return switch (syntaxKind) {
+            case WHITESPACE_MINUTIAE, END_OF_LINE_MINUTIAE, COMMENT_MINUTIAE, INVALID_NODE_MINUTIAE -> true;
+            default -> false;
+        };
     }
 
     public static String getTokenText(STToken token) {
@@ -432,1048 +427,560 @@ public class ParserTestUtils {
     }
 
     private static SyntaxKind getNodeKind(String kind) {
-        switch (kind) {
-            case "MODULE_PART":
-                return SyntaxKind.MODULE_PART;
-            case "TYPE_DEFINITION":
-                return SyntaxKind.TYPE_DEFINITION;
-            case "FUNCTION_DEFINITION":
-                return SyntaxKind.FUNCTION_DEFINITION;
-            case "IMPORT_DECLARATION":
-                return SyntaxKind.IMPORT_DECLARATION;
-            case "SERVICE_DECLARATION":
-                return SyntaxKind.SERVICE_DECLARATION;
-            case "LISTENER_DECLARATION":
-                return SyntaxKind.LISTENER_DECLARATION;
-            case "CONST_DECLARATION":
-                return SyntaxKind.CONST_DECLARATION;
-            case "MODULE_VAR_DECL":
-                return SyntaxKind.MODULE_VAR_DECL;
-            case "XML_NAMESPACE_DECLARATION":
-                return SyntaxKind.XML_NAMESPACE_DECLARATION;
-            case "MODULE_XML_NAMESPACE_DECLARATION":
-                return SyntaxKind.MODULE_XML_NAMESPACE_DECLARATION;
-            case "ANNOTATION_DECLARATION":
-                return SyntaxKind.ANNOTATION_DECLARATION;
-            case "ENUM_DECLARATION":
-                return SyntaxKind.ENUM_DECLARATION;
-            case "CLASS_DEFINITION":
-                return SyntaxKind.CLASS_DEFINITION;
+        return switch (kind) {
+            case "MODULE_PART" -> SyntaxKind.MODULE_PART;
+            case "TYPE_DEFINITION" -> SyntaxKind.TYPE_DEFINITION;
+            case "FUNCTION_DEFINITION" -> SyntaxKind.FUNCTION_DEFINITION;
+            case "IMPORT_DECLARATION" -> SyntaxKind.IMPORT_DECLARATION;
+            case "SERVICE_DECLARATION" -> SyntaxKind.SERVICE_DECLARATION;
+            case "LISTENER_DECLARATION" -> SyntaxKind.LISTENER_DECLARATION;
+            case "CONST_DECLARATION" -> SyntaxKind.CONST_DECLARATION;
+            case "MODULE_VAR_DECL" -> SyntaxKind.MODULE_VAR_DECL;
+            case "XML_NAMESPACE_DECLARATION" -> SyntaxKind.XML_NAMESPACE_DECLARATION;
+            case "MODULE_XML_NAMESPACE_DECLARATION" -> SyntaxKind.MODULE_XML_NAMESPACE_DECLARATION;
+            case "ANNOTATION_DECLARATION" -> SyntaxKind.ANNOTATION_DECLARATION;
+            case "ENUM_DECLARATION" -> SyntaxKind.ENUM_DECLARATION;
+            case "CLASS_DEFINITION" -> SyntaxKind.CLASS_DEFINITION;
 
             // Others
-            case "FUNCTION_BODY_BLOCK":
-                return SyntaxKind.FUNCTION_BODY_BLOCK;
-            case "LIST":
-                return SyntaxKind.LIST;
-            case "RETURN_TYPE_DESCRIPTOR":
-                return SyntaxKind.RETURN_TYPE_DESCRIPTOR;
-            case "EXTERNAL_FUNCTION_BODY":
-                return SyntaxKind.EXTERNAL_FUNCTION_BODY;
-            case "REQUIRED_PARAM":
-                return SyntaxKind.REQUIRED_PARAM;
-            case "INCLUDED_RECORD_PARAM":
-                return SyntaxKind.INCLUDED_RECORD_PARAM;
-            case "DEFAULTABLE_PARAM":
-                return SyntaxKind.DEFAULTABLE_PARAM;
-            case "REST_PARAM":
-                return SyntaxKind.REST_PARAM;
-            case "RECORD_FIELD":
-                return SyntaxKind.RECORD_FIELD;
-            case "RECORD_FIELD_WITH_DEFAULT_VALUE":
-                return SyntaxKind.RECORD_FIELD_WITH_DEFAULT_VALUE;
-            case "TYPE_REFERENCE":
-                return SyntaxKind.TYPE_REFERENCE;
-            case "RECORD_REST_TYPE":
-                return SyntaxKind.RECORD_REST_TYPE;
-            case "OBJECT_FIELD":
-                return SyntaxKind.OBJECT_FIELD;
-            case "IMPORT_ORG_NAME":
-                return SyntaxKind.IMPORT_ORG_NAME;
-            case "MODULE_NAME":
-                return SyntaxKind.MODULE_NAME;
-            case "SUB_MODULE_NAME":
-                return SyntaxKind.SUB_MODULE_NAME;
-            case "IMPORT_VERSION":
-                return SyntaxKind.IMPORT_VERSION;
-            case "IMPORT_PREFIX":
-                return SyntaxKind.IMPORT_PREFIX;
-            case "SPECIFIC_FIELD":
-                return SyntaxKind.SPECIFIC_FIELD;
-            case "COMPUTED_NAME_FIELD":
-                return SyntaxKind.COMPUTED_NAME_FIELD;
-            case "SPREAD_FIELD":
-                return SyntaxKind.SPREAD_FIELD;
-            case "ARRAY_DIMENSION":
-                return SyntaxKind.ARRAY_DIMENSION;
-            case "METADATA":
-                return SyntaxKind.METADATA;
-            case "ANNOTATION":
-                return SyntaxKind.ANNOTATION;
-            case "ANNOTATION_ATTACH_POINT":
-                return SyntaxKind.ANNOTATION_ATTACH_POINT;
-            case "NAMED_WORKER_DECLARATION":
-                return SyntaxKind.NAMED_WORKER_DECLARATION;
-            case "NAMED_WORKER_DECLARATOR":
-                return SyntaxKind.NAMED_WORKER_DECLARATOR;
-            case "TYPE_CAST_PARAM":
-                return SyntaxKind.TYPE_CAST_PARAM;
-            case "KEY_SPECIFIER":
-                return SyntaxKind.KEY_SPECIFIER;
-            case "LET_VAR_DECL":
-                return SyntaxKind.LET_VAR_DECL;
-            case "ORDER_KEY":
-                return SyntaxKind.ORDER_KEY;
-            case "GROUPING_KEY_VAR_DECLARATION":
-                return SyntaxKind.GROUPING_KEY_VAR_DECLARATION;
-            case "GROUPING_KEY_VAR_NAME":
-                return SyntaxKind.GROUPING_KEY_VAR_NAME;
-            case "STREAM_TYPE_PARAMS":
-                return SyntaxKind.STREAM_TYPE_PARAMS;
-            case "FUNCTION_SIGNATURE":
-                return SyntaxKind.FUNCTION_SIGNATURE;
-            case "QUERY_CONSTRUCT_TYPE":
-                return SyntaxKind.QUERY_CONSTRUCT_TYPE;
-            case "FROM_CLAUSE":
-                return SyntaxKind.FROM_CLAUSE;
-            case "WHERE_CLAUSE":
-                return SyntaxKind.WHERE_CLAUSE;
-            case "LET_CLAUSE":
-                return SyntaxKind.LET_CLAUSE;
-            case "ON_FAIL_CLAUSE":
-                return SyntaxKind.ON_FAIL_CLAUSE;
-            case "QUERY_PIPELINE":
-                return SyntaxKind.QUERY_PIPELINE;
-            case "SELECT_CLAUSE":
-                return SyntaxKind.SELECT_CLAUSE;
-            case "COLLECT_CLAUSE":
-                return SyntaxKind.COLLECT_CLAUSE;
-            case "ORDER_BY_CLAUSE":
-                return SyntaxKind.ORDER_BY_CLAUSE;
-            case "GROUP_BY_CLAUSE":
-                return SyntaxKind.GROUP_BY_CLAUSE;
-            case "PARENTHESIZED_ARG_LIST":
-                return SyntaxKind.PARENTHESIZED_ARG_LIST;
-            case "EXPRESSION_FUNCTION_BODY":
-                return SyntaxKind.EXPRESSION_FUNCTION_BODY;
-            case "INFER_PARAM_LIST":
-                return SyntaxKind.INFER_PARAM_LIST;
-            case "METHOD_DECLARATION":
-                return SyntaxKind.METHOD_DECLARATION;
-            case "TYPED_BINDING_PATTERN":
-                return SyntaxKind.TYPED_BINDING_PATTERN;
-            case "BINDING_PATTERN":
-                return SyntaxKind.BINDING_PATTERN;
-            case "CAPTURE_BINDING_PATTERN":
-                return SyntaxKind.CAPTURE_BINDING_PATTERN;
-            case "LIST_BINDING_PATTERN":
-                return SyntaxKind.LIST_BINDING_PATTERN;
-            case "REST_BINDING_PATTERN":
-                return SyntaxKind.REST_BINDING_PATTERN;
-            case "FIELD_BINDING_PATTERN":
-                return SyntaxKind.FIELD_BINDING_PATTERN;
-            case "MAPPING_BINDING_PATTERN":
-                return SyntaxKind.MAPPING_BINDING_PATTERN;
-            case "ERROR_BINDING_PATTERN":
-                return SyntaxKind.ERROR_BINDING_PATTERN;
-            case "NAMED_ARG_BINDING_PATTERN":
-                return SyntaxKind.NAMED_ARG_BINDING_PATTERN;
-            case "TYPE_PARAMETER":
-                return SyntaxKind.TYPE_PARAMETER;
-            case "KEY_TYPE_CONSTRAINT":
-                return SyntaxKind.KEY_TYPE_CONSTRAINT;
-            case "RECEIVE_FIELDS":
-                return SyntaxKind.RECEIVE_FIELDS;
-            case "REST_TYPE":
-                return SyntaxKind.REST_TYPE;
-            case "WAIT_FIELDS_LIST":
-                return SyntaxKind.WAIT_FIELDS_LIST;
-            case "WAIT_FIELD":
-                return SyntaxKind.WAIT_FIELD;
-            case "ENUM_MEMBER":
-                return SyntaxKind.ENUM_MEMBER;
-            case "WILDCARD_BINDING_PATTERN":
-                return SyntaxKind.WILDCARD_BINDING_PATTERN;
-            case "MATCH_CLAUSE":
-                return SyntaxKind.MATCH_CLAUSE;
-            case "MATCH_GUARD":
-                return SyntaxKind.MATCH_GUARD;
-            case "OBJECT_METHOD_DEFINITION":
-                return SyntaxKind.OBJECT_METHOD_DEFINITION;
-            case "LIST_MATCH_PATTERN":
-                return SyntaxKind.LIST_MATCH_PATTERN;
-            case "REST_MATCH_PATTERN":
-                return SyntaxKind.REST_MATCH_PATTERN;
-            case "MAPPING_MATCH_PATTERN":
-                return SyntaxKind.MAPPING_MATCH_PATTERN;
-            case "FIELD_MATCH_PATTERN":
-                return SyntaxKind.FIELD_MATCH_PATTERN;
-            case "ERROR_MATCH_PATTERN":
-                return SyntaxKind.ERROR_MATCH_PATTERN;
-            case "NAMED_ARG_MATCH_PATTERN":
-                return SyntaxKind.NAMED_ARG_MATCH_PATTERN;
-            case "ON_CONFLICT_CLAUSE":
-                return SyntaxKind.ON_CONFLICT_CLAUSE;
-            case "LIMIT_CLAUSE":
-                return SyntaxKind.LIMIT_CLAUSE;
-            case "JOIN_CLAUSE":
-                return SyntaxKind.JOIN_CLAUSE;
-            case "ON_CLAUSE":
-                return SyntaxKind.ON_CLAUSE;
-            case "RESOURCE_ACCESSOR_DEFINITION":
-                return SyntaxKind.RESOURCE_ACCESSOR_DEFINITION;
-            case "RESOURCE_ACCESSOR_DECLARATION":
-                return SyntaxKind.RESOURCE_ACCESSOR_DECLARATION;
-            case "RESOURCE_PATH_SEGMENT_PARAM":
-                return SyntaxKind.RESOURCE_PATH_SEGMENT_PARAM;
-            case "RESOURCE_PATH_REST_PARAM":
-                return SyntaxKind.RESOURCE_PATH_REST_PARAM;
-            case "CLIENT_RESOURCE_ACCESS_ACTION":
-                return SyntaxKind.CLIENT_RESOURCE_ACCESS_ACTION;
-            case "COMPUTED_RESOURCE_ACCESS_SEGMENT":
-                return SyntaxKind.COMPUTED_RESOURCE_ACCESS_SEGMENT;
-            case "RESOURCE_ACCESS_REST_SEGMENT":
-                return SyntaxKind.RESOURCE_ACCESS_REST_SEGMENT;
-            case "ALTERNATE_RECEIVE":
-                return SyntaxKind.ALTERNATE_RECEIVE;
-            case "RECEIVE_FIELD":
-                return SyntaxKind.RECEIVE_FIELD;
+            case "FUNCTION_BODY_BLOCK" -> SyntaxKind.FUNCTION_BODY_BLOCK;
+            case "LIST" -> SyntaxKind.LIST;
+            case "RETURN_TYPE_DESCRIPTOR" -> SyntaxKind.RETURN_TYPE_DESCRIPTOR;
+            case "EXTERNAL_FUNCTION_BODY" -> SyntaxKind.EXTERNAL_FUNCTION_BODY;
+            case "REQUIRED_PARAM" -> SyntaxKind.REQUIRED_PARAM;
+            case "INCLUDED_RECORD_PARAM" -> SyntaxKind.INCLUDED_RECORD_PARAM;
+            case "DEFAULTABLE_PARAM" -> SyntaxKind.DEFAULTABLE_PARAM;
+            case "REST_PARAM" -> SyntaxKind.REST_PARAM;
+            case "RECORD_FIELD" -> SyntaxKind.RECORD_FIELD;
+            case "RECORD_FIELD_WITH_DEFAULT_VALUE" -> SyntaxKind.RECORD_FIELD_WITH_DEFAULT_VALUE;
+            case "TYPE_REFERENCE" -> SyntaxKind.TYPE_REFERENCE;
+            case "RECORD_REST_TYPE" -> SyntaxKind.RECORD_REST_TYPE;
+            case "OBJECT_FIELD" -> SyntaxKind.OBJECT_FIELD;
+            case "IMPORT_ORG_NAME" -> SyntaxKind.IMPORT_ORG_NAME;
+            case "MODULE_NAME" -> SyntaxKind.MODULE_NAME;
+            case "SUB_MODULE_NAME" -> SyntaxKind.SUB_MODULE_NAME;
+            case "IMPORT_VERSION" -> SyntaxKind.IMPORT_VERSION;
+            case "IMPORT_PREFIX" -> SyntaxKind.IMPORT_PREFIX;
+            case "SPECIFIC_FIELD" -> SyntaxKind.SPECIFIC_FIELD;
+            case "COMPUTED_NAME_FIELD" -> SyntaxKind.COMPUTED_NAME_FIELD;
+            case "SPREAD_FIELD" -> SyntaxKind.SPREAD_FIELD;
+            case "ARRAY_DIMENSION" -> SyntaxKind.ARRAY_DIMENSION;
+            case "METADATA" -> SyntaxKind.METADATA;
+            case "ANNOTATION" -> SyntaxKind.ANNOTATION;
+            case "ANNOTATION_ATTACH_POINT" -> SyntaxKind.ANNOTATION_ATTACH_POINT;
+            case "NAMED_WORKER_DECLARATION" -> SyntaxKind.NAMED_WORKER_DECLARATION;
+            case "NAMED_WORKER_DECLARATOR" -> SyntaxKind.NAMED_WORKER_DECLARATOR;
+            case "TYPE_CAST_PARAM" -> SyntaxKind.TYPE_CAST_PARAM;
+            case "KEY_SPECIFIER" -> SyntaxKind.KEY_SPECIFIER;
+            case "LET_VAR_DECL" -> SyntaxKind.LET_VAR_DECL;
+            case "ORDER_KEY" -> SyntaxKind.ORDER_KEY;
+            case "GROUPING_KEY_VAR_DECLARATION" -> SyntaxKind.GROUPING_KEY_VAR_DECLARATION;
+            case "GROUPING_KEY_VAR_NAME" -> SyntaxKind.GROUPING_KEY_VAR_NAME;
+            case "STREAM_TYPE_PARAMS" -> SyntaxKind.STREAM_TYPE_PARAMS;
+            case "FUNCTION_SIGNATURE" -> SyntaxKind.FUNCTION_SIGNATURE;
+            case "QUERY_CONSTRUCT_TYPE" -> SyntaxKind.QUERY_CONSTRUCT_TYPE;
+            case "FROM_CLAUSE" -> SyntaxKind.FROM_CLAUSE;
+            case "WHERE_CLAUSE" -> SyntaxKind.WHERE_CLAUSE;
+            case "LET_CLAUSE" -> SyntaxKind.LET_CLAUSE;
+            case "ON_FAIL_CLAUSE" -> SyntaxKind.ON_FAIL_CLAUSE;
+            case "QUERY_PIPELINE" -> SyntaxKind.QUERY_PIPELINE;
+            case "SELECT_CLAUSE" -> SyntaxKind.SELECT_CLAUSE;
+            case "COLLECT_CLAUSE" -> SyntaxKind.COLLECT_CLAUSE;
+            case "ORDER_BY_CLAUSE" -> SyntaxKind.ORDER_BY_CLAUSE;
+            case "GROUP_BY_CLAUSE" -> SyntaxKind.GROUP_BY_CLAUSE;
+            case "PARENTHESIZED_ARG_LIST" -> SyntaxKind.PARENTHESIZED_ARG_LIST;
+            case "EXPRESSION_FUNCTION_BODY" -> SyntaxKind.EXPRESSION_FUNCTION_BODY;
+            case "INFER_PARAM_LIST" -> SyntaxKind.INFER_PARAM_LIST;
+            case "METHOD_DECLARATION" -> SyntaxKind.METHOD_DECLARATION;
+            case "TYPED_BINDING_PATTERN" -> SyntaxKind.TYPED_BINDING_PATTERN;
+            case "BINDING_PATTERN" -> SyntaxKind.BINDING_PATTERN;
+            case "CAPTURE_BINDING_PATTERN" -> SyntaxKind.CAPTURE_BINDING_PATTERN;
+            case "LIST_BINDING_PATTERN" -> SyntaxKind.LIST_BINDING_PATTERN;
+            case "REST_BINDING_PATTERN" -> SyntaxKind.REST_BINDING_PATTERN;
+            case "FIELD_BINDING_PATTERN" -> SyntaxKind.FIELD_BINDING_PATTERN;
+            case "MAPPING_BINDING_PATTERN" -> SyntaxKind.MAPPING_BINDING_PATTERN;
+            case "ERROR_BINDING_PATTERN" -> SyntaxKind.ERROR_BINDING_PATTERN;
+            case "NAMED_ARG_BINDING_PATTERN" -> SyntaxKind.NAMED_ARG_BINDING_PATTERN;
+            case "TYPE_PARAMETER" -> SyntaxKind.TYPE_PARAMETER;
+            case "KEY_TYPE_CONSTRAINT" -> SyntaxKind.KEY_TYPE_CONSTRAINT;
+            case "RECEIVE_FIELDS" -> SyntaxKind.RECEIVE_FIELDS;
+            case "REST_TYPE" -> SyntaxKind.REST_TYPE;
+            case "WAIT_FIELDS_LIST" -> SyntaxKind.WAIT_FIELDS_LIST;
+            case "WAIT_FIELD" -> SyntaxKind.WAIT_FIELD;
+            case "ENUM_MEMBER" -> SyntaxKind.ENUM_MEMBER;
+            case "WILDCARD_BINDING_PATTERN" -> SyntaxKind.WILDCARD_BINDING_PATTERN;
+            case "MATCH_CLAUSE" -> SyntaxKind.MATCH_CLAUSE;
+            case "MATCH_GUARD" -> SyntaxKind.MATCH_GUARD;
+            case "OBJECT_METHOD_DEFINITION" -> SyntaxKind.OBJECT_METHOD_DEFINITION;
+            case "LIST_MATCH_PATTERN" -> SyntaxKind.LIST_MATCH_PATTERN;
+            case "REST_MATCH_PATTERN" -> SyntaxKind.REST_MATCH_PATTERN;
+            case "MAPPING_MATCH_PATTERN" -> SyntaxKind.MAPPING_MATCH_PATTERN;
+            case "FIELD_MATCH_PATTERN" -> SyntaxKind.FIELD_MATCH_PATTERN;
+            case "ERROR_MATCH_PATTERN" -> SyntaxKind.ERROR_MATCH_PATTERN;
+            case "NAMED_ARG_MATCH_PATTERN" -> SyntaxKind.NAMED_ARG_MATCH_PATTERN;
+            case "ON_CONFLICT_CLAUSE" -> SyntaxKind.ON_CONFLICT_CLAUSE;
+            case "LIMIT_CLAUSE" -> SyntaxKind.LIMIT_CLAUSE;
+            case "JOIN_CLAUSE" -> SyntaxKind.JOIN_CLAUSE;
+            case "ON_CLAUSE" -> SyntaxKind.ON_CLAUSE;
+            case "RESOURCE_ACCESSOR_DEFINITION" -> SyntaxKind.RESOURCE_ACCESSOR_DEFINITION;
+            case "RESOURCE_ACCESSOR_DECLARATION" -> SyntaxKind.RESOURCE_ACCESSOR_DECLARATION;
+            case "RESOURCE_PATH_SEGMENT_PARAM" -> SyntaxKind.RESOURCE_PATH_SEGMENT_PARAM;
+            case "RESOURCE_PATH_REST_PARAM" -> SyntaxKind.RESOURCE_PATH_REST_PARAM;
+            case "CLIENT_RESOURCE_ACCESS_ACTION" -> SyntaxKind.CLIENT_RESOURCE_ACCESS_ACTION;
+            case "COMPUTED_RESOURCE_ACCESS_SEGMENT" -> SyntaxKind.COMPUTED_RESOURCE_ACCESS_SEGMENT;
+            case "RESOURCE_ACCESS_REST_SEGMENT" -> SyntaxKind.RESOURCE_ACCESS_REST_SEGMENT;
+            case "ALTERNATE_RECEIVE" -> SyntaxKind.ALTERNATE_RECEIVE;
+            case "RECEIVE_FIELD" -> SyntaxKind.RECEIVE_FIELD;
 
             // Trivia
-            case "EOF_TOKEN":
-                return SyntaxKind.EOF_TOKEN;
-            case "END_OF_LINE_MINUTIAE":
-                return SyntaxKind.END_OF_LINE_MINUTIAE;
-            case "WHITESPACE_MINUTIAE":
-                return SyntaxKind.WHITESPACE_MINUTIAE;
-            case "COMMENT_MINUTIAE":
-                return SyntaxKind.COMMENT_MINUTIAE;
-            case "INVALID_NODE_MINUTIAE":
-                return SyntaxKind.INVALID_NODE_MINUTIAE;
+            case "EOF_TOKEN" -> SyntaxKind.EOF_TOKEN;
+            case "END_OF_LINE_MINUTIAE" -> SyntaxKind.END_OF_LINE_MINUTIAE;
+            case "WHITESPACE_MINUTIAE" -> SyntaxKind.WHITESPACE_MINUTIAE;
+            case "COMMENT_MINUTIAE" -> SyntaxKind.COMMENT_MINUTIAE;
+            case "INVALID_NODE_MINUTIAE" -> SyntaxKind.INVALID_NODE_MINUTIAE;
 
             // Invalid Token
-            case "INVALID_TOKEN":
-                return SyntaxKind.INVALID_TOKEN;
-            case "INVALID_TOKEN_MINUTIAE_NODE":
-                return SyntaxKind.INVALID_TOKEN_MINUTIAE_NODE;
-
-            default:
-                return getStatementKind(kind);
-        }
+            case "INVALID_TOKEN" -> SyntaxKind.INVALID_TOKEN;
+            case "INVALID_TOKEN_MINUTIAE_NODE" -> SyntaxKind.INVALID_TOKEN_MINUTIAE_NODE;
+            default -> getStatementKind(kind);
+        };
     }
 
     private static SyntaxKind getStatementKind(String kind) {
-        switch (kind) {
-            case "BLOCK_STATEMENT":
-                return SyntaxKind.BLOCK_STATEMENT;
-            case "LOCAL_VAR_DECL":
-                return SyntaxKind.LOCAL_VAR_DECL;
-            case "ASSIGNMENT_STATEMENT":
-                return SyntaxKind.ASSIGNMENT_STATEMENT;
-            case "IF_ELSE_STATEMENT":
-                return SyntaxKind.IF_ELSE_STATEMENT;
-            case "ELSE_BLOCK":
-                return SyntaxKind.ELSE_BLOCK;
-            case "WHILE_STATEMENT":
-                return SyntaxKind.WHILE_STATEMENT;
-            case "DO_STATEMENT":
-                return SyntaxKind.DO_STATEMENT;
-            case "CALL_STATEMENT":
-                return SyntaxKind.CALL_STATEMENT;
-            case "PANIC_STATEMENT":
-                return SyntaxKind.PANIC_STATEMENT;
-            case "CONTINUE_STATEMENT":
-                return SyntaxKind.CONTINUE_STATEMENT;
-            case "BREAK_STATEMENT":
-                return SyntaxKind.BREAK_STATEMENT;
-            case "FAIL_STATEMENT":
-                return SyntaxKind.FAIL_STATEMENT;
-            case "RETURN_STATEMENT":
-                return SyntaxKind.RETURN_STATEMENT;
-            case "COMPOUND_ASSIGNMENT_STATEMENT":
-                return SyntaxKind.COMPOUND_ASSIGNMENT_STATEMENT;
-            case "LOCAL_TYPE_DEFINITION_STATEMENT":
-                return SyntaxKind.LOCAL_TYPE_DEFINITION_STATEMENT;
-            case "ACTION_STATEMENT":
-                return SyntaxKind.ACTION_STATEMENT;
-            case "LOCK_STATEMENT":
-                return SyntaxKind.LOCK_STATEMENT;
-            case "FORK_STATEMENT":
-                return SyntaxKind.FORK_STATEMENT;
-            case "FOREACH_STATEMENT":
-                return SyntaxKind.FOREACH_STATEMENT;
-            case "TRANSACTION_STATEMENT":
-                return SyntaxKind.TRANSACTION_STATEMENT;
-            case "RETRY_STATEMENT":
-                return SyntaxKind.RETRY_STATEMENT;
-            case "ROLLBACK_STATEMENT":
-                return SyntaxKind.ROLLBACK_STATEMENT;
-            case "MATCH_STATEMENT":
-                return SyntaxKind.MATCH_STATEMENT;
-            case "INVALID_EXPRESSION_STATEMENT":
-                return SyntaxKind.INVALID_EXPRESSION_STATEMENT;
-            default:
-                return getExpressionKind(kind);
-        }
+        return switch (kind) {
+            case "BLOCK_STATEMENT" -> SyntaxKind.BLOCK_STATEMENT;
+            case "LOCAL_VAR_DECL" -> SyntaxKind.LOCAL_VAR_DECL;
+            case "ASSIGNMENT_STATEMENT" -> SyntaxKind.ASSIGNMENT_STATEMENT;
+            case "IF_ELSE_STATEMENT" -> SyntaxKind.IF_ELSE_STATEMENT;
+            case "ELSE_BLOCK" -> SyntaxKind.ELSE_BLOCK;
+            case "WHILE_STATEMENT" -> SyntaxKind.WHILE_STATEMENT;
+            case "DO_STATEMENT" -> SyntaxKind.DO_STATEMENT;
+            case "CALL_STATEMENT" -> SyntaxKind.CALL_STATEMENT;
+            case "PANIC_STATEMENT" -> SyntaxKind.PANIC_STATEMENT;
+            case "CONTINUE_STATEMENT" -> SyntaxKind.CONTINUE_STATEMENT;
+            case "BREAK_STATEMENT" -> SyntaxKind.BREAK_STATEMENT;
+            case "FAIL_STATEMENT" -> SyntaxKind.FAIL_STATEMENT;
+            case "RETURN_STATEMENT" -> SyntaxKind.RETURN_STATEMENT;
+            case "COMPOUND_ASSIGNMENT_STATEMENT" -> SyntaxKind.COMPOUND_ASSIGNMENT_STATEMENT;
+            case "LOCAL_TYPE_DEFINITION_STATEMENT" -> SyntaxKind.LOCAL_TYPE_DEFINITION_STATEMENT;
+            case "ACTION_STATEMENT" -> SyntaxKind.ACTION_STATEMENT;
+            case "LOCK_STATEMENT" -> SyntaxKind.LOCK_STATEMENT;
+            case "FORK_STATEMENT" -> SyntaxKind.FORK_STATEMENT;
+            case "FOREACH_STATEMENT" -> SyntaxKind.FOREACH_STATEMENT;
+            case "TRANSACTION_STATEMENT" -> SyntaxKind.TRANSACTION_STATEMENT;
+            case "RETRY_STATEMENT" -> SyntaxKind.RETRY_STATEMENT;
+            case "ROLLBACK_STATEMENT" -> SyntaxKind.ROLLBACK_STATEMENT;
+            case "MATCH_STATEMENT" -> SyntaxKind.MATCH_STATEMENT;
+            case "INVALID_EXPRESSION_STATEMENT" -> SyntaxKind.INVALID_EXPRESSION_STATEMENT;
+            default -> getExpressionKind(kind);
+        };
     }
 
     private static SyntaxKind getExpressionKind(String kind) {
-        switch (kind) {
-            case "IDENTIFIER_TOKEN":
-                return SyntaxKind.IDENTIFIER_TOKEN;
-            case "BRACED_EXPRESSION":
-                return SyntaxKind.BRACED_EXPRESSION;
-            case "BINARY_EXPRESSION":
-                return SyntaxKind.BINARY_EXPRESSION;
-            case "STRING_LITERAL":
-                return SyntaxKind.STRING_LITERAL;
-            case "STRING_LITERAL_TOKEN":
-                return SyntaxKind.STRING_LITERAL_TOKEN;
-            case "NUMERIC_LITERAL":
-                return SyntaxKind.NUMERIC_LITERAL;
-            case "BOOLEAN_LITERAL":
-                return SyntaxKind.BOOLEAN_LITERAL;
-            case "DECIMAL_INTEGER_LITERAL_TOKEN":
-                return SyntaxKind.DECIMAL_INTEGER_LITERAL_TOKEN;
-            case "HEX_INTEGER_LITERAL_TOKEN":
-                return SyntaxKind.HEX_INTEGER_LITERAL_TOKEN;
-            case "DECIMAL_FLOATING_POINT_LITERAL_TOKEN":
-                return SyntaxKind.DECIMAL_FLOATING_POINT_LITERAL_TOKEN;
-            case "HEX_FLOATING_POINT_LITERAL_TOKEN":
-                return SyntaxKind.HEX_FLOATING_POINT_LITERAL_TOKEN;
-            case "ASTERISK_LITERAL":
-                return SyntaxKind.ASTERISK_LITERAL;
-            case "FUNCTION_CALL":
-                return SyntaxKind.FUNCTION_CALL;
-            case "POSITIONAL_ARG":
-                return SyntaxKind.POSITIONAL_ARG;
-            case "NAMED_ARG":
-                return SyntaxKind.NAMED_ARG;
-            case "REST_ARG":
-                return SyntaxKind.REST_ARG;
-            case "QUALIFIED_NAME_REFERENCE":
-                return SyntaxKind.QUALIFIED_NAME_REFERENCE;
-            case "FIELD_ACCESS":
-                return SyntaxKind.FIELD_ACCESS;
-            case "METHOD_CALL":
-                return SyntaxKind.METHOD_CALL;
-            case "INDEXED_EXPRESSION":
-                return SyntaxKind.INDEXED_EXPRESSION;
-            case "CHECK_EXPRESSION":
-                return SyntaxKind.CHECK_EXPRESSION;
-            case "MAPPING_CONSTRUCTOR":
-                return SyntaxKind.MAPPING_CONSTRUCTOR;
-            case "TYPEOF_EXPRESSION":
-                return SyntaxKind.TYPEOF_EXPRESSION;
-            case "UNARY_EXPRESSION":
-                return SyntaxKind.UNARY_EXPRESSION;
-            case "TYPE_TEST_EXPRESSION":
-                return SyntaxKind.TYPE_TEST_EXPRESSION;
-            case "NIL_LITERAL":
-                return SyntaxKind.NIL_LITERAL;
-            case "NULL_LITERAL":
-                return SyntaxKind.NULL_LITERAL;
-            case "SIMPLE_NAME_REFERENCE":
-                return SyntaxKind.SIMPLE_NAME_REFERENCE;
-            case "TRAP_EXPRESSION":
-                return SyntaxKind.TRAP_EXPRESSION;
-            case "LIST_CONSTRUCTOR":
-                return SyntaxKind.LIST_CONSTRUCTOR;
-            case "TYPE_CAST_EXPRESSION":
-                return SyntaxKind.TYPE_CAST_EXPRESSION;
-            case "TABLE_CONSTRUCTOR":
-                return SyntaxKind.TABLE_CONSTRUCTOR;
-            case "LET_EXPRESSION":
-                return SyntaxKind.LET_EXPRESSION;
-            case "RAW_TEMPLATE_EXPRESSION":
-                return SyntaxKind.RAW_TEMPLATE_EXPRESSION;
-            case "XML_TEMPLATE_EXPRESSION":
-                return SyntaxKind.XML_TEMPLATE_EXPRESSION;
-            case "STRING_TEMPLATE_EXPRESSION":
-                return SyntaxKind.STRING_TEMPLATE_EXPRESSION;
-            case "REGEX_TEMPLATE_EXPRESSION":
-                return SyntaxKind.REGEX_TEMPLATE_EXPRESSION;
-            case "QUERY_EXPRESSION":
-                return SyntaxKind.QUERY_EXPRESSION;
-            case "EXPLICIT_ANONYMOUS_FUNCTION_EXPRESSION":
-                return SyntaxKind.EXPLICIT_ANONYMOUS_FUNCTION_EXPRESSION;
-            case "IMPLICIT_ANONYMOUS_FUNCTION_EXPRESSION":
-                return SyntaxKind.IMPLICIT_ANONYMOUS_FUNCTION_EXPRESSION;
-            case "IMPLICIT_NEW_EXPRESSION":
-                return SyntaxKind.IMPLICIT_NEW_EXPRESSION;
-            case "EXPLICIT_NEW_EXPRESSION":
-                return SyntaxKind.EXPLICIT_NEW_EXPRESSION;
-            case "ANNOT_ACCESS":
-                return SyntaxKind.ANNOT_ACCESS;
-            case "OPTIONAL_FIELD_ACCESS":
-                return SyntaxKind.OPTIONAL_FIELD_ACCESS;
-            case "CONDITIONAL_EXPRESSION":
-                return SyntaxKind.CONDITIONAL_EXPRESSION;
-            case "TRANSACTIONAL_EXPRESSION":
-                return SyntaxKind.TRANSACTIONAL_EXPRESSION;
-            case "BYTE_ARRAY_LITERAL":
-                return SyntaxKind.BYTE_ARRAY_LITERAL;
-            case "XML_FILTER_EXPRESSION":
-                return SyntaxKind.XML_FILTER_EXPRESSION;
-            case "XML_STEP_EXPRESSION":
-                return SyntaxKind.XML_STEP_EXPRESSION;
-            case "XML_NAME_PATTERN_CHAIN":
-                return SyntaxKind.XML_NAME_PATTERN_CHAIN;
-            case "XML_ATOMIC_NAME_PATTERN":
-                return SyntaxKind.XML_ATOMIC_NAME_PATTERN;
-            case "REQUIRED_EXPRESSION":
-                return SyntaxKind.REQUIRED_EXPRESSION;
-            case "OBJECT_CONSTRUCTOR":
-                return SyntaxKind.OBJECT_CONSTRUCTOR;
-            case "ERROR_CONSTRUCTOR":
-                return SyntaxKind.ERROR_CONSTRUCTOR;
-            case "INFERRED_TYPEDESC_DEFAULT":
-                return SyntaxKind.INFERRED_TYPEDESC_DEFAULT;
-            case "SPREAD_MEMBER":
-                return SyntaxKind.SPREAD_MEMBER;
-            case "MEMBER_TYPE_DESC":
-                return SyntaxKind.MEMBER_TYPE_DESC;
-            default:
-                return getActionKind(kind);
-        }
+        return switch (kind) {
+            case "IDENTIFIER_TOKEN" -> SyntaxKind.IDENTIFIER_TOKEN;
+            case "BRACED_EXPRESSION" -> SyntaxKind.BRACED_EXPRESSION;
+            case "BINARY_EXPRESSION" -> SyntaxKind.BINARY_EXPRESSION;
+            case "STRING_LITERAL" -> SyntaxKind.STRING_LITERAL;
+            case "STRING_LITERAL_TOKEN" -> SyntaxKind.STRING_LITERAL_TOKEN;
+            case "NUMERIC_LITERAL" -> SyntaxKind.NUMERIC_LITERAL;
+            case "BOOLEAN_LITERAL" -> SyntaxKind.BOOLEAN_LITERAL;
+            case "DECIMAL_INTEGER_LITERAL_TOKEN" -> SyntaxKind.DECIMAL_INTEGER_LITERAL_TOKEN;
+            case "HEX_INTEGER_LITERAL_TOKEN" -> SyntaxKind.HEX_INTEGER_LITERAL_TOKEN;
+            case "DECIMAL_FLOATING_POINT_LITERAL_TOKEN" -> SyntaxKind.DECIMAL_FLOATING_POINT_LITERAL_TOKEN;
+            case "HEX_FLOATING_POINT_LITERAL_TOKEN" -> SyntaxKind.HEX_FLOATING_POINT_LITERAL_TOKEN;
+            case "ASTERISK_LITERAL" -> SyntaxKind.ASTERISK_LITERAL;
+            case "FUNCTION_CALL" -> SyntaxKind.FUNCTION_CALL;
+            case "POSITIONAL_ARG" -> SyntaxKind.POSITIONAL_ARG;
+            case "NAMED_ARG" -> SyntaxKind.NAMED_ARG;
+            case "REST_ARG" -> SyntaxKind.REST_ARG;
+            case "QUALIFIED_NAME_REFERENCE" -> SyntaxKind.QUALIFIED_NAME_REFERENCE;
+            case "FIELD_ACCESS" -> SyntaxKind.FIELD_ACCESS;
+            case "METHOD_CALL" -> SyntaxKind.METHOD_CALL;
+            case "INDEXED_EXPRESSION" -> SyntaxKind.INDEXED_EXPRESSION;
+            case "CHECK_EXPRESSION" -> SyntaxKind.CHECK_EXPRESSION;
+            case "MAPPING_CONSTRUCTOR" -> SyntaxKind.MAPPING_CONSTRUCTOR;
+            case "TYPEOF_EXPRESSION" -> SyntaxKind.TYPEOF_EXPRESSION;
+            case "UNARY_EXPRESSION" -> SyntaxKind.UNARY_EXPRESSION;
+            case "TYPE_TEST_EXPRESSION" -> SyntaxKind.TYPE_TEST_EXPRESSION;
+            case "NIL_LITERAL" -> SyntaxKind.NIL_LITERAL;
+            case "NULL_LITERAL" -> SyntaxKind.NULL_LITERAL;
+            case "SIMPLE_NAME_REFERENCE" -> SyntaxKind.SIMPLE_NAME_REFERENCE;
+            case "TRAP_EXPRESSION" -> SyntaxKind.TRAP_EXPRESSION;
+            case "LIST_CONSTRUCTOR" -> SyntaxKind.LIST_CONSTRUCTOR;
+            case "TYPE_CAST_EXPRESSION" -> SyntaxKind.TYPE_CAST_EXPRESSION;
+            case "TABLE_CONSTRUCTOR" -> SyntaxKind.TABLE_CONSTRUCTOR;
+            case "LET_EXPRESSION" -> SyntaxKind.LET_EXPRESSION;
+            case "RAW_TEMPLATE_EXPRESSION" -> SyntaxKind.RAW_TEMPLATE_EXPRESSION;
+            case "XML_TEMPLATE_EXPRESSION" -> SyntaxKind.XML_TEMPLATE_EXPRESSION;
+            case "STRING_TEMPLATE_EXPRESSION" -> SyntaxKind.STRING_TEMPLATE_EXPRESSION;
+            case "REGEX_TEMPLATE_EXPRESSION" -> SyntaxKind.REGEX_TEMPLATE_EXPRESSION;
+            case "QUERY_EXPRESSION" -> SyntaxKind.QUERY_EXPRESSION;
+            case "EXPLICIT_ANONYMOUS_FUNCTION_EXPRESSION" -> SyntaxKind.EXPLICIT_ANONYMOUS_FUNCTION_EXPRESSION;
+            case "IMPLICIT_ANONYMOUS_FUNCTION_EXPRESSION" -> SyntaxKind.IMPLICIT_ANONYMOUS_FUNCTION_EXPRESSION;
+            case "IMPLICIT_NEW_EXPRESSION" -> SyntaxKind.IMPLICIT_NEW_EXPRESSION;
+            case "EXPLICIT_NEW_EXPRESSION" -> SyntaxKind.EXPLICIT_NEW_EXPRESSION;
+            case "ANNOT_ACCESS" -> SyntaxKind.ANNOT_ACCESS;
+            case "OPTIONAL_FIELD_ACCESS" -> SyntaxKind.OPTIONAL_FIELD_ACCESS;
+            case "CONDITIONAL_EXPRESSION" -> SyntaxKind.CONDITIONAL_EXPRESSION;
+            case "TRANSACTIONAL_EXPRESSION" -> SyntaxKind.TRANSACTIONAL_EXPRESSION;
+            case "BYTE_ARRAY_LITERAL" -> SyntaxKind.BYTE_ARRAY_LITERAL;
+            case "XML_FILTER_EXPRESSION" -> SyntaxKind.XML_FILTER_EXPRESSION;
+            case "XML_STEP_EXPRESSION" -> SyntaxKind.XML_STEP_EXPRESSION;
+            case "XML_NAME_PATTERN_CHAIN" -> SyntaxKind.XML_NAME_PATTERN_CHAIN;
+            case "XML_ATOMIC_NAME_PATTERN" -> SyntaxKind.XML_ATOMIC_NAME_PATTERN;
+            case "REQUIRED_EXPRESSION" -> SyntaxKind.REQUIRED_EXPRESSION;
+            case "OBJECT_CONSTRUCTOR" -> SyntaxKind.OBJECT_CONSTRUCTOR;
+            case "ERROR_CONSTRUCTOR" -> SyntaxKind.ERROR_CONSTRUCTOR;
+            case "INFERRED_TYPEDESC_DEFAULT" -> SyntaxKind.INFERRED_TYPEDESC_DEFAULT;
+            case "SPREAD_MEMBER" -> SyntaxKind.SPREAD_MEMBER;
+            case "MEMBER_TYPE_DESC" -> SyntaxKind.MEMBER_TYPE_DESC;
+            default -> getActionKind(kind);
+        };
     }
 
     private static SyntaxKind getActionKind(String kind) {
-        switch (kind) {
-            case "REMOTE_METHOD_CALL_ACTION":
-                return SyntaxKind.REMOTE_METHOD_CALL_ACTION;
-            case "BRACED_ACTION":
-                return SyntaxKind.BRACED_ACTION;
-            case "CHECK_ACTION":
-                return SyntaxKind.CHECK_ACTION;
-            case "START_ACTION":
-                return SyntaxKind.START_ACTION;
-            case "TRAP_ACTION":
-                return SyntaxKind.TRAP_ACTION;
-            case "FLUSH_ACTION":
-                return SyntaxKind.FLUSH_ACTION;
-            case "ASYNC_SEND_ACTION":
-                return SyntaxKind.ASYNC_SEND_ACTION;
-            case "SYNC_SEND_ACTION":
-                return SyntaxKind.SYNC_SEND_ACTION;
-            case "RECEIVE_ACTION":
-                return SyntaxKind.RECEIVE_ACTION;
-            case "WAIT_ACTION":
-                return SyntaxKind.WAIT_ACTION;
-            case "QUERY_ACTION":
-                return SyntaxKind.QUERY_ACTION;
-            case "COMMIT_ACTION":
-                return SyntaxKind.COMMIT_ACTION;
-            default:
-                return getTypeKind(kind);
-        }
+        return switch (kind) {
+            case "REMOTE_METHOD_CALL_ACTION" -> SyntaxKind.REMOTE_METHOD_CALL_ACTION;
+            case "BRACED_ACTION" -> SyntaxKind.BRACED_ACTION;
+            case "CHECK_ACTION" -> SyntaxKind.CHECK_ACTION;
+            case "START_ACTION" -> SyntaxKind.START_ACTION;
+            case "TRAP_ACTION" -> SyntaxKind.TRAP_ACTION;
+            case "FLUSH_ACTION" -> SyntaxKind.FLUSH_ACTION;
+            case "ASYNC_SEND_ACTION" -> SyntaxKind.ASYNC_SEND_ACTION;
+            case "SYNC_SEND_ACTION" -> SyntaxKind.SYNC_SEND_ACTION;
+            case "RECEIVE_ACTION" -> SyntaxKind.RECEIVE_ACTION;
+            case "WAIT_ACTION" -> SyntaxKind.WAIT_ACTION;
+            case "QUERY_ACTION" -> SyntaxKind.QUERY_ACTION;
+            case "COMMIT_ACTION" -> SyntaxKind.COMMIT_ACTION;
+            default -> getTypeKind(kind);
+        };
     }
 
     private static SyntaxKind getTypeKind(String kind) {
-        switch (kind) {
-            case "TYPE_DESC":
-                return SyntaxKind.TYPE_DESC;
-            case "INT_TYPE_DESC":
-                return SyntaxKind.INT_TYPE_DESC;
-            case "FLOAT_TYPE_DESC":
-                return SyntaxKind.FLOAT_TYPE_DESC;
-            case "DECIMAL_TYPE_DESC":
-                return SyntaxKind.DECIMAL_TYPE_DESC;
-            case "BOOLEAN_TYPE_DESC":
-                return SyntaxKind.BOOLEAN_TYPE_DESC;
-            case "STRING_TYPE_DESC":
-                return SyntaxKind.STRING_TYPE_DESC;
-            case "BYTE_TYPE_DESC":
-                return SyntaxKind.BYTE_TYPE_DESC;
-            case "XML_TYPE_DESC":
-                return SyntaxKind.XML_TYPE_DESC;
-            case "JSON_TYPE_DESC":
-                return SyntaxKind.JSON_TYPE_DESC;
-            case "HANDLE_TYPE_DESC":
-                return SyntaxKind.HANDLE_TYPE_DESC;
-            case "ANY_TYPE_DESC":
-                return SyntaxKind.ANY_TYPE_DESC;
-            case "ANYDATA_TYPE_DESC":
-                return SyntaxKind.ANYDATA_TYPE_DESC;
-            case "NEVER_TYPE_DESC":
-                return SyntaxKind.NEVER_TYPE_DESC;
-            case "NIL_TYPE_DESC":
-                return SyntaxKind.NIL_TYPE_DESC;
-            case "OPTIONAL_TYPE_DESC":
-                return SyntaxKind.OPTIONAL_TYPE_DESC;
-            case "ARRAY_TYPE_DESC":
-                return SyntaxKind.ARRAY_TYPE_DESC;
-            case "RECORD_TYPE_DESC":
-                return SyntaxKind.RECORD_TYPE_DESC;
-            case "OBJECT_TYPE_DESC":
-                return SyntaxKind.OBJECT_TYPE_DESC;
-            case "UNION_TYPE_DESC":
-                return SyntaxKind.UNION_TYPE_DESC;
-            case "ERROR_TYPE_DESC":
-                return SyntaxKind.ERROR_TYPE_DESC;
-            case "EXPLICIT_TYPE_PARAMS":
-                return SyntaxKind.EXPLICIT_TYPE_PARAMS;
-            case "STREAM_TYPE_DESC":
-                return SyntaxKind.STREAM_TYPE_DESC;
-            case "FUNCTION_TYPE_DESC":
-                return SyntaxKind.FUNCTION_TYPE_DESC;
-            case "TABLE_TYPE_DESC":
-                return SyntaxKind.TABLE_TYPE_DESC;
-            case "TUPLE_TYPE_DESC":
-                return SyntaxKind.TUPLE_TYPE_DESC;
-            case "PARENTHESISED_TYPE_DESC":
-                return SyntaxKind.PARENTHESISED_TYPE_DESC;
-            case "READONLY_TYPE_DESC":
-                return SyntaxKind.READONLY_TYPE_DESC;
-            case "DISTINCT_TYPE_DESC":
-                return SyntaxKind.DISTINCT_TYPE_DESC;
-            case "INTERSECTION_TYPE_DESC":
-                return SyntaxKind.INTERSECTION_TYPE_DESC;
-            case "SINGLETON_TYPE_DESC":
-                return SyntaxKind.SINGLETON_TYPE_DESC;
-            case "TYPEDESC_TYPE_DESC":
-                return SyntaxKind.TYPEDESC_TYPE_DESC;
-            case "VAR_TYPE_DESC":
-                return SyntaxKind.VAR_TYPE_DESC;
-            case "SERVICE_TYPE_DESC":
-                return SyntaxKind.SERVICE_TYPE_DESC;
-            case "MAP_TYPE_DESC":
-                return SyntaxKind.MAP_TYPE_DESC;
-            case "FUTURE_TYPE_DESC":
-                return SyntaxKind.FUTURE_TYPE_DESC;
-            default:
-                return getOperatorKind(kind);
-        }
+        return switch (kind) {
+            case "TYPE_DESC" -> SyntaxKind.TYPE_DESC;
+            case "INT_TYPE_DESC" -> SyntaxKind.INT_TYPE_DESC;
+            case "FLOAT_TYPE_DESC" -> SyntaxKind.FLOAT_TYPE_DESC;
+            case "DECIMAL_TYPE_DESC" -> SyntaxKind.DECIMAL_TYPE_DESC;
+            case "BOOLEAN_TYPE_DESC" -> SyntaxKind.BOOLEAN_TYPE_DESC;
+            case "STRING_TYPE_DESC" -> SyntaxKind.STRING_TYPE_DESC;
+            case "BYTE_TYPE_DESC" -> SyntaxKind.BYTE_TYPE_DESC;
+            case "XML_TYPE_DESC" -> SyntaxKind.XML_TYPE_DESC;
+            case "JSON_TYPE_DESC" -> SyntaxKind.JSON_TYPE_DESC;
+            case "HANDLE_TYPE_DESC" -> SyntaxKind.HANDLE_TYPE_DESC;
+            case "ANY_TYPE_DESC" -> SyntaxKind.ANY_TYPE_DESC;
+            case "ANYDATA_TYPE_DESC" -> SyntaxKind.ANYDATA_TYPE_DESC;
+            case "NEVER_TYPE_DESC" -> SyntaxKind.NEVER_TYPE_DESC;
+            case "NIL_TYPE_DESC" -> SyntaxKind.NIL_TYPE_DESC;
+            case "OPTIONAL_TYPE_DESC" -> SyntaxKind.OPTIONAL_TYPE_DESC;
+            case "ARRAY_TYPE_DESC" -> SyntaxKind.ARRAY_TYPE_DESC;
+            case "RECORD_TYPE_DESC" -> SyntaxKind.RECORD_TYPE_DESC;
+            case "OBJECT_TYPE_DESC" -> SyntaxKind.OBJECT_TYPE_DESC;
+            case "UNION_TYPE_DESC" -> SyntaxKind.UNION_TYPE_DESC;
+            case "ERROR_TYPE_DESC" -> SyntaxKind.ERROR_TYPE_DESC;
+            case "EXPLICIT_TYPE_PARAMS" -> SyntaxKind.EXPLICIT_TYPE_PARAMS;
+            case "STREAM_TYPE_DESC" -> SyntaxKind.STREAM_TYPE_DESC;
+            case "FUNCTION_TYPE_DESC" -> SyntaxKind.FUNCTION_TYPE_DESC;
+            case "TABLE_TYPE_DESC" -> SyntaxKind.TABLE_TYPE_DESC;
+            case "TUPLE_TYPE_DESC" -> SyntaxKind.TUPLE_TYPE_DESC;
+            case "PARENTHESISED_TYPE_DESC" -> SyntaxKind.PARENTHESISED_TYPE_DESC;
+            case "READONLY_TYPE_DESC" -> SyntaxKind.READONLY_TYPE_DESC;
+            case "DISTINCT_TYPE_DESC" -> SyntaxKind.DISTINCT_TYPE_DESC;
+            case "INTERSECTION_TYPE_DESC" -> SyntaxKind.INTERSECTION_TYPE_DESC;
+            case "SINGLETON_TYPE_DESC" -> SyntaxKind.SINGLETON_TYPE_DESC;
+            case "TYPEDESC_TYPE_DESC" -> SyntaxKind.TYPEDESC_TYPE_DESC;
+            case "VAR_TYPE_DESC" -> SyntaxKind.VAR_TYPE_DESC;
+            case "SERVICE_TYPE_DESC" -> SyntaxKind.SERVICE_TYPE_DESC;
+            case "MAP_TYPE_DESC" -> SyntaxKind.MAP_TYPE_DESC;
+            case "FUTURE_TYPE_DESC" -> SyntaxKind.FUTURE_TYPE_DESC;
+            default -> getOperatorKind(kind);
+        };
     }
     
     private static SyntaxKind getOperatorKind(String kind) {
-        switch (kind) {
-            case "PLUS_TOKEN":
-                return SyntaxKind.PLUS_TOKEN;
-            case "MINUS_TOKEN":
-                return SyntaxKind.MINUS_TOKEN;
-            case "ASTERISK_TOKEN":
-                return SyntaxKind.ASTERISK_TOKEN;
-            case "SLASH_TOKEN":
-                return SyntaxKind.SLASH_TOKEN;
-            case "LT_TOKEN":
-                return SyntaxKind.LT_TOKEN;
-            case "EQUAL_TOKEN":
-                return SyntaxKind.EQUAL_TOKEN;
-            case "DOUBLE_EQUAL_TOKEN":
-                return SyntaxKind.DOUBLE_EQUAL_TOKEN;
-            case "TRIPPLE_EQUAL_TOKEN":
-                return SyntaxKind.TRIPPLE_EQUAL_TOKEN;
-            case "PERCENT_TOKEN":
-                return SyntaxKind.PERCENT_TOKEN;
-            case "GT_TOKEN":
-                return SyntaxKind.GT_TOKEN;
-            case "RIGHT_DOUBLE_ARROW_TOKEN":
-                return SyntaxKind.RIGHT_DOUBLE_ARROW_TOKEN;
-            case "QUESTION_MARK_TOKEN":
-                return SyntaxKind.QUESTION_MARK_TOKEN;
-            case "LT_EQUAL_TOKEN":
-                return SyntaxKind.LT_EQUAL_TOKEN;
-            case "GT_EQUAL_TOKEN":
-                return SyntaxKind.GT_EQUAL_TOKEN;
-            case "EXCLAMATION_MARK_TOKEN":
-                return SyntaxKind.EXCLAMATION_MARK_TOKEN;
-            case "NOT_EQUAL_TOKEN":
-                return SyntaxKind.NOT_EQUAL_TOKEN;
-            case "NOT_DOUBLE_EQUAL_TOKEN":
-                return SyntaxKind.NOT_DOUBLE_EQUAL_TOKEN;
-            case "BITWISE_AND_TOKEN":
-                return SyntaxKind.BITWISE_AND_TOKEN;
-            case "BITWISE_XOR_TOKEN":
-                return SyntaxKind.BITWISE_XOR_TOKEN;
-            case "LOGICAL_AND_TOKEN":
-                return SyntaxKind.LOGICAL_AND_TOKEN;
-            case "LOGICAL_OR_TOKEN":
-                return SyntaxKind.LOGICAL_OR_TOKEN;
-            case "NEGATION_TOKEN":
-                return SyntaxKind.NEGATION_TOKEN;
-            case "DOUBLE_LT_TOKEN":
-                return SyntaxKind.DOUBLE_LT_TOKEN;
-            case "DOUBLE_GT_TOKEN":
-                return SyntaxKind.DOUBLE_GT_TOKEN;
-            case "TRIPPLE_GT_TOKEN":
-                return SyntaxKind.TRIPPLE_GT_TOKEN;
-            case "DOUBLE_DOT_LT_TOKEN":
-                return SyntaxKind.DOUBLE_DOT_LT_TOKEN;
-            case "ANNOT_CHAINING_TOKEN":
-                return SyntaxKind.ANNOT_CHAINING_TOKEN;
-            case "OPTIONAL_CHAINING_TOKEN":
-                return SyntaxKind.OPTIONAL_CHAINING_TOKEN;
-            case "ELVIS_TOKEN":
-                return SyntaxKind.ELVIS_TOKEN;
-            case "DOT_LT_TOKEN":
-                return SyntaxKind.DOT_LT_TOKEN;
-            case "SLASH_LT_TOKEN":
-                return SyntaxKind.SLASH_LT_TOKEN;
-            case "DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN":
-                return SyntaxKind.DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN;
-            case "SLASH_ASTERISK_TOKEN":
-                return SyntaxKind.SLASH_ASTERISK_TOKEN;
-            default:
-                return getSeparatorKind(kind);
-        }
+        return switch (kind) {
+            case "PLUS_TOKEN" -> SyntaxKind.PLUS_TOKEN;
+            case "MINUS_TOKEN" -> SyntaxKind.MINUS_TOKEN;
+            case "ASTERISK_TOKEN" -> SyntaxKind.ASTERISK_TOKEN;
+            case "SLASH_TOKEN" -> SyntaxKind.SLASH_TOKEN;
+            case "LT_TOKEN" -> SyntaxKind.LT_TOKEN;
+            case "EQUAL_TOKEN" -> SyntaxKind.EQUAL_TOKEN;
+            case "DOUBLE_EQUAL_TOKEN" -> SyntaxKind.DOUBLE_EQUAL_TOKEN;
+            case "TRIPPLE_EQUAL_TOKEN" -> SyntaxKind.TRIPPLE_EQUAL_TOKEN;
+            case "PERCENT_TOKEN" -> SyntaxKind.PERCENT_TOKEN;
+            case "GT_TOKEN" -> SyntaxKind.GT_TOKEN;
+            case "RIGHT_DOUBLE_ARROW_TOKEN" -> SyntaxKind.RIGHT_DOUBLE_ARROW_TOKEN;
+            case "QUESTION_MARK_TOKEN" -> SyntaxKind.QUESTION_MARK_TOKEN;
+            case "LT_EQUAL_TOKEN" -> SyntaxKind.LT_EQUAL_TOKEN;
+            case "GT_EQUAL_TOKEN" -> SyntaxKind.GT_EQUAL_TOKEN;
+            case "EXCLAMATION_MARK_TOKEN" -> SyntaxKind.EXCLAMATION_MARK_TOKEN;
+            case "NOT_EQUAL_TOKEN" -> SyntaxKind.NOT_EQUAL_TOKEN;
+            case "NOT_DOUBLE_EQUAL_TOKEN" -> SyntaxKind.NOT_DOUBLE_EQUAL_TOKEN;
+            case "BITWISE_AND_TOKEN" -> SyntaxKind.BITWISE_AND_TOKEN;
+            case "BITWISE_XOR_TOKEN" -> SyntaxKind.BITWISE_XOR_TOKEN;
+            case "LOGICAL_AND_TOKEN" -> SyntaxKind.LOGICAL_AND_TOKEN;
+            case "LOGICAL_OR_TOKEN" -> SyntaxKind.LOGICAL_OR_TOKEN;
+            case "NEGATION_TOKEN" -> SyntaxKind.NEGATION_TOKEN;
+            case "DOUBLE_LT_TOKEN" -> SyntaxKind.DOUBLE_LT_TOKEN;
+            case "DOUBLE_GT_TOKEN" -> SyntaxKind.DOUBLE_GT_TOKEN;
+            case "TRIPPLE_GT_TOKEN" -> SyntaxKind.TRIPPLE_GT_TOKEN;
+            case "DOUBLE_DOT_LT_TOKEN" -> SyntaxKind.DOUBLE_DOT_LT_TOKEN;
+            case "ANNOT_CHAINING_TOKEN" -> SyntaxKind.ANNOT_CHAINING_TOKEN;
+            case "OPTIONAL_CHAINING_TOKEN" -> SyntaxKind.OPTIONAL_CHAINING_TOKEN;
+            case "ELVIS_TOKEN" -> SyntaxKind.ELVIS_TOKEN;
+            case "DOT_LT_TOKEN" -> SyntaxKind.DOT_LT_TOKEN;
+            case "SLASH_LT_TOKEN" -> SyntaxKind.SLASH_LT_TOKEN;
+            case "DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN" -> SyntaxKind.DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN;
+            case "SLASH_ASTERISK_TOKEN" -> SyntaxKind.SLASH_ASTERISK_TOKEN;
+            default -> getSeparatorKind(kind);
+        };
     
     }
 
     private static SyntaxKind getSeparatorKind(String kind) {
-        switch (kind) {
-            case "OPEN_BRACE_TOKEN":
-                return SyntaxKind.OPEN_BRACE_TOKEN;
-            case "CLOSE_BRACE_TOKEN":
-                return SyntaxKind.CLOSE_BRACE_TOKEN;
-            case "OPEN_PAREN_TOKEN":
-                return SyntaxKind.OPEN_PAREN_TOKEN;
-            case "CLOSE_PAREN_TOKEN":
-                return SyntaxKind.CLOSE_PAREN_TOKEN;
-            case "OPEN_BRACKET_TOKEN":
-                return SyntaxKind.OPEN_BRACKET_TOKEN;
-            case "CLOSE_BRACKET_TOKEN":
-                return SyntaxKind.CLOSE_BRACKET_TOKEN;
-            case "SEMICOLON_TOKEN":
-                return SyntaxKind.SEMICOLON_TOKEN;
-            case "DOT_TOKEN":
-                return SyntaxKind.DOT_TOKEN;
-            case "COLON_TOKEN":
-                return SyntaxKind.COLON_TOKEN;
-            case "COMMA_TOKEN":
-                return SyntaxKind.COMMA_TOKEN;
-            case "ELLIPSIS_TOKEN":
-                return SyntaxKind.ELLIPSIS_TOKEN;
-            case "OPEN_BRACE_PIPE_TOKEN":
-                return SyntaxKind.OPEN_BRACE_PIPE_TOKEN;
-            case "CLOSE_BRACE_PIPE_TOKEN":
-                return SyntaxKind.CLOSE_BRACE_PIPE_TOKEN;
-            case "PIPE_TOKEN":
-                return SyntaxKind.PIPE_TOKEN;
-            case "AT_TOKEN":
-                return SyntaxKind.AT_TOKEN;
-            case "RIGHT_ARROW_TOKEN":
-                return SyntaxKind.RIGHT_ARROW_TOKEN;
-            case "BACKTICK_TOKEN":
-                return SyntaxKind.BACKTICK_TOKEN;
-            case "DOUBLE_BACKTICK_TOKEN":
-                return SyntaxKind.DOUBLE_BACKTICK_TOKEN;
-            case "TRIPLE_BACKTICK_TOKEN":
-                return SyntaxKind.TRIPLE_BACKTICK_TOKEN;
-            case "DOUBLE_QUOTE_TOKEN":
-                return SyntaxKind.DOUBLE_QUOTE_TOKEN;
-            case "SINGLE_QUOTE_TOKEN":
-                return SyntaxKind.SINGLE_QUOTE_TOKEN;
-            case "SYNC_SEND_TOKEN":
-                return SyntaxKind.SYNC_SEND_TOKEN;
-            case "LEFT_ARROW_TOKEN":
-                return SyntaxKind.LEFT_ARROW_TOKEN;
-            case "HASH_TOKEN":
-                return SyntaxKind.HASH_TOKEN;
-            case "BACK_SLASH_TOKEN":
-                return SyntaxKind.BACK_SLASH_TOKEN;
-            default:
-                return getKeywordKind(kind);
-        }
+        return switch (kind) {
+            case "OPEN_BRACE_TOKEN" -> SyntaxKind.OPEN_BRACE_TOKEN;
+            case "CLOSE_BRACE_TOKEN" -> SyntaxKind.CLOSE_BRACE_TOKEN;
+            case "OPEN_PAREN_TOKEN" -> SyntaxKind.OPEN_PAREN_TOKEN;
+            case "CLOSE_PAREN_TOKEN" -> SyntaxKind.CLOSE_PAREN_TOKEN;
+            case "OPEN_BRACKET_TOKEN" -> SyntaxKind.OPEN_BRACKET_TOKEN;
+            case "CLOSE_BRACKET_TOKEN" -> SyntaxKind.CLOSE_BRACKET_TOKEN;
+            case "SEMICOLON_TOKEN" -> SyntaxKind.SEMICOLON_TOKEN;
+            case "DOT_TOKEN" -> SyntaxKind.DOT_TOKEN;
+            case "COLON_TOKEN" -> SyntaxKind.COLON_TOKEN;
+            case "COMMA_TOKEN" -> SyntaxKind.COMMA_TOKEN;
+            case "ELLIPSIS_TOKEN" -> SyntaxKind.ELLIPSIS_TOKEN;
+            case "OPEN_BRACE_PIPE_TOKEN" -> SyntaxKind.OPEN_BRACE_PIPE_TOKEN;
+            case "CLOSE_BRACE_PIPE_TOKEN" -> SyntaxKind.CLOSE_BRACE_PIPE_TOKEN;
+            case "PIPE_TOKEN" -> SyntaxKind.PIPE_TOKEN;
+            case "AT_TOKEN" -> SyntaxKind.AT_TOKEN;
+            case "RIGHT_ARROW_TOKEN" -> SyntaxKind.RIGHT_ARROW_TOKEN;
+            case "BACKTICK_TOKEN" -> SyntaxKind.BACKTICK_TOKEN;
+            case "DOUBLE_BACKTICK_TOKEN" -> SyntaxKind.DOUBLE_BACKTICK_TOKEN;
+            case "TRIPLE_BACKTICK_TOKEN" -> SyntaxKind.TRIPLE_BACKTICK_TOKEN;
+            case "DOUBLE_QUOTE_TOKEN" -> SyntaxKind.DOUBLE_QUOTE_TOKEN;
+            case "SINGLE_QUOTE_TOKEN" -> SyntaxKind.SINGLE_QUOTE_TOKEN;
+            case "SYNC_SEND_TOKEN" -> SyntaxKind.SYNC_SEND_TOKEN;
+            case "LEFT_ARROW_TOKEN" -> SyntaxKind.LEFT_ARROW_TOKEN;
+            case "HASH_TOKEN" -> SyntaxKind.HASH_TOKEN;
+            case "BACK_SLASH_TOKEN" -> SyntaxKind.BACK_SLASH_TOKEN;
+            default -> getKeywordKind(kind);
+        };
     }
     
     private static SyntaxKind getKeywordKind(String kind) {
-        switch (kind) {
-            case "PUBLIC_KEYWORD":
-                return SyntaxKind.PUBLIC_KEYWORD;
-            case "PRIVATE_KEYWORD":
-                return SyntaxKind.PRIVATE_KEYWORD;
-            case "FUNCTION_KEYWORD":
-                return SyntaxKind.FUNCTION_KEYWORD;
-            case "TYPE_KEYWORD":
-                return SyntaxKind.TYPE_KEYWORD;
-            case "EXTERNAL_KEYWORD":
-                return SyntaxKind.EXTERNAL_KEYWORD;
-            case "RETURNS_KEYWORD":
-                return SyntaxKind.RETURNS_KEYWORD;
-            case "RECORD_KEYWORD":
-                return SyntaxKind.RECORD_KEYWORD;
-            case "OBJECT_KEYWORD":
-                return SyntaxKind.OBJECT_KEYWORD;
-            case "REMOTE_KEYWORD":
-                return SyntaxKind.REMOTE_KEYWORD;
-            case "CLIENT_KEYWORD":
-                return SyntaxKind.CLIENT_KEYWORD;
-            case "ABSTRACT_KEYWORD":
-                return SyntaxKind.ABSTRACT_KEYWORD;
-            case "IF_KEYWORD":
-                return SyntaxKind.IF_KEYWORD;
-            case "ELSE_KEYWORD":
-                return SyntaxKind.ELSE_KEYWORD;
-            case "WHILE_KEYWORD":
-                return SyntaxKind.WHILE_KEYWORD;
-            case "TRUE_KEYWORD":
-                return SyntaxKind.TRUE_KEYWORD;
-            case "FALSE_KEYWORD":
-                return SyntaxKind.FALSE_KEYWORD;
-            case "CHECK_KEYWORD":
-                return SyntaxKind.CHECK_KEYWORD;
-            case "CHECKPANIC_KEYWORD":
-                return SyntaxKind.CHECKPANIC_KEYWORD;
-            case "FAIL_KEYWORD":
-                return SyntaxKind.FAIL_KEYWORD;
-            case "PANIC_KEYWORD":
-                return SyntaxKind.PANIC_KEYWORD;
-            case "IMPORT_KEYWORD":
-                return SyntaxKind.IMPORT_KEYWORD;
-            case "AS_KEYWORD":
-                return SyntaxKind.AS_KEYWORD;
-            case "CONTINUE_KEYWORD":
-                return SyntaxKind.CONTINUE_KEYWORD;
-            case "BREAK_KEYWORD":
-                return SyntaxKind.BREAK_KEYWORD;
-            case "RETURN_KEYWORD":
-                return SyntaxKind.RETURN_KEYWORD;
-            case "SERVICE_KEYWORD":
-                return SyntaxKind.SERVICE_KEYWORD;
-            case "ON_KEYWORD":
-                return SyntaxKind.ON_KEYWORD;
-            case "RESOURCE_KEYWORD":
-                return SyntaxKind.RESOURCE_KEYWORD;
-            case "LISTENER_KEYWORD":
-                return SyntaxKind.LISTENER_KEYWORD;
-            case "CONST_KEYWORD":
-                return SyntaxKind.CONST_KEYWORD;
-            case "FINAL_KEYWORD":
-                return SyntaxKind.FINAL_KEYWORD;
-            case "TYPEOF_KEYWORD":
-                return SyntaxKind.TYPEOF_KEYWORD;
-            case "ANNOTATION_KEYWORD":
-                return SyntaxKind.ANNOTATION_KEYWORD;
-            case "IS_KEYWORD":
-                return SyntaxKind.IS_KEYWORD;
-            case "NOT_IS_KEYWORD":
-                return SyntaxKind.NOT_IS_KEYWORD;
-            case "MAP_KEYWORD":
-                return SyntaxKind.MAP_KEYWORD;
-            case "FUTURE_KEYWORD":
-                return SyntaxKind.FUTURE_KEYWORD;
-            case "TYPEDESC_KEYWORD":
-                return SyntaxKind.TYPEDESC_KEYWORD;
-            case "NULL_KEYWORD":
-                return SyntaxKind.NULL_KEYWORD;
-            case "LOCK_KEYWORD":
-                return SyntaxKind.LOCK_KEYWORD;
-            case "VAR_KEYWORD":
-                return SyntaxKind.VAR_KEYWORD;
-            case "SOURCE_KEYWORD":
-                return SyntaxKind.SOURCE_KEYWORD;
-            case "WORKER_KEYWORD":
-                return SyntaxKind.WORKER_KEYWORD;
-            case "PARAMETER_KEYWORD":
-                return SyntaxKind.PARAMETER_KEYWORD;
-            case "FIELD_KEYWORD":
-                return SyntaxKind.FIELD_KEYWORD;
-            case "XMLNS_KEYWORD":
-                return SyntaxKind.XMLNS_KEYWORD;
-            case "INT_KEYWORD":
-                return SyntaxKind.INT_KEYWORD;
-            case "FLOAT_KEYWORD":
-                return SyntaxKind.FLOAT_KEYWORD;
-            case "DECIMAL_KEYWORD":
-                return SyntaxKind.DECIMAL_KEYWORD;
-            case "BOOLEAN_KEYWORD":
-                return SyntaxKind.BOOLEAN_KEYWORD;
-            case "STRING_KEYWORD":
-                return SyntaxKind.STRING_KEYWORD;
-            case "BYTE_KEYWORD":
-                return SyntaxKind.BYTE_KEYWORD;
-            case "XML_KEYWORD":
-                return SyntaxKind.XML_KEYWORD;
-            case "RE_KEYWORD":
-                return SyntaxKind.RE_KEYWORD;
-            case "JSON_KEYWORD":
-                return SyntaxKind.JSON_KEYWORD;
-            case "HANDLE_KEYWORD":
-                return SyntaxKind.HANDLE_KEYWORD;
-            case "ANY_KEYWORD":
-                return SyntaxKind.ANY_KEYWORD;
-            case "ANYDATA_KEYWORD":
-                return SyntaxKind.ANYDATA_KEYWORD;
-            case "NEVER_KEYWORD":
-                return SyntaxKind.NEVER_KEYWORD;
-            case "FORK_KEYWORD":
-                return SyntaxKind.FORK_KEYWORD;
-            case "TRAP_KEYWORD":
-                return SyntaxKind.TRAP_KEYWORD;
-            case "FOREACH_KEYWORD":
-                return SyntaxKind.FOREACH_KEYWORD;
-            case "IN_KEYWORD":
-                return SyntaxKind.IN_KEYWORD;
-            case "TABLE_KEYWORD":
-                return SyntaxKind.TABLE_KEYWORD;
-            case "KEY_KEYWORD":
-                return SyntaxKind.KEY_KEYWORD;
-            case "ERROR_KEYWORD":
-                return SyntaxKind.ERROR_KEYWORD;
-            case "LET_KEYWORD":
-                return SyntaxKind.LET_KEYWORD;
-            case "STREAM_KEYWORD":
-                return SyntaxKind.STREAM_KEYWORD;
-            case "READONLY_KEYWORD":
-                return SyntaxKind.READONLY_KEYWORD;
-            case "DISTINCT_KEYWORD":
-                return SyntaxKind.DISTINCT_KEYWORD;
-            case "FROM_KEYWORD":
-                return SyntaxKind.FROM_KEYWORD;
-            case "WHERE_KEYWORD":
-                return SyntaxKind.WHERE_KEYWORD;
-            case "SELECT_KEYWORD":
-                return SyntaxKind.SELECT_KEYWORD;
-            case "COLLECT_KEYWORD":
-                return SyntaxKind.COLLECT_KEYWORD;
-            case "ORDER_KEYWORD":
-                return SyntaxKind.ORDER_KEYWORD;
-            case "BY_KEYWORD":
-                return SyntaxKind.BY_KEYWORD;
-            case "GROUP_KEYWORD":
-                return SyntaxKind.GROUP_KEYWORD;
-            case "ASCENDING_KEYWORD":
-                return SyntaxKind.ASCENDING_KEYWORD;
-            case "DESCENDING_KEYWORD":
-                return SyntaxKind.DESCENDING_KEYWORD;
-            case "NEW_KEYWORD":
-                return SyntaxKind.NEW_KEYWORD;
-            case "START_KEYWORD":
-                return SyntaxKind.START_KEYWORD;
-            case "FLUSH_KEYWORD":
-                return SyntaxKind.FLUSH_KEYWORD;
-            case "WAIT_KEYWORD":
-                return SyntaxKind.WAIT_KEYWORD;
-            case "DO_KEYWORD":
-                return SyntaxKind.DO_KEYWORD;
-            case "TRANSACTION_KEYWORD":
-                return SyntaxKind.TRANSACTION_KEYWORD;
-            case "COMMIT_KEYWORD":
-                return SyntaxKind.COMMIT_KEYWORD;
-            case "RETRY_KEYWORD":
-                return SyntaxKind.RETRY_KEYWORD;
-            case "ROLLBACK_KEYWORD":
-                return SyntaxKind.ROLLBACK_KEYWORD;
-            case "TRANSACTIONAL_KEYWORD":
-                return SyntaxKind.TRANSACTIONAL_KEYWORD;
-            case "ISOLATED_KEYWORD":
-                return SyntaxKind.ISOLATED_KEYWORD;
-            case "ENUM_KEYWORD":
-                return SyntaxKind.ENUM_KEYWORD;
-            case "BASE16_KEYWORD":
-                return SyntaxKind.BASE16_KEYWORD;
-            case "BASE64_KEYWORD":
-                return SyntaxKind.BASE64_KEYWORD;
-            case "MATCH_KEYWORD":
-                return SyntaxKind.MATCH_KEYWORD;
-            case "CLASS_KEYWORD":
-                return SyntaxKind.CLASS_KEYWORD;
-            case "CONFLICT_KEYWORD":
-                return SyntaxKind.CONFLICT_KEYWORD;
-            case "LIMIT_KEYWORD":
-                return SyntaxKind.LIMIT_KEYWORD;
-            case "JOIN_KEYWORD":
-                return SyntaxKind.JOIN_KEYWORD;
-            case "EQUALS_KEYWORD":
-                return SyntaxKind.EQUALS_KEYWORD;
-            case "OUTER_KEYWORD":
-                return SyntaxKind.OUTER_KEYWORD;
-            case "CONFIGURABLE_KEYWORD":
-                return SyntaxKind.CONFIGURABLE_KEYWORD;
-            case "UNDERSCORE_KEYWORD":
-                return SyntaxKind.UNDERSCORE_KEYWORD;
-            default:
-                return getXMLTemplateKind(kind);
-        }
+        return switch (kind) {
+            case "PUBLIC_KEYWORD" -> SyntaxKind.PUBLIC_KEYWORD;
+            case "PRIVATE_KEYWORD" -> SyntaxKind.PRIVATE_KEYWORD;
+            case "FUNCTION_KEYWORD" -> SyntaxKind.FUNCTION_KEYWORD;
+            case "TYPE_KEYWORD" -> SyntaxKind.TYPE_KEYWORD;
+            case "EXTERNAL_KEYWORD" -> SyntaxKind.EXTERNAL_KEYWORD;
+            case "RETURNS_KEYWORD" -> SyntaxKind.RETURNS_KEYWORD;
+            case "RECORD_KEYWORD" -> SyntaxKind.RECORD_KEYWORD;
+            case "OBJECT_KEYWORD" -> SyntaxKind.OBJECT_KEYWORD;
+            case "REMOTE_KEYWORD" -> SyntaxKind.REMOTE_KEYWORD;
+            case "CLIENT_KEYWORD" -> SyntaxKind.CLIENT_KEYWORD;
+            case "ABSTRACT_KEYWORD" -> SyntaxKind.ABSTRACT_KEYWORD;
+            case "IF_KEYWORD" -> SyntaxKind.IF_KEYWORD;
+            case "ELSE_KEYWORD" -> SyntaxKind.ELSE_KEYWORD;
+            case "WHILE_KEYWORD" -> SyntaxKind.WHILE_KEYWORD;
+            case "TRUE_KEYWORD" -> SyntaxKind.TRUE_KEYWORD;
+            case "FALSE_KEYWORD" -> SyntaxKind.FALSE_KEYWORD;
+            case "CHECK_KEYWORD" -> SyntaxKind.CHECK_KEYWORD;
+            case "CHECKPANIC_KEYWORD" -> SyntaxKind.CHECKPANIC_KEYWORD;
+            case "FAIL_KEYWORD" -> SyntaxKind.FAIL_KEYWORD;
+            case "PANIC_KEYWORD" -> SyntaxKind.PANIC_KEYWORD;
+            case "IMPORT_KEYWORD" -> SyntaxKind.IMPORT_KEYWORD;
+            case "AS_KEYWORD" -> SyntaxKind.AS_KEYWORD;
+            case "CONTINUE_KEYWORD" -> SyntaxKind.CONTINUE_KEYWORD;
+            case "BREAK_KEYWORD" -> SyntaxKind.BREAK_KEYWORD;
+            case "RETURN_KEYWORD" -> SyntaxKind.RETURN_KEYWORD;
+            case "SERVICE_KEYWORD" -> SyntaxKind.SERVICE_KEYWORD;
+            case "ON_KEYWORD" -> SyntaxKind.ON_KEYWORD;
+            case "RESOURCE_KEYWORD" -> SyntaxKind.RESOURCE_KEYWORD;
+            case "LISTENER_KEYWORD" -> SyntaxKind.LISTENER_KEYWORD;
+            case "CONST_KEYWORD" -> SyntaxKind.CONST_KEYWORD;
+            case "FINAL_KEYWORD" -> SyntaxKind.FINAL_KEYWORD;
+            case "TYPEOF_KEYWORD" -> SyntaxKind.TYPEOF_KEYWORD;
+            case "ANNOTATION_KEYWORD" -> SyntaxKind.ANNOTATION_KEYWORD;
+            case "IS_KEYWORD" -> SyntaxKind.IS_KEYWORD;
+            case "NOT_IS_KEYWORD" -> SyntaxKind.NOT_IS_KEYWORD;
+            case "MAP_KEYWORD" -> SyntaxKind.MAP_KEYWORD;
+            case "FUTURE_KEYWORD" -> SyntaxKind.FUTURE_KEYWORD;
+            case "TYPEDESC_KEYWORD" -> SyntaxKind.TYPEDESC_KEYWORD;
+            case "NULL_KEYWORD" -> SyntaxKind.NULL_KEYWORD;
+            case "LOCK_KEYWORD" -> SyntaxKind.LOCK_KEYWORD;
+            case "VAR_KEYWORD" -> SyntaxKind.VAR_KEYWORD;
+            case "SOURCE_KEYWORD" -> SyntaxKind.SOURCE_KEYWORD;
+            case "WORKER_KEYWORD" -> SyntaxKind.WORKER_KEYWORD;
+            case "PARAMETER_KEYWORD" -> SyntaxKind.PARAMETER_KEYWORD;
+            case "FIELD_KEYWORD" -> SyntaxKind.FIELD_KEYWORD;
+            case "XMLNS_KEYWORD" -> SyntaxKind.XMLNS_KEYWORD;
+            case "INT_KEYWORD" -> SyntaxKind.INT_KEYWORD;
+            case "FLOAT_KEYWORD" -> SyntaxKind.FLOAT_KEYWORD;
+            case "DECIMAL_KEYWORD" -> SyntaxKind.DECIMAL_KEYWORD;
+            case "BOOLEAN_KEYWORD" -> SyntaxKind.BOOLEAN_KEYWORD;
+            case "STRING_KEYWORD" -> SyntaxKind.STRING_KEYWORD;
+            case "BYTE_KEYWORD" -> SyntaxKind.BYTE_KEYWORD;
+            case "XML_KEYWORD" -> SyntaxKind.XML_KEYWORD;
+            case "RE_KEYWORD" -> SyntaxKind.RE_KEYWORD;
+            case "JSON_KEYWORD" -> SyntaxKind.JSON_KEYWORD;
+            case "HANDLE_KEYWORD" -> SyntaxKind.HANDLE_KEYWORD;
+            case "ANY_KEYWORD" -> SyntaxKind.ANY_KEYWORD;
+            case "ANYDATA_KEYWORD" -> SyntaxKind.ANYDATA_KEYWORD;
+            case "NEVER_KEYWORD" -> SyntaxKind.NEVER_KEYWORD;
+            case "FORK_KEYWORD" -> SyntaxKind.FORK_KEYWORD;
+            case "TRAP_KEYWORD" -> SyntaxKind.TRAP_KEYWORD;
+            case "FOREACH_KEYWORD" -> SyntaxKind.FOREACH_KEYWORD;
+            case "IN_KEYWORD" -> SyntaxKind.IN_KEYWORD;
+            case "TABLE_KEYWORD" -> SyntaxKind.TABLE_KEYWORD;
+            case "KEY_KEYWORD" -> SyntaxKind.KEY_KEYWORD;
+            case "ERROR_KEYWORD" -> SyntaxKind.ERROR_KEYWORD;
+            case "LET_KEYWORD" -> SyntaxKind.LET_KEYWORD;
+            case "STREAM_KEYWORD" -> SyntaxKind.STREAM_KEYWORD;
+            case "READONLY_KEYWORD" -> SyntaxKind.READONLY_KEYWORD;
+            case "DISTINCT_KEYWORD" -> SyntaxKind.DISTINCT_KEYWORD;
+            case "FROM_KEYWORD" -> SyntaxKind.FROM_KEYWORD;
+            case "WHERE_KEYWORD" -> SyntaxKind.WHERE_KEYWORD;
+            case "SELECT_KEYWORD" -> SyntaxKind.SELECT_KEYWORD;
+            case "COLLECT_KEYWORD" -> SyntaxKind.COLLECT_KEYWORD;
+            case "ORDER_KEYWORD" -> SyntaxKind.ORDER_KEYWORD;
+            case "BY_KEYWORD" -> SyntaxKind.BY_KEYWORD;
+            case "GROUP_KEYWORD" -> SyntaxKind.GROUP_KEYWORD;
+            case "ASCENDING_KEYWORD" -> SyntaxKind.ASCENDING_KEYWORD;
+            case "DESCENDING_KEYWORD" -> SyntaxKind.DESCENDING_KEYWORD;
+            case "NEW_KEYWORD" -> SyntaxKind.NEW_KEYWORD;
+            case "START_KEYWORD" -> SyntaxKind.START_KEYWORD;
+            case "FLUSH_KEYWORD" -> SyntaxKind.FLUSH_KEYWORD;
+            case "WAIT_KEYWORD" -> SyntaxKind.WAIT_KEYWORD;
+            case "DO_KEYWORD" -> SyntaxKind.DO_KEYWORD;
+            case "TRANSACTION_KEYWORD" -> SyntaxKind.TRANSACTION_KEYWORD;
+            case "COMMIT_KEYWORD" -> SyntaxKind.COMMIT_KEYWORD;
+            case "RETRY_KEYWORD" -> SyntaxKind.RETRY_KEYWORD;
+            case "ROLLBACK_KEYWORD" -> SyntaxKind.ROLLBACK_KEYWORD;
+            case "TRANSACTIONAL_KEYWORD" -> SyntaxKind.TRANSACTIONAL_KEYWORD;
+            case "ISOLATED_KEYWORD" -> SyntaxKind.ISOLATED_KEYWORD;
+            case "ENUM_KEYWORD" -> SyntaxKind.ENUM_KEYWORD;
+            case "BASE16_KEYWORD" -> SyntaxKind.BASE16_KEYWORD;
+            case "BASE64_KEYWORD" -> SyntaxKind.BASE64_KEYWORD;
+            case "MATCH_KEYWORD" -> SyntaxKind.MATCH_KEYWORD;
+            case "CLASS_KEYWORD" -> SyntaxKind.CLASS_KEYWORD;
+            case "CONFLICT_KEYWORD" -> SyntaxKind.CONFLICT_KEYWORD;
+            case "LIMIT_KEYWORD" -> SyntaxKind.LIMIT_KEYWORD;
+            case "JOIN_KEYWORD" -> SyntaxKind.JOIN_KEYWORD;
+            case "EQUALS_KEYWORD" -> SyntaxKind.EQUALS_KEYWORD;
+            case "OUTER_KEYWORD" -> SyntaxKind.OUTER_KEYWORD;
+            case "CONFIGURABLE_KEYWORD" -> SyntaxKind.CONFIGURABLE_KEYWORD;
+            case "UNDERSCORE_KEYWORD" -> SyntaxKind.UNDERSCORE_KEYWORD;
+            default -> getXMLTemplateKind(kind);
+        };
     }
 
     private static SyntaxKind getXMLTemplateKind(String kind) {
-        switch (kind) {
-            case "XML_ELEMENT":
-                return SyntaxKind.XML_ELEMENT;
-            case "XML_EMPTY_ELEMENT":
-                return SyntaxKind.XML_EMPTY_ELEMENT;
-            case "XML_ELEMENT_START_TAG":
-                return SyntaxKind.XML_ELEMENT_START_TAG;
-            case "XML_ELEMENT_END_TAG":
-                return SyntaxKind.XML_ELEMENT_END_TAG;
-            case "XML_TEXT":
-                return SyntaxKind.XML_TEXT;
-            case "XML_PI":
-                return SyntaxKind.XML_PI;
-            case "XML_ATTRIBUTE":
-                return SyntaxKind.XML_ATTRIBUTE;
-            case "XML_SIMPLE_NAME":
-                return SyntaxKind.XML_SIMPLE_NAME;
-            case "XML_QUALIFIED_NAME":
-                return SyntaxKind.XML_QUALIFIED_NAME;
-            case "INTERPOLATION":
-                return SyntaxKind.INTERPOLATION;
-            case "INTERPOLATION_START_TOKEN":
-                return SyntaxKind.INTERPOLATION_START_TOKEN;
-            case "XML_COMMENT":
-                return SyntaxKind.XML_COMMENT;
-            case "XML_COMMENT_START_TOKEN":
-                return SyntaxKind.XML_COMMENT_START_TOKEN;
-            case "XML_COMMENT_END_TOKEN":
-                return SyntaxKind.XML_COMMENT_END_TOKEN;
-            case "XML_TEXT_CONTENT":
-                return SyntaxKind.XML_TEXT_CONTENT;
-            case "XML_PI_START_TOKEN":
-                return SyntaxKind.XML_PI_START_TOKEN;
-            case "XML_PI_END_TOKEN":
-                return SyntaxKind.XML_PI_END_TOKEN;
-            case "XML_ATTRIBUTE_VALUE":
-                return SyntaxKind.XML_ATTRIBUTE_VALUE;
-            case "TEMPLATE_STRING":
-                return SyntaxKind.TEMPLATE_STRING;
-            case "XML_CDATA":
-                return SyntaxKind.XML_CDATA;
-            case "XML_CDATA_START_TOKEN":
-                return SyntaxKind.XML_CDATA_START_TOKEN;
-            case "XML_CDATA_END_TOKEN":
-                return SyntaxKind.XML_CDATA_END_TOKEN;
-            default:
-                return getRegExpTemplateKind(kind);
-        }
+        return switch (kind) {
+            case "XML_ELEMENT" -> SyntaxKind.XML_ELEMENT;
+            case "XML_EMPTY_ELEMENT" -> SyntaxKind.XML_EMPTY_ELEMENT;
+            case "XML_ELEMENT_START_TAG" -> SyntaxKind.XML_ELEMENT_START_TAG;
+            case "XML_ELEMENT_END_TAG" -> SyntaxKind.XML_ELEMENT_END_TAG;
+            case "XML_TEXT" -> SyntaxKind.XML_TEXT;
+            case "XML_PI" -> SyntaxKind.XML_PI;
+            case "XML_ATTRIBUTE" -> SyntaxKind.XML_ATTRIBUTE;
+            case "XML_SIMPLE_NAME" -> SyntaxKind.XML_SIMPLE_NAME;
+            case "XML_QUALIFIED_NAME" -> SyntaxKind.XML_QUALIFIED_NAME;
+            case "INTERPOLATION" -> SyntaxKind.INTERPOLATION;
+            case "INTERPOLATION_START_TOKEN" -> SyntaxKind.INTERPOLATION_START_TOKEN;
+            case "XML_COMMENT" -> SyntaxKind.XML_COMMENT;
+            case "XML_COMMENT_START_TOKEN" -> SyntaxKind.XML_COMMENT_START_TOKEN;
+            case "XML_COMMENT_END_TOKEN" -> SyntaxKind.XML_COMMENT_END_TOKEN;
+            case "XML_TEXT_CONTENT" -> SyntaxKind.XML_TEXT_CONTENT;
+            case "XML_PI_START_TOKEN" -> SyntaxKind.XML_PI_START_TOKEN;
+            case "XML_PI_END_TOKEN" -> SyntaxKind.XML_PI_END_TOKEN;
+            case "XML_ATTRIBUTE_VALUE" -> SyntaxKind.XML_ATTRIBUTE_VALUE;
+            case "TEMPLATE_STRING" -> SyntaxKind.TEMPLATE_STRING;
+            case "XML_CDATA" -> SyntaxKind.XML_CDATA;
+            case "XML_CDATA_START_TOKEN" -> SyntaxKind.XML_CDATA_START_TOKEN;
+            case "XML_CDATA_END_TOKEN" -> SyntaxKind.XML_CDATA_END_TOKEN;
+            default -> getRegExpTemplateKind(kind);
+        };
     }
 
     private static SyntaxKind getRegExpTemplateKind(String kind) {
-        switch (kind) {
-            case "RE_SEQUENCE":
-                return SyntaxKind.RE_SEQUENCE;
-            case "RE_ATOM_QUANTIFIER":
-                return SyntaxKind.RE_ATOM_QUANTIFIER;
-            case "RE_ASSERTION":
-                return SyntaxKind.RE_ASSERTION;
-            case "DOLLAR_TOKEN":
-                return SyntaxKind.DOLLAR_TOKEN;
-            case "DOT_TOKEN":
-                return SyntaxKind.DOT_TOKEN;
-            case "RE_LITERAL_CHAR_DOT_OR_ESCAPE":
-                return SyntaxKind.RE_LITERAL_CHAR_DOT_OR_ESCAPE;
-            case "RE_LITERAL_CHAR":
-                return SyntaxKind.RE_LITERAL_CHAR;
-            case "RE_NUMERIC_ESCAPE":
-                return SyntaxKind.RE_NUMERIC_ESCAPE;
-            case "RE_CONTROL_ESCAPE":
-                return SyntaxKind.RE_CONTROL_ESCAPE;
-            case "RE_QUOTE_ESCAPE":
-                return SyntaxKind.RE_QUOTE_ESCAPE;
-            case "RE_SIMPLE_CHAR_CLASS_ESCAPE":
-                return SyntaxKind.RE_SIMPLE_CHAR_CLASS_ESCAPE;
-            case "RE_SIMPLE_CHAR_CLASS_CODE":
-                return SyntaxKind.RE_SIMPLE_CHAR_CLASS_CODE;
-            case "RE_UNICODE_PROPERTY_ESCAPE":
-                return SyntaxKind.RE_UNICODE_PROPERTY_ESCAPE;
-            case "RE_PROPERTY":
-                return SyntaxKind.RE_PROPERTY;
-            case "RE_UNICODE_SCRIPT":
-                return SyntaxKind.RE_UNICODE_SCRIPT;
-            case "RE_UNICODE_SCRIPT_START":
-                return SyntaxKind.RE_UNICODE_SCRIPT_START;
-            case "RE_UNICODE_PROPERTY_VALUE":
-                return SyntaxKind.RE_UNICODE_PROPERTY_VALUE;
-            case "RE_UNICODE_GENERAL_CATEGORY":
-                return SyntaxKind.RE_UNICODE_GENERAL_CATEGORY;
-            case "RE_UNICODE_GENERAL_CATEGORY_START":
-                return SyntaxKind.RE_UNICODE_GENERAL_CATEGORY_START;
-            case "RE_UNICODE_GENERAL_CATEGORY_NAME":
-                return SyntaxKind.RE_UNICODE_GENERAL_CATEGORY_NAME;
-            case "RE_CHARACTER_CLASS":
-                return SyntaxKind.RE_CHARACTER_CLASS;
-            case "RE_CHAR_SET_RANGE":
-                return SyntaxKind.RE_CHAR_SET_RANGE;
-            case "RE_CHAR_SET_RANGE_NO_DASH":
-                return SyntaxKind.RE_CHAR_SET_RANGE_NO_DASH;
-            case "RE_CHAR_SET_RANGE_WITH_RE_CHAR_SET":
-                return SyntaxKind.RE_CHAR_SET_RANGE_WITH_RE_CHAR_SET;
-            case "RE_CHAR_SET_RANGE_NO_DASH_WITH_RE_CHAR_SET":
-                return SyntaxKind.RE_CHAR_SET_RANGE_NO_DASH_WITH_RE_CHAR_SET;
-            case "RE_CHAR_SET_ATOM_WITH_RE_CHAR_SET_NO_DASH":
-                return SyntaxKind.RE_CHAR_SET_ATOM_WITH_RE_CHAR_SET_NO_DASH;
-            case "RE_CHAR_SET_ATOM_NO_DASH_WITH_RE_CHAR_SET_NO_DASH":
-                return SyntaxKind.RE_CHAR_SET_ATOM_NO_DASH_WITH_RE_CHAR_SET_NO_DASH;
-            case "RE_CAPTURING_GROUP":
-                return SyntaxKind.RE_CAPTURING_GROUP;
-            case "RE_FLAG_EXPR":
-                return SyntaxKind.RE_FLAG_EXPR;
-            case "RE_FLAGS_ON_OFF":
-                return SyntaxKind.RE_FLAGS_ON_OFF;
-            case "RE_FLAGS":
-                return SyntaxKind.RE_FLAGS;
-            case "RE_FLAGS_VALUE":
-                return SyntaxKind.RE_FLAGS_VALUE;
-            case "RE_QUANTIFIER":
-                return SyntaxKind.RE_QUANTIFIER;
-            case "RE_BRACED_QUANTIFIER":
-                return SyntaxKind.RE_BRACED_QUANTIFIER;
-            case "DIGIT":
-                return SyntaxKind.DIGIT;
-            case "ESCAPED_MINUS_TOKEN":
-                return SyntaxKind.ESCAPED_MINUS_TOKEN;
-            default:
-                return getDocumentationKind(kind);
-        }
+        return switch (kind) {
+            case "RE_SEQUENCE" -> SyntaxKind.RE_SEQUENCE;
+            case "RE_ATOM_QUANTIFIER" -> SyntaxKind.RE_ATOM_QUANTIFIER;
+            case "RE_ASSERTION" -> SyntaxKind.RE_ASSERTION;
+            case "DOLLAR_TOKEN" -> SyntaxKind.DOLLAR_TOKEN;
+            case "DOT_TOKEN" -> SyntaxKind.DOT_TOKEN;
+            case "RE_LITERAL_CHAR_DOT_OR_ESCAPE" -> SyntaxKind.RE_LITERAL_CHAR_DOT_OR_ESCAPE;
+            case "RE_LITERAL_CHAR" -> SyntaxKind.RE_LITERAL_CHAR;
+            case "RE_NUMERIC_ESCAPE" -> SyntaxKind.RE_NUMERIC_ESCAPE;
+            case "RE_CONTROL_ESCAPE" -> SyntaxKind.RE_CONTROL_ESCAPE;
+            case "RE_QUOTE_ESCAPE" -> SyntaxKind.RE_QUOTE_ESCAPE;
+            case "RE_SIMPLE_CHAR_CLASS_ESCAPE" -> SyntaxKind.RE_SIMPLE_CHAR_CLASS_ESCAPE;
+            case "RE_SIMPLE_CHAR_CLASS_CODE" -> SyntaxKind.RE_SIMPLE_CHAR_CLASS_CODE;
+            case "RE_UNICODE_PROPERTY_ESCAPE" -> SyntaxKind.RE_UNICODE_PROPERTY_ESCAPE;
+            case "RE_PROPERTY" -> SyntaxKind.RE_PROPERTY;
+            case "RE_UNICODE_SCRIPT" -> SyntaxKind.RE_UNICODE_SCRIPT;
+            case "RE_UNICODE_SCRIPT_START" -> SyntaxKind.RE_UNICODE_SCRIPT_START;
+            case "RE_UNICODE_PROPERTY_VALUE" -> SyntaxKind.RE_UNICODE_PROPERTY_VALUE;
+            case "RE_UNICODE_GENERAL_CATEGORY" -> SyntaxKind.RE_UNICODE_GENERAL_CATEGORY;
+            case "RE_UNICODE_GENERAL_CATEGORY_START" -> SyntaxKind.RE_UNICODE_GENERAL_CATEGORY_START;
+            case "RE_UNICODE_GENERAL_CATEGORY_NAME" -> SyntaxKind.RE_UNICODE_GENERAL_CATEGORY_NAME;
+            case "RE_CHARACTER_CLASS" -> SyntaxKind.RE_CHARACTER_CLASS;
+            case "RE_CHAR_SET_RANGE" -> SyntaxKind.RE_CHAR_SET_RANGE;
+            case "RE_CHAR_SET_RANGE_NO_DASH" -> SyntaxKind.RE_CHAR_SET_RANGE_NO_DASH;
+            case "RE_CHAR_SET_RANGE_WITH_RE_CHAR_SET" -> SyntaxKind.RE_CHAR_SET_RANGE_WITH_RE_CHAR_SET;
+            case "RE_CHAR_SET_RANGE_NO_DASH_WITH_RE_CHAR_SET" -> SyntaxKind.RE_CHAR_SET_RANGE_NO_DASH_WITH_RE_CHAR_SET;
+            case "RE_CHAR_SET_ATOM_WITH_RE_CHAR_SET_NO_DASH" -> SyntaxKind.RE_CHAR_SET_ATOM_WITH_RE_CHAR_SET_NO_DASH;
+            case "RE_CHAR_SET_ATOM_NO_DASH_WITH_RE_CHAR_SET_NO_DASH" ->
+                    SyntaxKind.RE_CHAR_SET_ATOM_NO_DASH_WITH_RE_CHAR_SET_NO_DASH;
+            case "RE_CAPTURING_GROUP" -> SyntaxKind.RE_CAPTURING_GROUP;
+            case "RE_FLAG_EXPR" -> SyntaxKind.RE_FLAG_EXPR;
+            case "RE_FLAGS_ON_OFF" -> SyntaxKind.RE_FLAGS_ON_OFF;
+            case "RE_FLAGS" -> SyntaxKind.RE_FLAGS;
+            case "RE_FLAGS_VALUE" -> SyntaxKind.RE_FLAGS_VALUE;
+            case "RE_QUANTIFIER" -> SyntaxKind.RE_QUANTIFIER;
+            case "RE_BRACED_QUANTIFIER" -> SyntaxKind.RE_BRACED_QUANTIFIER;
+            case "DIGIT" -> SyntaxKind.DIGIT;
+            case "ESCAPED_MINUS_TOKEN" -> SyntaxKind.ESCAPED_MINUS_TOKEN;
+            default -> getDocumentationKind(kind);
+        };
     }
     
     private static SyntaxKind getDocumentationKind(String kind) {
-        switch (kind) {
+        return switch (kind) {
             // Documentation reference
-            case "TYPE_DOC_REFERENCE_TOKEN":
-                return SyntaxKind.TYPE_DOC_REFERENCE_TOKEN;
-            case "SERVICE_DOC_REFERENCE_TOKEN":
-                return SyntaxKind.SERVICE_DOC_REFERENCE_TOKEN;
-            case "VARIABLE_DOC_REFERENCE_TOKEN":
-                return SyntaxKind.VARIABLE_DOC_REFERENCE_TOKEN;
-            case "VAR_DOC_REFERENCE_TOKEN":
-                return SyntaxKind.VAR_DOC_REFERENCE_TOKEN;
-            case "ANNOTATION_DOC_REFERENCE_TOKEN":
-                return SyntaxKind.ANNOTATION_DOC_REFERENCE_TOKEN;
-            case "MODULE_DOC_REFERENCE_TOKEN":
-                return SyntaxKind.MODULE_DOC_REFERENCE_TOKEN;
-            case "FUNCTION_DOC_REFERENCE_TOKEN":
-                return SyntaxKind.FUNCTION_DOC_REFERENCE_TOKEN;
-            case "PARAMETER_DOC_REFERENCE_TOKEN":
-                return SyntaxKind.PARAMETER_DOC_REFERENCE_TOKEN;
-            case "CONST_DOC_REFERENCE_TOKEN":
-                return SyntaxKind.CONST_DOC_REFERENCE_TOKEN;
+            case "TYPE_DOC_REFERENCE_TOKEN" -> SyntaxKind.TYPE_DOC_REFERENCE_TOKEN;
+            case "SERVICE_DOC_REFERENCE_TOKEN" -> SyntaxKind.SERVICE_DOC_REFERENCE_TOKEN;
+            case "VARIABLE_DOC_REFERENCE_TOKEN" -> SyntaxKind.VARIABLE_DOC_REFERENCE_TOKEN;
+            case "VAR_DOC_REFERENCE_TOKEN" -> SyntaxKind.VAR_DOC_REFERENCE_TOKEN;
+            case "ANNOTATION_DOC_REFERENCE_TOKEN" -> SyntaxKind.ANNOTATION_DOC_REFERENCE_TOKEN;
+            case "MODULE_DOC_REFERENCE_TOKEN" -> SyntaxKind.MODULE_DOC_REFERENCE_TOKEN;
+            case "FUNCTION_DOC_REFERENCE_TOKEN" -> SyntaxKind.FUNCTION_DOC_REFERENCE_TOKEN;
+            case "PARAMETER_DOC_REFERENCE_TOKEN" -> SyntaxKind.PARAMETER_DOC_REFERENCE_TOKEN;
+            case "CONST_DOC_REFERENCE_TOKEN" -> SyntaxKind.CONST_DOC_REFERENCE_TOKEN;
 
             // Documentation
-            case "MARKDOWN_DOCUMENTATION":
-                return SyntaxKind.MARKDOWN_DOCUMENTATION;
-            case "MARKDOWN_DOCUMENTATION_LINE":
-                return SyntaxKind.MARKDOWN_DOCUMENTATION_LINE;
-            case "MARKDOWN_REFERENCE_DOCUMENTATION_LINE":
-                return SyntaxKind.MARKDOWN_REFERENCE_DOCUMENTATION_LINE;
-            case "MARKDOWN_PARAMETER_DOCUMENTATION_LINE":
-                return SyntaxKind.MARKDOWN_PARAMETER_DOCUMENTATION_LINE;
-            case "MARKDOWN_RETURN_PARAMETER_DOCUMENTATION_LINE":
-                return SyntaxKind.MARKDOWN_RETURN_PARAMETER_DOCUMENTATION_LINE;
-            case "MARKDOWN_DEPRECATION_DOCUMENTATION_LINE":
-                return SyntaxKind.MARKDOWN_DEPRECATION_DOCUMENTATION_LINE;
-            case "MARKDOWN_CODE_LINE":
-                return SyntaxKind.MARKDOWN_CODE_LINE;
-            case "DOCUMENTATION_DESCRIPTION":
-                return SyntaxKind.DOCUMENTATION_DESCRIPTION;
-            case "BALLERINA_NAME_REFERENCE":
-                return SyntaxKind.BALLERINA_NAME_REFERENCE;
-            case "PARAMETER_NAME":
-                return SyntaxKind.PARAMETER_NAME;
-            case "DEPRECATION_LITERAL":
-                return SyntaxKind.DEPRECATION_LITERAL;
-            case "DOCUMENTATION_STRING":
-                return SyntaxKind.DOCUMENTATION_STRING;
-            case "CODE_CONTENT":
-                return SyntaxKind.CODE_CONTENT;
-            case "INLINE_CODE_REFERENCE":
-                return SyntaxKind.INLINE_CODE_REFERENCE;
-            case "MARKDOWN_CODE_BLOCK":
-                return SyntaxKind.MARKDOWN_CODE_BLOCK;
-                
+            case "MARKDOWN_DOCUMENTATION" -> SyntaxKind.MARKDOWN_DOCUMENTATION;
+            case "MARKDOWN_DOCUMENTATION_LINE" -> SyntaxKind.MARKDOWN_DOCUMENTATION_LINE;
+            case "MARKDOWN_REFERENCE_DOCUMENTATION_LINE" -> SyntaxKind.MARKDOWN_REFERENCE_DOCUMENTATION_LINE;
+            case "MARKDOWN_PARAMETER_DOCUMENTATION_LINE" -> SyntaxKind.MARKDOWN_PARAMETER_DOCUMENTATION_LINE;
+            case "MARKDOWN_RETURN_PARAMETER_DOCUMENTATION_LINE" ->
+                    SyntaxKind.MARKDOWN_RETURN_PARAMETER_DOCUMENTATION_LINE;
+            case "MARKDOWN_DEPRECATION_DOCUMENTATION_LINE" -> SyntaxKind.MARKDOWN_DEPRECATION_DOCUMENTATION_LINE;
+            case "MARKDOWN_CODE_LINE" -> SyntaxKind.MARKDOWN_CODE_LINE;
+            case "DOCUMENTATION_DESCRIPTION" -> SyntaxKind.DOCUMENTATION_DESCRIPTION;
+            case "BALLERINA_NAME_REFERENCE" -> SyntaxKind.BALLERINA_NAME_REFERENCE;
+            case "PARAMETER_NAME" -> SyntaxKind.PARAMETER_NAME;
+            case "DEPRECATION_LITERAL" -> SyntaxKind.DEPRECATION_LITERAL;
+            case "DOCUMENTATION_STRING" -> SyntaxKind.DOCUMENTATION_STRING;
+            case "CODE_CONTENT" -> SyntaxKind.CODE_CONTENT;
+            case "INLINE_CODE_REFERENCE" -> SyntaxKind.INLINE_CODE_REFERENCE;
+            case "MARKDOWN_CODE_BLOCK" -> SyntaxKind.MARKDOWN_CODE_BLOCK;
+
             // Unsupported
-            default:
-                throw new UnsupportedOperationException("cannot find syntax kind: " + kind);
-        }
+            default -> throw new UnsupportedOperationException("cannot find syntax kind: " + kind);
+        };
     }
 }

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/SyntaxTreeModifierTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/SyntaxTreeModifierTest.java
@@ -223,18 +223,13 @@ public class SyntaxTreeModifierTest extends AbstractSyntaxTreeAPITest {
 
             Token newOperator;
             Token oldOperator = binaryExprNode.operator();
-            switch (oldOperator.kind()) {
-                case PLUS_TOKEN:
-                    newOperator = NodeFactory.createToken(SyntaxKind.MINUS_TOKEN, oldOperator.leadingMinutiae(),
-                            oldOperator.trailingMinutiae());
-                    break;
-                case ASTERISK_TOKEN:
-                    newOperator = NodeFactory.createToken(SyntaxKind.SLASH_TOKEN, oldOperator.leadingMinutiae(),
-                            oldOperator.trailingMinutiae());
-                    break;
-                default:
-                    newOperator = oldOperator;
-            }
+            newOperator = switch (oldOperator.kind()) {
+                case PLUS_TOKEN -> NodeFactory.createToken(SyntaxKind.MINUS_TOKEN, oldOperator.leadingMinutiae(),
+                        oldOperator.trailingMinutiae());
+                case ASTERISK_TOKEN -> NodeFactory.createToken(SyntaxKind.SLASH_TOKEN, oldOperator.leadingMinutiae(),
+                        oldOperator.trailingMinutiae());
+                default -> oldOperator;
+            };
 
             return binaryExprNode.modify().withOperator(newOperator).withLhsExpr(newLHSExpr).withRhsExpr(newRHSExpr)
                     .apply();

--- a/langlib/jballerina.java/src/main/java/org/ballerinalang/langlib/java/JavaUtils.java
+++ b/langlib/jballerina.java/src/main/java/org/ballerinalang/langlib/java/JavaUtils.java
@@ -65,25 +65,16 @@ public class JavaUtils {
     }
 
     private static Class<?> getPrimitiveTypeClass(String name) {
-        switch (name) {
-            case booleanTypeName:
-                return Boolean.TYPE;
-            case byteTypeName:
-                return Byte.TYPE;
-            case shortTypeName:
-                return Short.TYPE;
-            case charTypeName:
-                return Character.TYPE;
-            case intTypeName:
-                return Integer.TYPE;
-            case longTypeName:
-                return Long.TYPE;
-            case floatTypeName:
-                return Float.TYPE;
-            case doubleTypeName:
-                return Double.TYPE;
-            default:
-                return null;
-        }
+        return switch (name) {
+            case booleanTypeName -> Boolean.TYPE;
+            case byteTypeName -> Byte.TYPE;
+            case shortTypeName -> Short.TYPE;
+            case charTypeName -> Character.TYPE;
+            case intTypeName -> Integer.TYPE;
+            case longTypeName -> Long.TYPE;
+            case floatTypeName -> Float.TYPE;
+            case doubleTypeName -> Double.TYPE;
+            default -> null;
+        };
     }
 }

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetElementType.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetElementType.java
@@ -47,18 +47,14 @@ public class GetElementType {
 
     private static BTypedesc getElementTypeDescValue(Type type) {
         type = TypeUtils.getImpliedType(type);
-        switch (type.getTag()) {
-            case TypeTags.ARRAY_TAG:
-                return ValueCreator.createTypedescValue(((ArrayType) type).getElementType());
-            case TypeTags.TUPLE_TAG:
-                return ValueCreator.createTypedescValue(
-                        TypeCreator.createUnionType(((TupleType) type).getTupleTypes()));
-            case TypeTags.FINITE_TYPE_TAG:
-                // this is reached only for immutable values
-                return getElementTypeDescValue(
-                        ((BValue) (((FiniteType) type).getValueSpace().iterator().next())).getType());
-            default:
-                return ValueCreator.createTypedescValue(((StreamType) type).getConstrainedType());
-        }
+        return switch (type.getTag()) {
+            case TypeTags.ARRAY_TAG -> ValueCreator.createTypedescValue(((ArrayType) type).getElementType());
+            case TypeTags.TUPLE_TAG -> ValueCreator.createTypedescValue(
+                    TypeCreator.createUnionType(((TupleType) type).getTupleTypes()));
+            // this is reached only for immutable values
+            case TypeTags.FINITE_TYPE_TAG -> getElementTypeDescValue(
+                    ((BValue) (((FiniteType) type).getValueSpace().iterator().next())).getType());
+            default -> ValueCreator.createTypedescValue(((StreamType) type).getConstrainedType());
+        };
     }
 }

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Filter.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Filter.java
@@ -50,17 +50,11 @@ public class Filter {
     public static BArray filter(BArray arr, BFunctionPointer<Object, Boolean> func) {
         BArray newArr;
         Type arrType = TypeUtils.getImpliedType(arr.getType());
-        switch (arrType.getTag()) {
-            case TypeTags.ARRAY_TAG:
-                newArr = ValueCreator.createArrayValue(TypeCreator.createArrayType(arr.getElementType()));
-                break;
-            case TypeTags.TUPLE_TAG:
-                newArr = ArrayUtils.createEmptyArrayFromTuple(arr);
-                break;
-            default:
-                throw createOpNotSupportedError(arrType, "filter()");
-
-        }
+        newArr = switch (arrType.getTag()) {
+            case TypeTags.ARRAY_TAG -> ValueCreator.createArrayValue(TypeCreator.createArrayType(arr.getElementType()));
+            case TypeTags.TUPLE_TAG -> ArrayUtils.createEmptyArrayFromTuple(arr);
+            default -> throw createOpNotSupportedError(arrType, "filter()");
+        };
         int size = arr.size();
         AtomicInteger newArraySize = new AtomicInteger(-1);
         AtomicInteger index = new AtomicInteger(-1);

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Map.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Map.java
@@ -63,16 +63,11 @@ public class Map {
         GetFunction getFn;
 
         Type arrType = TypeUtils.getImpliedType(arr.getType());
-        switch (arrType.getTag()) {
-            case TypeTags.ARRAY_TAG:
-                getFn = BArray::get;
-                break;
-            case TypeTags.TUPLE_TAG:
-                getFn = BArray::getRefValue;
-                break;
-            default:
-                throw createOpNotSupportedError(arrType, "map()");
-        }
+        getFn = switch (arrType.getTag()) {
+            case TypeTags.ARRAY_TAG -> BArray::get;
+            case TypeTags.TUPLE_TAG -> BArray::getRefValue;
+            default -> throw createOpNotSupportedError(arrType, "map()");
+        };
         AtomicInteger index = new AtomicInteger(-1);
         AsyncUtils.invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
                 () -> new Object[]{getFn.get(arr, index.incrementAndGet()), true},

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Reverse.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Reverse.java
@@ -37,17 +37,11 @@ public class Reverse {
 
     public static BArray reverse(BArray arr) {
         Type arrType = TypeUtils.getImpliedType(arr.getType());
-        BArray reversedArr;
-        switch (arrType.getTag()) {
-            case TypeTags.ARRAY_TAG:
-                reversedArr = ValueCreator.createArrayValue(TypeCreator.createArrayType(arr.getElementType()));
-                break;
-            case TypeTags.TUPLE_TAG:
-                reversedArr = ArrayUtils.createEmptyArrayFromTuple(arr);
-                break;
-            default:
-                throw createOpNotSupportedError(arrType, "reverse()");
-        }
+        BArray reversedArr = switch (arrType.getTag()) {
+            case TypeTags.ARRAY_TAG -> ValueCreator.createArrayValue(TypeCreator.createArrayType(arr.getElementType()));
+            case TypeTags.TUPLE_TAG -> ArrayUtils.createEmptyArrayFromTuple(arr);
+            default -> throw createOpNotSupportedError(arrType, "reverse()");
+        };
         for (int i = arr.size() - 1, j = 0; i >= 0; i--, j++) {
             reversedArr.add(j, arr.get(i));
         }

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/utils/ArrayUtils.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/utils/ArrayUtils.java
@@ -73,14 +73,11 @@ public class ArrayUtils {
     }
 
     public static GetFunction getElementAccessFunction(Type arrType, String funcName) {
-        switch (TypeUtils.getImpliedType(arrType).getTag()) {
-            case TypeTags.ARRAY_TAG:
-                return BArray::get;
-            case TypeTags.TUPLE_TAG:
-                return BArray::getRefValue;
-            default:
-                throw createOpNotSupportedError(arrType, funcName);
-        }
+        return switch (TypeUtils.getImpliedType(arrType).getTag()) {
+            case TypeTags.ARRAY_TAG -> BArray::get;
+            case TypeTags.TUPLE_TAG -> BArray::getRefValue;
+            default -> throw createOpNotSupportedError(arrType, funcName);
+        };
     }
 
     public static void checkIsArrayOnlyOperation(Type arrType, String op) {

--- a/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/FromHexString.java
+++ b/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/FromHexString.java
@@ -54,15 +54,10 @@ public class FromHexString {
     }
 
     private static boolean isValidHexString(String hexValue) {
-        switch (hexValue) {
-            case "+infinity":
-            case "-infinity":
-            case "infinity":
-            case "nan":
-                return true;
-            default:
-                return HEX_FLOAT_LITERAL.matcher(hexValue).matches();
-        }
+        return switch (hexValue) {
+            case "+infinity", "-infinity", "infinity", "nan" -> true;
+            default -> HEX_FLOAT_LITERAL.matcher(hexValue).matches();
+        };
     }
 
     private static BError getNumberFormatError(String message) {

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Filter.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Filter.java
@@ -52,18 +52,14 @@ public class Filter {
 
     public static BMap filter(BMap<?, ?> m, BFunctionPointer<Object, Boolean> func) {
         Type mapType = TypeUtils.getImpliedType(m.getType());
-        Type constraint;
-        switch (mapType.getTag()) {
-            case TypeTags.MAP_TAG:
+        Type constraint = switch (mapType.getTag()) {
+            case TypeTags.MAP_TAG -> {
                 MapType type = (MapType) mapType;
-                constraint = type.getConstrainedType();
-                break;
-            case TypeTags.RECORD_TYPE_TAG:
-                constraint = MapLibUtils.getCommonTypeForRecordField((RecordType) mapType);
-                break;
-            default:
-                throw createOpNotSupportedError(mapType, "filter()");
-        }
+                yield type.getConstrainedType();
+            }
+            case TypeTags.RECORD_TYPE_TAG -> MapLibUtils.getCommonTypeForRecordField((RecordType) mapType);
+            default -> throw createOpNotSupportedError(mapType, "filter()");
+        };
         BMap<BString, Object> newMap = ValueCreator.createMapValue(TypeCreator.createMapType(constraint));
         int size = m.size();
         AtomicInteger index = new AtomicInteger(-1);

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ToArray.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ToArray.java
@@ -50,17 +50,11 @@ public class ToArray {
 
     public static BArray toArray(BMap<?, ?> m) {
         Type mapType = TypeUtils.getImpliedType(m.getType());
-        Type arrElemType;
-        switch (mapType.getTag()) {
-            case TypeTags.MAP_TAG:
-                arrElemType = ((MapType) mapType).getConstrainedType();
-                break;
-            case TypeTags.RECORD_TYPE_TAG:
-                arrElemType = MapLibUtils.getCommonTypeForRecordField((RecordType) mapType);
-                break;
-            default:
-                throw createOpNotSupportedError(mapType, "toArray()");
-        }
+        Type arrElemType = switch (mapType.getTag()) {
+            case TypeTags.MAP_TAG -> ((MapType) mapType).getConstrainedType();
+            case TypeTags.RECORD_TYPE_TAG -> MapLibUtils.getCommonTypeForRecordField((RecordType) mapType);
+            default -> throw createOpNotSupportedError(mapType, "toArray()");
+        };
 
         Collection values = m.values();
         int size = values.size();

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/util/MapLibUtils.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/util/MapLibUtils.java
@@ -51,14 +51,11 @@ public class MapLibUtils {
 
     public static Type getFieldType(Type mapType, String funcName) {
         mapType = TypeUtils.getImpliedType(mapType);
-        switch (mapType.getTag()) {
-            case TypeTags.MAP_TAG:
-                return ((MapType) mapType).getConstrainedType();
-            case TypeTags.RECORD_TYPE_TAG:
-                return getCommonTypeForRecordField((RecordType) mapType);
-            default:
-                throw createOpNotSupportedError(mapType, funcName);
-        }
+        return switch (mapType.getTag()) {
+            case TypeTags.MAP_TAG -> ((MapType) mapType).getConstrainedType();
+            case TypeTags.RECORD_TYPE_TAG -> getCommonTypeForRecordField((RecordType) mapType);
+            default -> throw createOpNotSupportedError(mapType, funcName);
+        };
     }
 
     public static Type getCommonTypeForRecordField(RecordType  recordType) {

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/common/TomlSyntaxTreeUtil.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/common/TomlSyntaxTreeUtil.java
@@ -95,15 +95,11 @@ public class TomlSyntaxTreeUtil {
      * @return {@link String} default value.
      */
     public static String getDefaultValueForType(ValueType type) {
-        switch (type) {
-            case NUMBER:
-                return "0";
-            case BOOLEAN:
-                return "false";
-            case STRING:
-            default:
-                return "";
-        }
+        return switch (type) {
+            case NUMBER -> "0";
+            case BOOLEAN -> "false";
+            default -> "";
+        };
     }
 
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -309,18 +309,15 @@ public class CodeActionUtil {
             getPossibleTypeSymbols(arrayTypeSymbol.memberTypeDescriptor(), context, importsAcceptor).entrySet()
                     .forEach(entry -> {
                         ArrayTypeSymbol newArrType = typeBuilder.ARRAY_TYPE.withType(entry.getKey()).build();
-                        String signature;
-                        switch (newArrType.memberTypeDescriptor().typeKind()) {
-                            case FUNCTION:
-                            case UNION:
+                        String signature = switch (newArrType.memberTypeDescriptor().typeKind()) {
+                            case FUNCTION, UNION -> {
                                 String typeName = FunctionGenerator.processModuleIDsInText(importsAcceptor,
                                         newArrType.memberTypeDescriptor().signature(), context);
-                                signature = "(" + typeName + ")[]";
-                                break;
-                            default:
-                                signature = FunctionGenerator.processModuleIDsInText(importsAcceptor,
-                                        newArrType.signature(), context);
-                        }
+                                yield "(" + typeName + ")[]";
+                            }
+                            default -> FunctionGenerator.processModuleIDsInText(importsAcceptor,
+                                    newArrType.signature(), context);
+                        };
                         typesMap.put(newArrType, signature);
                     });
         } else {
@@ -338,24 +335,18 @@ public class CodeActionUtil {
      */
     public static boolean isJsonMemberType(TypeSymbol typeSymbol) {
         // type json = () | boolean | int | float | decimal | string | json[] | map<json>;
-        switch (typeSymbol.typeKind()) {
-            case NIL:
-            case BOOLEAN:
-            case INT:
-            case FLOAT:
-            case DECIMAL:
-            case STRING:
-            case JSON:
-                return true;
-            case ARRAY:
-                ArrayTypeSymbol arrayTypeSymbol = (ArrayTypeSymbol) typeSymbol;
-                return isJsonMemberType(arrayTypeSymbol.memberTypeDescriptor());
-            case MAP:
-                MapTypeSymbol mapTypeSymbol = (MapTypeSymbol) typeSymbol;
-                return isJsonMemberType(mapTypeSymbol.typeParam());
-            default:
-                return false;
-        }
+        return switch (typeSymbol.typeKind()) {
+            case NIL,
+                 BOOLEAN,
+                 INT,
+                 FLOAT,
+                 DECIMAL,
+                 STRING,
+                 JSON -> true;
+            case ARRAY -> isJsonMemberType(((ArrayTypeSymbol) typeSymbol).memberTypeDescriptor());
+            case MAP -> isJsonMemberType(((MapTypeSymbol) typeSymbol).typeParam());
+            default -> false;
+        };
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ConvertToReadonlyCloneCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ConvertToReadonlyCloneCodeAction.java
@@ -94,18 +94,13 @@ public class ConvertToReadonlyCloneCodeAction implements DiagnosticBasedCodeActi
     }
 
     private String getNewText(NonTerminalNode currentNode) {
-        String prefix;
-        switch (currentNode.kind()) {
-            case LET_EXPRESSION:
-            case CONDITIONAL_EXPRESSION:
-            case CHECK_EXPRESSION:
-            case XML_STEP_EXPRESSION:
-                prefix = "(" + currentNode.toSourceCode().trim() + ")";
-                break;
-            default:
-                prefix = currentNode.toSourceCode().trim();
-                break;
-        }
+        String prefix = switch (currentNode.kind()) {
+            case LET_EXPRESSION,
+                 CONDITIONAL_EXPRESSION,
+                 CHECK_EXPRESSION,
+                 XML_STEP_EXPRESSION -> "(" + currentNode.toSourceCode().trim() + ")";
+            default -> currentNode.toSourceCode().trim();
+        };
 
         return prefix + "." + CLONE_READONLY_PREFIX + "()";
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
@@ -225,18 +225,13 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
                 return getLetVarDeclTypeNode((LetVariableDeclarationNode) matchedNode);
             case LET_EXPRESSION:
                 Node parent = matchedNode.parent();
-                switch (parent.kind()) {
-                    case LOCAL_VAR_DECL:
-                        return getLocalVarTypeNode((VariableDeclarationNode) parent);
-                    case MODULE_VAR_DECL:
-                        return getModuleVarTypeNode((ModuleVariableDeclarationNode) parent);
-                    case OBJECT_FIELD:
-                        return getObjectFieldTypeNode((ObjectFieldNode) parent);
-                    case LET_VAR_DECL:
-                        return getLetVarDeclTypeNode((LetVariableDeclarationNode) parent);    
-                    default:
-                        return Optional.empty();
-                }
+                return switch (parent.kind()) {
+                    case LOCAL_VAR_DECL -> getLocalVarTypeNode((VariableDeclarationNode) parent);
+                    case MODULE_VAR_DECL -> getModuleVarTypeNode((ModuleVariableDeclarationNode) parent);
+                    case OBJECT_FIELD -> getObjectFieldTypeNode((ObjectFieldNode) parent);
+                    case LET_VAR_DECL -> getLetVarDeclTypeNode((LetVariableDeclarationNode) parent);
+                    default -> Optional.empty();
+                };
             default:
                 return Optional.empty();
         }
@@ -259,48 +254,41 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
     }
 
     private Optional<String> getVariableName(Node matchedNode) {
-        switch (matchedNode.kind()) {
-            case LOCAL_VAR_DECL:
-                return getVarNameFromBindingPattern(((VariableDeclarationNode) matchedNode)
-                        .typedBindingPattern().bindingPattern());
-            case MODULE_VAR_DECL:
-                return getVarNameFromBindingPattern(((ModuleVariableDeclarationNode) matchedNode)
-                        .typedBindingPattern().bindingPattern());
-            case ASSIGNMENT_STATEMENT:
+        return switch (matchedNode.kind()) {
+            case LOCAL_VAR_DECL -> getVarNameFromBindingPattern(((VariableDeclarationNode) matchedNode)
+                    .typedBindingPattern().bindingPattern());
+            case MODULE_VAR_DECL -> getVarNameFromBindingPattern(((ModuleVariableDeclarationNode) matchedNode)
+                    .typedBindingPattern().bindingPattern());
+            case ASSIGNMENT_STATEMENT -> {
                 AssignmentStatementNode assignmentStmtNode = (AssignmentStatementNode) matchedNode;
                 Node varRef = assignmentStmtNode.varRef();
                 if (varRef.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
-                    return Optional.of(((SimpleNameReferenceNode) varRef).name().text());
+                    yield Optional.of(((SimpleNameReferenceNode) varRef).name().text());
                 } else if (varRef.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
-                    return Optional.of(((QualifiedNameReferenceNode) varRef).identifier().text());
+                    yield Optional.of(((QualifiedNameReferenceNode) varRef).identifier().text());
                 }
-                return Optional.empty();
-            case CONST_DECLARATION:
+                yield Optional.empty();
+            }
+            case CONST_DECLARATION -> {
                 ConstantDeclarationNode constantDecl = (ConstantDeclarationNode) matchedNode;
-                return Optional.of(constantDecl.variableName().text());
-            case OBJECT_FIELD:
-                return getObjectFieldName((ObjectFieldNode) matchedNode);
-            case LET_VAR_DECL:
-                return getLetVarName((LetVariableDeclarationNode) matchedNode);
-            case LET_EXPRESSION:
+                yield Optional.of(constantDecl.variableName().text());
+            }
+            case OBJECT_FIELD -> getObjectFieldName((ObjectFieldNode) matchedNode);
+            case LET_VAR_DECL -> getLetVarName((LetVariableDeclarationNode) matchedNode);
+            case LET_EXPRESSION -> {
                 Node parent = matchedNode.parent();
-                switch (parent.kind()) {
-                    case LOCAL_VAR_DECL:
-                        return getVarNameFromBindingPattern(((VariableDeclarationNode) parent)
-                                .typedBindingPattern().bindingPattern());
-                    case MODULE_VAR_DECL:
-                        return getVarNameFromBindingPattern(((ModuleVariableDeclarationNode) parent)
-                                .typedBindingPattern().bindingPattern());
-                    case OBJECT_FIELD:
-                        return getObjectFieldName((ObjectFieldNode) parent);    
-                    case LET_VAR_DECL:
-                        return getLetVarName((LetVariableDeclarationNode) parent);
-                    default:
-                        return Optional.empty();
-                }
-            default:
-                return Optional.empty();
-        }
+                yield switch (parent.kind()) {
+                    case LOCAL_VAR_DECL -> getVarNameFromBindingPattern(((VariableDeclarationNode) parent)
+                            .typedBindingPattern().bindingPattern());
+                    case MODULE_VAR_DECL -> getVarNameFromBindingPattern(((ModuleVariableDeclarationNode) parent)
+                            .typedBindingPattern().bindingPattern());
+                    case OBJECT_FIELD -> getObjectFieldName((ObjectFieldNode) parent);
+                    case LET_VAR_DECL -> getLetVarName((LetVariableDeclarationNode) parent);
+                    default -> Optional.empty();
+                };
+            }
+            default -> Optional.empty();
+        };
     }
 
     private Optional<String> getVarNameFromBindingPattern(BindingPatternNode bindingPatternNode) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/docs/DocumentationGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/docs/DocumentationGenerator.java
@@ -105,62 +105,47 @@ public class DocumentationGenerator {
      */
     public static Optional<DocAttachmentInfo> getDocumentationEditForNode(NonTerminalNode node,
                                                                           SyntaxTree syntaxTree) {
-        switch (node.kind()) {
-            case FUNCTION_DEFINITION:
-            case RESOURCE_ACCESSOR_DEFINITION:
-            case OBJECT_METHOD_DEFINITION: {
-                return Optional.of(generateFunctionDocumentation((FunctionDefinitionNode) node, syntaxTree));
-            }
-            case METHOD_DECLARATION: {
-                return Optional.of(generateMethodDocumentation((MethodDeclarationNode) node, syntaxTree));
-            }
-            case SERVICE_DECLARATION: {
-                return Optional.of(generateServiceDocumentation((ServiceDeclarationNode) node, syntaxTree));
-            }
-            case TYPE_DEFINITION: {
-                return Optional.of(generateRecordOrObjectDocumentation((TypeDefinitionNode) node, syntaxTree));
-            }
-            case CLASS_DEFINITION: {
-                return Optional.of(generateClassDocumentation((ClassDefinitionNode) node, syntaxTree));
-            }
-            case CONST_DECLARATION: {
-                return Optional.of(generateModuleMemberDocumentation((ConstantDeclarationNode) node, syntaxTree));
-            }
-            case ENUM_DECLARATION: {
-                return Optional.of(generateModuleMemberDocumentation((EnumDeclarationNode) node, syntaxTree));
-            }
-            case MODULE_VAR_DECL: {
-                return Optional.of(generateModuleMemberDocumentation((ModuleVariableDeclarationNode) node, syntaxTree));
-            }
-            case ANNOTATION_DECLARATION: {
-                return Optional.of(generateAnnotationDocumentation((AnnotationDeclarationNode) node, syntaxTree));
-            }
-            default:
-                break;
-        }
-        return Optional.empty();
+        return switch (node.kind()) {
+            case FUNCTION_DEFINITION,
+                 RESOURCE_ACCESSOR_DEFINITION,
+                 OBJECT_METHOD_DEFINITION ->
+                    Optional.of(generateFunctionDocumentation((FunctionDefinitionNode) node, syntaxTree));
+            case METHOD_DECLARATION ->
+                    Optional.of(generateMethodDocumentation((MethodDeclarationNode) node, syntaxTree));
+            case SERVICE_DECLARATION ->
+                    Optional.of(generateServiceDocumentation((ServiceDeclarationNode) node, syntaxTree));
+            case TYPE_DEFINITION ->
+                    Optional.of(generateRecordOrObjectDocumentation((TypeDefinitionNode) node, syntaxTree));
+            case CLASS_DEFINITION -> Optional.of(generateClassDocumentation((ClassDefinitionNode) node, syntaxTree));
+            case CONST_DECLARATION ->
+                    Optional.of(generateModuleMemberDocumentation((ConstantDeclarationNode) node, syntaxTree));
+            case ENUM_DECLARATION ->
+                    Optional.of(generateModuleMemberDocumentation((EnumDeclarationNode) node, syntaxTree));
+            case MODULE_VAR_DECL ->
+                    Optional.of(generateModuleMemberDocumentation((ModuleVariableDeclarationNode) node, syntaxTree));
+            case ANNOTATION_DECLARATION ->
+                    Optional.of(generateAnnotationDocumentation((AnnotationDeclarationNode) node, syntaxTree));
+            default -> Optional.empty();
+        };
     }
 
     public static Optional<Symbol> getDocumentableSymbol(NonTerminalNode node, SemanticModel semanticModel) {
-        switch (node.kind()) {
-            case FUNCTION_DEFINITION:
-            case OBJECT_METHOD_DEFINITION:
-            case RESOURCE_ACCESSOR_DEFINITION:
-            case METHOD_DECLARATION:
-            case SERVICE_DECLARATION:    
-//            case SERVICE_DECLARATION: {
-//                ServiceDeclarationNode serviceDeclrNode = (ServiceDeclarationNode) node;
-//                return semanticModel.symbol(fileName, serviceDeclrNode.typeDescriptor().map(s->s.lineRange()
-//                .startLine()).);
-//            }
-            case TYPE_DEFINITION:
-            case ANNOTATION_DECLARATION:
-            case CLASS_DEFINITION:
-                return semanticModel.symbol(node);
-            default:
-                break;
-        }
-        return Optional.empty();
+        return switch (node.kind()) {
+            case FUNCTION_DEFINITION,
+                 OBJECT_METHOD_DEFINITION,
+                 RESOURCE_ACCESSOR_DEFINITION,
+                 METHOD_DECLARATION,
+                 SERVICE_DECLARATION,
+ //              SERVICE_DECLARATION -> {
+ //                  ServiceDeclarationNode serviceDeclrNode = (ServiceDeclarationNode) node;
+ //                  yield semanticModel.symbol(fileName, serviceDeclrNode.typeDescriptor().map(s->s.lineRange()
+ //                  .startLine()).);
+ //              }
+                 TYPE_DEFINITION,
+                 ANNOTATION_DECLARATION,
+                 CLASS_DEFINITION -> semanticModel.symbol(node);
+            default -> Optional.empty();
+        };
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/DefaultValueGenerationUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/DefaultValueGenerationUtil.java
@@ -131,18 +131,12 @@ public class DefaultValueGenerationUtil {
      * @see #getDefaultValueForType(TypeSymbol)
      */
     public static Optional<String> getDefaultValueForTypeDescKind(TypeSymbol typeSymbol) {
-        String defaultValue;
         TypeDescKind typeKind = typeSymbol.typeKind();
-        switch (typeKind) {
-            case SINGLETON:
-                defaultValue = typeSymbol.signature();
-                break;
-            case TYPE_REFERENCE:
-                defaultValue = getDefaultValueForTypeDescKind(CommonUtil.getRawType(typeSymbol)).orElse(null);
-                break;
-            default:
-                defaultValue = getDefaultValueForTypeDescKind(typeKind).orElse(null);
-        }
+        String defaultValue = switch (typeKind) {
+            case SINGLETON -> typeSymbol.signature();
+            case TYPE_REFERENCE -> getDefaultValueForTypeDescKind(CommonUtil.getRawType(typeSymbol)).orElse(null);
+            default -> getDefaultValueForTypeDescKind(typeKind).orElse(null);
+        };
         return Optional.ofNullable(defaultValue);
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/NameUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/NameUtil.java
@@ -87,18 +87,11 @@ public class NameUtil {
                 name = typeSymbol.getName().get();
             } else {
                 TypeSymbol rawType = CommonUtil.getRawType(typeSymbol);
-                switch (rawType.typeKind()) {
-                    case RECORD:
-                        name = "mappingResult";
-                        break;
-                    case TUPLE:
-                    case ARRAY:
-                        name = "listResult";
-                        break;
-                    default:
-                        name = rawType.typeKind().getName() + "Result";
-                        break;
-                }
+                name = switch (rawType.typeKind()) {
+                    case RECORD -> "mappingResult";
+                    case TUPLE, ARRAY -> "listResult";
+                    default -> rawType.typeKind().getName() + "Result";
+                };
             }
             return generateVariableName(1, name, names);
         } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
@@ -220,34 +220,22 @@ public class SymbolUtil {
         if (symbol == null) {
             return Optional.empty();
         }
-        switch (symbol.kind()) {
-            case TYPE_DEFINITION:
-                return Optional.ofNullable(((TypeDefinitionSymbol) symbol).typeDescriptor());
-            case VARIABLE:
-                return Optional.ofNullable(((VariableSymbol) symbol).typeDescriptor());
-            case PARAMETER:
-                return Optional.ofNullable(((ParameterSymbol) symbol).typeDescriptor());
-            case ANNOTATION:
-                return ((AnnotationSymbol) symbol).typeDescriptor();
-            case FUNCTION:
-            case METHOD:
-                return Optional.ofNullable(((FunctionSymbol) symbol).typeDescriptor());
-            case CONSTANT:
-            case ENUM_MEMBER:
-                return Optional.ofNullable(((ConstantSymbol) symbol).typeDescriptor());
-            case CLASS:
-                return Optional.of((ClassSymbol) symbol);
-            case RECORD_FIELD:
-                return Optional.ofNullable(((RecordFieldSymbol) symbol).typeDescriptor());
-            case OBJECT_FIELD:
-                return Optional.of(((ObjectFieldSymbol) symbol).typeDescriptor());
-            case CLASS_FIELD:
-                return Optional.of(((ClassFieldSymbol) symbol).typeDescriptor());
-            case TYPE:
-                return Optional.of((TypeSymbol) symbol);
-            default:
-                return Optional.empty();
-        }
+        return switch (symbol.kind()) {
+            case TYPE_DEFINITION -> Optional.ofNullable(((TypeDefinitionSymbol) symbol).typeDescriptor());
+            case VARIABLE -> Optional.ofNullable(((VariableSymbol) symbol).typeDescriptor());
+            case PARAMETER -> Optional.ofNullable(((ParameterSymbol) symbol).typeDescriptor());
+            case ANNOTATION -> ((AnnotationSymbol) symbol).typeDescriptor();
+            case FUNCTION,
+                 METHOD -> Optional.ofNullable(((FunctionSymbol) symbol).typeDescriptor());
+            case CONSTANT,
+                 ENUM_MEMBER -> Optional.ofNullable(((ConstantSymbol) symbol).typeDescriptor());
+            case CLASS -> Optional.of((ClassSymbol) symbol);
+            case RECORD_FIELD -> Optional.ofNullable(((RecordFieldSymbol) symbol).typeDescriptor());
+            case OBJECT_FIELD -> Optional.of(((ObjectFieldSymbol) symbol).typeDescriptor());
+            case CLASS_FIELD -> Optional.of(((ClassFieldSymbol) symbol).typeDescriptor());
+            case TYPE -> Optional.of((TypeSymbol) symbol);
+            default -> Optional.empty();
+        };
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/CompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/CompletionItemBuilder.java
@@ -19,12 +19,10 @@ public class CompletionItemBuilder {
      * @return {@link CompletionItemKind}
      */
     protected final CompletionItemKind getKind(Symbol symbol) {
-        switch (symbol.kind()) {
-            case ENUM:
-                return CompletionItemKind.Enum;
-            default:
-                return CompletionItemKind.Unit;
-        }
+        return switch (symbol.kind()) {
+            case ENUM -> CompletionItemKind.Enum;
+            default -> CompletionItemKind.Unit;
+        };
     }
 
     /**
@@ -34,17 +32,11 @@ public class CompletionItemBuilder {
      * @return {@link CompletionItemKind}
      */
     protected final CompletionItemKind getKind(SnippetBlock snippetBlock) {
-        switch (snippetBlock.kind()) {
-            case KEYWORD:
-                return CompletionItemKind.Keyword;
-            case TYPE:
-                return CompletionItemKind.TypeParameter;
-            case VALUE:
-                return CompletionItemKind.Value;
-            case SNIPPET:
-            case STATEMENT:
-            default:
-                return CompletionItemKind.Snippet;
-        }
+        return switch (snippetBlock.kind()) {
+            case KEYWORD -> CompletionItemKind.Keyword;
+            case TYPE -> CompletionItemKind.TypeParameter;
+            case VALUE -> CompletionItemKind.Value;
+            default -> CompletionItemKind.Snippet;
+        };
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ResourcePathCompletionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ResourcePathCompletionUtil.java
@@ -204,21 +204,19 @@ public class ResourcePathCompletionUtil {
         if (exprType.subtypeOf(paramType)) {
             return true;
         }
-        switch (paramType.typeKind()) {
-            case UNION:
+        return switch (paramType.typeKind()) {
+            case UNION -> {
                 for (TypeSymbol childSymbol : ((UnionTypeSymbol) paramType).memberTypeDescriptors()) {
                     if (checkSubtype(childSymbol, exprType, exprValue)) {
-                        return true;
+                        yield true;
                     }
                 }
-                return false;
-            case SINGLETON:
-                return paramType.subtypeOf(exprType) && exprValue.equals(paramType.signature());
-            case TYPE_REFERENCE:
-                return paramType.subtypeOf(exprType);
-            default:
-                return false;
-        }
+                yield false;
+            }
+            case SINGLETON -> paramType.subtypeOf(exprType) && exprValue.equals(paramType.signature());
+            case TYPE_REFERENCE -> paramType.subtypeOf(exprType);
+            default -> false;
+        };
     }
 
 
@@ -272,20 +270,18 @@ public class ResourcePathCompletionUtil {
         if (stringType.subtypeOf(paramType)) {
             return true;
         }
-        switch (paramType.typeKind()) {
-            case UNION:
+        return switch (paramType.typeKind()) {
+            case UNION -> {
                 for (TypeSymbol childSymbol : ((UnionTypeSymbol) paramType).memberTypeDescriptors()) {
                     if (isStringSubtype(childSymbol, stringType)) {
-                        return true;
+                        yield true;
                     }
                 }
-                return false;
-            case SINGLETON:
-            case TYPE_REFERENCE:
-                return paramType.subtypeOf(stringType);
-            default:
-                return false;
-        }
+                yield false;
+            }
+            case SINGLETON, TYPE_REFERENCE -> paramType.subtypeOf(stringType);
+            default -> false;
+        };
     }
 
     private static class ResourceAccessPathPart {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationNodeContext.java
@@ -142,63 +142,45 @@ public class AnnotationNodeContext extends AbstractCompletionProvider<Annotation
             }
         }
 
-        switch (attachedNode.kind()) {
-            case SERVICE_DECLARATION:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.SERVICE);
-            case EXPLICIT_ANONYMOUS_FUNCTION_EXPRESSION:
-            case IMPLICIT_ANONYMOUS_FUNCTION_EXPRESSION:
-            case FUNCTION_DEFINITION:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.FUNCTION);
-            case RESOURCE_ACCESSOR_DEFINITION:
-            case METHOD_DECLARATION:
-            case OBJECT_METHOD_DEFINITION:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.FUNCTION)
-                        || AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.OBJECT_METHOD);
-            case LISTENER_DECLARATION:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.LISTENER);
-            case NAMED_WORKER_DECLARATION:
-            case START_ACTION:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.WORKER);
-            case CONST_DECLARATION:
-            case ENUM_MEMBER:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.CONST);
-            case ENUM_DECLARATION:
-            case TYPE_CAST_PARAM:
-            case TYPE_DEFINITION:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.TYPE);
-            case CLASS_DEFINITION:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.CLASS);
-            case RETURN_TYPE_DESCRIPTOR:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.RETURN);
-            case OBJECT_FIELD:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.FIELD)
-                        || AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.OBJECT_FIELD);
-            case RECORD_FIELD:
-            case RECORD_FIELD_WITH_DEFAULT_VALUE:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.FIELD)
-                        || AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.RECORD_FIELD);
-            case MODULE_VAR_DECL:
-            case LOCAL_VAR_DECL:
-            case LET_VAR_DECL:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.VAR);
-            case EXTERNAL_FUNCTION_BODY:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.EXTERNAL);
-            case ANNOTATION_DECLARATION:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.ANNOTATION);
-            case REQUIRED_PARAM:
-            case DEFAULTABLE_PARAM:
-            case REST_PARAM:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.PARAMETER);
-            case OBJECT_CONSTRUCTOR:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.SERVICE)
-                        && ((ObjectConstructorExpressionNode) attachedNode).objectTypeQualifiers()
-                        .stream()
-                        .anyMatch(token -> token.kind() == SyntaxKind.SERVICE_KEYWORD);
-            case MEMBER_TYPE_DESC:
-                return AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.FIELD);
-            default:
-                return false;
-        }
+        return switch (attachedNode.kind()) {
+            case SERVICE_DECLARATION -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.SERVICE);
+            case EXPLICIT_ANONYMOUS_FUNCTION_EXPRESSION,
+                 IMPLICIT_ANONYMOUS_FUNCTION_EXPRESSION,
+                 FUNCTION_DEFINITION -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.FUNCTION);
+            case RESOURCE_ACCESSOR_DEFINITION,
+                 METHOD_DECLARATION,
+                 OBJECT_METHOD_DEFINITION -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.FUNCTION)
+                    || AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.OBJECT_METHOD);
+            case LISTENER_DECLARATION -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.LISTENER);
+            case NAMED_WORKER_DECLARATION,
+                 START_ACTION -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.WORKER);
+            case CONST_DECLARATION,
+                 ENUM_MEMBER -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.CONST);
+            case ENUM_DECLARATION,
+                 TYPE_CAST_PARAM,
+                 TYPE_DEFINITION -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.TYPE);
+            case CLASS_DEFINITION -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.CLASS);
+            case RETURN_TYPE_DESCRIPTOR -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.RETURN);
+            case OBJECT_FIELD -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.FIELD)
+                    || AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.OBJECT_FIELD);
+            case RECORD_FIELD,
+                 RECORD_FIELD_WITH_DEFAULT_VALUE -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.FIELD)
+                    || AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.RECORD_FIELD);
+            case MODULE_VAR_DECL,
+                 LOCAL_VAR_DECL,
+                 LET_VAR_DECL -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.VAR);
+            case EXTERNAL_FUNCTION_BODY -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.EXTERNAL);
+            case ANNOTATION_DECLARATION -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.ANNOTATION);
+            case REQUIRED_PARAM,
+                 DEFAULTABLE_PARAM,
+                 REST_PARAM -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.PARAMETER);
+            case OBJECT_CONSTRUCTOR -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.SERVICE)
+                    && ((ObjectConstructorExpressionNode) attachedNode).objectTypeQualifiers()
+                    .stream()
+                    .anyMatch(token -> token.kind() == SyntaxKind.SERVICE_KEYWORD);
+            case MEMBER_TYPE_DESC -> AnnotationUtil.hasAttachment(symbol, AnnotationAttachPoint.FIELD);
+            default -> false;
+        };
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
@@ -730,19 +730,12 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
         //  stream from...
         //  from...
         // In such cases, we take the member type
-        switch (typeSymbol.get().typeKind()) {
-            case TABLE:
-                TableTypeSymbol tableType = (TableTypeSymbol) typeSymbol.get();
-                return Optional.of(tableType.rowTypeParameter());
-            case STREAM:
-                StreamTypeSymbol streamType = (StreamTypeSymbol) typeSymbol.get();
-                return Optional.of(streamType.typeParameter());
-            case ARRAY:
-                ArrayTypeSymbol arrayType = (ArrayTypeSymbol) typeSymbol.get();
-                return Optional.of(arrayType.memberTypeDescriptor());
-            default:
-                return typeSymbol;
-        }
+        return switch (typeSymbol.get().typeKind()) {
+            case TABLE -> Optional.of(((TableTypeSymbol) typeSymbol.get()).rowTypeParameter());
+            case STREAM -> Optional.of(((StreamTypeSymbol) typeSymbol.get()).typeParameter());
+            case ARRAY -> Optional.of(((ArrayTypeSymbol) typeSymbol.get()).memberTypeDescriptor());
+            default -> typeSymbol;
+        };
     }
 
     //    @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SortingUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SortingUtil.java
@@ -346,19 +346,11 @@ public class SortingUtil {
      * @return Type Symbol or Empty if type parameter is not present
      */
     public static Optional<TypeSymbol> getTypeParameterFromTypeSymbol(TypeSymbol typeSymbol) {
-        Optional<TypeSymbol> optionalTypeSymbol;
-        switch (typeSymbol.typeKind()) {
-            case TYPEDESC:
-                optionalTypeSymbol = ((TypeDescTypeSymbol) typeSymbol).typeParameter();
-                break;
-            case FUTURE:
-                optionalTypeSymbol = ((FutureTypeSymbol) typeSymbol).typeParameter();
-                break;
-            default:
-                optionalTypeSymbol = Optional.empty();
-                break;
-        }
-        return optionalTypeSymbol;
+        return switch (typeSymbol.typeKind()) {
+            case TYPEDESC -> ((TypeDescTypeSymbol) typeSymbol).typeParameter();
+            case FUTURE -> ((FutureTypeSymbol) typeSymbol).typeParameter();
+            default -> Optional.empty();
+        };
     }
 
     /**
@@ -590,17 +582,12 @@ public class SortingUtil {
                 break;
             case SNIPPET:
                 if (completionItemKind != null) {
-                    switch (completionItemKind) {
-                        case TypeParameter:
-                            rank = 14;
-                            break;
-                        case Snippet:
-                            rank = 16;
-                            break;
-                        case Keyword:
-                            rank = 17;
-                            break;
-                    }
+                    rank = switch (completionItemKind) {
+                        case TypeParameter -> 14;
+                        case Snippet -> 16;
+                        case Keyword -> 17;
+                        default -> rank;
+                    };
                 }
                 break;
             case OBJECT_FIELD:

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverObjectResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverObjectResolver.java
@@ -78,29 +78,22 @@ public class HoverObjectResolver {
      * @return {@link Hover} hover object.
      */
     public Hover getHoverObjectForSymbol(Symbol symbol) {
-        switch (symbol.kind()) {
-            case FUNCTION:
-                return getHoverObjectForSymbol((FunctionSymbol) symbol);
-            case METHOD:
-                return getHoverObjectForSymbol((MethodSymbol) symbol);
-            case RESOURCE_METHOD:
-                return getHoverObjectForSymbol((ResourceMethodSymbol) symbol);
-            case TYPE_DEFINITION:
-                return getHoverObjectForSymbol((TypeDefinitionSymbol) symbol);
-            case CLASS:
-                return getHoverObjectForSymbol((ClassSymbol) symbol);
-            case VARIABLE:
-                return getHoverObjectForSymbol((VariableSymbol) symbol);
-            case PARAMETER:
-                return getHoverObjectForSymbol((ParameterSymbol) symbol);
-            case TYPE:
+        return switch (symbol.kind()) {
+            case FUNCTION -> getHoverObjectForSymbol((FunctionSymbol) symbol);
+            case METHOD -> getHoverObjectForSymbol((MethodSymbol) symbol);
+            case RESOURCE_METHOD -> getHoverObjectForSymbol((ResourceMethodSymbol) symbol);
+            case TYPE_DEFINITION -> getHoverObjectForSymbol((TypeDefinitionSymbol) symbol);
+            case CLASS -> getHoverObjectForSymbol((ClassSymbol) symbol);
+            case VARIABLE -> getHoverObjectForSymbol((VariableSymbol) symbol);
+            case PARAMETER -> getHoverObjectForSymbol((ParameterSymbol) symbol);
+            case TYPE -> {
                 if (symbol instanceof TypeReferenceTypeSymbol refTypeSymbol) {
-                    return getHoverObjectForSymbol(refTypeSymbol.definition());
+                    yield getHoverObjectForSymbol(refTypeSymbol.definition());
                 }
-                return HoverUtil.getHoverObject();
-            default:
-                return HoverUtil.getDescriptionOnlyHoverObject(symbol);
-        }
+                yield HoverUtil.getHoverObject();
+            }
+            default -> HoverUtil.getDescriptionOnlyHoverObject(symbol);
+        };
     }
 
     private Hover getHoverObjectForSymbol(VariableSymbol variableSymbol) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -327,37 +327,29 @@ public class SignatureHelpUtil {
     }
 
     private static Optional<? extends TypeSymbol> getTypeDesc(SignatureContext ctx, ExpressionNode expr) {
-        switch (expr.kind()) {
-            case SIMPLE_NAME_REFERENCE:
-                /*
-                Captures the following
-                (1) fieldName
-                 */
-                return getTypeDescForNameRef(ctx, (SimpleNameReferenceNode) expr);
-            case FUNCTION_CALL:
-                /*
-                Captures the following
-                (1) functionName()
-                 */
-                return getTypeDescForFunctionCall(ctx, (FunctionCallExpressionNode) expr);
-            case METHOD_CALL: {
-                /*
-                Address the following
-                (1) test.testMethod()
-                 */
-                return getTypeDescForMethodCall(ctx, (MethodCallExpressionNode) expr);
-            }
-            case FIELD_ACCESS: {
-                /*
-                Address the following
-                (1) test1.test2
-                 */
-                return getTypeDescForFieldAccess(ctx, (FieldAccessExpressionNode) expr);
-            }
-
-            default:
-                return Optional.empty();
-        }
+        return switch (expr.kind()) {
+            /*
+            Captures the following
+            (1) fieldName
+             */
+            case SIMPLE_NAME_REFERENCE -> getTypeDescForNameRef(ctx, (SimpleNameReferenceNode) expr);
+            /*
+            Captures the following
+            (1) functionName()
+             */
+            case FUNCTION_CALL -> getTypeDescForFunctionCall(ctx, (FunctionCallExpressionNode) expr);
+            /*
+            Address the following
+            (1) test.testMethod()
+             */
+            case METHOD_CALL -> getTypeDescForMethodCall(ctx, (MethodCallExpressionNode) expr);
+            /*
+            Address the following
+            (1) test1.test2
+             */
+            case FIELD_ACCESS -> getTypeDescForFieldAccess(ctx, (FieldAccessExpressionNode) expr);
+            default -> Optional.empty();
+        };
     }
 
     private static Optional<? extends TypeSymbol> getTypeDescForFieldAccess(
@@ -371,16 +363,17 @@ public class SignatureHelpUtil {
         }
 
         TypeSymbol rawType = CommonUtil.getRawType(typeDescriptor.get());
-        switch (rawType.typeKind()) {
-            case OBJECT:
+        return switch (rawType.typeKind()) {
+            case OBJECT -> {
                 ObjectFieldSymbol objField = ((ObjectTypeSymbol) rawType).fieldDescriptors().get(fieldName);
-                return objField != null ? Optional.of(objField.typeDescriptor()) : Optional.empty();
-            case RECORD:
+                yield objField != null ? Optional.of(objField.typeDescriptor()) : Optional.empty();
+            }
+            case RECORD -> {
                 RecordFieldSymbol recField = ((RecordTypeSymbol) rawType).fieldDescriptors().get(fieldName);
-                return recField != null ? Optional.of(recField.typeDescriptor()) : Optional.empty();
-            default:
-                return Optional.empty();
-        }
+                yield recField != null ? Optional.of(recField.typeDescriptor()) : Optional.empty();
+            }
+            default -> Optional.empty();
+        };
     }
 
     private static Optional<? extends TypeSymbol> getTypeDescForNameRef(SignatureContext context,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
@@ -1422,23 +1422,19 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
 
     private boolean hasDocumentOrToml(Path filePath, Project project) {
         String fileName = Optional.of(filePath.getFileName()).get().toString();
-        switch (fileName) {
-            case ProjectConstants.BALLERINA_TOML:
-                return project.currentPackage().ballerinaToml().isPresent();
-            case ProjectConstants.CLOUD_TOML:
-                return project.currentPackage().cloudToml().isPresent();
-            case ProjectConstants.COMPILER_PLUGIN_TOML:
-                return project.currentPackage().compilerPluginToml().isPresent();
-            case ProjectConstants.BAL_TOOL_TOML:
-                return project.currentPackage().balToolToml().isPresent();
-            case ProjectConstants.DEPENDENCIES_TOML:
-                return project.currentPackage().dependenciesToml().isPresent();
-            default:
+        return switch (fileName) {
+            case ProjectConstants.BALLERINA_TOML -> project.currentPackage().ballerinaToml().isPresent();
+            case ProjectConstants.CLOUD_TOML -> project.currentPackage().cloudToml().isPresent();
+            case ProjectConstants.COMPILER_PLUGIN_TOML -> project.currentPackage().compilerPluginToml().isPresent();
+            case ProjectConstants.BAL_TOOL_TOML -> project.currentPackage().balToolToml().isPresent();
+            case ProjectConstants.DEPENDENCIES_TOML -> project.currentPackage().dependenciesToml().isPresent();
+            default -> {
                 if (fileName.endsWith(ProjectConstants.BLANG_SOURCE_EXT)) {
-                    return document(filePath, project, null).isPresent();
+                    yield document(filePath, project, null).isPresent();
                 }
-                return false;
-        }
+                yield false;
+            }
+        };
     }
 
     private void reloadProject(ProjectContext projectContext, Path filePath, String operationName) {

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenUtils.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenUtils.java
@@ -280,41 +280,23 @@ public class BindgenUtils {
     }
 
     private static String getPrimitiveArrayBalType(String type) {
-        switch (type) {
-            case INT:
-            case SHORT:
-            case CHAR:
-            case LONG:
-                return INT_ARRAY;
-            case FLOAT:
-            case DOUBLE:
-                return FLOAT_ARRAY;
-            case BOOLEAN:
-                return BOOLEAN_ARRAY;
-            case BYTE:
-                return BYTE_ARRAY;
-            default:
-                return HANDLE;
-        }
+        return switch (type) {
+            case INT, SHORT, CHAR, LONG -> INT_ARRAY;
+            case FLOAT, DOUBLE -> FLOAT_ARRAY;
+            case BOOLEAN -> BOOLEAN_ARRAY;
+            case BYTE -> BYTE_ARRAY;
+            default -> HANDLE;
+        };
     }
 
     public static String getPrimitiveArrayType(String type) {
-        switch (type) {
-            case "[C":
-            case "[S":
-            case "[J":
-            case "[I":
-                return INT_ARRAY;
-            case "[D":
-            case "[F":
-                return FLOAT_ARRAY;
-            case "[B":
-                return BYTE_ARRAY;
-            case "[Z":
-                return BOOLEAN_ARRAY;
-            default:
-                return type;
-        }
+        return switch (type) {
+            case "[C", "[S", "[J", "[I" -> INT_ARRAY;
+            case "[D", "[F" -> FLOAT_ARRAY;
+            case "[B" -> BYTE_ARRAY;
+            case "[Z" -> BOOLEAN_ARRAY;
+            default -> type;
+        };
     }
 
     public static URLClassLoader getClassLoader(Set<String> jarPaths, ClassLoader parent) throws BindgenException {

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/utils/DefaultValueGenerator.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/utils/DefaultValueGenerator.java
@@ -25,45 +25,17 @@ import java.io.Serializable;
  */
 public class DefaultValueGenerator {
     public static Serializable generateDefaultValues(String type) {
-        switch (type) {
-            case "int":
-            case "Signed8":
-            case "Unsigned8":
-            case "Signed16":
-            case "Unsigned16":
-            case "Signed32":
-            case "Unsigned32":
-            case "byte":
-                return 0;
-            case "float":
-            case "decimal":
-                return 0.0;
-            case "string":
-            case "Char":
-                return "\"\"";
-            case "BOOLEAN":
-                return false;
-            case "nil":
-            case "any":
-            case "union":
-            case "json":
-                return "()";
-            case "array":
-            case "tuple":
-                return "[]";
-            case "object":
-                return "new T()";
-            case "record":
-            case "map":
-                return "{}";
-            case "xml":
-            case "Element":
-            case "ProcessingInstruction":
-            case "Comment":
-            case "Text":
-                return "``";
-            default:
-                return "";
-        }
+        return switch (type) {
+            case "int", "Signed8", "Unsigned8", "Signed16", "Unsigned16", "Signed32", "Unsigned32", "byte" -> 0;
+            case "float", "decimal" -> 0.0;
+            case "string", "Char" -> "\"\"";
+            case "BOOLEAN" -> false;
+            case "nil", "any", "union", "json" -> "()";
+            case "array", "tuple" -> "[]";
+            case "object" -> "new T()";
+            case "record", "map" -> "{}";
+            case "xml", "Element", "ProcessingInstruction", "Comment", "Text" -> "``";
+            default -> "";
+        };
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/resolver/FieldAccessCompletionResolver.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/resolver/FieldAccessCompletionResolver.java
@@ -340,34 +340,22 @@ public class FieldAccessCompletionResolver extends NodeTransformer<Optional<Type
         if (symbol == null) {
             return Optional.empty();
         }
-        switch (symbol.kind()) {
-            case TYPE_DEFINITION:
-                return Optional.ofNullable(((TypeDefinitionSymbol) symbol).typeDescriptor());
-            case VARIABLE:
-                return Optional.ofNullable(((VariableSymbol) symbol).typeDescriptor());
-            case PARAMETER:
-                return Optional.ofNullable(((ParameterSymbol) symbol).typeDescriptor());
-            case ANNOTATION:
-                return ((AnnotationSymbol) symbol).typeDescriptor();
-            case FUNCTION:
-            case METHOD:
-                return Optional.ofNullable(((FunctionSymbol) symbol).typeDescriptor());
-            case CONSTANT:
-            case ENUM_MEMBER:
-                return Optional.ofNullable(((ConstantSymbol) symbol).typeDescriptor());
-            case CLASS:
-                return Optional.of((ClassSymbol) symbol);
-            case RECORD_FIELD:
-                return Optional.ofNullable(((RecordFieldSymbol) symbol).typeDescriptor());
-            case OBJECT_FIELD:
-                return Optional.of(((ObjectFieldSymbol) symbol).typeDescriptor());
-            case CLASS_FIELD:
-                return Optional.of(((ClassFieldSymbol) symbol).typeDescriptor());
-            case TYPE:
-                return Optional.of((TypeSymbol) symbol);
-            default:
-                return Optional.empty();
-        }
+        return switch (symbol.kind()) {
+            case TYPE_DEFINITION -> Optional.ofNullable(((TypeDefinitionSymbol) symbol).typeDescriptor());
+            case VARIABLE -> Optional.ofNullable(((VariableSymbol) symbol).typeDescriptor());
+            case PARAMETER -> Optional.ofNullable(((ParameterSymbol) symbol).typeDescriptor());
+            case ANNOTATION -> ((AnnotationSymbol) symbol).typeDescriptor();
+            case FUNCTION,
+                 METHOD -> Optional.ofNullable(((FunctionSymbol) symbol).typeDescriptor());
+            case CONSTANT,
+                 ENUM_MEMBER -> Optional.ofNullable(((ConstantSymbol) symbol).typeDescriptor());
+            case CLASS -> Optional.of((ClassSymbol) symbol);
+            case RECORD_FIELD -> Optional.ofNullable(((RecordFieldSymbol) symbol).typeDescriptor());
+            case OBJECT_FIELD -> Optional.of(((ObjectFieldSymbol) symbol).typeDescriptor());
+            case CLASS_FIELD -> Optional.of(((ClassFieldSymbol) symbol).typeDescriptor());
+            case TYPE -> Optional.of((TypeSymbol) symbol);
+            default -> Optional.empty();
+        };
     }
 
     /**

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/util/CompletionUtil.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/util/CompletionUtil.java
@@ -206,37 +206,19 @@ public class CompletionUtil {
     }
 
     private static CompletionItemType getCompletionItemType(Symbol symbol) {
-        switch (symbol.kind()) {
-            case MODULE:
-                return CompletionItemType.MODULE;
-            case FUNCTION:
-                return CompletionItemType.FUNCTION;
-            case METHOD:
-            case RESOURCE_METHOD:
-                return CompletionItemType.METHOD;
-            case VARIABLE:
-                return CompletionItemType.VARIABLE;
-            case CLASS:
-                return CompletionItemType.CLASS;
-            case RECORD_FIELD:
-            case OBJECT_FIELD:
-            case CLASS_FIELD:
-                return CompletionItemType.FIELD;
-            case ENUM:
-                return CompletionItemType.ENUM;
-            case XMLNS:
-            case CONSTANT:
-            case TYPE_DEFINITION:
-            case TYPE:
-            case SERVICE_DECLARATION:
-            case WORKER:
-            case ANNOTATION:
-            case ENUM_MEMBER:
-            case PARAMETER:
-            case PATH_PARAMETER:
-            default:
-                return null;
-        }
+        return switch (symbol.kind()) {
+            case MODULE -> CompletionItemType.MODULE;
+            case FUNCTION -> CompletionItemType.FUNCTION;
+            case METHOD,
+                 RESOURCE_METHOD -> CompletionItemType.METHOD;
+            case VARIABLE -> CompletionItemType.VARIABLE;
+            case CLASS -> CompletionItemType.CLASS;
+            case RECORD_FIELD,
+                 OBJECT_FIELD,
+                 CLASS_FIELD -> CompletionItemType.FIELD;
+            case ENUM -> CompletionItemType.ENUM;
+            default -> null;
+        };
     }
 
     /**

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/util/SymbolUtil.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/completion/util/SymbolUtil.java
@@ -85,34 +85,22 @@ public class SymbolUtil {
         if (symbol == null) {
             return Optional.empty();
         }
-        switch (symbol.kind()) {
-            case TYPE_DEFINITION:
-                return Optional.ofNullable(((TypeDefinitionSymbol) symbol).typeDescriptor());
-            case VARIABLE:
-                return Optional.ofNullable(((VariableSymbol) symbol).typeDescriptor());
-            case PARAMETER:
-                return Optional.ofNullable(((ParameterSymbol) symbol).typeDescriptor());
-            case ANNOTATION:
-                return ((AnnotationSymbol) symbol).typeDescriptor();
-            case FUNCTION:
-            case METHOD:
-                return Optional.ofNullable(((FunctionSymbol) symbol).typeDescriptor());
-            case CONSTANT:
-            case ENUM_MEMBER:
-                return Optional.ofNullable(((ConstantSymbol) symbol).typeDescriptor());
-            case CLASS:
-                return Optional.of((ClassSymbol) symbol);
-            case RECORD_FIELD:
-                return Optional.ofNullable(((RecordFieldSymbol) symbol).typeDescriptor());
-            case OBJECT_FIELD:
-                return Optional.of(((ObjectFieldSymbol) symbol).typeDescriptor());
-            case CLASS_FIELD:
-                return Optional.of(((ClassFieldSymbol) symbol).typeDescriptor());
-            case TYPE:
-                return Optional.of((TypeSymbol) symbol);
-            default:
-                return Optional.empty();
-        }
+        return switch (symbol.kind()) {
+            case TYPE_DEFINITION -> Optional.ofNullable(((TypeDefinitionSymbol) symbol).typeDescriptor());
+            case VARIABLE -> Optional.ofNullable(((VariableSymbol) symbol).typeDescriptor());
+            case PARAMETER -> Optional.ofNullable(((ParameterSymbol) symbol).typeDescriptor());
+            case ANNOTATION -> ((AnnotationSymbol) symbol).typeDescriptor();
+            case FUNCTION,
+                 METHOD -> Optional.ofNullable(((FunctionSymbol) symbol).typeDescriptor());
+            case CONSTANT,
+                 ENUM_MEMBER -> Optional.ofNullable(((ConstantSymbol) symbol).typeDescriptor());
+            case CLASS -> Optional.of((ClassSymbol) symbol);
+            case RECORD_FIELD -> Optional.ofNullable(((RecordFieldSymbol) symbol).typeDescriptor());
+            case OBJECT_FIELD -> Optional.of(((ObjectFieldSymbol) symbol).typeDescriptor());
+            case CLASS_FIELD -> Optional.of(((ClassFieldSymbol) symbol).typeDescriptor());
+            case TYPE -> Optional.of((TypeSymbol) symbol);
+            default -> Optional.empty();
+        };
     }
 
     /**

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/NodeBasedArgProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/NodeBasedArgProcessor.java
@@ -191,35 +191,22 @@ public class NodeBasedArgProcessor extends InvocationArgProcessor {
     }
 
     private static String getParameterTypeName(ParameterNode parameterNode) {
-        switch (parameterNode.kind()) {
-            case REQUIRED_PARAM:
-                return ((RequiredParameterNode) parameterNode).typeName().toSourceCode().trim();
-            case DEFAULTABLE_PARAM:
-                return ((DefaultableParameterNode) parameterNode).typeName().toSourceCode().trim();
-            case REST_PARAM:
-                return ((RestParameterNode) parameterNode).typeName().toSourceCode().trim();
-            default:
-                return UNKNOWN_VALUE;
-        }
+        return switch (parameterNode.kind()) {
+            case REQUIRED_PARAM -> ((RequiredParameterNode) parameterNode).typeName().toSourceCode().trim();
+            case DEFAULTABLE_PARAM -> ((DefaultableParameterNode) parameterNode).typeName().toSourceCode().trim();
+            case REST_PARAM -> ((RestParameterNode) parameterNode).typeName().toSourceCode().trim();
+            default -> UNKNOWN_VALUE;
+        };
     }
 
     static String getParameterName(ParameterNode parameterNode) {
-        Optional<Token> paramNameToken;
-        switch (parameterNode.kind()) {
-            case REQUIRED_PARAM:
-                paramNameToken = ((RequiredParameterNode) parameterNode).paramName();
-                break;
-            case DEFAULTABLE_PARAM:
-                paramNameToken = ((DefaultableParameterNode) parameterNode).paramName();
-                break;
-            case REST_PARAM:
-                paramNameToken = ((RestParameterNode) parameterNode).paramName();
-                break;
-            default:
-                paramNameToken = Optional.empty();
-                break;
-        }
+        Optional<Token> paramNameToken = switch (parameterNode.kind()) {
+            case REQUIRED_PARAM -> ((RequiredParameterNode) parameterNode).paramName();
+            case DEFAULTABLE_PARAM -> ((DefaultableParameterNode) parameterNode).paramName();
+            case REST_PARAM -> ((RestParameterNode) parameterNode).paramName();
+            default -> Optional.empty();
+        };
 
-        return paramNameToken.isPresent() ? paramNameToken.get().text() : "unknown";
+        return paramNameToken.map(Token::text).orElse("unknown");
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/BasicLiteralEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/BasicLiteralEvaluator.java
@@ -76,19 +76,14 @@ public class BasicLiteralEvaluator extends Evaluator {
     public BExpressionValue evaluate() throws EvaluationException {
         try {
             SyntaxKind basicLiteralKind = syntaxNode.kind();
-            switch (basicLiteralKind) {
-                case NIL_LITERAL:
-                    return new BExpressionValue(context, null);
-                case NUMERIC_LITERAL:
-                    return parseAndGetNumericValue(literalString.trim());
-                case BOOLEAN_LITERAL:
-                    return VMUtils.make(context, Boolean.parseBoolean(literalString.trim()));
-                case STRING_LITERAL:
-                case TEMPLATE_STRING:
-                    return VMUtils.make(context, literalString);
-                default:
-                    throw createUnsupportedLiteralError(literalString);
-            }
+            return switch (basicLiteralKind) {
+                case NIL_LITERAL -> new BExpressionValue(context, null);
+                case NUMERIC_LITERAL -> parseAndGetNumericValue(literalString.trim());
+                case BOOLEAN_LITERAL -> VMUtils.make(context, Boolean.parseBoolean(literalString.trim()));
+                case STRING_LITERAL,
+                     TEMPLATE_STRING -> VMUtils.make(context, literalString);
+                default -> throw createUnsupportedLiteralError(literalString);
+            };
         } catch (EvaluationException e) {
             throw e;
         } catch (Exception e) {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/BinaryExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/BinaryExpressionEvaluator.java
@@ -116,40 +116,31 @@ public class BinaryExpressionEvaluator extends Evaluator {
         BVariable rVar = VariableFactory.getVariable(context, rValue);
         SyntaxKind operatorType = syntaxNode.operator().kind();
 
-        switch (operatorType) {
-            case PLUS_TOKEN:
-            case MINUS_TOKEN:
-            case ASTERISK_TOKEN:
-            case SLASH_TOKEN:
-            case PERCENT_TOKEN:
-                return performArithmeticOperation(lVar, rVar, operatorType);
-            case LT_TOKEN:
-            case GT_TOKEN:
-            case LT_EQUAL_TOKEN:
-            case GT_EQUAL_TOKEN:
-                return compare(lVar, rVar, operatorType);
-            case BITWISE_AND_TOKEN:
-            case PIPE_TOKEN:
-            case BITWISE_XOR_TOKEN:
-                return performBitwiseOperation(lVar, rVar, operatorType);
-            case DOUBLE_LT_TOKEN:
-            case DOUBLE_GT_TOKEN:
-            case TRIPPLE_GT_TOKEN:
-                return performShiftOperation(lVar, rVar, operatorType);
-            case LOGICAL_AND_TOKEN:
-            case LOGICAL_OR_TOKEN:
-                return performLogicalOperation(lVar, rVar, operatorType);
-            case ELVIS_TOKEN:
-                return conditionalReturn(lVar, rVar);
-            case DOUBLE_EQUAL_TOKEN:
-            case NOT_EQUAL_TOKEN:
-                return checkValueEquality(lVar, rVar, operatorType);
-            case TRIPPLE_EQUAL_TOKEN:
-            case NOT_DOUBLE_EQUAL_TOKEN:
-                return checkReferenceEquality(lVar, rVar, operatorType);
-            default:
-                throw createUnsupportedOperationException(lVar, rVar, operatorType);
-        }
+        return switch (operatorType) {
+            case PLUS_TOKEN,
+                 MINUS_TOKEN,
+                 ASTERISK_TOKEN,
+                 SLASH_TOKEN,
+                 PERCENT_TOKEN -> performArithmeticOperation(lVar, rVar, operatorType);
+            case LT_TOKEN,
+                 GT_TOKEN,
+                 LT_EQUAL_TOKEN,
+                 GT_EQUAL_TOKEN -> compare(lVar, rVar, operatorType);
+            case BITWISE_AND_TOKEN,
+                 PIPE_TOKEN,
+                 BITWISE_XOR_TOKEN -> performBitwiseOperation(lVar, rVar, operatorType);
+            case DOUBLE_LT_TOKEN,
+                 DOUBLE_GT_TOKEN,
+                 TRIPPLE_GT_TOKEN -> performShiftOperation(lVar, rVar, operatorType);
+            case LOGICAL_AND_TOKEN,
+                 LOGICAL_OR_TOKEN -> performLogicalOperation(lVar, rVar, operatorType);
+            case ELVIS_TOKEN -> conditionalReturn(lVar, rVar);
+            case DOUBLE_EQUAL_TOKEN,
+                 NOT_EQUAL_TOKEN -> checkValueEquality(lVar, rVar, operatorType);
+            case TRIPPLE_EQUAL_TOKEN,
+                 NOT_DOUBLE_EQUAL_TOKEN -> checkReferenceEquality(lVar, rVar, operatorType);
+            default -> throw createUnsupportedOperationException(lVar, rVar, operatorType);
+        };
     }
 
     /**
@@ -178,26 +169,14 @@ public class BinaryExpressionEvaluator extends Evaluator {
             argList.add(getValueAsObject(context, lVar));
             argList.add(getValueAsObject(context, rVar));
 
-            GeneratedStaticMethod genMethod;
-            switch (operator) {
-                case PLUS_TOKEN:
-                    genMethod = getGeneratedMethod(context, B_ARITHMETIC_EXPR_HELPER_CLASS, B_ADD_METHOD);
-                    break;
-                case MINUS_TOKEN:
-                    genMethod = getGeneratedMethod(context, B_ARITHMETIC_EXPR_HELPER_CLASS, B_SUB_METHOD);
-                    break;
-                case ASTERISK_TOKEN:
-                    genMethod = getGeneratedMethod(context, B_ARITHMETIC_EXPR_HELPER_CLASS, B_MUL_METHOD);
-                    break;
-                case SLASH_TOKEN:
-                    genMethod = getGeneratedMethod(context, B_ARITHMETIC_EXPR_HELPER_CLASS, B_DIV_METHOD);
-                    break;
-                case PERCENT_TOKEN:
-                    genMethod = getGeneratedMethod(context, B_ARITHMETIC_EXPR_HELPER_CLASS, B_MOD_METHOD);
-                    break;
-                default:
-                    throw createUnsupportedOperationException(lVar, rVar, operator);
-            }
+            GeneratedStaticMethod genMethod = switch (operator) {
+                case PLUS_TOKEN -> getGeneratedMethod(context, B_ARITHMETIC_EXPR_HELPER_CLASS, B_ADD_METHOD);
+                case MINUS_TOKEN -> getGeneratedMethod(context, B_ARITHMETIC_EXPR_HELPER_CLASS, B_SUB_METHOD);
+                case ASTERISK_TOKEN -> getGeneratedMethod(context, B_ARITHMETIC_EXPR_HELPER_CLASS, B_MUL_METHOD);
+                case SLASH_TOKEN -> getGeneratedMethod(context, B_ARITHMETIC_EXPR_HELPER_CLASS, B_DIV_METHOD);
+                case PERCENT_TOKEN -> getGeneratedMethod(context, B_ARITHMETIC_EXPR_HELPER_CLASS, B_MOD_METHOD);
+                default -> throw createUnsupportedOperationException(lVar, rVar, operator);
+            };
             genMethod.setArgValues(argList);
             Value result = genMethod.invokeSafely();
             return new BExpressionValue(context, result);
@@ -214,23 +193,13 @@ public class BinaryExpressionEvaluator extends Evaluator {
         argList.add(getValueAsObject(context, lVar));
         argList.add(getValueAsObject(context, rVar));
 
-        GeneratedStaticMethod genMethod;
-        switch (operator) {
-            case LT_TOKEN:
-                genMethod = getGeneratedMethod(context, B_RELATIONAL_EXPR_HELPER_CLASS, B_LT_METHOD);
-                break;
-            case LT_EQUAL_TOKEN:
-                genMethod = getGeneratedMethod(context, B_RELATIONAL_EXPR_HELPER_CLASS, B_LT_EQUALS_METHOD);
-                break;
-            case GT_TOKEN:
-                genMethod = getGeneratedMethod(context, B_RELATIONAL_EXPR_HELPER_CLASS, B_GT_METHOD);
-                break;
-            case GT_EQUAL_TOKEN:
-                genMethod = getGeneratedMethod(context, B_RELATIONAL_EXPR_HELPER_CLASS, B_GT_EQUALS_METHOD);
-                break;
-            default:
-                throw createUnsupportedOperationException(lVar, rVar, operator);
-        }
+        GeneratedStaticMethod genMethod = switch (operator) {
+            case LT_TOKEN -> getGeneratedMethod(context, B_RELATIONAL_EXPR_HELPER_CLASS, B_LT_METHOD);
+            case LT_EQUAL_TOKEN -> getGeneratedMethod(context, B_RELATIONAL_EXPR_HELPER_CLASS, B_LT_EQUALS_METHOD);
+            case GT_TOKEN -> getGeneratedMethod(context, B_RELATIONAL_EXPR_HELPER_CLASS, B_GT_METHOD);
+            case GT_EQUAL_TOKEN -> getGeneratedMethod(context, B_RELATIONAL_EXPR_HELPER_CLASS, B_GT_EQUALS_METHOD);
+            default -> throw createUnsupportedOperationException(lVar, rVar, operator);
+        };
         genMethod.setArgValues(argList);
         Value result = genMethod.invokeSafely();
         return new BExpressionValue(context, result);
@@ -242,20 +211,12 @@ public class BinaryExpressionEvaluator extends Evaluator {
         argList.add(getValueAsObject(context, lVar));
         argList.add(getValueAsObject(context, rVar));
 
-        GeneratedStaticMethod genMethod;
-        switch (operator) {
-            case BITWISE_AND_TOKEN:
-                genMethod = getGeneratedMethod(context, B_BITWISE_EXPR_HELPER_CLASS, B_BITWISE_AND_METHOD);
-                break;
-            case PIPE_TOKEN:
-                genMethod = getGeneratedMethod(context, B_BITWISE_EXPR_HELPER_CLASS, B_BITWISE_OR_METHOD);
-                break;
-            case BITWISE_XOR_TOKEN:
-                genMethod = getGeneratedMethod(context, B_BITWISE_EXPR_HELPER_CLASS, B_BITWISE_XOR_METHOD);
-                break;
-            default:
-                throw createUnsupportedOperationException(lVar, rVar, operator);
-        }
+        GeneratedStaticMethod genMethod = switch (operator) {
+            case BITWISE_AND_TOKEN -> getGeneratedMethod(context, B_BITWISE_EXPR_HELPER_CLASS, B_BITWISE_AND_METHOD);
+            case PIPE_TOKEN -> getGeneratedMethod(context, B_BITWISE_EXPR_HELPER_CLASS, B_BITWISE_OR_METHOD);
+            case BITWISE_XOR_TOKEN -> getGeneratedMethod(context, B_BITWISE_EXPR_HELPER_CLASS, B_BITWISE_XOR_METHOD);
+            default -> throw createUnsupportedOperationException(lVar, rVar, operator);
+        };
         genMethod.setArgValues(argList);
         Value result = genMethod.invokeSafely();
         return new BExpressionValue(context, result);
@@ -267,20 +228,13 @@ public class BinaryExpressionEvaluator extends Evaluator {
         argList.add(getValueAsObject(context, lVar));
         argList.add(getValueAsObject(context, rVar));
 
-        GeneratedStaticMethod genMethod;
-        switch (operator) {
-            case DOUBLE_LT_TOKEN:
-                genMethod = getGeneratedMethod(context, B_SHIFT_EXPR_HELPER_CLASS, B_LEFT_SHIFT_METHOD);
-                break;
-            case DOUBLE_GT_TOKEN:
-                genMethod = getGeneratedMethod(context, B_SHIFT_EXPR_HELPER_CLASS, B_SIGNED_RIGHT_SHIFT_METHOD);
-                break;
-            case TRIPPLE_GT_TOKEN:
-                genMethod = getGeneratedMethod(context, B_SHIFT_EXPR_HELPER_CLASS, B_UNSIGNED_RIGHT_SHIFT_METHOD);
-                break;
-            default:
-                throw createUnsupportedOperationException(lVar, rVar, operator);
-        }
+        GeneratedStaticMethod genMethod = switch (operator) {
+            case DOUBLE_LT_TOKEN -> getGeneratedMethod(context, B_SHIFT_EXPR_HELPER_CLASS, B_LEFT_SHIFT_METHOD);
+            case DOUBLE_GT_TOKEN -> getGeneratedMethod(context, B_SHIFT_EXPR_HELPER_CLASS, B_SIGNED_RIGHT_SHIFT_METHOD);
+            case TRIPPLE_GT_TOKEN ->
+                    getGeneratedMethod(context, B_SHIFT_EXPR_HELPER_CLASS, B_UNSIGNED_RIGHT_SHIFT_METHOD);
+            default -> throw createUnsupportedOperationException(lVar, rVar, operator);
+        };
         genMethod.setArgValues(argList);
         Value result = genMethod.invokeSafely();
         return new BExpressionValue(context, result);
@@ -292,17 +246,11 @@ public class BinaryExpressionEvaluator extends Evaluator {
         argList.add(getValueAsObject(context, lVar));
         argList.add(getValueAsObject(context, rVar));
 
-        GeneratedStaticMethod genMethod;
-        switch (operator) {
-            case LOGICAL_AND_TOKEN:
-                genMethod = getGeneratedMethod(context, B_LOGICAL_EXPR_HELPER_CLASS, B_LOGICAL_AND_METHOD);
-                break;
-            case LOGICAL_OR_TOKEN:
-                genMethod = getGeneratedMethod(context, B_LOGICAL_EXPR_HELPER_CLASS, B_LOGICAL_OR_METHOD);
-                break;
-            default:
-                throw createUnsupportedOperationException(lVar, rVar, operator);
-        }
+        GeneratedStaticMethod genMethod = switch (operator) {
+            case LOGICAL_AND_TOKEN -> getGeneratedMethod(context, B_LOGICAL_EXPR_HELPER_CLASS, B_LOGICAL_AND_METHOD);
+            case LOGICAL_OR_TOKEN -> getGeneratedMethod(context, B_LOGICAL_EXPR_HELPER_CLASS, B_LOGICAL_OR_METHOD);
+            default -> throw createUnsupportedOperationException(lVar, rVar, operator);
+        };
         genMethod.setArgValues(argList);
         Value result = genMethod.invokeSafely();
         return new BExpressionValue(context, result);

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/ExpressionAsProgramEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/ExpressionAsProgramEvaluator.java
@@ -555,43 +555,35 @@ public class ExpressionAsProgramEvaluator extends Evaluator {
      * @return type name
      */
     private String getTypeNameString(BVariable bVar) {
-        switch (bVar.getBType()) {
-            case BOOLEAN:
-            case INT:
-            case FLOAT:
-            case DECIMAL:
-            case STRING:
-            case XML:
-            case TABLE:
-            case ERROR:
-            case FUNCTION:
-            case FUTURE:
-            case TYPE_DESC:
-            case HANDLE:
-            case STREAM:
-            case SINGLETON:
-            case ANY:
-            case ANYDATA:
-            case NEVER:
-            case BYTE:
-            case SERVICE:
-                return bVar.getBType().getString();
-            case JSON:
-                return "map<json>";
-            case MAP:
-                return VariableUtils.getMapType(context, bVar.getJvmValue());
-            case NIL:
-                return "()";
-            case ARRAY:
-                return bVar.computeValue().substring(0, bVar.computeValue().indexOf("[")) + "[]";
-            case TUPLE:
-                return bVar.computeValue();
-            case RECORD:
-            case OBJECT:
-                return resolveObjectType(bVar);
-            default:
-                return UNKNOWN_VALUE;
-        }
+        return switch (bVar.getBType()) {
+            case BOOLEAN,
+                 INT,
+                 FLOAT,
+                 DECIMAL,
+                 STRING,
+                 XML,
+                 TABLE,
+                 ERROR,
+                 FUNCTION,
+                 FUTURE,
+                 TYPE_DESC,
+                 HANDLE,
+                 STREAM,
+                 SINGLETON,
+                 ANY,
+                 ANYDATA,
+                 NEVER,
+                 BYTE,
+                 SERVICE -> bVar.getBType().getString();
+            case JSON -> "map<json>";
+            case MAP -> VariableUtils.getMapType(context, bVar.getJvmValue());
+            case NIL -> "()";
+            case ARRAY -> bVar.computeValue().substring(0, bVar.computeValue().indexOf("[")) + "[]";
+            case TUPLE -> bVar.computeValue();
+            case RECORD,
+                 OBJECT -> resolveObjectType(bVar);
+            default -> UNKNOWN_VALUE;
+        };
     }
 
     private String resolveObjectType(BVariable bVar) {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/UnaryExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/UnaryExpressionEvaluator.java
@@ -59,23 +59,14 @@ public class UnaryExpressionEvaluator extends Evaluator {
             BExpressionValue result = exprEvaluator.evaluate();
             Value valueAsObject = getValueAsObject(context, result.getJdiValue());
 
-            GeneratedStaticMethod genMethod;
-            switch (syntaxNode.unaryOperator().kind()) {
-                case PLUS_TOKEN:
-                    genMethod = getGeneratedMethod(context, B_UNARY_EXPR_HELPER_CLASS, B_UNARY_PLUS_METHOD);
-                    break;
-                case MINUS_TOKEN:
-                    genMethod = getGeneratedMethod(context, B_UNARY_EXPR_HELPER_CLASS, B_UNARY_MINUS_METHOD);
-                    break;
-                case NEGATION_TOKEN:
-                    genMethod = getGeneratedMethod(context, B_UNARY_EXPR_HELPER_CLASS, B_UNARY_INVERT_METHOD);
-                    break;
-                case EXCLAMATION_MARK_TOKEN:
-                    genMethod = getGeneratedMethod(context, B_UNARY_EXPR_HELPER_CLASS, B_UNARY_NOT_METHOD);
-                    break;
-                default:
-                    throw createEvaluationException(INTERNAL_ERROR, syntaxNode.toSourceCode().trim());
-            }
+            GeneratedStaticMethod genMethod = switch (syntaxNode.unaryOperator().kind()) {
+                case PLUS_TOKEN -> getGeneratedMethod(context, B_UNARY_EXPR_HELPER_CLASS, B_UNARY_PLUS_METHOD);
+                case MINUS_TOKEN -> getGeneratedMethod(context, B_UNARY_EXPR_HELPER_CLASS, B_UNARY_MINUS_METHOD);
+                case NEGATION_TOKEN -> getGeneratedMethod(context, B_UNARY_EXPR_HELPER_CLASS, B_UNARY_INVERT_METHOD);
+                case EXCLAMATION_MARK_TOKEN ->
+                        getGeneratedMethod(context, B_UNARY_EXPR_HELPER_CLASS, B_UNARY_NOT_METHOD);
+                default -> throw createEvaluationException(INTERNAL_ERROR, syntaxNode.toSourceCode().trim());
+            };
             genMethod.setArgValues(Collections.singletonList(valueAsObject));
             return new BExpressionValue(context, genMethod.invokeSafely());
         } catch (EvaluationException e) {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/LangLibUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/LangLibUtils.java
@@ -122,30 +122,22 @@ public class LangLibUtils {
     }
 
     public static String getAssociatedLangLibName(BVariableType bVarType) {
-        switch (bVarType) {
-            case INT:
-            case BYTE:
-                return INT.getString();
-            case ARRAY:
-            case TUPLE:
-                return ARRAY.getString();
-            case RECORD:
-            case MAP:
-                return MAP.getString();
-            case FLOAT:
-            case DECIMAL:
-            case STRING:
-            case BOOLEAN:
-            case STREAM:
-            case OBJECT:
-            case ERROR:
-            case FUTURE:
-            case TYPE_DESC:
-            case XML:
-            case TABLE:
-                return bVarType.getString();
-            default:
-                return LANG_LIB_VALUE;
-        }
+        return switch (bVarType) {
+            case INT, BYTE -> INT.getString();
+            case ARRAY, TUPLE -> ARRAY.getString();
+            case RECORD, MAP -> MAP.getString();
+            case FLOAT,
+                 DECIMAL,
+                 STRING,
+                 BOOLEAN,
+                 STREAM,
+                 OBJECT,
+                 ERROR,
+                 FUTURE,
+                 TYPE_DESC,
+                 XML,
+                 TABLE -> bVarType.getString();
+            default -> LANG_LIB_VALUE;
+        };
     }
 }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/Formatter.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/Formatter.java
@@ -146,104 +146,42 @@ public class Formatter {
     public static String formatExpression(String text) throws FormatterException {
         FormattingTreeModifier treeModifier = new FormattingTreeModifier(FormattingOptions.builder().build(), null);
         ExpressionNode parsedNode = NodeParser.parseExpression(text);
-        ExpressionNode formattedNode;
-        switch (parsedNode.kind()) {
-            case ANNOT_ACCESS:
-                formattedNode = treeModifier.transform((AnnotAccessExpressionNode) parsedNode);
-                break;
-            case BINARY_EXPRESSION:
-                formattedNode = treeModifier.transform((BinaryExpressionNode) parsedNode);
-                break;
-            case BRACED_EXPRESSION:
-                formattedNode = treeModifier.transform((BracedExpressionNode) parsedNode);
-                break;
-            case CHECK_EXPRESSION:
-                formattedNode = treeModifier.transform((CheckExpressionNode) parsedNode);
-                break;
-            case CONDITIONAL_EXPRESSION:
-                formattedNode = treeModifier.transform((ConditionalExpressionNode) parsedNode);
-                break;
-            case ERROR_CONSTRUCTOR:
-                formattedNode = treeModifier.transform((ErrorConstructorExpressionNode) parsedNode);
-                break;
-            case EXPLICIT_ANONYMOUS_FUNCTION_EXPRESSION:
-                formattedNode = treeModifier.transform((ExplicitAnonymousFunctionExpressionNode) parsedNode);
-                break;
-            case EXPLICIT_NEW_EXPRESSION:
-                formattedNode = treeModifier.transform((ExplicitNewExpressionNode) parsedNode);
-                break;
-            case FIELD_ACCESS:
-                formattedNode = treeModifier.transform((FieldAccessExpressionNode) parsedNode);
-                break;
-            case FUNCTION_CALL:
-                formattedNode = treeModifier.transform((FunctionCallExpressionNode) parsedNode);
-                break;
-            case IMPLICIT_ANONYMOUS_FUNCTION_EXPRESSION:
-                formattedNode = treeModifier.transform((ImplicitAnonymousFunctionExpressionNode) parsedNode);
-                break;
-            case IMPLICIT_NEW_EXPRESSION:
-                formattedNode = treeModifier.transform((ImplicitNewExpressionNode) parsedNode);
-                break;
-            case INDEXED_EXPRESSION:
-                formattedNode = treeModifier.transform((IndexedExpressionNode) parsedNode);
-                break;
-            case LET_EXPRESSION:
-                formattedNode = treeModifier.transform((LetExpressionNode) parsedNode);
-                break;
-            case LIST_CONSTRUCTOR:
-                formattedNode = treeModifier.transform((ListConstructorExpressionNode) parsedNode);
-                break;
-            case MAPPING_CONSTRUCTOR:
-                formattedNode = treeModifier.transform((MappingConstructorExpressionNode) parsedNode);
-                break;
-            case METHOD_CALL:
-                formattedNode = treeModifier.transform((MethodCallExpressionNode) parsedNode);
-                break;
-            case OBJECT_CONSTRUCTOR:
-                formattedNode = treeModifier.transform((ObjectConstructorExpressionNode) parsedNode);
-                break;
-            case OPTIONAL_FIELD_ACCESS:
-                formattedNode = treeModifier.transform((OptionalFieldAccessExpressionNode) parsedNode);
-                break;
-            case QUERY_EXPRESSION:
-                formattedNode = treeModifier.transform((QueryExpressionNode) parsedNode);
-                break;
-            case REQUIRED_EXPRESSION:
-                formattedNode = treeModifier.transform((RequiredExpressionNode) parsedNode);
-                break;
-            case TABLE_CONSTRUCTOR:
-                formattedNode = treeModifier.transform((TableConstructorExpressionNode) parsedNode);
-                break;
-            case RAW_TEMPLATE_EXPRESSION:
-                formattedNode = treeModifier.transform((TemplateExpressionNode) parsedNode);
-                break;
-            case TRANSACTIONAL_EXPRESSION:
-                formattedNode = treeModifier.transform((TransactionalExpressionNode) parsedNode);
-                break;
-            case TRAP_EXPRESSION:
-                formattedNode = treeModifier.transform((TrapExpressionNode) parsedNode);
-                break;
-            case TYPE_CAST_EXPRESSION:
-                formattedNode = treeModifier.transform((TypeCastExpressionNode) parsedNode);
-                break;
-            case TYPE_TEST_EXPRESSION:
-                formattedNode = treeModifier.transform((TypeTestExpressionNode) parsedNode);
-                break;
-            case TYPEOF_EXPRESSION:
-                formattedNode = treeModifier.transform((TypeofExpressionNode) parsedNode);
-                break;
-            case UNARY_EXPRESSION:
-                formattedNode = treeModifier.transform((UnaryExpressionNode) parsedNode);
-                break;
-            case XML_FILTER_EXPRESSION:
-                formattedNode = treeModifier.transform((XMLFilterExpressionNode) parsedNode);
-                break;
-            case XML_STEP_EXPRESSION:
-                formattedNode = treeModifier.transform((XMLStepExpressionNode) parsedNode);
-                break;
-            default:
-                throw new FormatterException("Unsupported expression type: " + parsedNode.kind());
-        }
+        ExpressionNode formattedNode = switch (parsedNode.kind()) {
+            case ANNOT_ACCESS -> treeModifier.transform((AnnotAccessExpressionNode) parsedNode);
+            case BINARY_EXPRESSION -> treeModifier.transform((BinaryExpressionNode) parsedNode);
+            case BRACED_EXPRESSION -> treeModifier.transform((BracedExpressionNode) parsedNode);
+            case CHECK_EXPRESSION -> treeModifier.transform((CheckExpressionNode) parsedNode);
+            case CONDITIONAL_EXPRESSION -> treeModifier.transform((ConditionalExpressionNode) parsedNode);
+            case ERROR_CONSTRUCTOR -> treeModifier.transform((ErrorConstructorExpressionNode) parsedNode);
+            case EXPLICIT_ANONYMOUS_FUNCTION_EXPRESSION ->
+                    treeModifier.transform((ExplicitAnonymousFunctionExpressionNode) parsedNode);
+            case EXPLICIT_NEW_EXPRESSION -> treeModifier.transform((ExplicitNewExpressionNode) parsedNode);
+            case FIELD_ACCESS -> treeModifier.transform((FieldAccessExpressionNode) parsedNode);
+            case FUNCTION_CALL -> treeModifier.transform((FunctionCallExpressionNode) parsedNode);
+            case IMPLICIT_ANONYMOUS_FUNCTION_EXPRESSION ->
+                    treeModifier.transform((ImplicitAnonymousFunctionExpressionNode) parsedNode);
+            case IMPLICIT_NEW_EXPRESSION -> treeModifier.transform((ImplicitNewExpressionNode) parsedNode);
+            case INDEXED_EXPRESSION -> treeModifier.transform((IndexedExpressionNode) parsedNode);
+            case LET_EXPRESSION -> treeModifier.transform((LetExpressionNode) parsedNode);
+            case LIST_CONSTRUCTOR -> treeModifier.transform((ListConstructorExpressionNode) parsedNode);
+            case MAPPING_CONSTRUCTOR -> treeModifier.transform((MappingConstructorExpressionNode) parsedNode);
+            case METHOD_CALL -> treeModifier.transform((MethodCallExpressionNode) parsedNode);
+            case OBJECT_CONSTRUCTOR -> treeModifier.transform((ObjectConstructorExpressionNode) parsedNode);
+            case OPTIONAL_FIELD_ACCESS -> treeModifier.transform((OptionalFieldAccessExpressionNode) parsedNode);
+            case QUERY_EXPRESSION -> treeModifier.transform((QueryExpressionNode) parsedNode);
+            case REQUIRED_EXPRESSION -> treeModifier.transform((RequiredExpressionNode) parsedNode);
+            case TABLE_CONSTRUCTOR -> treeModifier.transform((TableConstructorExpressionNode) parsedNode);
+            case RAW_TEMPLATE_EXPRESSION -> treeModifier.transform((TemplateExpressionNode) parsedNode);
+            case TRANSACTIONAL_EXPRESSION -> treeModifier.transform((TransactionalExpressionNode) parsedNode);
+            case TRAP_EXPRESSION -> treeModifier.transform((TrapExpressionNode) parsedNode);
+            case TYPE_CAST_EXPRESSION -> treeModifier.transform((TypeCastExpressionNode) parsedNode);
+            case TYPE_TEST_EXPRESSION -> treeModifier.transform((TypeTestExpressionNode) parsedNode);
+            case TYPEOF_EXPRESSION -> treeModifier.transform((TypeofExpressionNode) parsedNode);
+            case UNARY_EXPRESSION -> treeModifier.transform((UnaryExpressionNode) parsedNode);
+            case XML_FILTER_EXPRESSION -> treeModifier.transform((XMLFilterExpressionNode) parsedNode);
+            case XML_STEP_EXPRESSION -> treeModifier.transform((XMLStepExpressionNode) parsedNode);
+            default -> throw new FormatterException("Unsupported expression type: " + parsedNode.kind());
+        };
 
         return formattedNode.toSourceCode().strip();
     }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -262,9 +262,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import static org.ballerinalang.formatter.core.FormatterUtils.getConstDefWidth;
 import static org.ballerinalang.formatter.core.FormatterUtils.isInlineRange;
 import static org.ballerinalang.formatter.core.FormatterUtils.openBraceTrailingNLs;
-import static org.ballerinalang.formatter.core.FormatterUtils.getConstDefWidth;
 import static org.ballerinalang.formatter.core.FormatterUtils.sortImportDeclarations;
 import static org.ballerinalang.formatter.core.FormatterUtils.swapLeadingMinutiae;
 
@@ -3973,21 +3973,15 @@ public class FormattingTreeModifier extends TreeModifier {
             return false;
         }
 
-        switch (node.kind()) {
-            case FUNCTION_DEFINITION:
-            case CLASS_DEFINITION:
-            case SERVICE_DECLARATION:
-            case TYPE_DEFINITION:
-            case ENUM_DECLARATION:
-            case ANNOTATION_DECLARATION:
-                return true;
-            case MODULE_VAR_DECL:
-            case MODULE_XML_NAMESPACE_DECLARATION:
-            case CONST_DECLARATION:
-            case LISTENER_DECLARATION:
-            default:
-                return false;
-        }
+        return switch (node.kind()) {
+            case FUNCTION_DEFINITION,
+                 CLASS_DEFINITION,
+                 SERVICE_DECLARATION,
+                 TYPE_DEFINITION,
+                 ENUM_DECLARATION,
+                 ANNOTATION_DECLARATION -> true;
+            default -> false;
+        };
     }
 
     private boolean isClassOrServiceMultiLineMember(Node node) {
@@ -3995,13 +3989,10 @@ public class FormattingTreeModifier extends TreeModifier {
             return false;
         }
 
-        switch (node.kind()) {
-            case OBJECT_METHOD_DEFINITION:
-            case RESOURCE_ACCESSOR_DEFINITION:
-                return true;
-            default:
-                return false;
-        }
+        return switch (node.kind()) {
+            case OBJECT_METHOD_DEFINITION, RESOURCE_ACCESSOR_DEFINITION -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -4849,14 +4840,10 @@ public class FormattingTreeModifier extends TreeModifier {
     }
 
     private boolean isClosingTypeToken(Token token) {
-        switch (token.kind()) {
-            case CLOSE_BRACE_TOKEN:
-            case CLOSE_BRACE_PIPE_TOKEN:
-            case CLOSE_BRACKET_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (token.kind()) {
+            case CLOSE_BRACE_TOKEN, CLOSE_BRACE_PIPE_TOKEN, CLOSE_BRACKET_TOKEN -> true;
+            default -> false;
+        };
     }
 
     /**

--- a/misc/identifier-util/src/main/java/io/ballerina/identifier/Utils.java
+++ b/misc/identifier-util/src/main/java/io/ballerina/identifier/Utils.java
@@ -117,28 +117,18 @@ public class Utils {
     }
 
     private static String getFormattedStringForJvmReservedSet(char c) {
-        switch (c) {
-            case '\\':
-                return "0092";
-            case '.':
-                return "0046";
-            case ':':
-                return "0058";
-            case ';':
-                return "0059";
-            case '[':
-                return "0091";
-            case ']':
-                return "0093";
-            case '/':
-                return "0047";
-            case '<':
-                return "0060";
-            case '>':
-                return "0062";
-            default:
-                return null;
-        }
+        return switch (c) {
+            case '\\' -> "0092";
+            case '.' -> "0046";
+            case ':' -> "0058";
+            case ';' -> "0059";
+            case '[' -> "0091";
+            case ']' -> "0093";
+            case '/' -> "0047";
+            case '<' -> "0060";
+            case '>' -> "0062";
+            default -> null;
+        };
     }
 
     /**

--- a/misc/ls-extensions/modules/bal-shell-service/src/main/java/io/ballerina/shell/service/util/TypeUtils.java
+++ b/misc/ls-extensions/modules/bal-shell-service/src/main/java/io/ballerina/shell/service/util/TypeUtils.java
@@ -34,24 +34,20 @@ public class TypeUtils {
      * @return mime type
      */
     public static String getMimeTypeFromName(Type type) {
-        switch (type.getTag()) {
-            case TypeTags.JSON_TAG:
-            case TypeTags.RECORD_TYPE_TAG:
-            case TypeTags.MAP_TAG:
-            case TypeTags.ARRAY_TAG:
-            case TypeTags.TUPLE_TAG:
-                return Constants.MIME_TYPE_JSON;
-            case TypeTags.TABLE_TAG:
-                return Constants.MIME_TYPE_TABLE;
-            case TypeTags.XML_TAG:
-            case TypeTags.XML_ELEMENT_TAG:
-            case TypeTags.XML_PI_TAG:
-            case TypeTags.XML_COMMENT_TAG:
-            case TypeTags.XML_TEXT_TAG:
-                return Constants.MIME_TYPE_XML;
-            default:
-                return Constants.MIME_TYPE_PLAIN_TEXT;
-        }
+        return switch (type.getTag()) {
+            case TypeTags.JSON_TAG,
+                 TypeTags.RECORD_TYPE_TAG,
+                 TypeTags.MAP_TAG,
+                 TypeTags.ARRAY_TAG,
+                 TypeTags.TUPLE_TAG -> Constants.MIME_TYPE_JSON;
+            case TypeTags.TABLE_TAG -> Constants.MIME_TYPE_TABLE;
+            case TypeTags.XML_TAG,
+                 TypeTags.XML_ELEMENT_TAG,
+                 TypeTags.XML_PI_TAG,
+                 TypeTags.XML_COMMENT_TAG,
+                 TypeTags.XML_TEXT_TAG -> Constants.MIME_TYPE_XML;
+            default -> Constants.MIME_TYPE_PLAIN_TEXT;
+        };
     }
 
     /**
@@ -63,23 +59,20 @@ public class TypeUtils {
      */
     public static String convertToJsonIfAcceptable(Object value) {
         Type type = io.ballerina.runtime.api.utils.TypeUtils.getType(value);
-        switch (type.getTag()) {
-            case TypeTags.JSON_TAG:
-            case TypeTags.RECORD_TYPE_TAG:
-            case TypeTags.MAP_TAG:
-            case TypeTags.ARRAY_TAG:
-            case TypeTags.TUPLE_TAG:
-            case TypeTags.TABLE_TAG:
-                return StringUtils.getJsonString(value);
-            case TypeTags.XML_TAG:
-            case TypeTags.XML_ELEMENT_TAG:
-            case TypeTags.XML_COMMENT_TAG:
-            case TypeTags.XML_PI_TAG:
-            case TypeTags.XML_TEXT_TAG:
-            case TypeTags.OBJECT_TYPE_TAG:
-                return StringUtils.getStringValue(value);
-            default:
-                return StringUtils.getExpressionStringValue(value);
-        }
+        return switch (type.getTag()) {
+            case TypeTags.JSON_TAG,
+                 TypeTags.RECORD_TYPE_TAG,
+                 TypeTags.MAP_TAG,
+                 TypeTags.ARRAY_TAG,
+                 TypeTags.TUPLE_TAG,
+                 TypeTags.TABLE_TAG -> StringUtils.getJsonString(value);
+            case TypeTags.XML_TAG,
+                 TypeTags.XML_ELEMENT_TAG,
+                 TypeTags.XML_COMMENT_TAG,
+                 TypeTags.XML_PI_TAG,
+                 TypeTags.XML_TEXT_TAG,
+                 TypeTags.OBJECT_TYPE_TAG -> StringUtils.getStringValue(value);
+            default -> StringUtils.getExpressionStringValue(value);
+        };
     }
 }

--- a/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/util/ConverterUtils.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/util/ConverterUtils.java
@@ -34,41 +34,24 @@ public class ConverterUtils {
      * @return {@link String} Ballerina type
      */
     public static String convertOpenAPITypeToBallerina(String type) {
-        String convertedType;
 
         //In the case where type is not specified return anydata by default
         if (type == null || type.isEmpty()) {
             return "anydata";
         }
 
-        switch (type) {
-            case Constants.INTEGER:
-                convertedType = "int";
-                break;
-            case Constants.STRING:
-                convertedType = "string";
-                break;
-            case Constants.BOOLEAN:
-                convertedType = "boolean";
-                break;
-            case Constants.ARRAY:
-                convertedType = "[]";
-                break;
-            case Constants.OBJECT:
-                convertedType = "record";
-                break;
-            case Constants.DECIMAL:
-            case Constants.NUMBER:
-            case Constants.DOUBLE:
-                convertedType = "decimal";
-                break;
-            case Constants.FLOAT:
-                convertedType = "float";
-                break;
-            default:
-                convertedType = "anydata";
-        }
-        return convertedType;
+        return switch (type) {
+            case Constants.INTEGER -> "int";
+            case Constants.STRING -> "string";
+            case Constants.BOOLEAN -> "boolean";
+            case Constants.ARRAY -> "[]";
+            case Constants.OBJECT -> "record";
+            case Constants.DECIMAL,
+                 Constants.NUMBER,
+                 Constants.DOUBLE -> "decimal";
+            case Constants.FLOAT -> "float";
+            default -> "anydata";
+        };
     }
 
     /**

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/ParamListComparator.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/comparator/ParamListComparator.java
@@ -111,15 +111,11 @@ public class ParamListComparator extends NodeListComparator<List<ParameterNode>>
     }
 
     private String getParameterName(Node paramNode) {
-        switch (paramNode.kind()) {
-            case REQUIRED_PARAM:
-                return ((RequiredParameterNode) paramNode).paramName().orElseThrow().text();
-            case DEFAULTABLE_PARAM:
-                return ((DefaultableParameterNode) paramNode).paramName().orElseThrow().text();
-            case REST_PARAM:
-                return ((RestParameterNode) paramNode).paramName().orElseThrow().text();
-            default:
-                return ""; // Todo
-        }
+        return switch (paramNode.kind()) {
+            case REQUIRED_PARAM -> ((RequiredParameterNode) paramNode).paramName().orElseThrow().text();
+            case DEFAULTABLE_PARAM -> ((DefaultableParameterNode) paramNode).paramName().orElseThrow().text();
+            case REST_PARAM -> ((RestParameterNode) paramNode).paramName().orElseThrow().text();
+            default -> ""; // Todo
+        };
     }
 }

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/util/DiffUtils.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/util/DiffUtils.java
@@ -233,31 +233,21 @@ public class DiffUtils {
      * @param diff diff type
      */
     private static String getDiffSign(Diff diff) {
-        switch (diff.getType()) {
-            case NEW:
-                return "[++]";
-            case REMOVED:
-                return "[--]";
-            case MODIFIED:
-                return "[+-]";
-            case UNKNOWN:
-            default:
-                return "[??]";
-        }
+        return switch (diff.getType()) {
+            case NEW -> "[++]";
+            case REMOVED -> "[--]";
+            case MODIFIED -> "[+-]";
+            default -> "[??]";
+        };
     }
 
     private static String getDiffVerb(Diff diff) {
-        switch (diff.getType()) {
-            case NEW:
-                return "added";
-            case REMOVED:
-                return "removed";
-            case MODIFIED:
-                return "modified";
-            case UNKNOWN:
-            default:
-                return "?";
-        }
+        return switch (diff.getType()) {
+            case NEW -> "added";
+            case REMOVED -> "removed";
+            case MODIFIED -> "modified";
+            default -> "?";
+        };
     }
 
     private static String getDiffName(Diff diff) {

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/util/PackageUtils.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/util/PackageUtils.java
@@ -52,15 +52,12 @@ public class PackageUtils {
     public static Package loadPackage(Path filePath) throws SemverToolException {
         try {
             Project project = PackageUtils.loadProject(filePath);
-            switch (project.kind()) {
-                case BUILD_PROJECT:
-                case BALA_PROJECT:
-                    return project.currentPackage();
-                case SINGLE_FILE_PROJECT:
-                    throw new SemverToolException("semver checker tool is not applicable for single file projects.");
-                default:
-                    throw new SemverToolException("semver checker tool is not applicable for " + project.kind().name());
-            }
+            return switch (project.kind()) {
+                case BUILD_PROJECT,
+                     BALA_PROJECT -> project.currentPackage();
+                case SINGLE_FILE_PROJECT -> throw new SemverToolException(
+                        "semver checker tool is not applicable for single file projects.");
+            };
         } catch (ProjectException e) {
             throw new SemverToolException(String.format("failed to load Ballerina package at: '%s'%sreason: %s",
                     filePath.toAbsolutePath(), System.lineSeparator(), e.getMessage()));

--- a/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/ClassComparatorTest.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/ClassComparatorTest.java
@@ -245,115 +245,42 @@ public class ClassComparatorTest {
 
     @DataProvider(name = "classTestDataProvider")
     public Object[] classTestDataProvider(Method method) throws SemverTestException {
-        String filePath;
-        switch (method.getName()) {
-            case "testClassAnnotation":
-                filePath = CLASS_ANNOTATION_TESTCASE;
-                break;
-            case "testClassDocumentation":
-                filePath = CLASS_DOCUMENTATION_TESTCASE;
-                break;
-            case "testClassIdentifier":
-                filePath = CLASS_IDENTIFIER_TESTCASE;
-                break;
-            case "testClassQualifier":
-                filePath = CLASS_QUALIFIER_TESTCASE;
-                break;
-            case "testAdvanceClass":
-                filePath = ADVANCE_CLASS_TESTCASE;
-                break;
+        String filePath = switch (method.getName()) {
+            case "testClassAnnotation" -> CLASS_ANNOTATION_TESTCASE;
+            case "testClassDocumentation" -> CLASS_DOCUMENTATION_TESTCASE;
+            case "testClassIdentifier" -> CLASS_IDENTIFIER_TESTCASE;
+            case "testClassQualifier" -> CLASS_QUALIFIER_TESTCASE;
+            case "testAdvanceClass" -> ADVANCE_CLASS_TESTCASE;
+            case "testClassMemberObjectFieldAnnotation" -> OBJECT_FIELD_ANNOTATION_TESTCASE;
+            case "testClassMemberObjectFieldDocumentation" -> OBJECT_FIELD_DOCUMENTATION_TESTCASE;
+            case "testClassMemberObjectFieldIdentifier" -> OBJECT_FIELD_IDENTIFIER_TESTCASE;
+            case "testClassMemberObjectFieldQualifier" -> OBJECT_FIELD_QUALIFIER_TESTCASE;
+            case "testClassMemberObjectFieldType" -> OBJECT_FIELD_TYPE_TESTCASE;
+            case "testClassMemberObjectFieldValue" -> OBJECT_FIELD_VALUE_TESTCASE;
+            case "testClassMethodDocumentation" -> METHOD_DOCUMENTATION_TESTCASE;
+            case "testClassMethodBody" -> METHOD_BODY_TESTCASE;
+            case "testClassMethodIdentifier" -> METHOD_IDENTIFIER_TESTCASE;
+            case "testClassMethodParameter" -> METHOD_PARAMETER_TESTCASE;
+            case "testClassMethodQualifier" -> METHOD_QUALIFIER_TESTCASE;
+            case "testClassMethodReturn" -> METHOD_RETURN_TESTCASE;
+            case "testClassMethodAnnotation" -> METHOD_ANNOTATION_TESTCASE;
+            case "testClassRemoteMethodDocumentation" -> REMOTE_METHOD_DOCUMENTATION_TESTCASE;
+            case "testClassRemoteMethodBody" -> REMOTE_METHOD_BODY_TESTCASE;
+            case "testClassRemoteMethodIdentifier" -> REMOTE_METHOD_IDENTIFIER_TESTCASE;
+            case "testClassRemoteMethodParameter" -> REMOTE_METHOD_PARAMETER_TESTCASE;
+            case "testClassRemoteMethodQualifier" -> REMOTE_METHOD_QUALIFIER_TESTCASE;
+            case "testClassRemoteMethodReturn" -> REMOTE_METHOD_RETURN_TESTCASE;
+            case "testClassRemoteMethodAnnotation" -> REMOTE_METHOD_ANNOTATION_TESTCASE;
+            case "testClassResourceMethodDocumentation" -> RESOURCE_METHOD_DOC_TESTCASE;
+            case "testClassResourceMethodBody" -> RESOURCE_METHOD_BODY_TESTCASE;
+            case "testClassResourceMethodIdentifier" -> RESOURCE_METHOD_IDENTIFIER_TESTCASE;
+            case "testClassResourceMethodParameter" -> RESOURCE_METHOD_PARAMETER_TESTCASE;
+            case "testClassResourceMethodQualifier" -> RESOURCE_METHOD_QUALIFIER_TESTCASE;
+            case "testClassResourceMethodReturn" -> RESOURCE_METHOD_RETURN_TESTCASE;
+            case "testClassResourceMethodAnnotation" -> RESOURCE_METHOD_ANNOTATION_TESTCASE;
+            default -> throw new SemverTestException("Failed to load dataset for method: " + method.getName());
+        };
 
-            case "testClassMemberObjectFieldAnnotation":
-                filePath = OBJECT_FIELD_ANNOTATION_TESTCASE;
-                break;
-            case "testClassMemberObjectFieldDocumentation":
-                filePath = OBJECT_FIELD_DOCUMENTATION_TESTCASE;
-                break;
-            case "testClassMemberObjectFieldIdentifier":
-                filePath = OBJECT_FIELD_IDENTIFIER_TESTCASE;
-                break;
-            case "testClassMemberObjectFieldQualifier":
-                filePath = OBJECT_FIELD_QUALIFIER_TESTCASE;
-                break;
-            case "testClassMemberObjectFieldType":
-                filePath = OBJECT_FIELD_TYPE_TESTCASE;
-                break;
-            case "testClassMemberObjectFieldValue":
-                filePath = OBJECT_FIELD_VALUE_TESTCASE;
-                break;
-
-            case "testClassMethodDocumentation":
-                filePath = METHOD_DOCUMENTATION_TESTCASE;
-                break;
-            case "testClassMethodBody":
-                filePath = METHOD_BODY_TESTCASE;
-                break;
-            case "testClassMethodIdentifier":
-                filePath = METHOD_IDENTIFIER_TESTCASE;
-                break;
-            case "testClassMethodParameter":
-                filePath = METHOD_PARAMETER_TESTCASE;
-                break;
-            case "testClassMethodQualifier":
-                filePath = METHOD_QUALIFIER_TESTCASE;
-                break;
-            case "testClassMethodReturn":
-                filePath = METHOD_RETURN_TESTCASE;
-                break;
-            case "testClassMethodAnnotation":
-                filePath = METHOD_ANNOTATION_TESTCASE;
-                break;
-
-            case "testClassRemoteMethodDocumentation":
-                filePath = REMOTE_METHOD_DOCUMENTATION_TESTCASE;
-                break;
-            case "testClassRemoteMethodBody":
-                filePath = REMOTE_METHOD_BODY_TESTCASE;
-                break;
-            case "testClassRemoteMethodIdentifier":
-                filePath = REMOTE_METHOD_IDENTIFIER_TESTCASE;
-                break;
-            case "testClassRemoteMethodParameter":
-                filePath = REMOTE_METHOD_PARAMETER_TESTCASE;
-                break;
-            case "testClassRemoteMethodQualifier":
-                filePath = REMOTE_METHOD_QUALIFIER_TESTCASE;
-                break;
-            case "testClassRemoteMethodReturn":
-                filePath = REMOTE_METHOD_RETURN_TESTCASE;
-                break;
-            case "testClassRemoteMethodAnnotation":
-                filePath = REMOTE_METHOD_ANNOTATION_TESTCASE;
-                break;
-
-            case "testClassResourceMethodDocumentation":
-                filePath = RESOURCE_METHOD_DOC_TESTCASE;
-                break;
-            case "testClassResourceMethodBody":
-                filePath = RESOURCE_METHOD_BODY_TESTCASE;
-                break;
-            case "testClassResourceMethodIdentifier":
-                filePath = RESOURCE_METHOD_IDENTIFIER_TESTCASE;
-                break;
-            case "testClassResourceMethodParameter":
-                filePath = RESOURCE_METHOD_PARAMETER_TESTCASE;
-                break;
-            case "testClassResourceMethodQualifier":
-                filePath = RESOURCE_METHOD_QUALIFIER_TESTCASE;
-                break;
-            case "testClassResourceMethodReturn":
-                filePath = RESOURCE_METHOD_RETURN_TESTCASE;
-                break;
-            case "testClassResourceMethodAnnotation":
-                filePath = RESOURCE_METHOD_ANNOTATION_TESTCASE;
-                break;
-            default:
-                filePath = null;
-        }
-
-        if (filePath == null) {
-            throw new SemverTestException("Failed to load dataset for method: " + method.getName());
-        }
         try (FileReader reader = new FileReader(filePath)) {
             Object testCaseObject = JsonParser.parseReader(reader);
             JsonArray fileData = (JsonArray) testCaseObject;

--- a/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/ConstantComparatorTest.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/ConstantComparatorTest.java
@@ -84,36 +84,17 @@ public class ConstantComparatorTest {
 
     @DataProvider(name = "constantTestDataProvider")
     public Object[] functionTestDataProvider(Method method) throws SemverTestException {
-        String filePath;
-        switch (method.getName()) {
-            case "testConstantAnnotation":
-                filePath = CONSTANT_ANNOTATION_TESTCASE;
-                break;
-            case "testConstantDocumentation":
-                filePath = CONSTANT_DOCUMENTATION_TESTCASE;
-                break;
-            case "testConstantExpression":
-                filePath = CONSTANT_EXPRESSION_TESTCASE;
-                break;
-            case "testConstantIdentifier":
-                filePath = CONSTANT_IDENTIFIER_TESTCASE;
-                break;
-            case "testConstantQualifier":
-                filePath = CONSTANT_QUALIFIER_TESTCASE;
-                break;
-            case "testConstantTypeDescriptor":
-                filePath = CONSTANT_TYPE_DESCRIPTOR_TESTCASE;
-                break;
-            case "testAdvanceConstant":
-                filePath = ADVANCE_CONSTANT_TESTCASE;
-                break;
-            default:
-                filePath = null;
-        }
+        String filePath = switch (method.getName()) {
+            case "testConstantAnnotation" -> CONSTANT_ANNOTATION_TESTCASE;
+            case "testConstantDocumentation" -> CONSTANT_DOCUMENTATION_TESTCASE;
+            case "testConstantExpression" -> CONSTANT_EXPRESSION_TESTCASE;
+            case "testConstantIdentifier" -> CONSTANT_IDENTIFIER_TESTCASE;
+            case "testConstantQualifier" -> CONSTANT_QUALIFIER_TESTCASE;
+            case "testConstantTypeDescriptor" -> CONSTANT_TYPE_DESCRIPTOR_TESTCASE;
+            case "testAdvanceConstant" -> ADVANCE_CONSTANT_TESTCASE;
+            default -> throw new SemverTestException("Failed to load dataset for method: " + method.getName());
+        };
 
-        if (filePath == null) {
-            throw new SemverTestException("Failed to load dataset for method: " + method.getName());
-        }
         try (FileReader reader = new FileReader(filePath)) {
             Object testCaseObject = JsonParser.parseReader(reader);
             JsonArray fileData = (JsonArray) testCaseObject;

--- a/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/EnumerationComparatorTest.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/EnumerationComparatorTest.java
@@ -80,33 +80,16 @@ public class EnumerationComparatorTest {
 
     @DataProvider(name = "enumerationTestDataProvider")
     public Object[] enumerationTestDataProvider(Method method) throws SemverTestException {
-        String filePath;
-        switch (method.getName()) {
-            case "testEnumerationAnnotation":
-                filePath = ENUMERATION_ANNOTATION_TESTCASE;
-                break;
-            case "testEnumerationDocumentation":
-                filePath = ENUMERATION_DOCUMENTATION_TESTCASE;
-                break;
-            case "testEnumerationIdentifier":
-                filePath = ENUMERATION_IDENTIFIER_TESTCASE;
-                break;
-            case "testEnumerationQualifier":
-                filePath = ENUMERATION_QUALIFIER_TESTCASE;
-                break;
-            case "testEnumerationMember":
-                filePath = ENUMERATION_MEMBER_TESTCASE;
-                break;
-            case "testAdvanceEnumeration":
-                filePath = ADVANCE_ENUMERATION_TESTCASE;
-                break;
-            default:
-                filePath = null;
-        }
+        String filePath = switch (method.getName()) {
+            case "testEnumerationAnnotation" -> ENUMERATION_ANNOTATION_TESTCASE;
+            case "testEnumerationDocumentation" -> ENUMERATION_DOCUMENTATION_TESTCASE;
+            case "testEnumerationIdentifier" -> ENUMERATION_IDENTIFIER_TESTCASE;
+            case "testEnumerationQualifier" -> ENUMERATION_QUALIFIER_TESTCASE;
+            case "testEnumerationMember" -> ENUMERATION_MEMBER_TESTCASE;
+            case "testAdvanceEnumeration" -> ADVANCE_ENUMERATION_TESTCASE;
+            default -> throw new SemverTestException("Failed to load dataset for method: " + method.getName());
+        };
 
-        if (filePath == null) {
-            throw new SemverTestException("Failed to load dataset for method: " + method.getName());
-        }
         try (FileReader reader = new FileReader(filePath)) {
             Object testCaseObject = JsonParser.parseReader(reader);
             JsonArray fileData = (JsonArray) testCaseObject;

--- a/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/FunctionComparatorTest.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/FunctionComparatorTest.java
@@ -92,39 +92,18 @@ public class FunctionComparatorTest {
 
     @DataProvider(name = "functionTestDataProvider")
     public Object[] functionTestDataProvider(Method method) throws SemverTestException {
-        String filePath;
-        switch (method.getName()) {
-            case "testFunctionAnnotation":
-                filePath = FUNCTION_ANNOTATION_TESTCASE;
-                break;
-            case "testFunctionDocumentation":
-                filePath = FUNCTION_DOCUMENTATION_TESTCASE;
-                break;
-            case "testFunctionBody":
-                filePath = FUNCTION_BODY_TESTCASE;
-                break;
-            case "testFunctionIdentifier":
-                filePath = FUNCTION_IDENTIFIER_TESTCASE;
-                break;
-            case "testFunctionParameter":
-                filePath = FUNCTION_PARAMETER_TESTCASE;
-                break;
-            case "testFunctionQualifier":
-                filePath = FUNCTION_QUALIFIER_TESTCASE;
-                break;
-            case "testFunctionReturn":
-                filePath = FUNCTION_RETURN_TESTCASE;
-                break;
-            case "testAdvanceFunction":
-                filePath = ADVANCE_FUNCTION_TESTCASE;
-                break;
-            default:
-                filePath = null;
-        }
+        String filePath = switch (method.getName()) {
+            case "testFunctionAnnotation" -> FUNCTION_ANNOTATION_TESTCASE;
+            case "testFunctionDocumentation" -> FUNCTION_DOCUMENTATION_TESTCASE;
+            case "testFunctionBody" -> FUNCTION_BODY_TESTCASE;
+            case "testFunctionIdentifier" -> FUNCTION_IDENTIFIER_TESTCASE;
+            case "testFunctionParameter" -> FUNCTION_PARAMETER_TESTCASE;
+            case "testFunctionQualifier" -> FUNCTION_QUALIFIER_TESTCASE;
+            case "testFunctionReturn" -> FUNCTION_RETURN_TESTCASE;
+            case "testAdvanceFunction" -> ADVANCE_FUNCTION_TESTCASE;
+            default -> throw new SemverTestException("Failed to load dataset for method: " + method.getName());
+        };
 
-        if (filePath == null) {
-            throw new SemverTestException("Failed to load dataset for method: " + method.getName());
-        }
         try (FileReader reader = new FileReader(filePath)) {
             Object testCaseObject = JsonParser.parseReader(reader);
             JsonArray fileData = (JsonArray) testCaseObject;

--- a/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/ServiceComparatorTest.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/ServiceComparatorTest.java
@@ -251,115 +251,42 @@ public class ServiceComparatorTest {
 
     @DataProvider(name = "serviceTestDataProvider")
     public Object[] serviceTestDataProvider(Method method) throws SemverTestException {
-        String filePath;
-        switch (method.getName()) {
-            case "testServiceAnnotation":
-                filePath = SERVICE_ANNOTATION_TESTCASE;
-                break;
-            case "testServiceDocumentation":
-                filePath = SERVICE_DOCUMENTATION_TESTCASE;
-                break;
-            case "testServiceAttachPoint":
-                filePath = SERVICE_ATTACH_POINT_TESTCASE;
-                break;
-            case "testServiceListenerExpressionList":
-                filePath = SERVICE_LISTENER_TESTCASE;
-                break;
-            case "testServiceQualifier":
-                filePath = SERVICE_ISOLATED_QUALIFIER_TESTCASE;
-                break;
-            case "testAdvanceServiceDeclaration":
-                filePath = ADVANCE_SERVICE_TESTCASE;
-                break;
-
-            case "testServiceMemberObjectFieldAnnotation":
-                filePath = OBJECT_FIELD_ANNOTATION_TESTCASE;
-                break;
-            case "testServiceMemberObjectFieldDocumentation":
-                filePath = OBJECT_FIELD_DOCUMENTATION_TESTCASE;
-                break;
-            case "testServiceMemberObjectFieldIdentifier":
-                filePath = OBJECT_FIELD_IDENTIFIER_TESTCASE;
-                break;
-            case "testServiceMemberObjectFieldQualifier":
-                filePath = OBJECT_FIELD_QUALIFIER_TESTCASE;
-                break;
-            case "testServiceMemberObjectFieldType":
-                filePath = OBJECT_FIELD_TYPE_TESTCASE;
-                break;
-            case "testServiceMemberObjectFieldValue":
-                filePath = OBJECT_FIELD_VALUE_TESTCASE;
-                break;
-
-            case "testServiceMethodDocumentation":
-                filePath = METHOD_DOCUMENTATION_TESTCASE;
-                break;
-            case "testServiceMethodBody":
-                filePath = METHOD_BODY_TESTCASE;
-                break;
-            case "testServiceMethodIdentifier":
-                filePath = METHOD_IDENTIFIER_TESTCASE;
-                break;
-            case "testServiceMethodParameter":
-                filePath = METHOD_PARAMETER_TESTCASE;
-                break;
-            case "testServiceMethodQualifier":
-                filePath = METHOD_QUALIFIER_TESTCASE;
-                break;
-            case "testServiceMethodReturn":
-                filePath = METHOD_RETURN_TESTCASE;
-                break;
-            case "testServiceMethodAnnotation":
-                filePath = METHOD_ANNOTATION_TESTCASE;
-                break;
-
-            case "testRemoteServiceMethodDocumentation":
-                filePath = REMOTE_METHOD_DOCUMENTATION_TESTCASE;
-                break;
-            case "testRemoteServiceMethodBody":
-                filePath = REMOTE_METHOD_BODY_TESTCASE;
-                break;
-            case "testRemoteServiceMethodIdentifier":
-                filePath = REMOTE_METHOD_IDENTIFIER_TESTCASE;
-                break;
-            case "testRemoteServiceMethodParameter":
-                filePath = REMOTE_METHOD_PARAMETER_TESTCASE;
-                break;
-            case "testRemoteServiceMethodQualifier":
-                filePath = REMOTE_METHOD_QUALIFIER_TESTCASE;
-                break;
-            case "testRemoteServiceMethodReturn":
-                filePath = REMOTE_METHOD_RETURN_TESTCASE;
-                break;
-            case "testRemoteServiceMethodAnnotation":
-                filePath = REMOTE_METHOD_ANNOTATION_TESTCASE;
-                break;
-
-            case "testResourceServiceMethodDocumentation":
-                filePath = RESOURCE_METHOD_DOC_TESTCASE;
-                break;
-            case "testResourceServiceMethodBody":
-                filePath = RESOURCE_METHOD_BODY_TESTCASE;
-                break;
-            case "testResourceServiceMethodIdentifier":
-                filePath = RESOURCE_METHOD_IDENTIFIER_TESTCASE;
-                break;
-            case "testResourceServiceMethodParameter":
-                filePath = RESOURCE_METHOD_PARAMETER_TESTCASE;
-                break;
-            case "testResourceServiceMethodQualifier":
-                filePath = RESOURCE_METHOD_QUALIFIER_TESTCASE;
-                break;
-            case "testResourceServiceMethodReturn":
-                filePath = RESOURCE_METHOD_RETURN_TESTCASE;
-                break;
-            case "testResourceServiceMethodAnnotation":
-                filePath = RESOURCE_METHOD_ANNOTATION_TESTCASE;
-                break;
-
-            default:
-                filePath = null;
-        }
+        String filePath = switch (method.getName()) {
+            case "testServiceAnnotation" -> SERVICE_ANNOTATION_TESTCASE;
+            case "testServiceDocumentation" -> SERVICE_DOCUMENTATION_TESTCASE;
+            case "testServiceAttachPoint" -> SERVICE_ATTACH_POINT_TESTCASE;
+            case "testServiceListenerExpressionList" -> SERVICE_LISTENER_TESTCASE;
+            case "testServiceQualifier" -> SERVICE_ISOLATED_QUALIFIER_TESTCASE;
+            case "testAdvanceServiceDeclaration" -> ADVANCE_SERVICE_TESTCASE;
+            case "testServiceMemberObjectFieldAnnotation" -> OBJECT_FIELD_ANNOTATION_TESTCASE;
+            case "testServiceMemberObjectFieldDocumentation" -> OBJECT_FIELD_DOCUMENTATION_TESTCASE;
+            case "testServiceMemberObjectFieldIdentifier" -> OBJECT_FIELD_IDENTIFIER_TESTCASE;
+            case "testServiceMemberObjectFieldQualifier" -> OBJECT_FIELD_QUALIFIER_TESTCASE;
+            case "testServiceMemberObjectFieldType" -> OBJECT_FIELD_TYPE_TESTCASE;
+            case "testServiceMemberObjectFieldValue" -> OBJECT_FIELD_VALUE_TESTCASE;
+            case "testServiceMethodDocumentation" -> METHOD_DOCUMENTATION_TESTCASE;
+            case "testServiceMethodBody" -> METHOD_BODY_TESTCASE;
+            case "testServiceMethodIdentifier" -> METHOD_IDENTIFIER_TESTCASE;
+            case "testServiceMethodParameter" -> METHOD_PARAMETER_TESTCASE;
+            case "testServiceMethodQualifier" -> METHOD_QUALIFIER_TESTCASE;
+            case "testServiceMethodReturn" -> METHOD_RETURN_TESTCASE;
+            case "testServiceMethodAnnotation" -> METHOD_ANNOTATION_TESTCASE;
+            case "testRemoteServiceMethodDocumentation" -> REMOTE_METHOD_DOCUMENTATION_TESTCASE;
+            case "testRemoteServiceMethodBody" -> REMOTE_METHOD_BODY_TESTCASE;
+            case "testRemoteServiceMethodIdentifier" -> REMOTE_METHOD_IDENTIFIER_TESTCASE;
+            case "testRemoteServiceMethodParameter" -> REMOTE_METHOD_PARAMETER_TESTCASE;
+            case "testRemoteServiceMethodQualifier" -> REMOTE_METHOD_QUALIFIER_TESTCASE;
+            case "testRemoteServiceMethodReturn" -> REMOTE_METHOD_RETURN_TESTCASE;
+            case "testRemoteServiceMethodAnnotation" -> REMOTE_METHOD_ANNOTATION_TESTCASE;
+            case "testResourceServiceMethodDocumentation" -> RESOURCE_METHOD_DOC_TESTCASE;
+            case "testResourceServiceMethodBody" -> RESOURCE_METHOD_BODY_TESTCASE;
+            case "testResourceServiceMethodIdentifier" -> RESOURCE_METHOD_IDENTIFIER_TESTCASE;
+            case "testResourceServiceMethodParameter" -> RESOURCE_METHOD_PARAMETER_TESTCASE;
+            case "testResourceServiceMethodQualifier" -> RESOURCE_METHOD_QUALIFIER_TESTCASE;
+            case "testResourceServiceMethodReturn" -> RESOURCE_METHOD_RETURN_TESTCASE;
+            case "testResourceServiceMethodAnnotation" -> RESOURCE_METHOD_ANNOTATION_TESTCASE;
+            default -> null;
+        };
 
         if (filePath == null) {
             throw new SemverTestException("Failed to load dataset for method: " + method.getName());

--- a/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/TypeComparatorTest.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/TypeComparatorTest.java
@@ -408,165 +408,57 @@ public class TypeComparatorTest {
 
     @DataProvider(name = "typeDefinitionTestDataProvider")
     public Object[] typeDefinitionTestDataProvider(Method method) throws SemverTestException {
-        String filePath;
-        switch (method.getName()) {
-            case "testTypeAnnotation":
-                filePath = TYPE_ANNOTATION_TESTCASE;
-                break;
-            case "testTypeDocumentation":
-                filePath = TYPE_DOCUMENTATION_TESTCASE;
-                break;
-            case "testTypeIdentifier":
-                filePath = TYPE_IDENTIFIER_TESTCASE;
-                break;
-            case "testTypeQualifier":
-                filePath = TYPE_QUALIFIER_TESTCASE;
-                break;
-            case "testAdvanceType":
-                filePath = ADVANCE_TESTCASE;
-                break;
-
-            case "testSimpleTypeBoolean":
-                filePath = SIMPLE_BOOLEAN_TESTCASE;
-                break;
-            case "testSimpleTypeFloat":
-                filePath = SIMPLE_FLOAT_TESTCASE;
-                break;
-            case "testSimpleTypeInt":
-                filePath = SIMPLE_INT_TESTCASE;
-                break;
-            case "testSimpleTypeNil":
-                filePath = SIMPLE_NIL_TESTCASE;
-                break;
-
-            case "testSequenceTypeString":
-                filePath = SEQUENCE_STRING_TESTCASE;
-                break;
-            case "testSequenceTypeXml":
-                filePath = SEQUENCE_XML_TESTCASE;
-                break;
-
-            case "testStructuredTypeList":
-                filePath = STRUCTURED_LIST_TESTCASE;
-                break;
-            case "testStructuredTypeMap":
-                filePath = STRUCTURED_MAP_TESTCASE;
-                break;
-            case "testStructuredTypeTable":
-                filePath = STRUCTURED_TABLE_TESTCASE;
-                break;
-
-            case "testBehaviouralTypeError":
-                filePath = BEHAVIOURAL_ERROR_TESTCASE;
-                break;
-            case "testBehaviouralTypeFuture":
-                filePath = BEHAVIOURAL_FUTURE_TESTCASE;
-                break;
-            case "testBehaviouralTypeHandle":
-                filePath = BEHAVIOURAL_HANDLE_TESTCASE;
-                break;
-            case "testBehaviouralTypeStream":
-                filePath = BEHAVIOURAL_STREAM_TESTCASE;
-                break;
-            case "testBehaviouralTypeTypeDesc":
-                filePath = BEHAVIOURAL_TYPE_DESC_TESTCASE;
-                break;
-
-            case "testBehaviouralTypeFunctionParameter":
-                filePath = BEHAVIOURAL_FUNCTION_PARAMETER_TESTCASE;
-                break;
-            case "testBehaviouralTypeFunctionQualifier":
-                filePath = BEHAVIOURAL_FUNCTION_QUALIFIER_TESTCASE;
-                break;
-            case "testBehaviouralTypeFunctionReturn":
-                filePath = BEHAVIOURAL_FUNCTION_RETURN_TESTCASE;
-                break;
-
-            case "testBehaviouralTypeObjectMethodAnnotation":
-                filePath = BEHAVIOURAL_OBJ_METHOD_ANNOTATION_TESTCASE;
-                break;
-            case "testBehaviouralTypeObjectMethodDocumentation":
-                filePath = BEHAVIOURAL_OBJ_METHOD_DOCUMENTATION_TESTCASE;
-                break;
-            case "testBehaviouralTypeObjectMethodBody":
-                filePath = BEHAVIOURAL_OBJ_METHOD_BODY_TESTCASE;
-                break;
-            case "testBehaviouralTypeObjectMethodIdentifier":
-                filePath = BEHAVIOURAL_OBJ_METHOD_IDENTIFIER_TESTCASE;
-                break;
-            case "testBehaviouralTypeObjectMethodParameter":
-                filePath = BEHAVIOURAL_OBJ_METHOD_PARAMETER_TESTCASE;
-                break;
-            case "testBehaviouralTypeObjectMethodQualifier":
-                filePath = BEHAVIOURAL_OBJ_METHOD_QUALIFIER_TESTCASE;
-                break;
-            case "testBehaviouralTypeObjectMethodReturn":
-                filePath = BEHAVIOURAL_OBJ_METHOD_RETURN_TESTCASE;
-                break;
-
-            case "testBehaviouralTypeObjectFieldAnnotation":
-                filePath = BEHAVIOURAL_OBJ_FIELD_ANNOTATION_TESTCASE;
-                break;
-            case "testBehaviouralTypeObjectFieldDocumentation":
-                filePath = BEHAVIOURAL_OBJ_FIELD_DOCUMENTATION_TESTCASE;
-                break;
-            case "testBehaviouralTypeObjectFieldIdentifier":
-                filePath = BEHAVIOURAL_OBJ_FIELD_IDENTIFIER_TESTCASE;
-                break;
-            case "testBehaviouralTypeObjectFieldQualifier":
-                filePath = BEHAVIOURAL_OBJ_FIELD_QUALIFIER_TESTCASE;
-                break;
-            case "testBehaviouralTypeObjectFieldType":
-                filePath = BEHAVIOURAL_OBJ_FIELD_TESTCASE;
-                break;
-
-            case "testBehaviouralTypeObjectQualifier":
-                filePath = BEHAVIOURAL_OBJ_QUALIFIER_TESTCASE;
-                break;
-
-            case "testOtherTypeAnyData":
-                filePath = OTHER_ANY_DATA_TESTCASE;
-                break;
-            case "testOtherTypeAnyType":
-                filePath = OTHER_ANY_TESTCASE;
-                break;
-            case "testOtherTypeByte":
-                filePath = OTHER_BYTE_TESTCASE;
-                break;
-            case "testOtherTypeDistinct":
-                filePath = OTHER_DISTINCT_TESTCASE;
-                break;
-            case "testOtherTypeIntersection":
-                filePath = OTHER_INTERSECTION_TESTCASE;
-                break;
-            case "testOtherTypeJsonType":
-                filePath = OTHER_JSON_TESTCASE;
-                break;
-            case "testOtherTypeNeverType":
-                filePath = OTHER_NEVER_TESTCASE;
-                break;
-            case "testOtherTypeOptional":
-                filePath = OTHER_OPTIONAL_TESTCASE;
-                break;
-            case "testOtherTypeReadOnly":
-                filePath = OTHER_READ_ONLY_TESTCASE;
-                break;
-            case "testOtherTypeRecord":
-                filePath = OTHER_RECORD_TESTCASE;
-                break;
-            case "testOtherTypeSingleton":
-                filePath = OTHER_SINGLETON_TESTCASE;
-                break;
-            case "testOtherTypeTypeReference":
-                filePath = OTHER_TYPE_REFERENCE_TESTCASE;
-                break;
-            case "testOtherTypeUnion":
-                filePath = OTHER_UNION_TESTCASE;
-                break;
-
-            default:
-                filePath = null;
-        }
+        String filePath = switch (method.getName()) {
+            case "testTypeAnnotation" -> TYPE_ANNOTATION_TESTCASE;
+            case "testTypeDocumentation" -> TYPE_DOCUMENTATION_TESTCASE;
+            case "testTypeIdentifier" -> TYPE_IDENTIFIER_TESTCASE;
+            case "testTypeQualifier" -> TYPE_QUALIFIER_TESTCASE;
+            case "testAdvanceType" -> ADVANCE_TESTCASE;
+            case "testSimpleTypeBoolean" -> SIMPLE_BOOLEAN_TESTCASE;
+            case "testSimpleTypeFloat" -> SIMPLE_FLOAT_TESTCASE;
+            case "testSimpleTypeInt" -> SIMPLE_INT_TESTCASE;
+            case "testSimpleTypeNil" -> SIMPLE_NIL_TESTCASE;
+            case "testSequenceTypeString" -> SEQUENCE_STRING_TESTCASE;
+            case "testSequenceTypeXml" -> SEQUENCE_XML_TESTCASE;
+            case "testStructuredTypeList" -> STRUCTURED_LIST_TESTCASE;
+            case "testStructuredTypeMap" -> STRUCTURED_MAP_TESTCASE;
+            case "testStructuredTypeTable" -> STRUCTURED_TABLE_TESTCASE;
+            case "testBehaviouralTypeError" -> BEHAVIOURAL_ERROR_TESTCASE;
+            case "testBehaviouralTypeFuture" -> BEHAVIOURAL_FUTURE_TESTCASE;
+            case "testBehaviouralTypeHandle" -> BEHAVIOURAL_HANDLE_TESTCASE;
+            case "testBehaviouralTypeStream" -> BEHAVIOURAL_STREAM_TESTCASE;
+            case "testBehaviouralTypeTypeDesc" -> BEHAVIOURAL_TYPE_DESC_TESTCASE;
+            case "testBehaviouralTypeFunctionParameter" -> BEHAVIOURAL_FUNCTION_PARAMETER_TESTCASE;
+            case "testBehaviouralTypeFunctionQualifier" -> BEHAVIOURAL_FUNCTION_QUALIFIER_TESTCASE;
+            case "testBehaviouralTypeFunctionReturn" -> BEHAVIOURAL_FUNCTION_RETURN_TESTCASE;
+            case "testBehaviouralTypeObjectMethodAnnotation" -> BEHAVIOURAL_OBJ_METHOD_ANNOTATION_TESTCASE;
+            case "testBehaviouralTypeObjectMethodDocumentation" -> BEHAVIOURAL_OBJ_METHOD_DOCUMENTATION_TESTCASE;
+            case "testBehaviouralTypeObjectMethodBody" -> BEHAVIOURAL_OBJ_METHOD_BODY_TESTCASE;
+            case "testBehaviouralTypeObjectMethodIdentifier" -> BEHAVIOURAL_OBJ_METHOD_IDENTIFIER_TESTCASE;
+            case "testBehaviouralTypeObjectMethodParameter" -> BEHAVIOURAL_OBJ_METHOD_PARAMETER_TESTCASE;
+            case "testBehaviouralTypeObjectMethodQualifier" -> BEHAVIOURAL_OBJ_METHOD_QUALIFIER_TESTCASE;
+            case "testBehaviouralTypeObjectMethodReturn" -> BEHAVIOURAL_OBJ_METHOD_RETURN_TESTCASE;
+            case "testBehaviouralTypeObjectFieldAnnotation" -> BEHAVIOURAL_OBJ_FIELD_ANNOTATION_TESTCASE;
+            case "testBehaviouralTypeObjectFieldDocumentation" -> BEHAVIOURAL_OBJ_FIELD_DOCUMENTATION_TESTCASE;
+            case "testBehaviouralTypeObjectFieldIdentifier" -> BEHAVIOURAL_OBJ_FIELD_IDENTIFIER_TESTCASE;
+            case "testBehaviouralTypeObjectFieldQualifier" -> BEHAVIOURAL_OBJ_FIELD_QUALIFIER_TESTCASE;
+            case "testBehaviouralTypeObjectFieldType" -> BEHAVIOURAL_OBJ_FIELD_TESTCASE;
+            case "testBehaviouralTypeObjectQualifier" -> BEHAVIOURAL_OBJ_QUALIFIER_TESTCASE;
+            case "testOtherTypeAnyData" -> OTHER_ANY_DATA_TESTCASE;
+            case "testOtherTypeAnyType" -> OTHER_ANY_TESTCASE;
+            case "testOtherTypeByte" -> OTHER_BYTE_TESTCASE;
+            case "testOtherTypeDistinct" -> OTHER_DISTINCT_TESTCASE;
+            case "testOtherTypeIntersection" -> OTHER_INTERSECTION_TESTCASE;
+            case "testOtherTypeJsonType" -> OTHER_JSON_TESTCASE;
+            case "testOtherTypeNeverType" -> OTHER_NEVER_TESTCASE;
+            case "testOtherTypeOptional" -> OTHER_OPTIONAL_TESTCASE;
+            case "testOtherTypeReadOnly" -> OTHER_READ_ONLY_TESTCASE;
+            case "testOtherTypeRecord" -> OTHER_RECORD_TESTCASE;
+            case "testOtherTypeSingleton" -> OTHER_SINGLETON_TESTCASE;
+            case "testOtherTypeTypeReference" -> OTHER_TYPE_REFERENCE_TESTCASE;
+            case "testOtherTypeUnion" -> OTHER_UNION_TESTCASE;
+            default -> null;
+        };
 
         if (filePath == null) {
             throw new SemverTestException("Failed to load dataset for method: " + method.getName());

--- a/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/VariableComparatorTest.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/test/java/org/ballerinalang/semver/checker/comparator/VariableComparatorTest.java
@@ -84,32 +84,16 @@ public class VariableComparatorTest {
 
     @DataProvider(name = "variableTestDataProvider")
     public Object[] functionTestDataProvider(Method method) throws SemverTestException {
-        String filePath;
-        switch (method.getName()) {
-            case "testVariableAnnotation":
-                filePath = VARIABLE_ANNOTATION_TESTCASE;
-                break;
-            case "testVariableDocumentation":
-                filePath = VARIABLE_DOCUMENTATION_TESTCASE;
-                break;
-            case "testVariableValue":
-                filePath = VARIABLE_VALUE_TESTCASE;
-                break;
-            case "testVariableIdentifier":
-                filePath = VARIABLE_IDENTIFIER_TESTCASE;
-                break;
-            case "testVariableQualifier":
-                filePath = VARIABLE_QUALIFIER_TESTCASE;
-                break;
-            case "testVariableTypeDescriptor":
-                filePath = VARIABLE_TYPE_DESCRIPTOR_TESTCASE;
-                break;
-            case "testAdvanceVariable":
-                filePath = ADVANCE_VARIABLE_TESTCASE;
-                break;
-            default:
-                filePath = null;
-        }
+        String filePath = switch (method.getName()) {
+            case "testVariableAnnotation" -> VARIABLE_ANNOTATION_TESTCASE;
+            case "testVariableDocumentation" -> VARIABLE_DOCUMENTATION_TESTCASE;
+            case "testVariableValue" -> VARIABLE_VALUE_TESTCASE;
+            case "testVariableIdentifier" -> VARIABLE_IDENTIFIER_TESTCASE;
+            case "testVariableQualifier" -> VARIABLE_QUALIFIER_TESTCASE;
+            case "testVariableTypeDescriptor" -> VARIABLE_TYPE_DESCRIPTOR_TESTCASE;
+            case "testAdvanceVariable" -> ADVANCE_VARIABLE_TESTCASE;
+            default -> null;
+        };
 
         if (filePath == null) {
             throw new SemverTestException("Failed to load dataset for method: " + method.getName());

--- a/misc/syntax-api-calls-gen/src/main/java/io/ballerina/syntaxapicallsgen/formatter/SegmentFormatter.java
+++ b/misc/syntax-api-calls-gen/src/main/java/io/ballerina/syntaxapicallsgen/formatter/SegmentFormatter.java
@@ -52,14 +52,11 @@ public abstract class SegmentFormatter {
      * @return Created formatter.
      */
     protected static SegmentFormatter getInternalFormatter(SyntaxApiCallsGenConfig config) {
-        switch (config.formatter()) {
-            case NONE:
-                return new NoFormatter();
-            case VARIABLE:
-                return new VariableFormatter();
-            default:
-                return new DefaultFormatter();
-        }
+        return switch (config.formatter()) {
+            case NONE -> new NoFormatter();
+            case VARIABLE -> new VariableFormatter();
+            default -> new DefaultFormatter();
+        };
     }
 
     /**

--- a/misc/syntax-api-calls-gen/src/main/java/io/ballerina/syntaxapicallsgen/parser/SyntaxApiCallsGenParser.java
+++ b/misc/syntax-api-calls-gen/src/main/java/io/ballerina/syntaxapicallsgen/parser/SyntaxApiCallsGenParser.java
@@ -57,14 +57,11 @@ public abstract class SyntaxApiCallsGenParser {
      */
     public static SyntaxApiCallsGenParser fromConfig(SyntaxApiCallsGenConfig config) {
         long timeoutMs = config.parserTimeout();
-        switch (config.parser()) {
-            case EXPRESSION:
-                return new ExpressionParser(timeoutMs);
-            case STATEMENT:
-                return new StatementParser(timeoutMs);
-            default:
-                return new ModuleParser(timeoutMs);
-        }
+        return switch (config.parser()) {
+            case EXPRESSION -> new ExpressionParser(timeoutMs);
+            case STATEMENT -> new StatementParser(timeoutMs);
+            default -> new ModuleParser(timeoutMs);
+        };
     }
 
     /**

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
@@ -845,16 +845,13 @@ public class ObjectMock {
     private static boolean isValidReturnValue(Object returnVal, MethodType attachedFunction) {
         Type functionReturnType = TypeUtils.getImpliedType(
                 attachedFunction.getType().getReturnParameterType());
-        switch (functionReturnType.getTag()) {
-            case TypeTags.UNION_TAG:
-                return validateUnionValue(returnVal, (UnionType) functionReturnType);
-            case TypeTags.STREAM_TAG:
-                return validateStreamValue(returnVal, (StreamType) functionReturnType);
-            case TypeTags.PARAMETERIZED_TYPE_TAG:
-                return validateParameterizedValue(returnVal, (ParameterizedType) functionReturnType);
-            default:
-                return TypeChecker.checkIsType(returnVal, functionReturnType);
-        }
+        return switch (functionReturnType.getTag()) {
+            case TypeTags.UNION_TAG -> validateUnionValue(returnVal, (UnionType) functionReturnType);
+            case TypeTags.STREAM_TAG -> validateStreamValue(returnVal, (StreamType) functionReturnType);
+            case TypeTags.PARAMETERIZED_TYPE_TAG ->
+                    validateParameterizedValue(returnVal, (ParameterizedType) functionReturnType);
+            default -> TypeChecker.checkIsType(returnVal, functionReturnType);
+        };
     }
 
     /**

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
@@ -59,20 +59,13 @@ public class PartialCoverageModifiedCounter implements ICounter {
      */
     @Override
     public double getValue(CounterValue value) {
-        switch (value) {
-            case TOTALCOUNT:
-                return getTotalCount();
-            case MISSEDCOUNT:
-                return getMissedCount();
-            case COVEREDCOUNT:
-                return getCoveredCount();
-            case MISSEDRATIO:
-                return getMissedRatio();
-            case COVEREDRATIO:
-                return getCoveredRatio();
-            default:
-                throw new RuntimeException("No such CounterValue object");
-        }
+        return switch (value) {
+            case TOTALCOUNT -> getTotalCount();
+            case MISSEDCOUNT -> getMissedCount();
+            case COVEREDCOUNT -> getCoveredCount();
+            case MISSEDRATIO -> getMissedRatio();
+            case COVEREDRATIO -> getCoveredRatio();
+        };
     }
 
     @Override

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/SyntaxErrors.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/SyntaxErrors.java
@@ -89,52 +89,36 @@ public class SyntaxErrors {
     }
 
     private static DiagnosticCode getErrorCode(ParserRuleContext currentCtx) {
-        switch (currentCtx) {
-            case STRING_BODY:
-                return DiagnosticErrorCode.ERROR_MISSING_STRING_LITERAL;
-            case ASSIGN_OP:
-                return DiagnosticErrorCode.ERROR_MISSING_EQUAL_TOKEN;
-            case ARRAY_VALUE_LIST_END:
-            case TABLE_END:
-            case ARRAY_TABLE_FIRST_END:
-            case ARRAY_TABLE_SECOND_END:
-                return DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACKET_TOKEN;
-            case COMMA:
-                return DiagnosticErrorCode.ERROR_MISSING_COMMA_TOKEN;
-            case ARRAY_VALUE_LIST_START:
-            case TABLE_START:
-            case ARRAY_TABLE_FIRST_START:
-            case ARRAY_TABLE_SECOND_START:
-                return DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACKET_TOKEN;
-            case INLINE_TABLE_END:
-                return DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACE_TOKEN;
-            case INLINE_TABLE_START:
-                return DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACE_TOKEN;
-            case DOT:
-                return DiagnosticErrorCode.ERROR_MISSING_DOT_TOKEN;
-            case STRING_END:
-            case STRING_START:
-                return DiagnosticErrorCode.ERROR_MISSING_DOUBLE_QUOTE_TOKEN;
-            case MULTILINE_STRING_START:
-            case MULTILINE_STRING_END:
-                return DiagnosticErrorCode.ERROR_MISSING_TRIPLE_DOUBLE_QUOTE_TOKEN;
-            case LITERAL_STRING_END:
-            case LITERAL_STRING_START:
-                return DiagnosticErrorCode.ERROR_MISSING_SINGLE_QUOTE_TOKEN;
-            case MULTILINE_LITERAL_STRING_START:
-            case MULTILINE_LITERAL_STRING_END:
-                return DiagnosticErrorCode.ERROR_MISSING_TRIPLE_SINGLE_QUOTE_TOKEN;
-            case DECIMAL_INTEGER_LITERAL:
-            case DECIMAL_FLOATING_POINT_LITERAL:
-            case BOOLEAN_LITERAL:
-                return DiagnosticErrorCode.ERROR_MISSING_VALUE;
-            case NEWLINE:
-                return DiagnosticErrorCode.ERROR_MISSING_NEW_LINE;
-            case IDENTIFIER_LITERAL:
-                return DiagnosticErrorCode.ERROR_MISSING_IDENTIFIER;
-            default:
-                return DiagnosticErrorCode.ERROR_SYNTAX_ERROR;
-        }
+        return switch (currentCtx) {
+            case STRING_BODY -> DiagnosticErrorCode.ERROR_MISSING_STRING_LITERAL;
+            case ASSIGN_OP -> DiagnosticErrorCode.ERROR_MISSING_EQUAL_TOKEN;
+            case ARRAY_VALUE_LIST_END,
+                 TABLE_END,
+                 ARRAY_TABLE_FIRST_END,
+                 ARRAY_TABLE_SECOND_END -> DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACKET_TOKEN;
+            case COMMA -> DiagnosticErrorCode.ERROR_MISSING_COMMA_TOKEN;
+            case ARRAY_VALUE_LIST_START,
+                 TABLE_START,
+                 ARRAY_TABLE_FIRST_START,
+                 ARRAY_TABLE_SECOND_START -> DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACKET_TOKEN;
+            case INLINE_TABLE_END -> DiagnosticErrorCode.ERROR_MISSING_CLOSE_BRACE_TOKEN;
+            case INLINE_TABLE_START -> DiagnosticErrorCode.ERROR_MISSING_OPEN_BRACE_TOKEN;
+            case DOT -> DiagnosticErrorCode.ERROR_MISSING_DOT_TOKEN;
+            case STRING_END,
+                 STRING_START -> DiagnosticErrorCode.ERROR_MISSING_DOUBLE_QUOTE_TOKEN;
+            case MULTILINE_STRING_START,
+                 MULTILINE_STRING_END -> DiagnosticErrorCode.ERROR_MISSING_TRIPLE_DOUBLE_QUOTE_TOKEN;
+            case LITERAL_STRING_END,
+                 LITERAL_STRING_START -> DiagnosticErrorCode.ERROR_MISSING_SINGLE_QUOTE_TOKEN;
+            case MULTILINE_LITERAL_STRING_START,
+                 MULTILINE_LITERAL_STRING_END -> DiagnosticErrorCode.ERROR_MISSING_TRIPLE_SINGLE_QUOTE_TOKEN;
+            case DECIMAL_INTEGER_LITERAL,
+                 DECIMAL_FLOATING_POINT_LITERAL,
+                 BOOLEAN_LITERAL -> DiagnosticErrorCode.ERROR_MISSING_VALUE;
+            case NEWLINE -> DiagnosticErrorCode.ERROR_MISSING_NEW_LINE;
+            case IDENTIFIER_LITERAL -> DiagnosticErrorCode.ERROR_MISSING_IDENTIFIER;
+            default -> DiagnosticErrorCode.ERROR_SYNTAX_ERROR;
+        };
     }
 
     /**

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/TomlLexer.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/TomlLexer.java
@@ -522,17 +522,16 @@ public class TomlLexer extends AbstractLexer {
      */
     private STNode processEndOfLine() {
         char c = reader.peek();
-        switch (c) {
-            case LexerTerminals.NEWLINE:
-                return STNodeFactory.createMinutiae(SyntaxKind.END_OF_LINE_MINUTIAE, "\n");
-            case LexerTerminals.CARRIAGE_RETURN:
+        return switch (c) {
+            case LexerTerminals.NEWLINE -> STNodeFactory.createMinutiae(SyntaxKind.END_OF_LINE_MINUTIAE, "\n");
+            case LexerTerminals.CARRIAGE_RETURN -> {
                 if (reader.peek(1) == LexerTerminals.NEWLINE) {
                     reader.advance();
                 }
-                return STNodeFactory.createMinutiae(SyntaxKind.END_OF_LINE_MINUTIAE, "\r\n");
-            default:
-                throw new IllegalStateException();
-        }
+                yield STNodeFactory.createMinutiae(SyntaxKind.END_OF_LINE_MINUTIAE, "\r\n");
+            }
+            default -> throw new IllegalStateException();
+        };
     }
 
     /**
@@ -654,13 +653,11 @@ public class TomlLexer extends AbstractLexer {
             nextChar = peek();
         }
 
-        switch (nextChar) {
-            case 'e':
-            case 'E':
-                return processExponent();
-        }
+        return switch (nextChar) {
+            case 'e', 'E' -> processExponent();
+            default -> getLiteral(SyntaxKind.DECIMAL_FLOAT_TOKEN);
+        };
 
-        return getLiteral(SyntaxKind.DECIMAL_FLOAT_TOKEN);
     }
 
     /**
@@ -754,18 +751,13 @@ public class TomlLexer extends AbstractLexer {
         }
 
         String tokenText = getLexeme();
-        switch (tokenText) {
-            case LexerTerminals.TRUE:
-                return getSyntaxToken(SyntaxKind.TRUE_KEYWORD);
-            case LexerTerminals.FALSE:
-                return getSyntaxToken(SyntaxKind.FALSE_KEYWORD);
-            case LexerTerminals.INF:
-                return getSyntaxToken(SyntaxKind.INF_TOKEN);
-            case LexerTerminals.NAN:
-                return getSyntaxToken(SyntaxKind.NAN_TOKEN);
-            default:
-                return getUnquotedKey();
-        }
+        return switch (tokenText) {
+            case LexerTerminals.TRUE -> getSyntaxToken(SyntaxKind.TRUE_KEYWORD);
+            case LexerTerminals.FALSE -> getSyntaxToken(SyntaxKind.FALSE_KEYWORD);
+            case LexerTerminals.INF -> getSyntaxToken(SyntaxKind.INF_TOKEN);
+            case LexerTerminals.NAN -> getSyntaxToken(SyntaxKind.NAN_TOKEN);
+            default -> getUnquotedKey();
+        };
     }
 
     /**
@@ -801,22 +793,20 @@ public class TomlLexer extends AbstractLexer {
         }
 
         int currentChar = peek();
-        switch (currentChar) {
-            case LexerTerminals.NEWLINE:
-            case LexerTerminals.CARRIAGE_RETURN:
-            case LexerTerminals.SPACE:
-            case LexerTerminals.TAB:
-            case LexerTerminals.SEMICOLON:
-            case LexerTerminals.OPEN_BRACE:
-            case LexerTerminals.CLOSE_BRACE:
-            case LexerTerminals.OPEN_BRACKET:
-            case LexerTerminals.CLOSE_BRACKET:
-            case LexerTerminals.OPEN_PARANTHESIS:
-            case LexerTerminals.CLOSE_PARANTHESIS:
-                return true;
-            default:
-                return false;
-        }
+        return switch (currentChar) {
+            case LexerTerminals.NEWLINE,
+                 LexerTerminals.CARRIAGE_RETURN,
+                 LexerTerminals.SPACE,
+                 LexerTerminals.TAB,
+                 LexerTerminals.SEMICOLON,
+                 LexerTerminals.OPEN_BRACE,
+                 LexerTerminals.CLOSE_BRACE,
+                 LexerTerminals.OPEN_BRACKET,
+                 LexerTerminals.CLOSE_BRACKET,
+                 LexerTerminals.OPEN_PARANTHESIS,
+                 LexerTerminals.CLOSE_PARANTHESIS -> true;
+            default -> false;
+        };
     }
 
     /**

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/TomlParser.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/TomlParser.java
@@ -198,19 +198,19 @@ public class TomlParser extends AbstractParser {
 
     private STNode parseInlineKeyValuePair() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case IDENTIFIER_LITERAL:
-            case SINGLE_QUOTE_TOKEN:
-            case DOUBLE_QUOTE_TOKEN:
-            case TRUE_KEYWORD:
-            case FALSE_KEYWORD:
-            case DECIMAL_INT_TOKEN:
-            case DECIMAL_FLOAT_TOKEN:
-                return parseKeyValue(true);
-            default:
+        return switch (nextToken.kind) {
+            case IDENTIFIER_LITERAL,
+                 SINGLE_QUOTE_TOKEN,
+                 DOUBLE_QUOTE_TOKEN,
+                 TRUE_KEYWORD,
+                 FALSE_KEYWORD,
+                 DECIMAL_INT_TOKEN,
+                 DECIMAL_FLOAT_TOKEN -> parseKeyValue(true);
+            default -> {
                 recover(peek(), ParserRuleContext.INLINE_TABLE_ENTRY_START);
-                return parseInlineKeyValuePair();
-        }
+                yield parseInlineKeyValuePair();
+            }
+        };
     }
 
     private boolean isEndOfInlineTable(STToken token) {
@@ -218,16 +218,15 @@ public class TomlParser extends AbstractParser {
     }
 
     private STNode parseInlineTableEntryEnd() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return consume();
-            case CLOSE_BRACE_TOKEN:
-                // null marks the end of values
-                return null;
-            default:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> consume();
+            // null marks the end of values
+            case CLOSE_BRACE_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.INLINE_TABLE_ENTRY_END);
-                return parseInlineTableEntryEnd();
-        }
+                yield parseInlineTableEntryEnd();
+            }
+        };
     }
 
     private STNode parseOpenBrace() {
@@ -390,25 +389,20 @@ public class TomlParser extends AbstractParser {
 
     private STNode parseSingleKey() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case DECIMAL_INT_TOKEN:
-            case DECIMAL_FLOAT_TOKEN:
-                return parseNumericalNode();
-            case TRUE_KEYWORD:
-            case FALSE_KEYWORD:
-                return parseBoolean();
-            case IDENTIFIER_LITERAL:
-                return parseIdentifierLiteral();
-            case DOUBLE_QUOTE_TOKEN:
-                return parseStringValue();
-            case SINGLE_QUOTE_TOKEN:
-                return parseLiteralStringValue();
-            case EQUAL_TOKEN:
-                return null;
-            default:
+        return switch (nextToken.kind) {
+            case DECIMAL_INT_TOKEN,
+                 DECIMAL_FLOAT_TOKEN -> parseNumericalNode();
+            case TRUE_KEYWORD,
+                 FALSE_KEYWORD -> parseBoolean();
+            case IDENTIFIER_LITERAL -> parseIdentifierLiteral();
+            case DOUBLE_QUOTE_TOKEN -> parseStringValue();
+            case SINGLE_QUOTE_TOKEN -> parseLiteralStringValue();
+            case EQUAL_TOKEN -> null;
+            default -> {
                 recover(peek(), ParserRuleContext.KEY_START);
-                return parseSingleKey();
-        }
+                yield parseSingleKey();
+            }
+        };
     }
 
     private STNode parseKeyList(STNode firstKey) {
@@ -437,17 +431,15 @@ public class TomlParser extends AbstractParser {
 
     private STNode parseKeyEnd() {
         STToken token = peek();
-        switch (token.kind) {
-            case DOT_TOKEN:
-                return consume();
-            case EQUAL_TOKEN:
-            case CLOSE_BRACKET_TOKEN:
-                // null marks the end of values
-                return null;
-            default:
+        return switch (token.kind) {
+            case DOT_TOKEN -> consume();
+            // null marks the end of values
+            case EQUAL_TOKEN, CLOSE_BRACKET_TOKEN -> null;
+            default -> {
                 recover(token, ParserRuleContext.KEY_END);
-                return parseKeyEnd();
-        }
+                yield parseKeyEnd();
+            }
+        };
     }
 
     private STNode parseEquals() {
@@ -475,34 +467,27 @@ public class TomlParser extends AbstractParser {
      */
     private STNode parseValue() {
         STToken token = peek();
-        switch (token.kind) {
-            case DOUBLE_QUOTE_TOKEN:
-                return parseStringValue();
-            case TRIPLE_DOUBLE_QUOTE_TOKEN:
-                return parseMultilineStringValue();
-            case SINGLE_QUOTE_TOKEN:
-                return parseLiteralStringValue();
-            case TRIPLE_SINGLE_QUOTE_TOKEN:
-                return parseMultilineLiteralStringValue();
-            case DECIMAL_INT_TOKEN:
-            case DECIMAL_FLOAT_TOKEN:
-            case HEX_INTEGER_LITERAL_TOKEN:
-            case OCTAL_INTEGER_LITERAL_TOKEN:
-            case BINARY_INTEGER_LITERAL_TOKEN:
-            case PLUS_TOKEN:
-            case MINUS_TOKEN:
-                return parseNumericalNode();
-            case TRUE_KEYWORD:
-            case FALSE_KEYWORD:
-                return parseBoolean();
-            case OPEN_BRACKET_TOKEN:
-                return parseArray();
-            case OPEN_BRACE_TOKEN:
-                return parseInlineTable();
-            default:
+        return switch (token.kind) {
+            case DOUBLE_QUOTE_TOKEN -> parseStringValue();
+            case TRIPLE_DOUBLE_QUOTE_TOKEN -> parseMultilineStringValue();
+            case SINGLE_QUOTE_TOKEN -> parseLiteralStringValue();
+            case TRIPLE_SINGLE_QUOTE_TOKEN -> parseMultilineLiteralStringValue();
+            case DECIMAL_INT_TOKEN,
+                 DECIMAL_FLOAT_TOKEN,
+                 HEX_INTEGER_LITERAL_TOKEN,
+                 OCTAL_INTEGER_LITERAL_TOKEN,
+                 BINARY_INTEGER_LITERAL_TOKEN,
+                 PLUS_TOKEN,
+                 MINUS_TOKEN -> parseNumericalNode();
+            case TRUE_KEYWORD,
+                 FALSE_KEYWORD -> parseBoolean();
+            case OPEN_BRACKET_TOKEN -> parseArray();
+            case OPEN_BRACE_TOKEN -> parseInlineTable();
+            default -> {
                 recover(token, ParserRuleContext.VALUE);
-                return parseValue();
-        }
+                yield parseValue();
+            }
+        };
     }
 
     private STNode parseNumericalNode() {
@@ -513,18 +498,13 @@ public class TomlParser extends AbstractParser {
     }
 
     private SyntaxKind getNumericLiteralKind(SyntaxKind tokenKind) {
-        switch (tokenKind) {
-            case DECIMAL_INT_TOKEN:
-                return DEC_INT;
-            case HEX_INTEGER_LITERAL_TOKEN:
-                return HEX_INT;
-            case OCTAL_INTEGER_LITERAL_TOKEN:
-                return OCT_INT;
-            case BINARY_INTEGER_LITERAL_TOKEN:
-                return BINARY_INT;
-            default:
-                return FLOAT;
-        }
+        return switch (tokenKind) {
+            case DECIMAL_INT_TOKEN -> DEC_INT;
+            case HEX_INTEGER_LITERAL_TOKEN -> HEX_INT;
+            case OCTAL_INTEGER_LITERAL_TOKEN -> OCT_INT;
+            case BINARY_INTEGER_LITERAL_TOKEN -> BINARY_INT;
+            default -> FLOAT;
+        };
     }
 
     private STNode parseNumericalToken() {
@@ -538,16 +518,14 @@ public class TomlParser extends AbstractParser {
     }
 
     private boolean isNumericalLiteral(STToken token) {
-        switch (token.kind) {
-            case DECIMAL_INT_TOKEN:
-            case DECIMAL_FLOAT_TOKEN:
-            case HEX_INTEGER_LITERAL_TOKEN:
-            case OCTAL_INTEGER_LITERAL_TOKEN:
-            case BINARY_INTEGER_LITERAL_TOKEN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (token.kind) {
+            case DECIMAL_INT_TOKEN,
+                 DECIMAL_FLOAT_TOKEN,
+                 HEX_INTEGER_LITERAL_TOKEN,
+                 OCTAL_INTEGER_LITERAL_TOKEN,
+                 BINARY_INTEGER_LITERAL_TOKEN -> true;
+            default -> false;
+        };
     }
 
     private STNode parseSign() {
@@ -791,49 +769,43 @@ public class TomlParser extends AbstractParser {
     }
 
     private STNode parseValueEnd() {
-        switch (peek().kind) {
-            case COMMA_TOKEN:
-                return consume();
-            case CLOSE_BRACKET_TOKEN:
-                // null marks the end of values
-                return null;
-            case NEWLINE:
+        return switch (peek().kind) {
+            case COMMA_TOKEN -> consume();
+            // null marks the end of values
+            case CLOSE_BRACKET_TOKEN -> null;
+            case NEWLINE -> {
                 consume();
-                return parseValueEnd();
-            default:
+                yield parseValueEnd();
+            }
+            default -> {
                 recover(peek(), ParserRuleContext.ARRAY_VALUE_END);
-                return parseValueEnd();
-        }
+                yield parseValueEnd();
+            }
+        };
     }
 
     private STNode parseArrayValue() {
         STToken nextToken = peek();
-        switch (nextToken.kind) {
-            case DOUBLE_QUOTE_TOKEN:
-                return parseStringValue();
-            case TRIPLE_DOUBLE_QUOTE_TOKEN:
-                return parseMultilineStringValue();
-            case SINGLE_QUOTE_TOKEN:
-                return parseLiteralStringValue();
-            case TRIPLE_SINGLE_QUOTE_TOKEN:
-                return parseMultilineLiteralStringValue();
-            case DECIMAL_INT_TOKEN:
-            case DECIMAL_FLOAT_TOKEN:
-            case TRUE_KEYWORD:
-            case FALSE_KEYWORD:
-                return parseValue();
-            case OPEN_BRACKET_TOKEN:
-                return parseArray();
-            case CLOSE_BRACKET_TOKEN:
-                return null;
-            case OPEN_BRACE_TOKEN:
-                return parseInlineTable();
-            case NEWLINE:
+        return switch (nextToken.kind) {
+            case DOUBLE_QUOTE_TOKEN -> parseStringValue();
+            case TRIPLE_DOUBLE_QUOTE_TOKEN -> parseMultilineStringValue();
+            case SINGLE_QUOTE_TOKEN -> parseLiteralStringValue();
+            case TRIPLE_SINGLE_QUOTE_TOKEN -> parseMultilineLiteralStringValue();
+            case DECIMAL_INT_TOKEN,
+                 DECIMAL_FLOAT_TOKEN,
+                 TRUE_KEYWORD,
+                 FALSE_KEYWORD -> parseValue();
+            case OPEN_BRACKET_TOKEN -> parseArray();
+            case CLOSE_BRACKET_TOKEN -> null;
+            case OPEN_BRACE_TOKEN -> parseInlineTable();
+            case NEWLINE -> {
                 consume();
-                return parseArrayValue();
-            default:
+                yield parseArrayValue();
+            }
+            default -> {
                 recover(peek(), ParserRuleContext.ARRAY_VALUE_START);
-                return parseArrayValue();
-        }
+                yield parseArrayValue();
+            }
+        };
     }
 }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/TomlParserErrorHandler.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/TomlParserErrorHandler.java
@@ -423,74 +423,46 @@ public class TomlParserErrorHandler extends AbstractParserErrorHandler {
      */
     @Override
     protected SyntaxKind getExpectedTokenKind(ParserRuleContext ctx) {
-        switch (ctx) {
-            case TOML_TABLE:
-                return SyntaxKind.TABLE;
-            case TOML_TABLE_ARRAY:
-                return SyntaxKind.TABLE_ARRAY;
-            case KEY_VALUE_PAIR:
-                return SyntaxKind.KEY_VALUE;
-            case ASSIGN_OP:
-                return SyntaxKind.EQUAL_TOKEN;
-            case IDENTIFIER_LITERAL:
-                return SyntaxKind.IDENTIFIER_LITERAL;
-            case EOF:
-                return SyntaxKind.EOF_TOKEN;
-            case COMMA:
-                return SyntaxKind.COMMA_TOKEN;
-            case STRING_START:
-            case STRING_END:
-                return SyntaxKind.DOUBLE_QUOTE_TOKEN;
-            case LITERAL_STRING_START:
-            case LITERAL_STRING_END:
-                return SyntaxKind.SINGLE_QUOTE_TOKEN;
-            case MULTILINE_STRING_START:
-            case MULTILINE_STRING_END:
-                return SyntaxKind.TRIPLE_DOUBLE_QUOTE_TOKEN;
-            case MULTILINE_LITERAL_STRING_START:
-            case MULTILINE_LITERAL_STRING_END:
-                return SyntaxKind.TRIPLE_SINGLE_QUOTE_TOKEN;
-            case STRING_BODY:
-            case LITERAL_STRING_BODY:
-            case MULTILINE_STRING_BODY:
-            case MULTILINE_LITERAL_STRING_BODY:
-                return SyntaxKind.IDENTIFIER_LITERAL;
-            case INLINE_TABLE_START:
-                return SyntaxKind.OPEN_BRACE_TOKEN;
-            case ARRAY_VALUE_LIST_START:
-            case TABLE_START:
-                return SyntaxKind.OPEN_BRACKET_TOKEN;
-            case ARRAY_VALUE_LIST_END:
-            case TABLE_END:
-                return SyntaxKind.CLOSE_BRACKET_TOKEN;
-            case INLINE_TABLE_END:
-                return SyntaxKind.CLOSE_BRACE_TOKEN;
-            case DECIMAL_INTEGER_LITERAL:
-                return SyntaxKind.DECIMAL_INT_TOKEN;
-            case HEX_INTEGER_LITERAL:
-                return SyntaxKind.HEX_INTEGER_LITERAL_TOKEN;
-            case OCTAL_INTEGER_LITERAL:
-                return SyntaxKind.OCTAL_INTEGER_LITERAL_TOKEN;
-            case BINARY_INTEGER_LITERAL:
-                return SyntaxKind.BINARY_INTEGER_LITERAL_TOKEN;
-            case DECIMAL_FLOATING_POINT_LITERAL:
-                return SyntaxKind.DECIMAL_FLOAT_TOKEN;
-            case BOOLEAN_LITERAL:
-                return SyntaxKind.FALSE_KEYWORD;
-            case NEWLINE:
-                return SyntaxKind.NEWLINE;
-            case DOT:
-                return SyntaxKind.DOT_TOKEN;
-            case ARRAY_TABLE_FIRST_END:
-            case ARRAY_TABLE_SECOND_END:
-                return SyntaxKind.CLOSE_BRACKET_TOKEN;
-            case ARRAY_TABLE_FIRST_START:
-            case ARRAY_TABLE_SECOND_START:
-                return SyntaxKind.OPEN_BRACKET_TOKEN;
-            case SIGN_TOKEN:
-                return SyntaxKind.PLUS_TOKEN;
-            default:
-                return SyntaxKind.NONE;
-        }
+        return switch (ctx) {
+            case TOML_TABLE -> SyntaxKind.TABLE;
+            case TOML_TABLE_ARRAY -> SyntaxKind.TABLE_ARRAY;
+            case KEY_VALUE_PAIR -> SyntaxKind.KEY_VALUE;
+            case ASSIGN_OP -> SyntaxKind.EQUAL_TOKEN;
+            case IDENTIFIER_LITERAL -> SyntaxKind.IDENTIFIER_LITERAL;
+            case EOF -> SyntaxKind.EOF_TOKEN;
+            case COMMA -> SyntaxKind.COMMA_TOKEN;
+            case STRING_START,
+                 STRING_END -> SyntaxKind.DOUBLE_QUOTE_TOKEN;
+            case LITERAL_STRING_START,
+                 LITERAL_STRING_END -> SyntaxKind.SINGLE_QUOTE_TOKEN;
+            case MULTILINE_STRING_START,
+                 MULTILINE_STRING_END -> SyntaxKind.TRIPLE_DOUBLE_QUOTE_TOKEN;
+            case MULTILINE_LITERAL_STRING_START,
+                 MULTILINE_LITERAL_STRING_END -> SyntaxKind.TRIPLE_SINGLE_QUOTE_TOKEN;
+            case STRING_BODY,
+                 LITERAL_STRING_BODY,
+                 MULTILINE_STRING_BODY,
+                 MULTILINE_LITERAL_STRING_BODY -> SyntaxKind.IDENTIFIER_LITERAL;
+            case INLINE_TABLE_START -> SyntaxKind.OPEN_BRACE_TOKEN;
+            case ARRAY_VALUE_LIST_START,
+                 TABLE_START -> SyntaxKind.OPEN_BRACKET_TOKEN;
+            case ARRAY_VALUE_LIST_END,
+                 TABLE_END -> SyntaxKind.CLOSE_BRACKET_TOKEN;
+            case INLINE_TABLE_END -> SyntaxKind.CLOSE_BRACE_TOKEN;
+            case DECIMAL_INTEGER_LITERAL -> SyntaxKind.DECIMAL_INT_TOKEN;
+            case HEX_INTEGER_LITERAL -> SyntaxKind.HEX_INTEGER_LITERAL_TOKEN;
+            case OCTAL_INTEGER_LITERAL -> SyntaxKind.OCTAL_INTEGER_LITERAL_TOKEN;
+            case BINARY_INTEGER_LITERAL -> SyntaxKind.BINARY_INTEGER_LITERAL_TOKEN;
+            case DECIMAL_FLOATING_POINT_LITERAL -> SyntaxKind.DECIMAL_FLOAT_TOKEN;
+            case BOOLEAN_LITERAL -> SyntaxKind.FALSE_KEYWORD;
+            case NEWLINE -> SyntaxKind.NEWLINE;
+            case DOT -> SyntaxKind.DOT_TOKEN;
+            case ARRAY_TABLE_FIRST_END,
+                 ARRAY_TABLE_SECOND_END -> SyntaxKind.CLOSE_BRACKET_TOKEN;
+            case ARRAY_TABLE_FIRST_START,
+                 ARRAY_TABLE_SECOND_START -> SyntaxKind.OPEN_BRACKET_TOKEN;
+            case SIGN_TOKEN -> SyntaxKind.PLUS_TOKEN;
+            default -> SyntaxKind.NONE;
+        };
     }
 }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/tree/STMissingToken.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/tree/STMissingToken.java
@@ -60,12 +60,10 @@ public class STMissingToken extends STToken {
 
     @Override
     public Node createFacade(int position, NonTerminalNode parent) {
-        switch (kind) {
-            case IDENTIFIER_LITERAL:
-                return new IdentifierToken(this, position, parent);
-            default:
-                return new Token(this, position, parent);
-        }
+        return switch (kind) {
+            case IDENTIFIER_LITERAL -> new IdentifierToken(this, position, parent);
+            default -> new Token(this, position, parent);
+        };
     }
 
     @Override

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/validator/ValidationUtil.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/validator/ValidationUtil.java
@@ -47,23 +47,14 @@ public class ValidationUtil {
     }
 
     public static Type tomlTypeValueToSchemaType(TomlType tomlType) {
-        switch (tomlType) {
-            case STRING:
-                return Type.STRING;
-            case DOUBLE:
-            case INTEGER:
-                return Type.NUMBER;
-            case BOOLEAN:
-                return Type.BOOLEAN;
-            case ARRAY:
-            case TABLE_ARRAY:
-                return Type.ARRAY;
-            case TABLE:
-            case INLINE_TABLE:
-                return Type.OBJECT;
-            default:
-                throw new IllegalArgumentException("Toml type is a invalid value");
-        }
+        return switch (tomlType) {
+            case STRING -> Type.STRING;
+            case DOUBLE, INTEGER -> Type.NUMBER;
+            case BOOLEAN -> Type.BOOLEAN;
+            case ARRAY, TABLE_ARRAY -> Type.ARRAY;
+            case TABLE, INLINE_TABLE -> Type.OBJECT;
+            default -> throw new IllegalArgumentException("Toml type is a invalid value");
+        };
     }
 
     public static TomlDiagnostic getTomlDiagnostic(TomlNodeLocation location, String code, String template,

--- a/misc/toml-parser/src/test/java/toml/parser/test/ParserTestUtils.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/ParserTestUtils.java
@@ -325,33 +325,26 @@ public class ParserTestUtils {
     }
 
     public static boolean isTrivia(SyntaxKind syntaxKind) {
-        switch (syntaxKind) {
-            case WHITESPACE_MINUTIAE:
-            case END_OF_LINE_MINUTIAE:
-            case COMMENT_MINUTIAE:
-            case INVALID_NODE_MINUTIAE:
-                return true;
-            default:
-                return false;
-        }
+        return switch (syntaxKind) {
+            case WHITESPACE_MINUTIAE, END_OF_LINE_MINUTIAE, COMMENT_MINUTIAE, INVALID_NODE_MINUTIAE -> true;
+            default -> false;
+        };
     }
 
     public static String getTokenText(STToken token) {
-        switch (token.kind) {
-            case IDENTIFIER_LITERAL:
+        return switch (token.kind) {
+            case IDENTIFIER_LITERAL -> {
                 String text = ((STIdentifierToken) token).text;
-                return cleanupText(text);
-            case STRING_LITERAL:
-            case DECIMAL_INT_TOKEN:
-            case DECIMAL_FLOAT_TOKEN:
-            case TRUE_KEYWORD:
-            case FALSE_KEYWORD:
-                return token.text();
-            case INVALID_TOKEN:
-                return token.text();
-            default:
-                return token.kind.toString();
-        }
+                yield cleanupText(text);
+            }
+            case STRING_LITERAL,
+                 DECIMAL_INT_TOKEN,
+                 DECIMAL_FLOAT_TOKEN,
+                 TRUE_KEYWORD,
+                 FALSE_KEYWORD -> token.text();
+            case INVALID_TOKEN -> token.text();
+            default -> token.kind.toString();
+        };
     }
 
     private static String cleanupText(String text) {
@@ -393,123 +386,66 @@ public class ParserTestUtils {
     }
 
     private static SyntaxKind getNodeKind(String kind) {
-        switch (kind) {
-            case "INLINE_TABLE":
-                return SyntaxKind.INLINE_TABLE;
-            case "NEW_LINE":
-                return SyntaxKind.NEWLINE;
-            case "TRUE_KEYWORD":
-                return SyntaxKind.TRUE_KEYWORD;
-            case "FALSE_KEYWORD":
-                return SyntaxKind.FALSE_KEYWORD;
-            case "OPEN_BRACE_TOKEN":
-                return SyntaxKind.OPEN_BRACE_TOKEN;
-            case "CLOSE_BRACE_TOKEN":
-                return SyntaxKind.CLOSE_BRACE_TOKEN;
-            case "OPEN_BRACKET_TOKEN":
-                return SyntaxKind.OPEN_BRACKET_TOKEN;
-            case "CLOSE_BRACKET_TOKEN":
-                return SyntaxKind.CLOSE_BRACKET_TOKEN;
-            case "DOT_TOKEN":
-                return SyntaxKind.DOT_TOKEN;
-            case "COMMA_TOKEN":
-                return SyntaxKind.COMMA_TOKEN;
-            case "HASH_TOKEN":
-                return SyntaxKind.HASH_TOKEN;
-            case "DOUBLE_QUOTE_TOKEN":
-                return SyntaxKind.DOUBLE_QUOTE_TOKEN;
-            case "SINGLE_QUOTE_TOKEN":
-                return SyntaxKind.SINGLE_QUOTE_TOKEN;
-            case "TRIPLE_DOUBLE_QUOTE_TOKEN":
-                return SyntaxKind.TRIPLE_DOUBLE_QUOTE_TOKEN;
-            case "TRIPLE_SINGLE_QUOTE_TOKEN":
-                return SyntaxKind.TRIPLE_SINGLE_QUOTE_TOKEN;
-            case "EQUAL_TOKEN":
-                return SyntaxKind.EQUAL_TOKEN;
-            case "PLUS_TOKEN":
-                return SyntaxKind.PLUS_TOKEN;
-            case "MINUS_TOKEN":
-                return SyntaxKind.MINUS_TOKEN;
-            case "STRING_LITERAL_TOKEN":
-                return SyntaxKind.STRING_LITERAL_TOKEN;
-            case "IDENTIFIER_LITERAL":
-                return SyntaxKind.IDENTIFIER_LITERAL;
-            case "STRING_LITERAL":
-                return SyntaxKind.STRING_LITERAL;
-            case "LITERAL_STRING":
-                return SyntaxKind.LITERAL_STRING;
-            case "WHITESPACE_MINUTIAE":
-                return SyntaxKind.WHITESPACE_MINUTIAE;
-            case "END_OF_LINE_MINUTIAE":
-                return SyntaxKind.END_OF_LINE_MINUTIAE;
-            case "COMMENT_MINUTIAE":
-                return SyntaxKind.COMMENT_MINUTIAE;
-            case "INVALID_NODE_MINUTIAE":
-                return SyntaxKind.INVALID_NODE_MINUTIAE;
-            case "INVALID_TOKEN":
-                return SyntaxKind.INVALID_TOKEN;
-            case "INVALID_TOKEN_MINUTIAE_NODE":
-                return SyntaxKind.INVALID_TOKEN_MINUTIAE_NODE;
-            case "MARKDOWN_DOCUMENTATION_LINE":
-                return SyntaxKind.MARKDOWN_DOCUMENTATION_LINE;
-            case "TABLE":
-                return SyntaxKind.TABLE;
-            case "KEY_VALUE":
-                return SyntaxKind.KEY_VALUE;
-            case "TABLE_ARRAY":
-                return SyntaxKind.TABLE_ARRAY;
-            case "KEY":
-                return SyntaxKind.KEY;
-            case "DEC_INT":
-                return SyntaxKind.DEC_INT;
-            case "HEX_INT":
-                return SyntaxKind.HEX_INT;
-            case "OCT_INT":
-                return SyntaxKind.OCT_INT;
-            case "BINARY_INT":
-                return SyntaxKind.BINARY_INT;
-            case "FLOAT":
-                return SyntaxKind.FLOAT;
-            case "INF_TOKEN":
-                return SyntaxKind.INF_TOKEN;
-            case "NAN_TOKEN":
-                return SyntaxKind.NAN_TOKEN;
-            case "ML_STRING_LITERAL":
-                return SyntaxKind.ML_STRING_LITERAL;
-            case "DECIMAL_INT_TOKEN":
-                return SyntaxKind.DECIMAL_INT_TOKEN;
-            case "DECIMAL_FLOAT_TOKEN":
-                return SyntaxKind.DECIMAL_FLOAT_TOKEN;
-            case "HEX_INTEGER_LITERAL_TOKEN":
-                return SyntaxKind.HEX_INTEGER_LITERAL_TOKEN;
-            case "OCTAL_INTEGER_LITERAL_TOKEN":
-                return SyntaxKind.OCTAL_INTEGER_LITERAL_TOKEN;
-            case "BINARY_INTEGER_LITERAL_TOKEN":
-                return SyntaxKind.BINARY_INTEGER_LITERAL_TOKEN;
-            case "BOOLEAN":
-                return SyntaxKind.BOOLEAN;
-            case "OFFSET_DATE_TIME":
-                return SyntaxKind.OFFSET_DATE_TIME;
-            case "LOCAL_DATE_TIME":
-                return SyntaxKind.LOCAL_DATE_TIME;
-            case "LOCAL_DATE":
-                return SyntaxKind.LOCAL_DATE;
-            case "LOCAL_TIME":
-                return SyntaxKind.LOCAL_TIME;
-            case "ARRAY":
-                return SyntaxKind.ARRAY;
-            case "INVALID":
-                return SyntaxKind.INVALID;
-            case "MODULE_PART":
-                return SyntaxKind.MODULE_PART;
-            case "EOF_TOKEN":
-                return SyntaxKind.EOF_TOKEN;
-            case "LIST":
-                return SyntaxKind.LIST;
-            case "NONE":
-                return SyntaxKind.NONE;
-        }
-        return null;
+        return switch (kind) {
+            case "INLINE_TABLE" -> SyntaxKind.INLINE_TABLE;
+            case "NEW_LINE" -> SyntaxKind.NEWLINE;
+            case "TRUE_KEYWORD" -> SyntaxKind.TRUE_KEYWORD;
+            case "FALSE_KEYWORD" -> SyntaxKind.FALSE_KEYWORD;
+            case "OPEN_BRACE_TOKEN" -> SyntaxKind.OPEN_BRACE_TOKEN;
+            case "CLOSE_BRACE_TOKEN" -> SyntaxKind.CLOSE_BRACE_TOKEN;
+            case "OPEN_BRACKET_TOKEN" -> SyntaxKind.OPEN_BRACKET_TOKEN;
+            case "CLOSE_BRACKET_TOKEN" -> SyntaxKind.CLOSE_BRACKET_TOKEN;
+            case "DOT_TOKEN" -> SyntaxKind.DOT_TOKEN;
+            case "COMMA_TOKEN" -> SyntaxKind.COMMA_TOKEN;
+            case "HASH_TOKEN" -> SyntaxKind.HASH_TOKEN;
+            case "DOUBLE_QUOTE_TOKEN" -> SyntaxKind.DOUBLE_QUOTE_TOKEN;
+            case "SINGLE_QUOTE_TOKEN" -> SyntaxKind.SINGLE_QUOTE_TOKEN;
+            case "TRIPLE_DOUBLE_QUOTE_TOKEN" -> SyntaxKind.TRIPLE_DOUBLE_QUOTE_TOKEN;
+            case "TRIPLE_SINGLE_QUOTE_TOKEN" -> SyntaxKind.TRIPLE_SINGLE_QUOTE_TOKEN;
+            case "EQUAL_TOKEN" -> SyntaxKind.EQUAL_TOKEN;
+            case "PLUS_TOKEN" -> SyntaxKind.PLUS_TOKEN;
+            case "MINUS_TOKEN" -> SyntaxKind.MINUS_TOKEN;
+            case "STRING_LITERAL_TOKEN" -> SyntaxKind.STRING_LITERAL_TOKEN;
+            case "IDENTIFIER_LITERAL" -> SyntaxKind.IDENTIFIER_LITERAL;
+            case "STRING_LITERAL" -> SyntaxKind.STRING_LITERAL;
+            case "LITERAL_STRING" -> SyntaxKind.LITERAL_STRING;
+            case "WHITESPACE_MINUTIAE" -> SyntaxKind.WHITESPACE_MINUTIAE;
+            case "END_OF_LINE_MINUTIAE" -> SyntaxKind.END_OF_LINE_MINUTIAE;
+            case "COMMENT_MINUTIAE" -> SyntaxKind.COMMENT_MINUTIAE;
+            case "INVALID_NODE_MINUTIAE" -> SyntaxKind.INVALID_NODE_MINUTIAE;
+            case "INVALID_TOKEN" -> SyntaxKind.INVALID_TOKEN;
+            case "INVALID_TOKEN_MINUTIAE_NODE" -> SyntaxKind.INVALID_TOKEN_MINUTIAE_NODE;
+            case "MARKDOWN_DOCUMENTATION_LINE" -> SyntaxKind.MARKDOWN_DOCUMENTATION_LINE;
+            case "TABLE" -> SyntaxKind.TABLE;
+            case "KEY_VALUE" -> SyntaxKind.KEY_VALUE;
+            case "TABLE_ARRAY" -> SyntaxKind.TABLE_ARRAY;
+            case "KEY" -> SyntaxKind.KEY;
+            case "DEC_INT" -> SyntaxKind.DEC_INT;
+            case "HEX_INT" -> SyntaxKind.HEX_INT;
+            case "OCT_INT" -> SyntaxKind.OCT_INT;
+            case "BINARY_INT" -> SyntaxKind.BINARY_INT;
+            case "FLOAT" -> SyntaxKind.FLOAT;
+            case "INF_TOKEN" -> SyntaxKind.INF_TOKEN;
+            case "NAN_TOKEN" -> SyntaxKind.NAN_TOKEN;
+            case "ML_STRING_LITERAL" -> SyntaxKind.ML_STRING_LITERAL;
+            case "DECIMAL_INT_TOKEN" -> SyntaxKind.DECIMAL_INT_TOKEN;
+            case "DECIMAL_FLOAT_TOKEN" -> SyntaxKind.DECIMAL_FLOAT_TOKEN;
+            case "HEX_INTEGER_LITERAL_TOKEN" -> SyntaxKind.HEX_INTEGER_LITERAL_TOKEN;
+            case "OCTAL_INTEGER_LITERAL_TOKEN" -> SyntaxKind.OCTAL_INTEGER_LITERAL_TOKEN;
+            case "BINARY_INTEGER_LITERAL_TOKEN" -> SyntaxKind.BINARY_INTEGER_LITERAL_TOKEN;
+            case "BOOLEAN" -> SyntaxKind.BOOLEAN;
+            case "OFFSET_DATE_TIME" -> SyntaxKind.OFFSET_DATE_TIME;
+            case "LOCAL_DATE_TIME" -> SyntaxKind.LOCAL_DATE_TIME;
+            case "LOCAL_DATE" -> SyntaxKind.LOCAL_DATE;
+            case "LOCAL_TIME" -> SyntaxKind.LOCAL_TIME;
+            case "ARRAY" -> SyntaxKind.ARRAY;
+            case "INVALID" -> SyntaxKind.INVALID;
+            case "MODULE_PART" -> SyntaxKind.MODULE_PART;
+            case "EOF_TOKEN" -> SyntaxKind.EOF_TOKEN;
+            case "LIST" -> SyntaxKind.LIST;
+            case "NONE" -> SyntaxKind.NONE;
+            default -> null;
+        };
     }
 
     public static void assertLineRange(LineRange lineRange, int startLine, int startOffset, int endLine,

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -285,20 +285,12 @@ public class SymbolAtCursorTest {
         assertEquals(symbol.get().kind(), symbolKind);
         assertEquals(symbol.get().getName().get(), name);
 
-        TypeSymbol type;
-        switch (symbolKind) {
-            case RECORD_FIELD:
-                type = ((RecordFieldSymbol) symbol.get()).typeDescriptor();
-                break;
-            case OBJECT_FIELD:
-                type = ((ObjectFieldSymbol) symbol.get()).typeDescriptor();
-                break;
-            case VARIABLE:
-                type = ((VariableSymbol) symbol.get()).typeDescriptor();
-                break;
-            default:
-                throw new IllegalStateException("Unexpected symbol kind: " + symbolKind);
-        }
+        TypeSymbol type = switch (symbolKind) {
+            case RECORD_FIELD -> ((RecordFieldSymbol) symbol.get()).typeDescriptor();
+            case OBJECT_FIELD -> ((ObjectFieldSymbol) symbol.get()).typeDescriptor();
+            case VARIABLE -> ((VariableSymbol) symbol.get()).typeDescriptor();
+            default -> throw new IllegalStateException("Unexpected symbol kind: " + symbolKind);
+        };
 
         assertEquals(type.typeKind(), TYPE_REFERENCE);
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
@@ -122,16 +122,11 @@ public class SymbolEquivalenceTest {
     public void testTypedescriptors(List<LinePosition> positions) {
         List<TypeSymbol> types = positions.stream()
                 .map(pos -> typesModel.symbol(typesSrcFile, pos).get())
-                .map(s -> {
-                    switch (s.kind()) {
-                        case RECORD_FIELD:
-                            return ((RecordFieldSymbol) s).typeDescriptor();
-                        case PARAMETER:
-                            return ((ParameterSymbol) s).typeDescriptor();
-                        case VARIABLE:
-                            return ((VariableSymbol) s).typeDescriptor();
-                    }
-                    throw new AssertionError("Unexpected symbol kind: " + s.kind());
+                .map(s -> switch (s.kind()) {
+                    case RECORD_FIELD -> ((RecordFieldSymbol) s).typeDescriptor();
+                    case PARAMETER -> ((ParameterSymbol) s).typeDescriptor();
+                    case VARIABLE -> ((VariableSymbol) s).typeDescriptor();
+                    default -> throw new AssertionError("Unexpected symbol kind: " + s.kind());
                 })
                 .collect(Collectors.toList());
         assertTypeSymbols(types);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypesTest.java
@@ -316,17 +316,12 @@ public class TypesTest {
     }
 
     private Optional<TypeSymbol> getTypeSymbolOfTypeDef(Symbol symbol) {
-        switch (symbol.kind()) {
-            case TYPE_DEFINITION:
-                return Optional.of(((TypeDefinitionSymbol) symbol).typeDescriptor());
-            case CONSTANT:
-            case ENUM_MEMBER:
-                return Optional.of(((ConstantSymbol) symbol).typeDescriptor());
-            case ENUM:
-                return Optional.of(((EnumSymbol) symbol).typeDescriptor());
-            case CLASS:
-                return Optional.of((ClassSymbol) symbol);
-        }
-        return Optional.empty();
+        return switch (symbol.kind()) {
+            case TYPE_DEFINITION -> Optional.of(((TypeDefinitionSymbol) symbol).typeDescriptor());
+            case CONSTANT, ENUM_MEMBER -> Optional.of(((ConstantSymbol) symbol).typeDescriptor());
+            case ENUM -> Optional.of(((EnumSymbol) symbol).typeDescriptor());
+            case CLASS -> Optional.of((ClassSymbol) symbol);
+            default -> Optional.empty();
+        };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByMiscExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByMiscExprTest.java
@@ -66,26 +66,12 @@ public class TypeByMiscExprTest extends TypeByNodeTest {
 
             @Override
             public void visit(BinaryExpressionNode binaryExpressionNode) {
-                TypeDescKind typeKind;
-                switch (OperatorKind.valueFrom(binaryExpressionNode.operator().text())) {
-                    case SUB:
-                    case MUL:
-                    case ADD:
-                    case DIV:
-                        typeKind = INT;
-                        break;
-                    case GREATER_EQUAL:
-                    case NOT_EQUAL:
-                    case EQUAL:
-                    case AND:
-                        typeKind = BOOLEAN;
-                        break;
-                    case CLOSED_RANGE:
-                        typeKind = OBJECT;
-                        break;
-                    default:
-                        throw new IllegalStateException();
-                }
+                TypeDescKind typeKind = switch (OperatorKind.valueFrom(binaryExpressionNode.operator().text())) {
+                    case SUB, MUL, ADD, DIV -> INT;
+                    case GREATER_EQUAL, NOT_EQUAL, EQUAL, AND -> BOOLEAN;
+                    case CLOSED_RANGE -> OBJECT;
+                    default -> throw new IllegalStateException();
+                };
 
                 assertType(binaryExpressionNode, model, typeKind);
                 binaryExpressionNode.rhsExpr().accept(this);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByReferenceTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByReferenceTest.java
@@ -64,17 +64,11 @@ public class TypeByReferenceTest extends TypeByNodeTest {
 
             @Override
             public void visit(BuiltinSimpleNameReferenceNode builtinSimpleNameReferenceNode) {
-                TypeDescKind typeKind;
-                switch (builtinSimpleNameReferenceNode.kind()) {
-                    case FLOAT_TYPE_DESC:
-                        typeKind = FLOAT;
-                        break;
-                    case INT_TYPE_DESC:
-                        typeKind = INT;
-                        break;
-                    default:
-                        throw new IllegalStateException();
-                }
+                TypeDescKind typeKind = switch (builtinSimpleNameReferenceNode.kind()) {
+                    case FLOAT_TYPE_DESC -> FLOAT;
+                    case INT_TYPE_DESC -> INT;
+                    default -> throw new IllegalStateException();
+                };
                 assertType(builtinSimpleNameReferenceNode, model, typeKind);
             }
         };

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByTemplateExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByTemplateExprTest.java
@@ -56,20 +56,11 @@ public class TypeByTemplateExprTest extends TypeByNodeTest {
 
             @Override
             public void visit(TemplateExpressionNode templateExpressionNode) {
-                TypeDescKind expTypeKind;
-                switch (templateExpressionNode.kind()) {
-                    case STRING_TEMPLATE_EXPRESSION:
-                        expTypeKind = STRING;
-                        break;
-                    case XML_TEMPLATE_EXPRESSION:
-                        expTypeKind = TYPE_REFERENCE;
-                        break;
-                    case RAW_TEMPLATE_EXPRESSION:
-                        expTypeKind = TYPE_REFERENCE;
-                        break;
-                    default:
-                        throw new IllegalStateException();
-                }
+                TypeDescKind expTypeKind = switch (templateExpressionNode.kind()) {
+                    case STRING_TEMPLATE_EXPRESSION -> STRING;
+                    case XML_TEMPLATE_EXPRESSION, RAW_TEMPLATE_EXPRESSION -> TYPE_REFERENCE;
+                    default -> throw new IllegalStateException();
+                };
 
                 assertType(templateExpressionNode, model, expTypeKind, templateExpressionNode.kind());
             }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByMiscExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByMiscExprTest.java
@@ -66,26 +66,12 @@ public class TypeByMiscExprTest extends TypeByNodeTest {
 
             @Override
             public void visit(BinaryExpressionNode binaryExpressionNode) {
-                TypeDescKind typeKind;
-                switch (OperatorKind.valueFrom(binaryExpressionNode.operator().text())) {
-                    case SUB:
-                    case MUL:
-                    case ADD:
-                    case DIV:
-                        typeKind = INT;
-                        break;
-                    case GREATER_EQUAL:
-                    case NOT_EQUAL:
-                    case EQUAL:
-                    case AND:
-                        typeKind = BOOLEAN;
-                        break;
-                    case CLOSED_RANGE:
-                        typeKind = OBJECT;
-                        break;
-                    default:
-                        throw new IllegalStateException();
-                }
+                TypeDescKind typeKind = switch (OperatorKind.valueFrom(binaryExpressionNode.operator().text())) {
+                    case SUB, MUL, ADD, DIV -> INT;
+                    case GREATER_EQUAL, NOT_EQUAL, EQUAL, AND -> BOOLEAN;
+                    case CLOSED_RANGE -> OBJECT;
+                    default -> throw new IllegalStateException();
+                };
 
                 assertType(binaryExpressionNode, model, typeKind);
                 binaryExpressionNode.rhsExpr().accept(this);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByTemplateExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByTemplateExprTest.java
@@ -56,20 +56,11 @@ public class TypeByTemplateExprTest extends TypeByNodeTest {
 
             @Override
             public void visit(TemplateExpressionNode templateExpressionNode) {
-                TypeDescKind expTypeKind;
-                switch (templateExpressionNode.kind()) {
-                    case STRING_TEMPLATE_EXPRESSION:
-                        expTypeKind = STRING;
-                        break;
-                    case XML_TEMPLATE_EXPRESSION:
-                        expTypeKind = TYPE_REFERENCE;
-                        break;
-                    case RAW_TEMPLATE_EXPRESSION:
-                        expTypeKind = TYPE_REFERENCE;
-                        break;
-                    default:
-                        throw new IllegalStateException();
-                }
+                TypeDescKind expTypeKind = switch (templateExpressionNode.kind()) {
+                    case STRING_TEMPLATE_EXPRESSION -> STRING;
+                    case XML_TEMPLATE_EXPRESSION, RAW_TEMPLATE_EXPRESSION -> TYPE_REFERENCE;
+                    default -> throw new IllegalStateException();
+                };
 
                 assertType(templateExpressionNode, model, expTypeKind, templateExpressionNode.kind());
             }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
@@ -161,33 +161,23 @@ public class StaticMethods {
     }
 
     public static Object acceptIntUnionReturn(int flag) {
-        switch (flag) {
-            case 1:
-                return 25;
-            case 2:
-                return StringUtils.fromString("sample value return");
-            case 3:
-                return 54.88;
-            case 4:
-                return null;
-            case 5:
-                return ValueCreator.createMapValue(TypeCreator.createMapType(PredefinedTypes.TYPE_ANYDATA));
-            default:
-                return true;
-        }
+        return switch (flag) {
+            case 1 -> 25;
+            case 2 -> StringUtils.fromString("sample value return");
+            case 3 -> 54.88;
+            case 4 -> null;
+            case 5 -> ValueCreator.createMapValue(TypeCreator.createMapType(PredefinedTypes.TYPE_ANYDATA));
+            default -> true;
+        };
     }
 
     public static Object acceptIntAnyReturn(int flag) {
-        switch (flag) {
-            case 1:
-                return 25;
-            case 2:
-                return "sample value return";
-            case 3:
-                return 54.88;
-            default:
-                return true;
-        }
+        return switch (flag) {
+            case 1 -> 25;
+            case 2 -> "sample value return";
+            case 3 -> 54.88;
+            default -> true;
+        };
     }
 
     public static Object acceptNothingInvalidAnydataReturn() {
@@ -343,16 +333,12 @@ public class StaticMethods {
 
     public static Object acceptIntUnionReturnWhichThrowsCheckedException(int flag)
             throws JavaInteropTestCheckedException {
-        switch (flag) {
-            case 1:
-                return 25;
-            case 2:
-                return "sample value return";
-            case 3:
-                return 54.88;
-            default:
-                return true;
-        }
+        return switch (flag) {
+            case 1 -> 25;
+            case 2 -> "sample value return";
+            case 3 -> 54.88;
+            default -> true;
+        };
     }
 
     public static ObjectValue acceptObjectAndObjectReturnWhichThrowsCheckedException(ObjectValue p, int newVal)
@@ -605,17 +591,14 @@ public class StaticMethods {
     public static Object acceptAndReturnReadOnly(Object value) {
         Type type = TypeUtils.getImpliedType(TypeChecker.getType(value));
 
-        switch (type.getTag()) {
-            case TypeTags.INT_TAG:
-                return 100L;
-            case TypeTags.ARRAY_TAG:
-            case TypeTags.OBJECT_TYPE_TAG:
-                return value;
-            case TypeTags.RECORD_TYPE_TAG:
-            case TypeTags.MAP_TAG:
-                return ((MapValue) value).get(StringUtils.fromString("first"));
-        }
-        return StringUtils.fromString("other");
+        return switch (type.getTag()) {
+            case TypeTags.INT_TAG -> 100L;
+            case TypeTags.ARRAY_TAG,
+                 TypeTags.OBJECT_TYPE_TAG -> value;
+            case TypeTags.RECORD_TYPE_TAG,
+                 TypeTags.MAP_TAG -> ((MapValue) value).get(StringUtils.fromString("first"));
+            default -> StringUtils.fromString("other");
+        };
     }
 
     public static void getNilAsReadOnly() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
@@ -295,13 +295,11 @@ public class VariableReturnType {
     public static Object get(ObjectValue objectValue, BTypedesc td) {
         Type describingType = td.getDescribingType();
 
-        switch (describingType.getTag()) {
-            case INT_TAG:
-                return objectValue.getIntValue(StringUtils.fromString("a"));
-            case STRING_TAG:
-                return objectValue.getStringValue(StringUtils.fromString("b"));
-        }
-        return objectValue.get(StringUtils.fromString("c"));
+        return switch (describingType.getTag()) {
+            case INT_TAG -> objectValue.getIntValue(StringUtils.fromString("a"));
+            case STRING_TAG -> objectValue.getStringValue(StringUtils.fromString("b"));
+            default -> objectValue.get(StringUtils.fromString("c"));
+        };
     }
 
     public static Object getIntFieldOrDefault(ObjectValue objectValue, BTypedesc td) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeWithBValueAPITests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeWithBValueAPITests.java
@@ -305,16 +305,12 @@ public class RefTypeWithBValueAPITests {
     }
 
     public static Object acceptIntUnionReturn(int flag) {
-        switch (flag) {
-            case 1:
-                return 25;
-            case 2:
-                return StringUtils.fromString("sample value return");
-            case 3:
-                return 54.88;
-            default:
-                return true;
-        }
+        return switch (flag) {
+            case 1 -> 25;
+            case 2 -> StringUtils.fromString("sample value return");
+            case 3 -> 54.88;
+            default -> true;
+        };
     }
 
     public static BObject acceptObjectAndObjectReturn(BObject p, int newVal) {
@@ -339,16 +335,12 @@ public class RefTypeWithBValueAPITests {
 
     public static Object acceptIntUnionReturnWhichThrowsCheckedException(int flag)
             throws JavaInteropTestCheckedException {
-        switch (flag) {
-            case 1:
-                return 25;
-            case 2:
-                return "sample value return";
-            case 3:
-                return 54.88;
-            default:
-                return true;
-        }
+        return switch (flag) {
+            case 1 -> 25;
+            case 2 -> "sample value return";
+            case 3 -> 54.88;
+            default -> true;
+        };
     }
 
     public static BMap acceptRefTypesAndReturnMapWhichThrowsCheckedException(BObject a, BArray b, Object c, BError d,


### PR DESCRIPTION
## Purpose
Many existing switch statements are essentially simulations of switch expressions, where each arm either assigns to a common target variable or returns a value. Expressing this as a statement is roundabout, repetitive, and error-prone.

Java 14 added support for switch expressions, which provide more succinct and less error-prone version of switch.
See also: https://sonarcloud.io/organizations/ballerina-platform/rules?languages=java&open=java%3AS5194&q=switch+expression
Partly also fixes: https://sonarcloud.io/organizations/ballerina-platform/rules?open=java%3AS6208&rule_key=java%3AS6208


## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
