### PR TITLE
[1.2.x] Fix concurrent issue in observability

### DIFF
--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -27,9 +27,9 @@ import org.ballerinalang.jvm.observability.TracingUtils;
 import org.ballerinalang.jvm.observability.tracer.TracersStore;
 import org.ballerinalang.jvm.scheduling.Strand;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.ballerinalang.jvm.observability.ObservabilityConstants.CONFIG_TRACING_ENABLED;
@@ -139,7 +139,7 @@ public class OpenTracerBallerinaWrapper {
             return false;
         }
     }
-    
+
     /**
      * Method to add tags to an existing span.
      *

--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -43,7 +43,7 @@ public class OpenTracerBallerinaWrapper {
     private static OpenTracerBallerinaWrapper instance = new OpenTracerBallerinaWrapper();
     private TracersStore tracerStore;
     private final boolean enabled;
-    private Map<Long, ObserverContext> observerContextList = new HashMap<>();
+    private ConcurrentMap<Long, ObserverContext> observerContextList = new ConcurrentHashMap<>();
     private AtomicLong spanId = new AtomicLong();
     private static final int SYSTEM_TRACE_INDICATOR = -1;
 
@@ -126,7 +126,10 @@ public class OpenTracerBallerinaWrapper {
         if (!enabled) {
             return false;
         }
-        ObserverContext observerContext = observerContextList.get(spanId);
+        ObserverContext observerContext = null;
+        if (observerContextList.containsKey(spanId)) {
+            observerContext = observerContextList.get(spanId);
+        }
         if (observerContext != null) {
             if (observerContext.isSystemSpan()) {
                 ObserveUtils.setObserverContextToCurrentFrame(strand, observerContext.getParent());
@@ -153,7 +156,10 @@ public class OpenTracerBallerinaWrapper {
         if (!enabled) {
             return false;
         }
-        ObserverContext observerContext = observerContextList.get(spanId);
+        ObserverContext observerContext = null;
+        if (observerContextList.containsKey(spanId)) {
+            observerContext = observerContextList.get(spanId);
+        }
         if (spanId == -1) {
             Optional<ObserverContext> observer = ObserveUtils.getObserverContextOfCurrentFrame(strand);
             if (observer.isPresent()) {

--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -126,10 +126,7 @@ public class OpenTracerBallerinaWrapper {
         if (!enabled) {
             return false;
         }
-        ObserverContext observerContext = null;
-        if (observerContextList.containsKey(spanId)) {
-            observerContext = observerContextList.get(spanId);
-        }
+        ObserverContext observerContext = observerContextList.getOrDefault(spanId, null);
         if (observerContext != null) {
             if (observerContext.isSystemSpan()) {
                 ObserveUtils.setObserverContextToCurrentFrame(strand, observerContext.getParent());
@@ -156,10 +153,7 @@ public class OpenTracerBallerinaWrapper {
         if (!enabled) {
             return false;
         }
-        ObserverContext observerContext = null;
-        if (observerContextList.containsKey(spanId)) {
-            observerContext = observerContextList.get(spanId);
-        }
+        ObserverContext observerContext = observerContextList.getOrDefault(spanId, null);
         if (spanId == -1) {
             Optional<ObserverContext> observer = ObserveUtils.getObserverContextOfCurrentFrame(strand);
             if (observer.isPresent()) {

--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -27,6 +27,7 @@ import org.ballerinalang.jvm.observability.TracingUtils;
 import org.ballerinalang.jvm.observability.tracer.TracersStore;
 import org.ballerinalang.jvm.scheduling.Strand;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;

--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -126,7 +126,7 @@ public class OpenTracerBallerinaWrapper {
         if (!enabled) {
             return false;
         }
-        ObserverContext observerContext = observerContextList.getOrDefault(spanId, null);
+        ObserverContext observerContext = observerContextList.get(spanId);
         if (observerContext != null) {
             if (observerContext.isSystemSpan()) {
                 ObserveUtils.setObserverContextToCurrentFrame(strand, observerContext.getParent());
@@ -153,7 +153,7 @@ public class OpenTracerBallerinaWrapper {
         if (!enabled) {
             return false;
         }
-        ObserverContext observerContext = observerContextList.getOrDefault(spanId, null);
+        ObserverContext observerContext = observerContextList.get(spanId);
         if (spanId == -1) {
             Optional<ObserverContext> observer = ObserveUtils.getObserverContextOfCurrentFrame(strand);
             if (observer.isPresent()) {


### PR DESCRIPTION
## Purpose
Due to high throughput of inprogress requests, we have been notified that the `http_inprogress_requests_value` metric value is higher than the expected value. 

There is a observer context list (HashMap) which contains the observer contexts with span IDs as keys. since it is updated with multiple threads concurrently, it resulted in incorrect calculations of new array sizes, including negative sizes for the HashMap. 

Therefore HashMap has been replaced with ConcurrentHashMap which is a thread-safe implementation. With this approach, multiple threads can access it simultaneously without any synchronization issues.

Fixes https://github.com/wso2-enterprise/internal-support-ballerina/issues/679

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
