### PR TITLE
Fix windows build (fixup)

### DIFF
--- a/.github/workflows/push_master.yml
+++ b/.github/workflows/push_master.yml
@@ -35,6 +35,15 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ github.sha }}
           restore-keys: ${{ runner.os }}-gradle
 
+      - name: Setup GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '17.0.7'
+          distribution: 'graalvm'
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          set-java-home: 'false'
+
       - name: Build with Gradle
         run: |
           export DISPLAY=':99.0'

--- a/.github/workflows/push_master.yml
+++ b/.github/workflows/push_master.yml
@@ -61,7 +61,7 @@ jobs:
           java-version: '17.0.7'
 
       - name: configure Pagefile
-        uses: al-cheb/configure-pagefile-action@1.4
+        uses: al-cheb/configure-pagefile-action@v1.4
         with:
           minimum-size: 8GB
           maximum-size: 16GB


### PR DESCRIPTION
## Purpose
In my PR #42797 I unfortunately broke the `push_master.yml` pipeline for the ubuntu and windows build.
This PR should resolve this via two changes:
- Fix al-cheb/configure-pagefile-action version in the `push_master` pipeline from `1.4` to `v1.4`
- Setup GraalVM also in the `push_master` pipeline. Some tests that test the GraalVM image generation were not executed before, since a previous test would call `Runtime.getRuntime().exit(0);` and would cancel all remaining tests. See also [here](https://github.com/ballerina-platform/ballerina-lang/pull/42797#discussion_r1616194603)

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
