### PR TITLE
[Refactoring] Mark fields as final if they are not reassigned

### DIFF
--- a/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/handlers/help/BbeRecord.java
+++ b/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/handlers/help/BbeRecord.java
@@ -23,11 +23,11 @@ package io.ballerina.shell.cli.handlers.help;
  */
 public class BbeRecord {
 
-    private String name;
-    private String url;
-    private String verifyBuild;
-    private String verifyOutput;
-    private String isLearnByExample;
+    private final String name;
+    private final String url;
+    private final String verifyBuild;
+    private final String verifyOutput;
+    private final String isLearnByExample;
 
     public BbeRecord(String name, String url, String verifyBuild, String verifyOutput, String isLearnByExample) {
         this.name = name;

--- a/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/handlers/help/BbeTitle.java
+++ b/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/handlers/help/BbeTitle.java
@@ -25,10 +25,10 @@ import java.util.Arrays;
  */
 public class BbeTitle {
 
-    private String title;
-    private String column;
-    private String category;
-    private BbeRecord[] samples;
+    private final String title;
+    private final String column;
+    private final String category;
+    private final BbeRecord[] samples;
 
     public BbeTitle(String title, String column, String category, BbeRecord[] samples) {
         this.title = title;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BLock.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BLock.java
@@ -29,9 +29,9 @@ import java.util.ArrayDeque;
  */
 public class BLock {
 
-    private ArrayDeque<Strand> current;
+    private final ArrayDeque<Strand> current;
 
-    private ArrayDeque<Strand> waitingForLock;
+    private final ArrayDeque<Strand> waitingForLock;
 
     public BLock() {
         this.current = new ArrayDeque<>();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BLockStore.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BLockStore.java
@@ -34,7 +34,7 @@ public class BLockStore {
     /**
      * The map of locks inferred.
      */
-    private  Map<String, BLock> globalLockMap;
+    private final Map<String, BLock> globalLockMap;
 
     public BLockStore() {
         globalLockMap = new ConcurrentHashMap<>();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonGenerator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonGenerator.java
@@ -54,15 +54,15 @@ public class JsonGenerator implements Closeable {
 
     private boolean fieldActive;
 
-    private static final boolean[] escChars = new boolean[93];
+    private static final boolean[] ESC_CHARS = new boolean[93];
 
     static {
-        escChars['"'] = true;
-        escChars['\\'] = true;
-        escChars['\b'] = true;
-        escChars['\n'] = true;
-        escChars['\r'] = true;
-        escChars['\t'] = true;
+        ESC_CHARS['"'] = true;
+        ESC_CHARS['\\'] = true;
+        ESC_CHARS['\b'] = true;
+        ESC_CHARS['\n'] = true;
+        ESC_CHARS['\r'] = true;
+        ESC_CHARS['\t'] = true;
     }
 
     public JsonGenerator(OutputStream out) {
@@ -159,7 +159,7 @@ public class JsonGenerator implements Closeable {
         char[] chs = value.toCharArray();
         for (int i = 0; i < count; i++) {
             ch = chs[i];
-            if (ch < escChars.length && escChars[ch]) {
+            if (ch < ESC_CHARS.length && ESC_CHARS[ch]) {
                 escaped = true;
                 break;
             }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonGenerator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonGenerator.java
@@ -46,7 +46,7 @@ public class JsonGenerator implements Closeable {
 
     private static final int DEFAULT_DEPTH = 10;
 
-    private Writer writer;
+    private final Writer writer;
 
     private boolean[] levelInit = new boolean[DEFAULT_DEPTH];
 
@@ -54,7 +54,7 @@ public class JsonGenerator implements Closeable {
 
     private boolean fieldActive;
 
-    private static boolean[] escChars = new boolean[93];
+    private static final boolean[] escChars = new boolean[93];
 
     static {
         escChars['"'] = true;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableJsonDataSource.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableJsonDataSource.java
@@ -47,8 +47,8 @@ import java.util.Map;
  */
 public class TableJsonDataSource implements JsonDataSource {
 
-    private BTable<?, ?> tableValue;
-    private JSONObjectGenerator objGen;
+    private final BTable<?, ?> tableValue;
+    private final JSONObjectGenerator objGen;
 
     public TableJsonDataSource(BTable<?, ?> tableValue) {
         this(tableValue, new DefaultJSONObjectGenerator());

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableOmDataSource.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableOmDataSource.java
@@ -51,9 +51,9 @@ public class TableOmDataSource extends AbstractPushOMDataSource {
     private static final String DEFAULT_ROOT_WRAPPER = "results";
     private static final String DEFAULT_ROW_WRAPPER = "result";
 
-    private TableValueImpl<?, ?> table;
-    private String rootWrapper;
-    private String rowWrapper;
+    private final TableValueImpl<?, ?> table;
+    private final String rootWrapper;
+    private final String rowWrapper;
 
     public TableOmDataSource(TableValueImpl<?, ?> table, String rootWrapper, String rowWrapper) {
         this.table = table;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/XmlTreeBuilder.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/XmlTreeBuilder.java
@@ -63,11 +63,11 @@ import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 public class XmlTreeBuilder {
 
     // XMLInputFactory2
-    private static final XMLInputFactory xmlInputFactory;
+    private static final XMLInputFactory XML_INPUT_FACTORY;
 
     static {
-        xmlInputFactory = XMLInputFactory.newInstance();
-        xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        XML_INPUT_FACTORY = XMLInputFactory.newInstance();
+        XML_INPUT_FACTORY.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
     }
 
     private XMLStreamReader xmlStreamReader;
@@ -89,7 +89,7 @@ public class XmlTreeBuilder {
         seqDeque.push(new XmlSequence(siblings));
 
         try {
-            xmlStreamReader = xmlInputFactory.createXMLStreamReader(stringReader);
+            xmlStreamReader = XML_INPUT_FACTORY.createXMLStreamReader(stringReader);
         } catch (XMLStreamException e) {
             handleXMLStreamException(e);
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/XmlTreeBuilder.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/XmlTreeBuilder.java
@@ -71,9 +71,9 @@ public class XmlTreeBuilder {
     }
 
     private XMLStreamReader xmlStreamReader;
-    private Map<String, String> namespaces; // xml ns declarations from Bal source [xmlns "http://ns.com" as ns]
-    private Deque<BXmlSequence> seqDeque;
-    private Deque<List<BXml>> siblingDeque;
+    private final Map<String, String> namespaces; // xml ns declarations from Bal source [xmlns "http://ns.com" as ns]
+    private final Deque<BXmlSequence> seqDeque;
+    private final Deque<List<BXml>> siblingDeque;
 
     public XmlTreeBuilder(String str) {
         this(new StringReader(str));

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/exceptions/ConfigException.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/exceptions/ConfigException.java
@@ -27,9 +27,9 @@ import io.ballerina.runtime.internal.errors.ErrorCodes;
  */
 public class ConfigException extends RuntimeException {
 
-    private ErrorCodes errorCode;
+    private final ErrorCodes errorCode;
 
-    private Object[] args;
+    private final Object[] args;
 
     public ConfigException(ErrorCodes errorCode, Object... args) {
         this.errorCode = errorCode;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/diagnostics/RuntimeDiagnostic.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/diagnostics/RuntimeDiagnostic.java
@@ -35,9 +35,9 @@ public class RuntimeDiagnostic extends Diagnostic {
 
     private final DiagnosticInfo diagnosticInfo;
 
-    private Object[] args;
+    private final Object[] args;
 
-    private RuntimeDiagnosticLocation location;
+    private final RuntimeDiagnosticLocation location;
 
     public RuntimeDiagnostic(DiagnosticInfo diagnosticInfo, String location, Object[] args) {
         this.diagnosticInfo = diagnosticInfo;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/diagnostics/RuntimeDiagnosticLocation.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/diagnostics/RuntimeDiagnosticLocation.java
@@ -28,7 +28,7 @@ import io.ballerina.tools.text.TextRange;
  */
 public class RuntimeDiagnosticLocation implements Location {
 
-    private String location;
+    private final String location;
 
     public RuntimeDiagnosticLocation(String location) {
         this.location = location;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/diagnostics/RuntimeDiagnosticLog.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/diagnostics/RuntimeDiagnosticLog.java
@@ -32,7 +32,7 @@ import java.util.List;
  */
 public class RuntimeDiagnosticLog {
 
-    private List<RuntimeDiagnostic> diagnosticList = new LinkedList<>();
+    private final List<RuntimeDiagnostic> diagnosticList = new LinkedList<>();
 
     private int errorCount = 0;
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/CharReader.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/CharReader.java
@@ -27,9 +27,9 @@ import java.util.Arrays;
  */
 public class CharReader {
 
-    private char[] charBuffer;
+    private final char[] charBuffer;
     private int offset = 0;
-    private int charBufferLength;
+    private final int charBufferLength;
 
     private int lexemeStartPos;
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TokenReader.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TokenReader.java
@@ -28,7 +28,7 @@ public class TokenReader {
     private static final int BUFFER_SIZE = 20;
 
     private final TreeTraverser treeTraverser;
-    private TokenBuffer tokensAhead = new TokenBuffer(BUFFER_SIZE);
+    private final TokenBuffer tokensAhead = new TokenBuffer(BUFFER_SIZE);
 
     public TokenReader(TreeTraverser treeTraverser) {
         this.treeTraverser = treeTraverser;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TreeTraverser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TreeTraverser.java
@@ -30,9 +30,9 @@ import java.util.ArrayDeque;
  */
 public class TreeTraverser {
 
-    private CharReader reader;
+    private final CharReader reader;
     private ParserMode mode;
-    private ArrayDeque<ParserMode> modeStack = new ArrayDeque<>();
+    private final ArrayDeque<ParserMode> modeStack = new ArrayDeque<>();
 
     public TreeTraverser(CharReader charReader) {
         this.reader = charReader;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/AsyncFunctionCallback.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/AsyncFunctionCallback.java
@@ -30,7 +30,7 @@ import io.ballerina.runtime.internal.values.FutureValue;
 public abstract class AsyncFunctionCallback implements Callback {
 
     private FutureValue future;
-    private Strand strand;
+    private final Strand strand;
 
     public AsyncFunctionCallback(Strand strand) {
         this.strand = strand;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/Scheduler.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/Scheduler.java
@@ -72,7 +72,7 @@ public class Scheduler {
 
     private final AtomicInteger totalStrands = new AtomicInteger();
 
-    private static String poolSizeConf = System.getenv(RuntimeConstants.BALLERINA_MAX_POOL_SIZE_ENV_VAR);
+    private static final String poolSizeConf = System.getenv(RuntimeConstants.BALLERINA_MAX_POOL_SIZE_ENV_VAR);
 
     /**
      * This can be changed by setting the BALLERINA_MAX_POOL_SIZE system variable.
@@ -84,7 +84,7 @@ public class Scheduler {
 
     private Semaphore mainBlockSem;
     private final RuntimeRegistry runtimeRegistry;
-    private AtomicReference<ItemGroup> objectGroup = new AtomicReference<>();
+    private final AtomicReference<ItemGroup> objectGroup = new AtomicReference<>();
     private static Strand daemonStrand = null;
 
     public static void setDaemonStrand(Strand strand) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/SchedulerItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/SchedulerItem.java
@@ -29,8 +29,8 @@ import java.util.function.Function;
  * @since 0.995.0
  */
 class SchedulerItem {
-    private Function<Object[], ?> function;
-    private Object[] params;
+    private final Function<Object[], ?> function;
+    private final Object[] params;
     final FutureValue future;
     boolean parked;
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BFiniteType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BFiniteType.java
@@ -39,8 +39,8 @@ import static io.ballerina.runtime.api.utils.TypeUtils.getType;
 public class BFiniteType extends BType implements FiniteType {
 
     public Set<Object> valueSpace;
-    private int typeFlags;
-    private String originalName;
+    private final int typeFlags;
+    private final String originalName;
 
     public BFiniteType(String typeName) {
         this(typeName, new LinkedHashSet<>(), 0);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BParameterizedType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BParameterizedType.java
@@ -29,8 +29,8 @@ import io.ballerina.runtime.api.types.Type;
  */
 public class BParameterizedType extends BType implements ParameterizedType {
 
-    private Type paramValueType;
-    private int paramIndex;
+    private final Type paramValueType;
+    private final int paramIndex;
 
     public BParameterizedType(Type paramValueType, int paramIndex) {
         super(null, null, null);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BStreamType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BStreamType.java
@@ -35,8 +35,8 @@ import java.util.Objects;
  */
 public class BStreamType extends BType implements StreamType {
 
-    private Type constraint;
-    private Type completionType;
+    private final Type constraint;
+    private final Type completionType;
 
     /**
      * Creates a {@link BStreamType} which represents the stream type.

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/HandleValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/HandleValue.java
@@ -37,7 +37,7 @@ import java.util.Map;
  */
 public class HandleValue implements BHandle, RefValue {
 
-    private Object value;
+    private final Object value;
     private BTypedesc typedesc;
 
     public HandleValue(Object value) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/RegExpCharSetRange.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/RegExpCharSetRange.java
@@ -31,7 +31,7 @@ import io.ballerina.runtime.api.values.BLink;
  */
 public class RegExpCharSetRange extends RegExpCommonValue {
     private String lhsCharSetAtom;
-    private String dash;
+    private final String dash;
     private String rhsCharSetAom;
 
     public RegExpCharSetRange(String lhsCharSetAtom, String dash, String rhsCharSetAom) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/RegExpCharacterClass.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/RegExpCharacterClass.java
@@ -31,7 +31,7 @@ import io.ballerina.runtime.api.values.BLink;
  */
 public class RegExpCharacterClass extends RegExpCommonValue implements RegExpAtom {
     private String characterClassStart;
-    private String negation;
+    private final String negation;
     private RegExpCharSet reCharSet;
     private String characterClassEnd;
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StreamValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StreamValue.java
@@ -42,11 +42,11 @@ import java.util.UUID;
 public class StreamValue implements RefValue, BStream {
 
     private BTypedesc typedesc;
-    private Type type;
-    private Type constraintType;
-    private Type completionType;
+    private final Type type;
+    private final Type constraintType;
+    private final Type completionType;
     private Type iteratorNextReturnType;
-    private BObject iteratorObj;
+    private final BObject iteratorObj;
 
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -89,16 +89,16 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
     private Type type;
     private TableType tableType;
     private Type iteratorNextReturnType;
-    private ConcurrentHashMap<Long, List<Map.Entry<K, V>>> entries;
-    private LinkedHashMap<Long, List<V>> values;
+    private final ConcurrentHashMap<Long, List<Map.Entry<K, V>>> entries;
+    private final LinkedHashMap<Long, List<V>> values;
     private String[] fieldNames;
     private ValueHolder valueHolder;
     private long maxIntKey = 0;
 
     //These are required to achieve the iterator behavior
-    private Map<Long, K> indexToKeyMap;
-    private Map<K, Long> keyToIndexMap;
-    private Map<K, V> keyValues;
+    private final Map<Long, K> indexToKeyMap;
+    private final Map<K, Long> keyToIndexMap;
+    private final Map<K, V> keyValues;
     private long noOfAddedEntries = 0;
 
     private boolean nextKeySupported;
@@ -594,7 +594,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
     }
 
     private class KeyHashValueHolder extends ValueHolder {
-        private DefaultKeyWrapper keyWrapper;
+        private final DefaultKeyWrapper keyWrapper;
         private Type keyType;
 
         public KeyHashValueHolder() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
@@ -71,9 +71,9 @@ public final class XmlItem extends XmlValue implements BXmlItem {
 
     private QName name;
     private XmlSequence children;
-    private AttributeMapValueImpl attributes;
+    private final AttributeMapValueImpl attributes;
     // Keep track of probable parents of xml element to detect probable cycles in xml.
-    private List<WeakReference<XmlItem>> probableParents;
+    private final List<WeakReference<XmlItem>> probableParents;
 
     public XmlItem(QName name, XmlSequence children, boolean readonly) {
         this.name = name;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlPi.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlPi.java
@@ -34,8 +34,8 @@ import java.util.Set;
  */
 public class XmlPi extends XmlNonElementItem {
 
-    private String data;
-    private String target;
+    private final String data;
+    private final String target;
 
     public XmlPi(String data, String target) {
         this.data = data;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
@@ -614,7 +614,7 @@ public final class XmlSequence extends XmlValue implements BXmlSequence {
     @Override
     public IteratorValue<BXml> getIterator() {
         return new IteratorValue<>() {
-            Iterator<BXml> iterator = children.iterator();
+            final Iterator<BXml> iterator = children.iterator();
 
             @Override
             public boolean hasNext() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlText.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlText.java
@@ -35,7 +35,7 @@ import java.util.Set;
  */
 public class XmlText extends XmlNonElementItem {
 
-    private String data;
+    private final String data;
 
     public XmlText(String data) {
         // data is the content of xml comment or text node

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/PolledGauge.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/PolledGauge.java
@@ -51,8 +51,8 @@ public interface PolledGauge extends Metric {
         // Expecting at least 10 tags
         private final Set<Tag> tags = new HashSet<>(10);
         private String description;
-        private T obj;
-        private ToDoubleFunction<T> valueFunction;
+        private final T obj;
+        private final ToDoubleFunction<T> valueFunction;
 
         private Builder(String name, T obj, ToDoubleFunction<T> valueFunction) {
             this.name = name;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/StatisticConfig.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/StatisticConfig.java
@@ -103,7 +103,7 @@ public class StatisticConfig {
      */
     public static class Builder {
 
-        private StatisticConfig config = new StatisticConfig();
+        private final StatisticConfig config = new StatisticConfig();
 
         /**
          * Percentiles to compute and publish. Percentile is in the domain [0,1].

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/BSpan.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/BSpan.java
@@ -53,8 +53,8 @@ public class BSpan {
     private static final MapType IMMUTABLE_STRING_MAP_TYPE = TypeCreator.createMapType(
             PredefinedTypes.TYPE_STRING, true);
 
-    private static PropagatingParentContextGetter getter = new PropagatingParentContextGetter();
-    private static PropagatingParentContextSetter setter = new PropagatingParentContextSetter();
+    private static final PropagatingParentContextGetter getter = new PropagatingParentContextGetter();
+    private static final PropagatingParentContextSetter setter = new PropagatingParentContextSetter();
 
     static class PropagatingParentContextGetter implements TextMapGetter<Map<String, String>> {
         @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/BSpan.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/BSpan.java
@@ -53,8 +53,8 @@ public class BSpan {
     private static final MapType IMMUTABLE_STRING_MAP_TYPE = TypeCreator.createMapType(
             PredefinedTypes.TYPE_STRING, true);
 
-    private static final PropagatingParentContextGetter getter = new PropagatingParentContextGetter();
-    private static final PropagatingParentContextSetter setter = new PropagatingParentContextSetter();
+    private static final PropagatingParentContextGetter GETTER = new PropagatingParentContextGetter();
+    private static final PropagatingParentContextSetter SETTER = new PropagatingParentContextSetter();
 
     static class PropagatingParentContextGetter implements TextMapGetter<Map<String, String>> {
         @Override
@@ -137,7 +137,7 @@ public class BSpan {
 
         Tracer tracer = TracersStore.getInstance().getTracer(serviceName);
         Context parentContext = TracersStore.getInstance().getPropagators()
-                .getTextMapPropagator().extract(Context.current(), parentTraceContext, getter);
+                .getTextMapPropagator().extract(Context.current(), parentTraceContext, GETTER);
         return start(tracer, parentContext, operationName, isClient);
     }
 
@@ -165,7 +165,7 @@ public class BSpan {
         if (span != null) {
             carrierMap = new HashMap<>();
             TextMapPropagator propagator = TracersStore.getInstance().getPropagators().getTextMapPropagator();
-            propagator.inject(Context.current().with(span), carrierMap, setter);
+            propagator.inject(Context.current().with(span), carrierMap, SETTER);
         } else {
             carrierMap = Collections.emptyMap();
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionLocalContext.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionLocalContext.java
@@ -44,7 +44,7 @@ public class TransactionLocalContext {
     private Map<String, BallerinaTransactionContext> transactionContextStore;
     private final Deque<String> transactionBlockIdStack;
     private final Deque<TransactionFailure> transactionFailure;
-    private static final TransactionResourceManager transactionResourceManager =
+    private static final TransactionResourceManager TRANSACTION_RESOURCE_MANAGER =
             TransactionResourceManager.getInstance();
     private boolean isResourceParticipant;
     private Object rollbackOnlyError;
@@ -72,7 +72,7 @@ public class TransactionLocalContext {
         if (infoRecord == null) {
             return;
         }
-        transactionResourceManager.transactionInfoMap.put(transactionIdBytes, infoRecord);
+        TRANSACTION_RESOURCE_MANAGER.transactionInfoMap.put(transactionIdBytes, infoRecord);
     }
 
     public static TransactionLocalContext createTransactionParticipantLocalCtx(String globalTransactionId,
@@ -160,8 +160,8 @@ public class TransactionLocalContext {
 
     public void notifyAbortAndClearTransaction(String transactionBlockId) {
         transactionContextStore.clear();
-        transactionResourceManager.endXATransaction(globalTransactionId, transactionBlockId, true);
-        transactionResourceManager.notifyAbort(globalTransactionId, transactionBlockId);
+        TRANSACTION_RESOURCE_MANAGER.endXATransaction(globalTransactionId, transactionBlockId, true);
+        TRANSACTION_RESOURCE_MANAGER.notifyAbort(globalTransactionId, transactionBlockId);
     }
 
     public void setRollbackOnlyError(Object error) {
@@ -181,12 +181,12 @@ public class TransactionLocalContext {
     }
 
     public void removeTransactionInfo() {
-        transactionResourceManager.transactionInfoMap.remove(ByteBuffer.wrap(transactionId.getBytes()));
+        TRANSACTION_RESOURCE_MANAGER.transactionInfoMap.remove(ByteBuffer.wrap(transactionId.getBytes()));
     }
 
     public void notifyLocalParticipantFailure() {
         String blockId = transactionBlockIdStack.peek();
-        transactionResourceManager.notifyLocalParticipantFailure(globalTransactionId, blockId);
+        TRANSACTION_RESOURCE_MANAGER.notifyLocalParticipantFailure(globalTransactionId, blockId);
     }
 
     public void notifyLocalRemoteParticipantFailure() {
@@ -236,7 +236,7 @@ public class TransactionLocalContext {
     }
 
     public Object getInfoRecord() {
-        return transactionResourceManager.getTransactionRecord(transactionId);
+        return TRANSACTION_RESOURCE_MANAGER.getTransactionRecord(transactionId);
     }
 
     public boolean isTransactional() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionLocalContext.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionLocalContext.java
@@ -34,22 +34,22 @@ import java.util.Map;
  */
 public class TransactionLocalContext {
 
-    private String globalTransactionId;
-    private String url;
-    private String protocol;
+    private final String globalTransactionId;
+    private final String url;
+    private final String protocol;
 
     private int transactionLevel;
-    private Map<String, Integer> allowedTransactionRetryCounts;
-    private Map<String, Integer> currentTransactionRetryCounts;
+    private final Map<String, Integer> allowedTransactionRetryCounts;
+    private final Map<String, Integer> currentTransactionRetryCounts;
     private Map<String, BallerinaTransactionContext> transactionContextStore;
-    private Deque<String> transactionBlockIdStack;
-    private Deque<TransactionFailure> transactionFailure;
+    private final Deque<String> transactionBlockIdStack;
+    private final Deque<TransactionFailure> transactionFailure;
     private static final TransactionResourceManager transactionResourceManager =
             TransactionResourceManager.getInstance();
     private boolean isResourceParticipant;
     private Object rollbackOnlyError;
     private Object transactionData;
-    private BArray transactionId;
+    private final BArray transactionId;
     private boolean isTransactional;
 
     private TransactionLocalContext(String globalTransactionId, String url, String protocol, Object infoRecord) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
@@ -78,7 +78,7 @@ import static javax.transaction.xa.XAResource.TMSUCCESS;
 public class TransactionResourceManager {
 
     private static TransactionResourceManager transactionResourceManager = null;
-    private  static UserTransactionManager userTransactionManager = null;
+    private static UserTransactionManager userTransactionManager = null;
 
     private static final StrandMetadata COMMIT_METADATA = new StrandMetadata(BALLERINA_BUILTIN_PKG_PREFIX,
             TRANSACTION_PACKAGE_NAME,
@@ -93,12 +93,12 @@ public class TransactionResourceManager {
     public static final String TRANSACTION_CLEANUP_TIMEOUT_KEY = "transactionCleanupTimeout";
 
     private static final Logger log = LoggerFactory.getLogger(TransactionResourceManager.class);
-    private final Map<String, List<BallerinaTransactionContext>> resourceRegistry;
+    private final Map<String, List<BallerinaTransactionContext>> resourceRegistry = new HashMap<>();
     private Map<String, Transaction> trxRegistry;
     private Map<String, Xid> xidRegistry;
 
-    private final Map<String, List<BFunctionPointer<?, ?>>> committedFuncRegistry;
-    private final Map<String, List<BFunctionPointer<?, ?>>> abortedFuncRegistry;
+    private final Map<String, List<BFunctionPointer<?, ?>>> committedFuncRegistry = new HashMap<>();
+    private final Map<String, List<BFunctionPointer<?, ?>>> abortedFuncRegistry = new HashMap<>();
 
     private final Set<String> failedResourceParticipantSet = new ConcurrentSkipListSet<>();
     private final Set<String> failedLocalParticipantSet = new ConcurrentSkipListSet<>();
@@ -107,13 +107,9 @@ public class TransactionResourceManager {
     private final boolean transactionManagerEnabled;
     private static final PrintStream stderr = System.err;
 
-    Map<ByteBuffer, Object> transactionInfoMap;
+    final Map<ByteBuffer, Object> transactionInfoMap = new ConcurrentHashMap<>();
 
     private TransactionResourceManager() {
-        resourceRegistry = new HashMap<>();
-        committedFuncRegistry = new HashMap<>();
-        abortedFuncRegistry = new HashMap<>();
-        transactionInfoMap = new ConcurrentHashMap<>();
         transactionManagerEnabled = getTransactionManagerEnabled();
         if (transactionManagerEnabled) {
             trxRegistry = new HashMap<>();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
@@ -92,7 +92,7 @@ public class TransactionResourceManager {
     public static final String TRANSACTION_AUTO_COMMIT_TIMEOUT_KEY = "transactionAutoCommitTimeout";
     public static final String TRANSACTION_CLEANUP_TIMEOUT_KEY = "transactionCleanupTimeout";
 
-    private static final Logger log = LoggerFactory.getLogger(TransactionResourceManager.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TransactionResourceManager.class);
     private final Map<String, List<BallerinaTransactionContext>> resourceRegistry = new HashMap<>();
     private Map<String, Transaction> trxRegistry;
     private Map<String, Xid> xidRegistry;
@@ -105,7 +105,7 @@ public class TransactionResourceManager {
     private final ConcurrentMap<String, Set<String>> localParticipants = new ConcurrentHashMap<>();
 
     private final boolean transactionManagerEnabled;
-    private static final PrintStream stderr = System.err;
+    private static final PrintStream STDERR = System.err;
 
     final Map<ByteBuffer, Object> transactionInfoMap = new ConcurrentHashMap<>();
 
@@ -151,7 +151,7 @@ public class TransactionResourceManager {
                 try {
                     Files.createDirectory(transactionLogDirectory);
                 } catch (IOException e) {
-                    stderr.println("error: failed to create transaction log directory in " + logDir);
+                    STDERR.println("error: failed to create transaction log directory in " + logDir);
                 }
             }
             System.setProperty(ATOMIKOS_LOG_BASE_PROPERTY, logDir);
@@ -313,7 +313,7 @@ public class TransactionResourceManager {
                         xaResource.prepare(xid);
                     }
                 } catch (XAException e) {
-                    log.error("error at transaction prepare phase in transaction " + transactionId
+                    LOG.error("error at transaction prepare phase in transaction " + transactionId
                             + ":" + e.getMessage(), e);
                     return false;
                 }
@@ -325,7 +325,7 @@ public class TransactionResourceManager {
             // resource participant reported failure.
             status = false;
         }
-        log.info(String.format("Transaction prepare (participants): %s", status ? "success" : "failed"));
+        LOG.info(String.format("Transaction prepare (participants): %s", status ? "success" : "failed"));
         return status;
     }
 
@@ -349,7 +349,7 @@ public class TransactionResourceManager {
                     }
                 } catch (SystemException | HeuristicMixedException | HeuristicRollbackException
                         | RollbackException e) {
-                    log.error("error when committing transaction " + transactionId + ":" + e.getMessage(), e);
+                    LOG.error("error when committing transaction " + transactionId + ":" + e.getMessage(), e);
                     commitSuccess = false;
                 }
             }
@@ -368,7 +368,7 @@ public class TransactionResourceManager {
                         }
                     }
                 } catch (XAException e) {
-                    log.error("error when committing transaction " + transactionId + ":" + e.getMessage(), e);
+                    LOG.error("error when committing transaction " + transactionId + ":" + e.getMessage(), e);
                     commitSuccess = false;
                 } finally {
                     ctx.close();
@@ -406,7 +406,7 @@ public class TransactionResourceManager {
                         trx.rollback();
                     }
                 } catch (SystemException e) {
-                    log.error("error when aborting transaction " + transactionId + ":" + e.getMessage(), e);
+                    LOG.error("error when aborting transaction " + transactionId + ":" + e.getMessage(), e);
                     abortSuccess = false;
                 }
             }
@@ -425,7 +425,7 @@ public class TransactionResourceManager {
                         }
                     }
                 } catch (XAException e) {
-                    log.error("error when aborting the transaction " + transactionId + ":" + e.getMessage(), e);
+                    LOG.error("error when aborting the transaction " + transactionId + ":" + e.getMessage(), e);
                     abortSuccess = false;
                 } finally {
                     ctx.close();
@@ -464,7 +464,7 @@ public class TransactionResourceManager {
                     trxRegistry.put(combinedId, trx);
                 }
             } catch (SystemException | NotSupportedException e) {
-                log.error("error in initiating transaction " + transactionId + ":" + e.getMessage(), e);
+                LOG.error("error in initiating transaction " + transactionId + ":" + e.getMessage(), e);
             }
         } else {
             Xid xid = xidRegistry.get(combinedId);
@@ -475,7 +475,7 @@ public class TransactionResourceManager {
             try {
                 xaResource.start(xid, TMNOFLAGS);
             } catch (XAException e) {
-                log.error("error in starting XA transaction " + transactionId + ":" + e.getMessage(), e);
+                LOG.error("error in starting XA transaction " + transactionId + ":" + e.getMessage(), e);
             }
         }
     }
@@ -608,7 +608,7 @@ public class TransactionResourceManager {
                                 trx.delistResource(xaResource, TMSUCCESS);
                             }
                         } catch (IllegalStateException | SystemException e) {
-                            log.error("error in ending the XA transaction " + transactionId
+                            LOG.error("error in ending the XA transaction " + transactionId
                                     + ":" + e.getMessage(), e);
                         }
                     }
@@ -625,7 +625,7 @@ public class TransactionResourceManager {
                             xaResource.end(xid, abortOnly ? TMFAIL : TMSUCCESS);
                         }
                     } catch (XAException e) {
-                        log.error("error in ending XA transaction " + transactionId + ":" + e.getMessage(), e);
+                        LOG.error("error in ending XA transaction " + transactionId + ":" + e.getMessage(), e);
                     }
                 }
             }
@@ -652,7 +652,7 @@ public class TransactionResourceManager {
     public void notifyResourceFailure(String gTransactionId) {
         failedResourceParticipantSet.add(gTransactionId);
         // The resource excepted (uncaught).
-        log.info("Trx infected callable unit excepted id : " + gTransactionId);
+        LOG.info("Trx infected callable unit excepted id : " + gTransactionId);
     }
 
     public void notifyLocalParticipantFailure(String gTransactionId, String blockId) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionResourceManager.java
@@ -45,7 +45,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 
 import javax.transaction.HeuristicMixedException;
@@ -91,18 +93,18 @@ public class TransactionResourceManager {
     public static final String TRANSACTION_CLEANUP_TIMEOUT_KEY = "transactionCleanupTimeout";
 
     private static final Logger log = LoggerFactory.getLogger(TransactionResourceManager.class);
-    private Map<String, List<BallerinaTransactionContext>> resourceRegistry;
+    private final Map<String, List<BallerinaTransactionContext>> resourceRegistry;
     private Map<String, Transaction> trxRegistry;
     private Map<String, Xid> xidRegistry;
 
-    private Map<String, List<BFunctionPointer<?, ?>>> committedFuncRegistry;
-    private Map<String, List<BFunctionPointer<?, ?>>> abortedFuncRegistry;
+    private final Map<String, List<BFunctionPointer<?, ?>>> committedFuncRegistry;
+    private final Map<String, List<BFunctionPointer<?, ?>>> abortedFuncRegistry;
 
-    private ConcurrentSkipListSet<String> failedResourceParticipantSet = new ConcurrentSkipListSet<>();
-    private ConcurrentSkipListSet<String> failedLocalParticipantSet = new ConcurrentSkipListSet<>();
-    private ConcurrentHashMap<String, ConcurrentSkipListSet<String>> localParticipants = new ConcurrentHashMap<>();
+    private final Set<String> failedResourceParticipantSet = new ConcurrentSkipListSet<>();
+    private final Set<String> failedLocalParticipantSet = new ConcurrentSkipListSet<>();
+    private final ConcurrentMap<String, Set<String>> localParticipants = new ConcurrentHashMap<>();
 
-    private boolean transactionManagerEnabled;
+    private final boolean transactionManagerEnabled;
     private static final PrintStream stderr = System.err;
 
     Map<ByteBuffer, Object> transactionInfoMap;
@@ -658,7 +660,7 @@ public class TransactionResourceManager {
     }
 
     public void notifyLocalParticipantFailure(String gTransactionId, String blockId) {
-        ConcurrentSkipListSet<String> participantBlockIds = localParticipants.get(gTransactionId);
+        Set<String> participantBlockIds = localParticipants.get(gTransactionId);
         if (participantBlockIds != null && participantBlockIds.contains(blockId)) {
             failedLocalParticipantSet.add(gTransactionId);
         }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/DocCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/DocCommand.java
@@ -55,7 +55,7 @@ public class DocCommand implements BLauncherCmd {
     private final PrintStream errStream;
     private Path projectPath;
     private Path outputPath;
-    private boolean exitWhenFinish;
+    private final boolean exitWhenFinish;
 
     public DocCommand() {
         this.projectPath = Paths.get(System.getProperty("user.dir"));

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
@@ -100,10 +100,10 @@ public class PushCommand implements BLauncherCmd {
     @CommandLine.Option(names = {"--skip-source-check"}, description = "skip checking if source has changed")
     private boolean skipSourceCheck;
 
-    private Path userDir;
-    private PrintStream errStream;
-    private PrintStream outStream;
-    private boolean exitWhenFinish;
+    private final Path userDir;
+    private final PrintStream errStream;
+    private final PrintStream outStream;
+    private final boolean exitWhenFinish;
 
     public PushCommand() {
         this.userDir = Paths.get(System.getProperty(ProjectConstants.USER_DIR));

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/ShellCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/ShellCommand.java
@@ -34,7 +34,7 @@ import static io.ballerina.cli.cmd.Constants.SHELL_COMMAND;
  */
 @CommandLine.Command(name = SHELL_COMMAND, description = "Run Ballerina interactive REPL")
 public class ShellCommand implements BLauncherCmd {
-    private PrintStream errStream;
+    private final PrintStream errStream;
 
     @CommandLine.Option(names = {"--help", "-h", "?"}, hidden = true)
     private boolean helpFlag;

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TokenUpdater.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TokenUpdater.java
@@ -43,8 +43,8 @@ import static io.ballerina.projects.util.ProjectConstants.SETTINGS_FILE_NAME;
  */
 public final class TokenUpdater {
 
-    private static final PrintStream errStream = System.err;
-    private static final PrintStream outStream = System.out;
+    private static final PrintStream ERR_STREAM = System.err;
+    private static final PrintStream OUT_STREAM = System.out;
 
     private TokenUpdater() {
     }
@@ -96,10 +96,10 @@ public final class TokenUpdater {
                         outputStream.close();
                     }
                 } catch (IOException e) {
-                    errStream.println("error occurred while closing the output stream: " + e.getMessage());
+                    ERR_STREAM.println("error occurred while closing the output stream: " + e.getMessage());
                 }
             }
-            outStream.println("token updated");
+            OUT_STREAM.println("token updated");
 
             OutputStream os = null;
             try {
@@ -117,7 +117,7 @@ public final class TokenUpdater {
                         os.close();
                     }
                 } catch (IOException e) {
-                    errStream.println("error occurred while closing the output stream: " + e.getMessage());
+                    ERR_STREAM.println("error occurred while closing the output stream: " + e.getMessage());
                 }
             }
         }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TokenUpdater.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/TokenUpdater.java
@@ -43,8 +43,8 @@ import static io.ballerina.projects.util.ProjectConstants.SETTINGS_FILE_NAME;
  */
 public final class TokenUpdater {
 
-    private static PrintStream errStream = System.err;
-    private static PrintStream outStream = System.out;
+    private static final PrintStream errStream = System.err;
+    private static final PrintStream outStream = System.out;
 
     private TokenUpdater() {
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaModuleID.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaModuleID.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 public class BallerinaModuleID implements ModuleID {
 
     private static final String ANON_ORG = "$anon";
-    private PackageID moduleID;
+    private final PackageID moduleID;
     private Name prefix;
 
     public BallerinaModuleID(PackageID moduleID) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -216,7 +216,7 @@ class NodeFinder extends BaseVisitor {
     private LineRange range;
     private BLangNode enclosingNode;
     private BLangNode enclosingContainer;
-    private boolean allowExprStmts;
+    private final boolean allowExprStmts;
 
     NodeFinder(boolean allowExprStmts) {
         this.allowExprStmts = allowExprStmts;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
@@ -137,8 +137,8 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
         private final List<Qualifier> qualifiers = new ArrayList<>();
         private TypeSymbol typeDescriptor;
         private List<AnnotationAttachPoint> attachPoints;
-        private List<AnnotationSymbol> annots = new ArrayList<>();
-        private List<AnnotationAttachmentSymbol> annotAttachments = new ArrayList<>();
+        private final List<AnnotationSymbol> annots = new ArrayList<>();
+        private final List<AnnotationAttachmentSymbol> annotAttachments = new ArrayList<>();
 
         public AnnotationSymbolBuilder(String name, BAnnotationSymbol annotationSymbol, CompilerContext context) {
             super(name, SymbolKind.ANNOTATION, annotationSymbol, context);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
@@ -48,7 +48,7 @@ import static org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols.is
 public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements ConstantSymbol {
 
     private final BallerinaConstantValue constValue;
-    private TypeSymbol broaderType;
+    private final TypeSymbol broaderType;
 
     private BallerinaConstantSymbol(String name, List<Qualifier> qualifiers, List<AnnotationSymbol> annots,
                                     List<AnnotationAttachmentSymbol> annotAttachments, TypeSymbol typeDescriptor,

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaDocumentation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaDocumentation.java
@@ -32,7 +32,7 @@ import java.util.Optional;
  */
 public class BallerinaDocumentation implements Documentation {
 
-    private MarkdownDocAttachment markdownDocAttachment;
+    private final MarkdownDocAttachment markdownDocAttachment;
 
     public BallerinaDocumentation(MarkdownDocAttachment markdownDocAttachment) {
         this.markdownDocAttachment = markdownDocAttachment;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
@@ -41,8 +41,8 @@ import java.util.List;
  */
 public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implements EnumSymbol {
 
-    private List<ConstantSymbol> members;
-    private List<AnnotationSymbol> annots;
+    private final List<ConstantSymbol> members;
+    private final List<AnnotationSymbol> annots;
     private final List<AnnotationAttachmentSymbol> annotAttachments;
 
     protected BallerinaEnumSymbol(String name, List<ConstantSymbol> members, List<Qualifier> qualifiers,

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
@@ -59,7 +59,7 @@ import static org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols.is
  */
 public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
 
-    private BPackageSymbol packageSymbol;
+    private final BPackageSymbol packageSymbol;
     private List<TypeDefinitionSymbol> typeDefs;
     private List<ClassSymbol> classes;
     private List<FunctionSymbol> functions;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
@@ -55,7 +55,7 @@ public class BallerinaObjectFieldSymbol extends BallerinaSymbol implements Objec
     private TypeSymbol typeDescriptor;
     private List<AnnotationSymbol> annots;
     private String signature;
-    private boolean deprecated;
+    private final boolean deprecated;
     private List<io.ballerina.compiler.api.symbols.AnnotationAttachmentSymbol> annotAttachments;
 
     public BallerinaObjectFieldSymbol(CompilerContext context, BField bField, SymbolKind kind) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
@@ -55,7 +55,7 @@ public class BallerinaRecordFieldSymbol extends BallerinaSymbol implements Recor
     private List<io.ballerina.compiler.api.symbols.AnnotationAttachmentSymbol> annotAttachments;
     private List<Qualifier> qualifiers;
     private String signature;
-    private boolean deprecated;
+    private final boolean deprecated;
 
     public BallerinaRecordFieldSymbol(CompilerContext context, BField bField) {
         super(bField.symbol.getOriginalName().value, SymbolKind.RECORD_FIELD, bField.symbol, context);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -56,7 +56,7 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
     private ModuleSymbol module;
     private Symbol definition;
     private boolean moduleEvaluated;
-    private boolean fromIntersectionType;
+    private final boolean fromIntersectionType;
     public BSymbol tSymbol;
     public BType referredType;
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
@@ -37,8 +37,8 @@ import java.util.List;
  */
 public class BallerinaWorkerSymbol extends BallerinaSymbol implements WorkerSymbol {
 
-    private TypeSymbol returnType;
-    private List<AnnotationSymbol> annots;
+    private final TypeSymbol returnType;
+    private final List<AnnotationSymbol> annots;
     private final List<AnnotationAttachmentSymbol> annotAttachments;
 
     private BallerinaWorkerSymbol(String name, SymbolKind ballerinaSymbolKind, TypeSymbol returnType,

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/type/builders/BallerinaObjectTypeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/type/builders/BallerinaObjectTypeBuilder.java
@@ -60,7 +60,7 @@ public class BallerinaObjectTypeBuilder implements TypeBuilder.OBJECT {
 
     private final TypesFactory typesFactory;
     private final SymbolTable symTable;
-    private List<Qualifier> qualifiers = new ArrayList<>();
+    private final List<Qualifier> qualifiers = new ArrayList<>();
     private final List<OBJECT_FIELD> objectFieldList = new ArrayList<>();
     private final List<BAttachedFunction> objectMethodList = new ArrayList<>();
     private final List<TypeReferenceTypeSymbol> typeInclusions = new ArrayList<>();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalToolToml.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalToolToml.java
@@ -27,8 +27,8 @@ import io.ballerina.toml.semantic.ast.TomlTableNode;
  * @since 2201.6.0
  */
 public class BalToolToml {
-    private TomlDocumentContext balToolTomlContext;
-    private Package packageInstance;
+    private final TomlDocumentContext balToolTomlContext;
+    private final Package packageInstance;
 
     private BalToolToml(TomlDocumentContext balToolTomlContext, Package packageInstance) {
         this.balToolTomlContext = balToolTomlContext;
@@ -73,7 +73,7 @@ public class BalToolToml {
      */
     public static class Modifier {
         private TomlDocument tomlDocument;
-        private Package oldPackage;
+        private final Package oldPackage;
 
         private Modifier(BalToolToml oldDocument) {
             this.tomlDocument = oldDocument.tomlDocument();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalToolsManifest.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalToolsManifest.java
@@ -108,7 +108,7 @@ public class BalToolsManifest {
         private final String name;
         private final String version;
         private Boolean active;
-        private String repository;
+        private final String repository;
 
         public Tool(String id, String org, String name, String version, Boolean active, String repository) {
             this.id = id;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BallerinaToml.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BallerinaToml.java
@@ -27,8 +27,8 @@ import io.ballerina.toml.semantic.ast.TomlTableNode;
  */
 public class BallerinaToml {
 
-    private TomlDocumentContext ballerinaTomlContext;
-    private Package packageInstance;
+    private final TomlDocumentContext ballerinaTomlContext;
+    private final Package packageInstance;
 
     private BallerinaToml(Package aPackage, TomlDocumentContext ballerinaTomlContext) {
         this.packageInstance = aPackage;
@@ -74,7 +74,7 @@ public class BallerinaToml {
      */
     public static class Modifier {
         private TomlDocument tomlDocument;
-        private Package oldPackage;
+        private final Package oldPackage;
 
         private Modifier(BallerinaToml oldDocument) {
             this.tomlDocument = oldDocument.tomlDocument();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CloudToml.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CloudToml.java
@@ -27,8 +27,8 @@ import io.ballerina.toml.semantic.ast.TomlTableNode;
  * @since 2.0.0
  */
 public class CloudToml {
-    private TomlDocumentContext cloudTomlContext;
-    private Package packageInstance;
+    private final TomlDocumentContext cloudTomlContext;
+    private final Package packageInstance;
 
     private CloudToml(Package aPackage, TomlDocumentContext cloudTomlContext) {
         this.packageInstance = aPackage;
@@ -74,7 +74,7 @@ public class CloudToml {
      */
     public static class Modifier {
         private TomlDocument tomlDocument;
-        private Package oldPackage;
+        private final Package oldPackage;
 
         private Modifier(CloudToml oldDocument) {
             this.tomlDocument = oldDocument.tomlDocument();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilerLifecycleManager.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilerLifecycleManager.java
@@ -157,8 +157,8 @@ class CompilerLifecycleManager {
 
     static class CodeGenerationCompletedTask {
 
-        private CompilerLifecycleTask<CompilerLifecycleEventContext> lifecycleTask;
-        private LifecycleListenerInfo lifecycleListenerInfo;
+        private final CompilerLifecycleTask<CompilerLifecycleEventContext> lifecycleTask;
+        private final LifecycleListenerInfo lifecycleListenerInfo;
 
         public CodeGenerationCompletedTask(CompilerLifecycleTask<CompilerLifecycleEventContext> lifecycleTask,
                                            LifecycleListenerInfo lifecycleListenerInfo) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilerPluginToml.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilerPluginToml.java
@@ -9,8 +9,8 @@ import io.ballerina.toml.semantic.ast.TomlTableNode;
  * @since 2.0.0
  */
 public class CompilerPluginToml {
-    private TomlDocumentContext compilerPluginTomlContext;
-    private Package packageInstance;
+    private final TomlDocumentContext compilerPluginTomlContext;
+    private final Package packageInstance;
 
     private CompilerPluginToml(TomlDocumentContext compilerPluginTomlContext, Package packageInstance) {
         this.compilerPluginTomlContext = compilerPluginTomlContext;
@@ -55,7 +55,7 @@ public class CompilerPluginToml {
      */
     public static class Modifier {
         private TomlDocument tomlDocument;
-        private Package oldPackage;
+        private final Package oldPackage;
 
         private Modifier(CompilerPluginToml oldDocument) {
             this.tomlDocument = oldDocument.tomlDocument();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompletionManager.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompletionManager.java
@@ -226,7 +226,7 @@ public class CompletionManager {
      */
     static class ServiceDeclarationContextValidator extends NodeVisitor {
 
-        private CompletionContext context;
+        private final CompletionContext context;
         private boolean isValidContext = false;
 
         public ServiceDeclarationContextValidator(CompletionContext context) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependenciesToml.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependenciesToml.java
@@ -27,8 +27,8 @@ import io.ballerina.toml.semantic.ast.TomlTableNode;
  * @since 2.0.0
  */
 public class DependenciesToml {
-    private TomlDocumentContext dependenciesTomlContext;
-    private Package packageInstance;
+    private final TomlDocumentContext dependenciesTomlContext;
+    private final Package packageInstance;
 
     private DependenciesToml(Package aPackage, TomlDocumentContext dependenciesTomlContext) {
         this.packageInstance = aPackage;
@@ -72,7 +72,7 @@ public class DependenciesToml {
      */
     public static class Modifier {
         private TomlDocument tomlDocument;
-        private Package oldPackage;
+        private final Package oldPackage;
 
         private Modifier(DependenciesToml oldDocument) {
             this.tomlDocument = oldDocument.tomlDocument();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Document.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Document.java
@@ -72,9 +72,9 @@ public class Document {
      */
     public static class Modifier {
         private String content;
-        private String name;
-        private DocumentId documentId;
-        private Module oldModule;
+        private final String name;
+        private final DocumentId documentId;
+        private final Module oldModule;
 
         private Modifier(Document oldDocument) {
             this.documentId = oldDocument.documentId();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -375,9 +375,6 @@ public class JBallerinaBackend extends CompilerBackend {
         }
         boolean isRemoteMgtEnabled = moduleContext.project().buildOptions().compilationOptions().remoteManagement();
         CompiledJarFile compiledJarFile = jvmCodeGenerator.generate(bLangPackage, isRemoteMgtEnabled);
-        if (compiledJarFile == null) {
-            throw new IllegalStateException("Missing generated jar, module: " + moduleContext.moduleName());
-        }
         String jarFileName = getJarFileName(moduleContext) + JAR_FILE_NAME_SUFFIX;
         try {
             ByteArrayOutputStream byteStream = compiledJarFile.toByteArrayStream();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBalaWriter.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBalaWriter.java
@@ -58,7 +58,7 @@ public class JBallerinaBalaWriter extends BalaWriter {
     public static final String LIBS = "libs";
     public static final String COMPILER_PLUGIN = "compiler-plugin";
     public static final String ANNON = "annon";
-    private JBallerinaBackend backend;
+    private final JBallerinaBackend backend;
 
     public JBallerinaBalaWriter(JBallerinaBackend backend) {
         this.backend = backend;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JarResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JarResolver.java
@@ -59,7 +59,7 @@ public class JarResolver {
     private final PackageContext rootPackageContext;
     private final List<Diagnostic> diagnosticList;
     private DiagnosticResult diagnosticResult;
-    private List<PlatformLibrary> providedPlatformLibs;
+    private final List<PlatformLibrary> providedPlatformLibs;
 
     private ClassLoader classLoaderWithAllJars;
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/MdDocumentContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/MdDocumentContext.java
@@ -29,9 +29,9 @@ import io.ballerina.tools.text.TextDocuments;
  */
 class MdDocumentContext {
     private TextDocument textDocument;
-    private DocumentId documentId;
-    private String name;
-    private String content;
+    private final DocumentId documentId;
+    private final String name;
+    private final String content;
 
     private MdDocumentContext(DocumentId documentId, String name, String content) {
         this.documentId = documentId;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Module.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Module.java
@@ -168,14 +168,14 @@ public class Module {
      * Inner class that handles module modifications.
      */
     public static class Modifier {
-        private ModuleId moduleId;
-        private ModuleDescriptor moduleDescriptor;
+        private final ModuleId moduleId;
+        private final ModuleDescriptor moduleDescriptor;
         private Map<DocumentId, DocumentContext> srcDocContextMap;
         private Map<DocumentId, DocumentContext> testDocContextMap;
-        private boolean isDefaultModule;
+        private final boolean isDefaultModule;
         private final List<ModuleDescriptor> dependencies;
-        private Package packageInstance;
-        private Project project;
+        private final Package packageInstance;
+        private final Project project;
         private MdDocumentContext moduleMdContext;
 
         private Modifier(Module oldModule) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleMd.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleMd.java
@@ -60,9 +60,9 @@ public class ModuleMd {
      */
     public static class Modifier {
         private String content;
-        private String name;
-        private DocumentId documentId;
-        private Module oldModule;
+        private final String name;
+        private final DocumentId documentId;
+        private final Module oldModule;
 
         private Modifier(ModuleMd oldDocument) {
             this.content = oldDocument.mdDocumentContext.content();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
@@ -437,13 +437,13 @@ public class Package {
      * Inner class that handles package modifications.
      */
     public static class Modifier {
-        private PackageId packageId;
+        private final PackageId packageId;
         private PackageManifest packageManifest;
         private DependencyManifest dependencyManifest;
-        private Map<ModuleId, ModuleContext> moduleContextMap;
-        private Project project;
+        private final Map<ModuleId, ModuleContext> moduleContextMap;
+        private final Project project;
         private final DependencyGraph<ResolvedPackageDependency> dependencyGraph;
-        private CompilationOptions compilationOptions;
+        private final CompilationOptions compilationOptions;
         private TomlDocumentContext ballerinaTomlContext;
         private TomlDocumentContext dependenciesTomlContext;
         private TomlDocumentContext cloudTomlContext;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageMd.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageMd.java
@@ -65,9 +65,9 @@ public class PackageMd {
      */
     public static class Modifier {
         private String content;
-        private String name;
-        private DocumentId documentId;
-        private Package oldPackage;
+        private final String name;
+        private final DocumentId documentId;
+        private final Package oldPackage;
 
         private Modifier(PackageMd oldDocument) {
             this.content = oldDocument.mdDocumentContext.content();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Project.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Project.java
@@ -42,7 +42,7 @@ public abstract class Project {
     protected ProjectEnvironment projectEnvironment;
     private final ProjectKind projectKind;
     private Map<PackageManifest.Tool.Field, ToolContext> toolContextMap;
-    private List<CompilerPluginContextIml> compilerPluginContexts;
+    private final List<CompilerPluginContextIml> compilerPluginContexts;
 
     protected Project(ProjectKind projectKind,
                       Path projectPath,

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/SettingsToml.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/SettingsToml.java
@@ -27,7 +27,7 @@ import io.ballerina.toml.semantic.ast.TomlTableNode;
  */
 public class SettingsToml {
 
-    private TomlDocumentContext settingsTomlContext;
+    private final TomlDocumentContext settingsTomlContext;
 
     private SettingsToml(TomlDocumentContext tomlDocumentContext) {
         this.settingsTomlContext = tomlDocumentContext;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/TomlDocumentContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/TomlDocumentContext.java
@@ -25,7 +25,7 @@ package io.ballerina.projects;
  * @since 2.0.0
  */
 public class TomlDocumentContext {
-    private TomlDocument tomlDocument;
+    private final TomlDocument tomlDocument;
 
     private TomlDocumentContext(TomlDocument tomlDocument) {
         this.tomlDocument = tomlDocument;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/CompilerPhaseRunner.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/CompilerPhaseRunner.java
@@ -64,7 +64,7 @@ public class CompilerPhaseRunner {
     private final CompilerPhase compilerPhase;
     private final DataflowAnalyzer dataflowAnalyzer;
     private final IsolationAnalyzer isolationAnalyzer;
-    private boolean isToolingCompilation;
+    private final boolean isToolingCompilation;
 
 
     public static CompilerPhaseRunner getInstance(CompilerContext context) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/DocumentData.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/DocumentData.java
@@ -25,7 +25,7 @@ package io.ballerina.projects.internal;
 public class DocumentData {
     //TODO: Remove this class and use DocumentConfig for creating a document
     private final String name;
-    private String content;
+    private final String content;
 
     private DocumentData(String name, String content) {
         this.name = name;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/SettingsBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/SettingsBuilder.java
@@ -56,10 +56,10 @@ public class SettingsBuilder {
     private static final String WRITE_TIMEOUT = "writeTimeout";
     private static final String CALL_TIMEOUT = "callTimeout";
     private static final String MAX_RETRIES = "maxRetries";
-    private TomlDocument settingsToml;
-    private Settings settings;
+    private final TomlDocument settingsToml;
+    private final Settings settings;
     private DiagnosticResult diagnostics;
-    private List<Diagnostic> diagnosticList;
+    private final List<Diagnostic> diagnosticList;
 
     private static final String PROXY = "proxy";
     private static final String CENTRAL = "central";

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/bala/BalToolJson.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/bala/BalToolJson.java
@@ -25,7 +25,7 @@ import java.util.List;
  * @since 2201.6.0
  */
 public class BalToolJson {
-    private String tool_id;
+    private final String tool_id;
     private List<String> dependency_paths;
 
     public BalToolJson(String tool_id, List<String> dependency_paths) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/bala/CompilerPluginJson.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/bala/CompilerPluginJson.java
@@ -25,8 +25,8 @@ import java.util.List;
  * @since 2.0.0
  */
 public class CompilerPluginJson {
-    private String plugin_id;
-    private String plugin_class;
+    private final String plugin_id;
+    private final String plugin_class;
     private List<String> dependency_paths;
 
     public CompilerPluginJson(String pluginId, String pluginClass, List<String> dependencyPaths) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/TypeConverter.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/TypeConverter.java
@@ -58,7 +58,7 @@ public class TypeConverter {
     static final String ADDITIONAL_PROPERTIES = "additionalProperties";
     static final String TYPE = "type";
     // Stores already visited complex types against the type name
-    private Map<String, VisitedType> visitedTypeMap = new HashMap<>();
+    private final Map<String, VisitedType> visitedTypeMap = new HashMap<>();
 
     private VisitedType getVisitedType(String typeName) {
         if (visitedTypeMap.containsKey(typeName)) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/BalToolDescriptor.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/BalToolDescriptor.java
@@ -49,8 +49,8 @@ public class BalToolDescriptor {
     private static final String DEPENDENCY = "dependency";
     public static final String PATH = "path";
 
-    private BalToolDescriptor.Tool tool;
-    private List<BalToolDescriptor.Dependency> dependencies;
+    private final BalToolDescriptor.Tool tool;
+    private final List<BalToolDescriptor.Dependency> dependencies;
 
     private BalToolDescriptor(BalToolDescriptor.Tool tool, List<BalToolDescriptor.Dependency> dependencies) {
         this.tool = tool;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/CompilerPluginDescriptor.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/CompilerPluginDescriptor.java
@@ -40,8 +40,8 @@ public class CompilerPluginDescriptor {
     private static final String DEPENDENCY = "dependency";
     private static final String CLASS = "class";
 
-    private Plugin plugin;
-    private List<Dependency> dependencies;
+    private final Plugin plugin;
+    private final List<Dependency> dependencies;
 
     private CompilerPluginDescriptor(Plugin plugin, List<Dependency> dependencies) {
         this.plugin = plugin;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Repository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Repository.java
@@ -22,10 +22,10 @@ package io.ballerina.projects.internal.model;
  * @since 2201.8.0
  */
 public class Repository {
-    private String id;
-    private String url;
-    private String username;
-    private String password;
+    private final String id;
+    private final String url;
+    private final String username;
+    private final String password;
 
     private Repository(String id, String url, String username, String password) {
         this.id = id;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Target.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Target.java
@@ -35,18 +35,18 @@ import java.nio.file.Path;
 public class Target {
     private final Path targetPath;
     private Path outputPath = null;
-    private Path cache;
-    private Path jarCachePath;
-    private Path balaCachePath;
-    private Path birCachePath;
-    private Path testsCachePath;
-    private Path binPath;
-    private Path reportPath;
-    private Path docPath;
-    private Path nativePath;
-    private Path nativeConfigPath;
-    private Path profilerPath;
-    private Path resourcesPath;
+    private final Path cache;
+    private final Path jarCachePath;
+    private final Path balaCachePath;
+    private final Path birCachePath;
+    private final Path testsCachePath;
+    private final Path binPath;
+    private final Path reportPath;
+    private final Path docPath;
+    private final Path nativePath;
+    private final Path nativeConfigPath;
+    private final Path profilerPath;
+    private final Path resourcesPath;
 
     public Target(Path targetPath) throws IOException {
         this.targetPath = targetPath;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/CodeActionArgument.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/CodeActionArgument.java
@@ -28,8 +28,8 @@ public class CodeActionArgument {
 
     private static final Gson GSON = new Gson();
 
-    private String key;
-    private Object value;
+    private final String key;
+    private final Object value;
 
     private CodeActionArgument(String argumentK, Object value) {
         this.key = argumentK;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/CodeActionContextImpl.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/CodeActionContextImpl.java
@@ -29,7 +29,7 @@ import java.nio.file.Path;
  */
 public class CodeActionContextImpl extends PositionedActionContextImpl implements CodeActionContext {
 
-    private Diagnostic diagnostic;
+    private final Diagnostic diagnostic;
 
     private CodeActionContextImpl(String fileUri, Path filePath, LinePosition cursorPosition,
                                   Document document, SemanticModel semanticModel, Diagnostic diagnostic) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/CodeActionExecutionContextImpl.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/CodeActionExecutionContextImpl.java
@@ -29,7 +29,7 @@ import java.util.List;
  */
 public class CodeActionExecutionContextImpl extends PositionedActionContextImpl implements CodeActionExecutionContext {
 
-    private List<CodeActionArgument> arguments;
+    private final List<CodeActionArgument> arguments;
 
     private CodeActionExecutionContextImpl(String fileUri, Path filePath, LinePosition cursorPosition,
                                            Document document, SemanticModel semanticModel,

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/DocumentEdit.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/DocumentEdit.java
@@ -25,8 +25,8 @@ import io.ballerina.compiler.syntax.tree.SyntaxTree;
  */
 public class DocumentEdit {
 
-    private String fileUri;
-    private SyntaxTree modifiedSyntaxTree;
+    private final String fileUri;
+    private final SyntaxTree modifiedSyntaxTree;
 
     public DocumentEdit(String fileUri, SyntaxTree modifiedSyntaxTree) {
         this.fileUri = fileUri;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/completion/CompletionException.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/completion/CompletionException.java
@@ -21,7 +21,7 @@ package io.ballerina.projects.plugins.completion;
  * @since 2201.7.0
  */
 public class CompletionException extends RuntimeException {
-    private String providerName;
+    private final String providerName;
     
     public CompletionException(Throwable cause, String providerName) {
         super(cause);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/completion/CompletionItem.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/completion/CompletionItem.java
@@ -29,12 +29,12 @@ public class CompletionItem {
      * The label of this completion item. By default, also the text that is inserted when selecting
      * this completion.
      */
-    private String label;
+    private final String label;
     
     /**
      * Indicates the priority(sorted position) of the completion item.
      */
-    private Priority priority;
+    private final Priority priority;
 
     /**
      * An optional array of additional text edits that are applied when selecting this completion. 
@@ -49,7 +49,7 @@ public class CompletionItem {
      * A string that should be inserted a document when selecting this completion. 
      * When omitted or empty, the label is used as the insert text for this item.
      */
-    private String insertText;
+    private final String insertText;
     
     public CompletionItem(String label, String insertText, Priority priority) {
         this.label = label;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
@@ -340,11 +340,11 @@ public final class FileUtils {
      * Copy files to the given destination.
      */
     public static class Copy extends SimpleFileVisitor<Path> {
-        private Path fromPath;
-        private Path toPath;
-        private String templateName;
-        private String packageName;
-        private StandardCopyOption copyOption;
+        private final Path fromPath;
+        private final Path toPath;
+        private final String templateName;
+        private final String packageName;
+        private final StandardCopyOption copyOption;
 
 
         public Copy(Path fromPath, Path toPath, String templateName, String packageName,
@@ -402,7 +402,7 @@ public final class FileUtils {
      * Look for existing Ballerina.toml file in the given directory up to 10 levels.
      */
     public static class BallerinaTomlChecker extends SimpleFileVisitor<Path> {
-        private Path startingPath;
+        private final Path startingPath;
         private boolean ballerinaTomlFound = false;
 
         public boolean isBallerinaTomlFound() {

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeUtils.java
@@ -27,39 +27,39 @@ import java.util.Map;
  */
 public final class TreeUtils {
 
-    private static final Map<String, TypeKind> stringTypeKindMap = new HashMap<>();
+    private static final Map<String, TypeKind> STRING_TYPE_KIND_MAP = new HashMap<>();
     
     static {
-        stringTypeKindMap.put("int", TypeKind.INT);
-        stringTypeKindMap.put("byte", TypeKind.BYTE);
-        stringTypeKindMap.put("float", TypeKind.FLOAT);
-        stringTypeKindMap.put("decimal", TypeKind.DECIMAL);
-        stringTypeKindMap.put("boolean", TypeKind.BOOLEAN);
-        stringTypeKindMap.put("string", TypeKind.STRING);
-        stringTypeKindMap.put("json", TypeKind.JSON);
-        stringTypeKindMap.put("xml", TypeKind.XML);
-        stringTypeKindMap.put("stream", TypeKind.STREAM);
-        stringTypeKindMap.put("table", TypeKind.TABLE);
-        stringTypeKindMap.put("any", TypeKind.ANY);
-        stringTypeKindMap.put("anydata", TypeKind.ANYDATA);
-        stringTypeKindMap.put("map", TypeKind.MAP);
-        stringTypeKindMap.put("future", TypeKind.FUTURE);
-        stringTypeKindMap.put("typedesc", TypeKind.TYPEDESC);
-        stringTypeKindMap.put("error", TypeKind.ERROR);
-        stringTypeKindMap.put("()", TypeKind.NIL);
-        stringTypeKindMap.put("null", TypeKind.NIL);
-        stringTypeKindMap.put("never", TypeKind.NEVER);
-        stringTypeKindMap.put("channel", TypeKind.CHANNEL);
-        stringTypeKindMap.put("service", TypeKind.SERVICE);
-        stringTypeKindMap.put("handle", TypeKind.HANDLE);
-        stringTypeKindMap.put("readonly", TypeKind.READONLY);
+        STRING_TYPE_KIND_MAP.put("int", TypeKind.INT);
+        STRING_TYPE_KIND_MAP.put("byte", TypeKind.BYTE);
+        STRING_TYPE_KIND_MAP.put("float", TypeKind.FLOAT);
+        STRING_TYPE_KIND_MAP.put("decimal", TypeKind.DECIMAL);
+        STRING_TYPE_KIND_MAP.put("boolean", TypeKind.BOOLEAN);
+        STRING_TYPE_KIND_MAP.put("string", TypeKind.STRING);
+        STRING_TYPE_KIND_MAP.put("json", TypeKind.JSON);
+        STRING_TYPE_KIND_MAP.put("xml", TypeKind.XML);
+        STRING_TYPE_KIND_MAP.put("stream", TypeKind.STREAM);
+        STRING_TYPE_KIND_MAP.put("table", TypeKind.TABLE);
+        STRING_TYPE_KIND_MAP.put("any", TypeKind.ANY);
+        STRING_TYPE_KIND_MAP.put("anydata", TypeKind.ANYDATA);
+        STRING_TYPE_KIND_MAP.put("map", TypeKind.MAP);
+        STRING_TYPE_KIND_MAP.put("future", TypeKind.FUTURE);
+        STRING_TYPE_KIND_MAP.put("typedesc", TypeKind.TYPEDESC);
+        STRING_TYPE_KIND_MAP.put("error", TypeKind.ERROR);
+        STRING_TYPE_KIND_MAP.put("()", TypeKind.NIL);
+        STRING_TYPE_KIND_MAP.put("null", TypeKind.NIL);
+        STRING_TYPE_KIND_MAP.put("never", TypeKind.NEVER);
+        STRING_TYPE_KIND_MAP.put("channel", TypeKind.CHANNEL);
+        STRING_TYPE_KIND_MAP.put("service", TypeKind.SERVICE);
+        STRING_TYPE_KIND_MAP.put("handle", TypeKind.HANDLE);
+        STRING_TYPE_KIND_MAP.put("readonly", TypeKind.READONLY);
     }
 
     private TreeUtils() {
     }
 
     public static TypeKind stringToTypeKind(String typeName) {
-        return stringTypeKindMap.get(typeName);
+        return STRING_TYPE_KIND_MAP.get(typeName);
     }
     
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeUtils.java
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 public final class TreeUtils {
 
-    private static Map<String, TypeKind> stringTypeKindMap = new HashMap<>();
+    private static final Map<String, TypeKind> stringTypeKindMap = new HashMap<>();
     
     static {
         stringTypeKindMap.put("int", TypeKind.INT);

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/natives/NativeElementRepository.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/natives/NativeElementRepository.java
@@ -30,9 +30,9 @@ import java.util.Map;
 @Deprecated
 public class NativeElementRepository {
 
-    private Map<String, NativeFunctionDef> nativeFuncEntries = new HashMap<>();
+    private final Map<String, NativeFunctionDef> nativeFuncEntries = new HashMap<>();
     
-    private Map<String, NativeActionDef> nativeActionEntries = new HashMap<>();
+    private final Map<String, NativeActionDef> nativeActionEntries = new HashMap<>();
 
     private static final String ORG_NAME_SEPARATOR = "/";
 
@@ -69,19 +69,19 @@ public class NativeElementRepository {
      */
     public static class NativeFunctionDef {
 
-        private String orgName;
+        private final String orgName;
 
-        private String pkgName;
+        private final String pkgName;
 
-        private String version;
+        private final String version;
         
-        private String callableName;
+        private final String callableName;
         
-        private String className;
+        private final String className;
         
-        private TypeKind[] argTypes;
+        private final TypeKind[] argTypes;
         
-        private TypeKind[] retTypes;
+        private final TypeKind[] retTypes;
 
         public NativeFunctionDef(String orgName, String pkgName, String version, String callableName,
                                  TypeKind[] argTypes,
@@ -128,7 +128,7 @@ public class NativeElementRepository {
      */
     public static class NativeActionDef extends NativeFunctionDef {
 
-        private String connectorName;
+        private final String connectorName;
 
         public NativeActionDef(String orgName, String pkgName, String version, String connectorName, String actionDef,
                                TypeKind[] argTypes, TypeKind[] retTypes, String className) {

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/AggregatedPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/AggregatedPackageRepository.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  */
 public class AggregatedPackageRepository implements PackageRepository {
 
-    private List<PackageRepository> repos = new ArrayList<>();
+    private final List<PackageRepository> repos = new ArrayList<>();
     
     public void addRepository(PackageRepository repo) {
         this.repos.add(repo);

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/CompositePackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/CompositePackageRepository.java
@@ -29,7 +29,7 @@ import java.util.Set;
  */
 public class CompositePackageRepository extends HierarchicalPackageRepository {
     
-    private PackageRepository myRepo;
+    private final PackageRepository myRepo;
 
     public CompositePackageRepository(PackageRepository systemRepo,
                                       PackageRepository parentRepo, PackageRepository myRepo) {

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/HierarchicalPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/HierarchicalPackageRepository.java
@@ -33,9 +33,9 @@ public abstract class HierarchicalPackageRepository implements PackageRepository
 
     private static final String BALLERINA_SYSTEM_PKG_PREFIX = "ballerina";
 
-    private PackageRepository systemRepo;
+    private final PackageRepository systemRepo;
 
-    private PackageRepository parentRepo;
+    private final PackageRepository parentRepo;
     
     private Set<PackageID> cachedPackageIds;
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/GeneralFSPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/GeneralFSPackageRepository.java
@@ -268,11 +268,11 @@ public class GeneralFSPackageRepository implements PackageRepository {
          */
         public class FSCompilerInput implements CompilerInput {
 
-            private String name;
+            private final String name;
 
-            private byte[] code;
+            private final byte[] code;
 
-            private SyntaxTree tree;
+            private final SyntaxTree tree;
 
             public FSCompilerInput(String name) {
                 this.name = name;

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/model/Manifest.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/model/Manifest.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  */
 public class Manifest {
     private Project project = new Project();
-    private Map<String, Object> dependencies = new LinkedHashMap<>();
+    private final Map<String, Object> dependencies = new LinkedHashMap<>();
     public Platform platform = new Platform();
     private BuildOptions buildOptions;
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/BackendCodeGeneratorProvider.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/BackendCodeGeneratorProvider.java
@@ -29,7 +29,7 @@ import java.util.ServiceLoader;
  */
 public class BackendCodeGeneratorProvider {
 
-    private static BackendCodeGeneratorProvider provider = new BackendCodeGeneratorProvider();
+    private static final BackendCodeGeneratorProvider provider = new BackendCodeGeneratorProvider();
 
     private final ServiceLoader<CompilerBackendCodeGenerator> loader;
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/BackendCodeGeneratorProvider.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/BackendCodeGeneratorProvider.java
@@ -29,7 +29,7 @@ import java.util.ServiceLoader;
  */
 public class BackendCodeGeneratorProvider {
 
-    private static final BackendCodeGeneratorProvider provider = new BackendCodeGeneratorProvider();
+    private static final BackendCodeGeneratorProvider PROVIDER = new BackendCodeGeneratorProvider();
 
     private final ServiceLoader<CompilerBackendCodeGenerator> loader;
 
@@ -46,7 +46,7 @@ public class BackendCodeGeneratorProvider {
      * @return instance of BackendCodeGeneratorProvider
      */
     public static BackendCodeGeneratorProvider getInstance() {
-        return provider;
+        return PROVIDER;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/EmbeddedExecutorProvider.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/EmbeddedExecutorProvider.java
@@ -9,7 +9,7 @@ import java.util.ServiceLoader;
  * Ballerina package provider class used in package management.
  */
 public class EmbeddedExecutorProvider {
-    private static final EmbeddedExecutorProvider provider = new EmbeddedExecutorProvider();
+    private static final EmbeddedExecutorProvider PROVIDER = new EmbeddedExecutorProvider();
 
     private final ServiceLoader<EmbeddedExecutor> loader;
 
@@ -26,7 +26,7 @@ public class EmbeddedExecutorProvider {
      * @return instance of EmbeddedExecutorProvider
      */
     public static EmbeddedExecutorProvider getInstance() {
-        return provider;
+        return PROVIDER;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/EmbeddedExecutorProvider.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/EmbeddedExecutorProvider.java
@@ -9,7 +9,7 @@ import java.util.ServiceLoader;
  * Ballerina package provider class used in package management.
  */
 public class EmbeddedExecutorProvider {
-    private static EmbeddedExecutorProvider provider = new EmbeddedExecutorProvider();
+    private static final EmbeddedExecutorProvider provider = new EmbeddedExecutorProvider();
 
     private final ServiceLoader<EmbeddedExecutor> loader;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -143,14 +143,14 @@ public class BIRPackageSymbolEnter {
     private BIRPackageSymbolEnv env;
     private List<BStructureTypeSymbol> structureTypes; // TODO find a better way
     private BStructureTypeSymbol currentStructure = null;
-    private LinkedList<Object> compositeStack = new LinkedList<>();
+    private final LinkedList<Object> compositeStack = new LinkedList<>();
 
     private static final int SERVICE_TYPE_TAG = 54;
 
     private static final CompilerContext.Key<BIRPackageSymbolEnter> COMPILED_PACKAGE_SYMBOL_ENTER_KEY =
             new CompilerContext.Key<>();
 
-    private Map<String, BVarSymbol> globalVarMap = new HashMap<>();
+    private final Map<String, BVarSymbol> globalVarMap = new HashMap<>();
 
     public static BIRPackageSymbolEnter getInstance(CompilerContext context) {
         BIRPackageSymbolEnter packageReader = context.get(COMPILED_PACKAGE_SYMBOL_ENTER_KEY);
@@ -1133,7 +1133,7 @@ public class BIRPackageSymbolEnter {
     }
 
     private class BIRTypeReader {
-        private DataInputStream inputStream;
+        private final DataInputStream inputStream;
 
         public BIRTypeReader(DataInputStream inputStream) {
             this.inputStream = inputStream;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProgramDirectory.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProgramDirectory.java
@@ -55,7 +55,7 @@ import static org.wso2.ballerinalang.util.LambdaExceptionUtils.rethrow;
  */
 public class FileSystemProgramDirectory implements SourceDirectory {
     private final Path programDirPath;
-    private static PrintStream outStream = System.out;
+    private static final PrintStream outStream = System.out;
 
     public FileSystemProgramDirectory(Path programDirPath) {
         this.programDirPath = programDirPath;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProgramDirectory.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProgramDirectory.java
@@ -55,7 +55,7 @@ import static org.wso2.ballerinalang.util.LambdaExceptionUtils.rethrow;
  */
 public class FileSystemProgramDirectory implements SourceDirectory {
     private final Path programDirPath;
-    private static final PrintStream outStream = System.out;
+    private static final PrintStream OUT_STREAM = System.out;
 
     public FileSystemProgramDirectory(Path programDirPath) {
         this.programDirPath = programDirPath;
@@ -113,7 +113,7 @@ public class FileSystemProgramDirectory implements SourceDirectory {
         // the user
         Path targetFilePath = Paths.get(fileName);
         try {
-            outStream.println("    " + fileName);
+            OUT_STREAM.println("    " + fileName);
             Files.copy(source, targetFilePath, StandardCopyOption.REPLACE_EXISTING);
             return targetFilePath;
         } catch (DirectoryNotEmptyException e) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProjectDirectory.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProjectDirectory.java
@@ -57,7 +57,7 @@ public class FileSystemProjectDirectory extends FileSystemProgramDirectory {
     private final Path sourceDirPath;
     private List<String> packageNames;
     protected boolean scanned = false;
-    private static PrintStream outStream = System.out;
+    private static final PrintStream outStream = System.out;
 
     public FileSystemProjectDirectory(Path projectDirPath) {
         super(projectDirPath);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProjectDirectory.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProjectDirectory.java
@@ -57,7 +57,7 @@ public class FileSystemProjectDirectory extends FileSystemProgramDirectory {
     private final Path sourceDirPath;
     private List<String> packageNames;
     protected boolean scanned = false;
-    private static final PrintStream outStream = System.out;
+    private static final PrintStream OUT_STREAM = System.out;
 
     public FileSystemProjectDirectory(Path projectDirPath) {
         super(projectDirPath);
@@ -132,7 +132,7 @@ public class FileSystemProjectDirectory extends FileSystemProgramDirectory {
     public Path saveCompiledProgram(InputStream source, String fileName) {
         Path targetFilePath = ensureAndGetTargetDirPath().resolve(fileName);
         try {
-            outStream.println("    ./target/" + fileName);
+            OUT_STREAM.println("    ./target/" + fileName);
             Files.copy(source, targetFilePath, StandardCopyOption.REPLACE_EXISTING);
             return targetFilePath;
         } catch (DirectoryNotEmptyException e) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CompiledJarFile.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CompiledJarFile.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  */
 public class CompiledJarFile {
 
-    public JarEntries jarEntries;
+    public final JarEntries jarEntries;
 
     public CompiledJarFile(String mainClassName) {
         this.jarEntries = new JarEntries(mainClassName);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -825,7 +825,7 @@ public abstract class BIRNode {
     public static class BIRLockDetailsHolder {
 
         //This is the list of recursive locks in the current scope.
-        private List<BIRTerminator.Lock> locks = new ArrayList<>();
+        private final List<BIRTerminator.Lock> locks = new ArrayList<>();
 
         public boolean isEmpty() {
             return locks.isEmpty();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
@@ -136,9 +136,9 @@ public class AnnotationDesugar {
     private final SymbolTable symTable;
     private final Types types;
     private final Names names;
-    private SymbolResolver symResolver;
-    private ConstantValueResolver constantValueResolver;
-    private ClosureGenerator closureGenerator;
+    private final SymbolResolver symResolver;
+    private final ConstantValueResolver constantValueResolver;
+    private final ClosureGenerator closureGenerator;
 
     public static AnnotationDesugar getInstance(CompilerContext context) {
         AnnotationDesugar annotationDesugar = context.get(ANNOTATION_DESUGAR_KEY);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClassClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClassClosureDesugar.java
@@ -171,7 +171,7 @@ public class ClassClosureDesugar extends BLangNodeVisitor {
     private static final String OBJECT_CTOR_FUNCTION_MAP_SYM_NAME = "$map$objectCtor" + UNDERSCORE + "function";
     private static final BVarSymbol CLOSURE_MAP_NOT_FOUND;
 
-    private int blockClosureMapCount = 1;
+    private final int blockClosureMapCount = 1;
     private BLangClassDefinition classDef;
     private BLangNode result;
     private SymbolEnv env;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -205,13 +205,13 @@ public class ClosureDesugar extends BLangNodeVisitor {
     private static final BVarSymbol CLOSURE_MAP_NOT_FOUND;
 
     private SymbolResolver symResolver;
-    private SymbolTable symTable;
+    private final SymbolTable symTable;
     private SymbolEnv env;
     private BLangNode result;
-    private Types types;
-    private Desugar desugar;
-    private Names names;
-    private ClassClosureDesugar classClosureDesugar;
+    private final Types types;
+    private final Desugar desugar;
+    private final Names names;
+    private final ClassClosureDesugar classClosureDesugar;
     private int funClosureMapCount = 1;
     private int blockClosureMapCount = 1;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
@@ -223,12 +223,12 @@ public class ClosureGenerator extends BLangNodeVisitor {
     private static final CompilerContext.Key<ClosureGenerator> CLOSURE_GENERATOR_KEY = new CompilerContext.Key<>();
     private Queue<BLangSimpleVariableDef> queue;
     private Queue<BLangSimpleVariableDef> annotationClosureReferences;
-    private SymbolTable symTable;
+    private final SymbolTable symTable;
     private SymbolEnv env;
     private BLangNode result;
-    private SymbolResolver symResolver;
-    private AnnotationDesugar annotationDesugar;
-    private Types types;
+    private final SymbolResolver symResolver;
+    private final AnnotationDesugar annotationDesugar;
+    private final Types types;
 
     public static ClosureGenerator getInstance(CompilerContext context) {
         ClosureGenerator closureGenerator = context.get(CLOSURE_GENERATOR_KEY);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
@@ -196,7 +196,7 @@ public class ConstantPropagation extends BLangNodeVisitor {
             new CompilerContext.Key<>();
 
     private BLangNode result;
-    private Types types;
+    private final Types types;
 
     public static ConstantPropagation getInstance(CompilerContext context) {
         ConstantPropagation constantPropagation = context.get(CONSTANT_PROPAGATION_KEY);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -376,36 +376,36 @@ public class Desugar extends BLangNodeVisitor {
     public static final String XML_INTERNAL_GET_ELEMENTS = "getElements";
     public static final String XML_GET_CONTENT_OF_TEXT = "getContent";
 
-    private SymbolTable symTable;
-    private SymbolResolver symResolver;
+    private final SymbolTable symTable;
+    private final SymbolResolver symResolver;
     private final SymbolEnter symbolEnter;
-    private ClosureDesugar closureDesugar;
-    private ClosureGenerator closureGenerator;
-    private QueryDesugar queryDesugar;
-    private TransactionDesugar transactionDesugar;
-    private ObservabilityDesugar observabilityDesugar;
-    private Code2CloudDesugar code2CloudDesugar;
-    private AnnotationDesugar annotationDesugar;
-    private Types types;
+    private final ClosureDesugar closureDesugar;
+    private final ClosureGenerator closureGenerator;
+    private final QueryDesugar queryDesugar;
+    private final TransactionDesugar transactionDesugar;
+    private final ObservabilityDesugar observabilityDesugar;
+    private final Code2CloudDesugar code2CloudDesugar;
+    private final AnnotationDesugar annotationDesugar;
+    private final Types types;
     private Names names;
-    private ServiceDesugar serviceDesugar;
+    private final ServiceDesugar serviceDesugar;
     private BLangNode result;
-    private NodeCloner nodeCloner;
-    private SemanticAnalyzer semanticAnalyzer;
-    private BLangAnonymousModelHelper anonModelHelper;
-    private Unifier unifier;
-    private MockDesugar mockDesugar;
-    private ClassClosureDesugar classClosureDesugar;
-    private LargeMethodSplitter largeMethodSplitter;
+    private final NodeCloner nodeCloner;
+    private final SemanticAnalyzer semanticAnalyzer;
+    private final BLangAnonymousModelHelper anonModelHelper;
+    private final Unifier unifier;
+    private final MockDesugar mockDesugar;
+    private final ClassClosureDesugar classClosureDesugar;
+    private final LargeMethodSplitter largeMethodSplitter;
 
     public Deque<BLangLockStmt> enclLocks = new ArrayDeque<>();
     private BLangOnFailClause onFailClause;
     private boolean shouldReturnErrors;
     private int transactionBlockCount;
     private BLangLiteral trxBlockId;
-    private List<BLangOnFailClause> enclosingOnFailClause = new ArrayList<>();
-    private Map<BLangOnFailClause, BLangSimpleVarRef> enclosingShouldPanic = new HashMap<>();
-    private List<BLangSimpleVarRef> enclosingShouldContinue = new ArrayList<>();
+    private final List<BLangOnFailClause> enclosingOnFailClause = new ArrayList<>();
+    private final Map<BLangOnFailClause, BLangSimpleVarRef> enclosingShouldPanic = new HashMap<>();
+    private final List<BLangSimpleVarRef> enclosingShouldContinue = new ArrayList<>();
     private BLangSimpleVarRef shouldRetryRef;
 
     private SymbolEnv env;
@@ -431,8 +431,8 @@ public class Desugar extends BLangNodeVisitor {
     static boolean isJvmTarget = false;
 
     private Map<BSymbol, Set<BVarSymbol>> globalVariablesDependsOn;
-    private List<BLangStatement> matchStmtsForPattern = new ArrayList<>();
-    private Map<String, BLangSimpleVarRef> declaredVarDef = new HashMap<>();
+    private final List<BLangStatement> matchStmtsForPattern = new ArrayList<>();
+    private final Map<String, BLangSimpleVarRef> declaredVarDef = new HashMap<>();
     private List<BLangXMLNS> inlineXMLNamespaces;
     private Map<Name, BLangStatement> stmtsToBePropagatedToQuery = new HashMap<>();
     // Reuse the strand annotation in isolated workers and start action

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/MockDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/MockDesugar.java
@@ -77,7 +77,7 @@ public class MockDesugar {
     private BLangFunction originalFunction;
     private BInvokableSymbol importFunction;
     private String mockFnObjectName;
-    private String testPackageSymbol = "ballerina/test";
+    private final String testPackageSymbol = "ballerina/test";
 
     public static final String MOCK_FUNCTION = "$MOCK_";
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
@@ -77,8 +77,8 @@ public class ServiceDesugar {
     private final SymbolTable symTable;
     private final SymbolResolver symResolver;
     private final Names names;
-    private DeclarativeAuthDesugar declarativeAuthDesugar;
-    private TransactionDesugar transactionDesugar;
+    private final DeclarativeAuthDesugar declarativeAuthDesugar;
+    private final TransactionDesugar transactionDesugar;
     private final Types types;
 
     public static ServiceDesugar getInstance(CompilerContext context) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnostic.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnostic.java
@@ -35,11 +35,11 @@ import java.util.List;
  */
 public class BLangDiagnostic extends Diagnostic {
 
-    private Location location;
-    private String msg;
-    private DiagnosticInfo diagnosticInfo;
-    private DiagnosticCode diagnosticCode;
-    private List<DiagnosticProperty<?>> properties;
+    private final Location location;
+    private final String msg;
+    private final DiagnosticInfo diagnosticInfo;
+    private final DiagnosticCode diagnosticCode;
+    private final List<DiagnosticProperty<?>> properties;
 
     public BLangDiagnostic(Location location, String msg, DiagnosticInfo diagnosticInfo,
                            DiagnosticCode diagnosticCode) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLocation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLocation.java
@@ -33,8 +33,8 @@ import java.util.Objects;
  */
 public class BLangDiagnosticLocation implements Location {
 
-    private String filePath;
-    private int startLine, endLine, startColumn, endColumn, startOffset, length;
+    private final String filePath;
+    private final int startLine, endLine, startColumn, endColumn, startOffset, length;
 
     @Deprecated
     public BLangDiagnosticLocation(String filePath, int startLine, int endLine, int startColumn, int endColumn) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLog.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLog.java
@@ -64,9 +64,9 @@ public class BLangDiagnosticLog implements DiagnosticLog {
     private static final ResourceBundle MESSAGES = ResourceBundle.getBundle("compiler", Locale.getDefault());
 
     private int errorCount = 0;
-    private PackageCache packageCache;
-    private TypesFactory typesFactory;
-    private SymbolFactory symbolFactory;
+    private final PackageCache packageCache;
+    private final TypesFactory typesFactory;
+    private final SymbolFactory symbolFactory;
     private PackageID currentPackageId;
     private boolean isMute = false;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FilterSearch.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FilterSearch.java
@@ -16,7 +16,7 @@ import java.util.List;
 class FilterSearch<T> extends SimpleFileVisitor<T> {
 
     private final List<Path> excludeDir;
-    private List<Path> pathList = new ArrayList<>();
+    private final List<Path> pathList = new ArrayList<>();
 
     FilterSearch(List<Path> exclude) {
         this.excludeDir = exclude;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
@@ -46,8 +46,8 @@ import java.util.stream.Stream;
 public class PathConverter implements Converter<Path> {
 
     private final Path root;
-    private PathMatcher isResourceFile;
-    private PathMatcher isTestResourceFile;
+    private final PathMatcher isResourceFile;
+    private final PathMatcher isTestResourceFile;
 
     public PathConverter(Path root) {
         this.root = root;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/URIConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/URIConverter.java
@@ -43,11 +43,11 @@ import static org.wso2.ballerinalang.programfile.ProgramFileConstants.SUPPORTED_
  */
 public class URIConverter implements Converter<URI> {
 
-    private HomeBalaRepo homeBalaRepo;
+    private final HomeBalaRepo homeBalaRepo;
     protected URI base;
     protected final Map<PackageID, Manifest> dependencyManifests;
     private boolean isBuild = true;
-    private PrintStream errStream = System.err;
+    private final PrintStream errStream = System.err;
 
     public URIConverter(URI base, Map<PackageID, Manifest> dependencyManifests) {
         this.base = URI.create(base.toString() + "/modules/");

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBalaRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBalaRepo.java
@@ -46,11 +46,11 @@ import static org.wso2.ballerinalang.programfile.ProgramFileConstants.SUPPORTED_
  * Repo for bala_cache.
  */
 public class HomeBalaRepo implements Repo<Path> {
-    private Path repoLocation;
-    private ZipConverter zipConverter;
-    private List<String> supportedPlatforms = Stream.concat(
+    private final Path repoLocation;
+    private final ZipConverter zipConverter;
+    private final List<String> supportedPlatforms = Stream.concat(
             Arrays.stream(SUPPORTED_PLATFORMS), Stream.of("any")).toList();
-    private Map<PackageID, Manifest> dependencyManifests;
+    private final Map<PackageID, Manifest> dependencyManifests;
     
     public HomeBalaRepo(Map<PackageID, Manifest> dependencyManifests) {
         this.repoLocation = RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.BALA_CACHE_DIR_NAME);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBirRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBirRepo.java
@@ -34,7 +34,7 @@ import static org.wso2.ballerinalang.compiler.packaging.Patten.path;
  * Repo for bir_cache in home repository.
  */
 public class HomeBirRepo implements Repo<Path> {
-    private PathConverter pathConverter;
+    private final PathConverter pathConverter;
     
     public HomeBirRepo() {
         Path repoLocation = RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.BIR_CACHE_DIR_NAME + "-" +

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/PathBalaRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/PathBalaRepo.java
@@ -46,8 +46,8 @@ public class PathBalaRepo implements Repo<Path> {
     private static final Pattern semVerPattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)");
     
     private final Manifest manifest;
-    private Map<PackageID, Manifest> dependencyManifests;
-    private ZipConverter zipConverter;
+    private final Map<PackageID, Manifest> dependencyManifests;
+    private final ZipConverter zipConverter;
     
     public PathBalaRepo(Manifest manifest, Map<PackageID, Manifest> dependencyManifests) {
         this.manifest = manifest;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/PathBalaRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/PathBalaRepo.java
@@ -43,7 +43,7 @@ import static org.wso2.ballerinalang.compiler.packaging.Patten.path;
  * Resolve a bala using the path given in the Ballerina.toml.
  */
 public class PathBalaRepo implements Repo<Path> {
-    private static final Pattern semVerPattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)");
+    private static final Pattern SEM_VER_PATTERN = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)");
     
     private final Manifest manifest;
     private final Map<PackageID, Manifest> dependencyManifests;
@@ -92,7 +92,7 @@ public class PathBalaRepo implements Repo<Path> {
         
         // update version of the dependency from the current(root) project
         if (moduleID.version.value.isEmpty() && null != dep.getMetadata().getVersion()) {
-            Matcher semverMatcher = semVerPattern.matcher(dep.getMetadata().getVersion());
+            Matcher semverMatcher = SEM_VER_PATTERN.matcher(dep.getMetadata().getVersion());
             if (semverMatcher.matches()) {
                 moduleID.version = new Name(dep.getMetadata().getVersion());
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/RemoteRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/RemoteRepo.java
@@ -37,7 +37,7 @@ import static org.wso2.ballerinalang.util.RepoUtils.COMPILE_BALLERINA_ORG;
  */
 public class RemoteRepo extends NonSysRepo<URI> {
 
-    private Path systemBirRepoPath;
+    private final Path systemBirRepoPath;
 
     public RemoteRepo(Converter<URI> converter, Path ballerinaHome) {
         super(converter);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangAnonymousModelHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangAnonymousModelHelper.java
@@ -36,18 +36,18 @@ import static io.ballerina.runtime.api.constants.RuntimeConstants.UNDERSCORE;
  */
 public class BLangAnonymousModelHelper {
 
-    private Map<PackageID, Integer> anonTypeCount;
-    private Map<PackageID, Integer> anonServiceCount;
-    private Map<PackageID, Integer> anonFunctionCount;
-    private Map<PackageID, Integer> anonForkCount;
-    private Map<PackageID, Integer> distinctTypeIdCount;
-    private Map<PackageID, Integer> rawTemplateTypeCount;
-    private Map<PackageID, Integer> tupleVarCount;
-    private Map<PackageID, Integer> recordVarCount;
-    private Map<PackageID, Integer> errorVarCount;
-    private Map<PackageID, Integer> intersectionRecordCount;
-    private Map<PackageID, Integer> intersectionErrorCount;
-    private Map<PackageID, Map<String, Integer>> anonTypesNamesPerPkg;
+    private final Map<PackageID, Integer> anonTypeCount;
+    private final Map<PackageID, Integer> anonServiceCount;
+    private final Map<PackageID, Integer> anonFunctionCount;
+    private final Map<PackageID, Integer> anonForkCount;
+    private final Map<PackageID, Integer> distinctTypeIdCount;
+    private final Map<PackageID, Integer> rawTemplateTypeCount;
+    private final Map<PackageID, Integer> tupleVarCount;
+    private final Map<PackageID, Integer> recordVarCount;
+    private final Map<PackageID, Integer> errorVarCount;
+    private final Map<PackageID, Integer> intersectionRecordCount;
+    private final Map<PackageID, Integer> intersectionErrorCount;
+    private final Map<PackageID, Map<String, Integer>> anonTypesNamesPerPkg;
 
     public static final String ANON_PREFIX = "$anon";
     private static final String ANON_TYPE = ANON_PREFIX + "Type$";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangMissingNodesHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangMissingNodesHelper.java
@@ -34,7 +34,7 @@ import static io.ballerina.runtime.api.constants.RuntimeConstants.UNDERSCORE;
  */
 public class BLangMissingNodesHelper {
 
-    private Map<PackageID, Integer> missingIdentifierCount;
+    private final Map<PackageID, Integer> missingIdentifierCount;
 
     private static final String MISSING_NODE_PREFIX = "$missingNode$";
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
@@ -528,19 +528,19 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
     private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 10; // -10 was added due to the JVM limitations
     private static final String IDENTIFIER_LITERAL_PREFIX = "'";
     private static final String DOLLAR = "$";
-    private BLangDiagnosticLog dlog;
-    private SymbolTable symTable;
+    private final BLangDiagnosticLog dlog;
+    private final SymbolTable symTable;
 
     private PackageCache packageCache;
-    private PackageID packageID;
-    private String currentCompUnitName;
+    private final PackageID packageID;
+    private final String currentCompUnitName;
 
     private BLangCompilationUnit currentCompilationUnit;
-    private BLangAnonymousModelHelper anonymousModelHelper;
-    private BLangMissingNodesHelper missingNodesHelper;
+    private final BLangAnonymousModelHelper anonymousModelHelper;
+    private final BLangMissingNodesHelper missingNodesHelper;
 
     /* To keep track of additional statements produced from multi-BLangNode resultant transformations */
-    private Deque<BLangStatement> additionalStatements = new ArrayDeque<>();
+    private final Deque<BLangStatement> additionalStatements = new ArrayDeque<>();
     private final Deque<String> anonTypeNameSuffixes = new ArrayDeque<>();
     /* To keep track if we are inside a block statment for the use of type definition creation */
     private boolean isInLocalContext = false;
@@ -550,7 +550,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
     boolean isInCharacterClass = false;
     boolean inCollectContext = false;
 
-    private  HashSet<String> constantSet = new HashSet<String>();
+    private final HashSet<String> constantSet = new HashSet<String>();
 
     public BLangNodeBuilder(CompilerContext context,
                             PackageID packageID, String entryName) {
@@ -6872,7 +6872,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         private BLangIdentifier name;
         private BLangType type;
         private boolean isDeclaredWithVar;
-        private Set<Flag> flags = new HashSet<>();
+        private final Set<Flag> flags = new HashSet<>();
         private boolean isFinal;
         private ExpressionNode expr;
         private Location pos;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -4157,9 +4157,9 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
 
         public final List<BLangAlternateWorkerReceive> alternateWorkerReceives = new ArrayList<>();
         public List<WorkerActionStateMachine> finshedWorkers = new ArrayList<>();
-        private Deque<WorkerActionStateMachine> workerActionStateMachines = new ArrayDeque<>();
-        private Map<BLangNode, SymbolEnv> workerInteractionEnvironments = new IdentityHashMap<>();
-        private Map<String, Integer> workerEventIndexMap = new HashMap<>();
+        private final Deque<WorkerActionStateMachine> workerActionStateMachines = new ArrayDeque<>();
+        private final Map<BLangNode, SymbolEnv> workerInteractionEnvironments = new IdentityHashMap<>();
+        private final Map<String, Integer> workerEventIndexMap = new HashMap<>();
         private boolean hasErrors = false;
 
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
@@ -83,20 +83,20 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
     private static final CompilerContext.Key<CompilerPluginRunner> COMPILER_PLUGIN_RUNNER_KEY =
             new CompilerContext.Key<>();
 
-    private SymbolTable symTable;
-    private PackageCache packageCache;
-    private SymbolResolver symResolver;
-    private Names names;
+    private final SymbolTable symTable;
+    private final PackageCache packageCache;
+    private final SymbolResolver symResolver;
+    private final Names names;
     private final Types types;
-    private BLangDiagnosticLog dlog;
+    private final BLangDiagnosticLog dlog;
 
     private Location defaultPos;
-    private CompilerContext context;
-    private List<CompilerPlugin> pluginList;
-    private Map<DefinitionID, Set<CompilerPlugin>> processorMap;
-    private Map<CompilerPlugin, List<DefinitionID>> resourceTypeProcessorMap;
-    private Map<CompilerPlugin, BType> serviceListenerMap;
-    private List<CompilerPlugin> failedPlugins;
+    private final CompilerContext context;
+    private final List<CompilerPlugin> pluginList;
+    private final Map<DefinitionID, Set<CompilerPlugin>> processorMap;
+    private final Map<CompilerPlugin, List<DefinitionID>> resourceTypeProcessorMap;
+    private final Map<CompilerPlugin, BType> serviceListenerMap;
+    private final List<CompilerPlugin> failedPlugins;
 
 
     public static CompilerPluginRunner getInstance(CompilerContext context) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantAnalyzer.java
@@ -59,8 +59,8 @@ public class ConstantAnalyzer extends BLangNodeVisitor {
     private final Names names;
     private final SymbolTable symTable;
     private final SymbolResolver symResolver;
-    private BLangDiagnosticLog dlog;
-    private Deque<BLangExpression> expressions = new ArrayDeque<>();
+    private final BLangDiagnosticLog dlog;
+    private final Deque<BLangExpression> expressions = new ArrayDeque<>();
 
     private ConstantAnalyzer(CompilerContext context) {
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantTypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantTypeChecker.java
@@ -135,7 +135,7 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
     private final TypeChecker typeChecker;
     private final TypeResolver typeResolver;
     private final ConstantTypeChecker.FillMembers fillMembers;
-    private BLangAnonymousModelHelper anonymousModelHelper;
+    private final BLangAnonymousModelHelper anonymousModelHelper;
 
     public ConstantTypeChecker(CompilerContext context) {
         context.put(CONSTANT_TYPE_CHECKER_KEY, this);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
@@ -99,19 +99,19 @@ public class ConstantValueResolver extends BLangNodeVisitor {
             new CompilerContext.Key<>();
     private BConstantSymbol currentConstSymbol;
     private BLangConstantValue result;
-    private BLangDiagnosticLog dlog;
+    private final BLangDiagnosticLog dlog;
     private Location currentPos;
-    private BLangAnonymousModelHelper anonymousModelHelper;
+    private final BLangAnonymousModelHelper anonymousModelHelper;
     private SymbolEnv symEnv;
-    private Names names;
-    private SymbolTable symTable;
-    private Types types;
+    private final Names names;
+    private final SymbolTable symTable;
+    private final Types types;
     private PackageID pkgID;
-    private Map<BConstantSymbol, BLangConstant> unresolvedConstants = new HashMap<>();
-    private Map<String, BLangConstantValue> constantMap = new HashMap<>();
-    private ArrayList<BConstantSymbol> resolvingConstants = new ArrayList<>();
-    private HashSet<BConstantSymbol> unresolvableConstants = new HashSet<>();
-    private HashMap<BSymbol, BLangTypeDefinition> createdTypeDefinitions = new HashMap<>();
+    private final Map<BConstantSymbol, BLangConstant> unresolvedConstants = new HashMap<>();
+    private final Map<String, BLangConstantValue> constantMap = new HashMap<>();
+    private final ArrayList<BConstantSymbol> resolvingConstants = new ArrayList<>();
+    private final HashSet<BConstantSymbol> unresolvableConstants = new HashSet<>();
+    private final HashMap<BSymbol, BLangTypeDefinition> createdTypeDefinitions = new HashMap<>();
     private Deque<String> anonTypeNameSuffixes = new ArrayDeque<>();
 
     private ConstantValueResolver(CompilerContext context) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -261,9 +261,9 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     private final SymbolResolver symResolver;
     private final Names names;
     private SymbolEnv env;
-    private SymbolTable symTable;
-    private BLangDiagnosticLog dlog;
-    private Types types;
+    private final SymbolTable symTable;
+    private final BLangDiagnosticLog dlog;
+    private final Types types;
     private Map<BSymbol, InitStatus> uninitializedVars;
     private Map<BSymbol, Location> unusedErrorVarsDeclaredWithVar;
     private Map<BSymbol, Location> unusedLocalVariables;
@@ -276,7 +276,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     private boolean definiteFailureReached = false;
 
     private static final CompilerContext.Key<DataflowAnalyzer> DATAFLOW_ANALYZER_KEY = new CompilerContext.Key<>();
-    private Deque<BSymbol> currDependentSymbolDeque;
+    private final Deque<BSymbol> currDependentSymbolDeque;
     private final GlobalVariableRefAnalyzer globalVariableRefAnalyzer;
 
     private DataflowAnalyzer(CompilerContext context) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsAnydataUniqueVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsAnydataUniqueVisitor.java
@@ -46,8 +46,8 @@ import java.util.HashSet;
  */
 public class IsAnydataUniqueVisitor implements UniqueTypeVisitor<Boolean> {
 
-    private HashSet<BType> visited;
-    private boolean isAnydata;
+    private final HashSet<BType> visited;
+    private final boolean isAnydata;
 
     public IsAnydataUniqueVisitor() {
         visited = new HashSet<>();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsPureTypeUniqueVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsPureTypeUniqueVisitor.java
@@ -44,8 +44,8 @@ import java.util.HashSet;
  */
 public class IsPureTypeUniqueVisitor implements UniqueTypeVisitor<Boolean> {
 
-    private HashSet<BType> visited;
-    private boolean isPureType;
+    private final HashSet<BType> visited;
+    private final boolean isPureType;
 
     public IsPureTypeUniqueVisitor() {
         visited = new HashSet<>();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -233,14 +233,14 @@ public class SymbolEnter extends BLangNodeVisitor {
     private Set<BLangNode> unresolvedRecordDueToFields;
     private boolean resolveRecordsUnresolvedDueToFields;
     private List<BLangClassDefinition> unresolvedClasses;
-    private HashSet<LocationData> unknownTypeRefs;
-    private List<PackageID> importedPackages;
+    private final HashSet<LocationData> unknownTypeRefs;
+    private final List<PackageID> importedPackages;
     private int typePrecedence;
     private final TypeParamAnalyzer typeParamAnalyzer;
-    private BLangAnonymousModelHelper anonymousModelHelper;
-    private BLangMissingNodesHelper missingNodesHelper;
-    private PackageCache packageCache;
-    private List<BLangNode> intersectionTypes;
+    private final BLangAnonymousModelHelper anonymousModelHelper;
+    private final BLangMissingNodesHelper missingNodesHelper;
+    private final PackageCache packageCache;
+    private final List<BLangNode> intersectionTypes;
     private Map<BType, BLangTypeDefinition> typeToTypeDef;
 
     private SymbolEnv env;
@@ -5445,9 +5445,9 @@ public class SymbolEnter extends BLangNodeVisitor {
      */
     private static class LocationData {
 
-        private String name;
-        private int row;
-        private int column;
+        private final String name;
+        private final int row;
+        private final int column;
 
         LocationData(String name, int row, int column) {
             this.name = name;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -221,8 +221,8 @@ import static org.wso2.ballerinalang.compiler.util.CompilerUtils.isInParameterLi
 public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerData> {
 
     private static final CompilerContext.Key<TypeChecker> TYPE_CHECKER_KEY = new CompilerContext.Key<>();
-    private static final Set<String> listLengthModifierFunctions = new HashSet<>();
-    private static final Map<String, HashSet<String>> modifierFunctions = new HashMap<>();
+    private static final Set<String> LIST_LENGTH_MODIFIER_FUNCTIONS = new HashSet<>();
+    private static final Map<String, HashSet<String>> MODIFIER_FUNCTIONS = new HashMap<>();
 
     private static final String LIST_LANG_LIB = "lang.array";
     private static final String MAP_LANG_LIB = "lang.map";
@@ -252,12 +252,12 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
     protected final QueryTypeChecker queryTypeChecker;
 
     static {
-        listLengthModifierFunctions.add(FUNCTION_NAME_PUSH);
-        listLengthModifierFunctions.add(FUNCTION_NAME_POP);
-        listLengthModifierFunctions.add(FUNCTION_NAME_SHIFT);
-        listLengthModifierFunctions.add(FUNCTION_NAME_UNSHIFT);
+        LIST_LENGTH_MODIFIER_FUNCTIONS.add(FUNCTION_NAME_PUSH);
+        LIST_LENGTH_MODIFIER_FUNCTIONS.add(FUNCTION_NAME_POP);
+        LIST_LENGTH_MODIFIER_FUNCTIONS.add(FUNCTION_NAME_SHIFT);
+        LIST_LENGTH_MODIFIER_FUNCTIONS.add(FUNCTION_NAME_UNSHIFT);
 
-        modifierFunctions.put(LIST_LANG_LIB, new HashSet<String>() {{
+        MODIFIER_FUNCTIONS.put(LIST_LANG_LIB, new HashSet<String>() {{
             add("remove");
             add("removeAll");
             add("setLength");
@@ -269,13 +269,13 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             add("unshift");
         }});
 
-        modifierFunctions.put(MAP_LANG_LIB, new HashSet<String>() {{
+        MODIFIER_FUNCTIONS.put(MAP_LANG_LIB, new HashSet<String>() {{
             add("remove");
             add("removeIfHasKey");
             add("removeAll");
         }});
 
-        modifierFunctions.put(TABLE_LANG_LIB, new HashSet<String>() {{
+        MODIFIER_FUNCTIONS.put(TABLE_LANG_LIB, new HashSet<String>() {{
             add("put");
             add("add");
             add("remove");
@@ -283,11 +283,11 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             add("removeAll");
         }});
 
-        modifierFunctions.put(VALUE_LANG_LIB, new HashSet<String>() {{
+        MODIFIER_FUNCTIONS.put(VALUE_LANG_LIB, new HashSet<String>() {{
             add("mergeJson");
         }});
 
-        modifierFunctions.put(XML_LANG_LIB, new HashSet<String>() {{
+        MODIFIER_FUNCTIONS.put(XML_LANG_LIB, new HashSet<String>() {{
             add("setName");
             add("setChildren");
             add("strip");
@@ -4246,12 +4246,12 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
         String packageId = langLibMethodSymbol.pkgID.name.value;
 
-        if (!modifierFunctions.containsKey(packageId)) {
+        if (!MODIFIER_FUNCTIONS.containsKey(packageId)) {
             return false;
         }
 
         String funcName = langLibMethodSymbol.name.value;
-        if (!modifierFunctions.get(packageId).contains(funcName)) {
+        if (!MODIFIER_FUNCTIONS.get(packageId).contains(funcName)) {
             return false;
         }
 
@@ -4289,7 +4289,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
     private void checkIllegalStorageSizeChangeMethodCall(BLangInvocation iExpr, BType varRefType, AnalyzerData data) {
         String invocationName = iExpr.name.getValue();
-        if (!listLengthModifierFunctions.contains(invocationName)) {
+        if (!LIST_LENGTH_MODIFIER_FUNCTIONS.contains(invocationName)) {
             return;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -221,8 +221,8 @@ import static org.wso2.ballerinalang.compiler.util.CompilerUtils.isInParameterLi
 public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerData> {
 
     private static final CompilerContext.Key<TypeChecker> TYPE_CHECKER_KEY = new CompilerContext.Key<>();
-    private static Set<String> listLengthModifierFunctions = new HashSet<>();
-    private static Map<String, HashSet<String>> modifierFunctions = new HashMap<>();
+    private static final Set<String> listLengthModifierFunctions = new HashSet<>();
+    private static final Map<String, HashSet<String>> modifierFunctions = new HashMap<>();
 
     private static final String LIST_LANG_LIB = "lang.array";
     private static final String MAP_LANG_LIB = "lang.map";
@@ -9811,8 +9811,8 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
     }
 
     private static class TypeSymbolPair {
-        private BVarSymbol fieldSymbol;
-        private BType determinedType;
+        private final BVarSymbol fieldSymbol;
+        private final BType determinedType;
 
         public TypeSymbolPair(BVarSymbol fieldSymbol, BType determinedType) {
             this.fieldSymbol = fieldSymbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeNarrower.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeNarrower.java
@@ -69,10 +69,10 @@ import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 public class TypeNarrower extends BLangNodeVisitor {
 
     private SymbolEnv env;
-    private SymbolTable symTable;
-    private Types types;
-    private SymbolEnter symbolEnter;
-    private TypeChecker typeChecker;
+    private final SymbolTable symTable;
+    private final Types types;
+    private final SymbolEnter symbolEnter;
+    private final TypeChecker typeChecker;
     private static final CompilerContext.Key<TypeNarrower> TYPE_NARROWER_KEY = new CompilerContext.Key<>();
 
     private TypeNarrower(CompilerContext context) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -101,11 +101,11 @@ public class TypeParamAnalyzer {
     private static final CompilerContext.Key<TypeParamAnalyzer> TYPE_PARAM_ANALYZER_KEY =
             new CompilerContext.Key<>();
 
-    private SymbolTable symTable;
-    private Types types;
-    private Names names;
-    private BLangDiagnosticLog dlog;
-    private BLangAnonymousModelHelper anonymousModelHelper;
+    private final SymbolTable symTable;
+    private final Types types;
+    private final Names names;
+    private final BLangDiagnosticLog dlog;
+    private final BLangAnonymousModelHelper anonymousModelHelper;
 
     public static TypeParamAnalyzer getInstance(CompilerContext context) {
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -153,18 +153,18 @@ public class TypeResolver {
     private final ConstantTypeChecker constantTypeChecker;
     private final ConstantTypeChecker.ResolveConstantExpressionType resolveConstantExpressionType;
     private final EffectiveTypePopulator effectiveTypePopulator;
-    private BLangAnonymousModelHelper anonymousModelHelper;
-    private BLangMissingNodesHelper missingNodesHelper;
+    private final BLangAnonymousModelHelper anonymousModelHelper;
+    private final BLangMissingNodesHelper missingNodesHelper;
 
-    private List<BLangTypeDefinition> resolvingTypeDefinitions = new ArrayList<>();
+    private final List<BLangTypeDefinition> resolvingTypeDefinitions = new ArrayList<>();
     private HashMap<BIntersectionType, BLangIntersectionTypeNode> intersectionTypeList;
     public HashSet<BLangConstant> resolvedConstants = new HashSet<>();
-    private ArrayList<BLangConstant> resolvingConstants = new ArrayList<>();
+    private final ArrayList<BLangConstant> resolvingConstants = new ArrayList<>();
     private Deque<String> resolvingModuleDefs;
-    private HashSet<BLangClassDefinition> resolvedClassDef = new HashSet<>();
-    private Map<String, BLangNode> modTable = new LinkedHashMap<>();
-    private Map<String, BLangConstantValue> constantMap = new HashMap<>();
-    private HashSet<LocationData> unknownTypeRefs;
+    private final HashSet<BLangClassDefinition> resolvedClassDef = new HashSet<>();
+    private final Map<String, BLangNode> modTable = new LinkedHashMap<>();
+    private final Map<String, BLangConstantValue> constantMap = new HashMap<>();
+    private final HashSet<LocationData> unknownTypeRefs;
     private SymbolEnv pkgEnv;
     private int currentDepth;
     private Deque<BType> resolvingTypes;
@@ -2134,9 +2134,9 @@ public class TypeResolver {
      * @since 2201.7.0
      */
     private static class LocationData {
-        private String name;
-        private int row;
-        private int column;
+        private final String name;
+        private final int row;
+        private final int column;
 
         LocationData(String name, int row, int column) {
             this.name = name;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -164,14 +164,14 @@ public class Types {
     private static final CompilerContext.Key<Types> TYPES_KEY =
             new CompilerContext.Key<>();
     private final Unifier unifier;
-    private SymbolTable symTable;
-    private SymbolResolver symResolver;
-    private BLangDiagnosticLog dlog;
-    private Names names;
+    private final SymbolTable symTable;
+    private final SymbolResolver symResolver;
+    private final BLangDiagnosticLog dlog;
+    private final Names names;
     private int finiteTypeCount = 0;
-    private BUnionType expandedXMLBuiltinSubtypes;
+    private final BUnionType expandedXMLBuiltinSubtypes;
     private final BLangAnonymousModelHelper anonymousModelHelper;
-    private int recordCount = 0;
+    private final int recordCount = 0;
     private SymbolEnv env;
     private boolean ignoreObjectTypeIds = false;
     private static final String BASE_16 = "base16";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -223,8 +223,8 @@ public class SymbolTable {
 
     public BPackageSymbol langRegexpModuleSymbol;
 
-    private Names names;
-    private Types types;
+    private final Names names;
+    private final Types types;
     public Map<BPackageSymbol, SymbolEnv> pkgEnvMap = new HashMap<>();
     public Map<Name, BPackageSymbol> predeclaredModules = new HashMap<>();
     public Map<String, Map<SelectivelyImmutableReferenceType, BIntersectionType>> immutableTypeMaps = new HashMap<>();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BAnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BAnnotationSymbol.java
@@ -44,7 +44,7 @@ public class BAnnotationSymbol extends BTypeSymbol implements AnnotationSymbol {
     public BType attachedType;
     public Set<AttachPoint> points;
     public int maskedPoints;
-    private List<BAnnotationAttachmentSymbol> annotationAttachments;
+    private final List<BAnnotationAttachmentSymbol> annotationAttachments;
 
     public BAnnotationSymbol(Name name, Name originalName, long flags, Set<AttachPoint> points, PackageID pkgID,
                              BType type, BSymbol owner, Location pos, SymbolOrigin origin) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BClassSymbol.java
@@ -37,7 +37,7 @@ import java.util.List;
 public class BClassSymbol extends BObjectTypeSymbol implements Annotatable {
 
     public boolean isServiceDecl;
-    private List<BAnnotationAttachmentSymbol> annotationAttachments;
+    private final List<BAnnotationAttachmentSymbol> annotationAttachments;
 
     public BClassSymbol(long symTag, long flags, Name name, PackageID pkgID, BType type,
                         BSymbol owner, Location pos, SymbolOrigin origin) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
@@ -38,7 +38,7 @@ import java.util.List;
 public class BEnumSymbol extends BTypeSymbol implements Annotatable {
 
     public List<BConstantSymbol> members;
-    private List<BAnnotationAttachmentSymbol> annotationAttachments;
+    private final List<BAnnotationAttachmentSymbol> annotationAttachments;
 
     public BEnumSymbol(List<BConstantSymbol> members, long flags, Name name, Name originalName,
                        PackageID pkgID, BType type, BSymbol owner, Location pos, SymbolOrigin origin) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BTypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BTypeDefinitionSymbol.java
@@ -37,7 +37,7 @@ import java.util.List;
 public class BTypeDefinitionSymbol extends BSymbol implements Annotatable {
 
     public BTypeReferenceType referenceType = null;
-    private List<BAnnotationAttachmentSymbol> annAttachments;
+    private final List<BAnnotationAttachmentSymbol> annAttachments;
 
     public BTypeDefinitionSymbol(long flags, Name name, PackageID pkgID, BType type, BSymbol owner,
                                  Location pos, SymbolOrigin origin) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
  */
 public class BFiniteType extends BType implements FiniteType {
 
-    private Set<BLangExpression> valueSpace;
+    private final Set<BLangExpression> valueSpace;
     private boolean nullable = false;
     public Boolean isAnyData = null;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangAnnotation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangAnnotation.java
@@ -47,7 +47,7 @@ public class BLangAnnotation extends BLangNode implements AnnotationNode {
 
     // Parser Flags and Data
     public Set<Flag> flagSet;
-    private Set<AttachPoint> attachPoints;
+    private final Set<AttachPoint> attachPoints;
 
     // Semantic Data
     public BSymbol symbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangPackage.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangPackage.java
@@ -88,7 +88,7 @@ public class BLangPackage extends BLangNode implements PackageNode {
 
     private int errorCount;
     private int warnCount;
-    private TreeSet<Diagnostic> diagnostics;
+    private final TreeSet<Diagnostic> diagnostics;
 
     public ModuleContextDataHolder moduleContextDataHolder;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangTestablePackage.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangTestablePackage.java
@@ -28,7 +28,7 @@ public class BLangTestablePackage extends BLangPackage {
     public BLangPackage parent;
     // Semantic Data
     //Map to maintain all the mock functions
-    private Map<String, String> mockFunctionNamesMap = new HashMap<>();
+    private final Map<String, String> mockFunctionNamesMap = new HashMap<>();
 
     private final Map<String, Boolean> isLegacyMockingMap = new HashMap<>();
     public Map<String, String> getMockFunctionNamesMap() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/CompilerContext.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/CompilerContext.java
@@ -26,8 +26,8 @@ import java.util.Map;
  */
 public class CompilerContext {
 
-    private Map<Key<?>, Object> props = new HashMap<>();
-    private Map<Class<?>, Object> objects = new HashMap<>();
+    private final Map<Key<?>, Object> props = new HashMap<>();
+    private final Map<Class<?>, Object> objects = new HashMap<>();
 
     public CompilerContext() {
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/CompilerOptions.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/CompilerOptions.java
@@ -33,7 +33,7 @@ public class CompilerOptions {
     private static final CompilerContext.Key<CompilerOptions> OPTIONS_KEY =
             new CompilerContext.Key<>();
 
-    private Map<CompilerOptionName, String> optionMap;
+    private final Map<CompilerOptionName, String> optionMap;
 
     public static CompilerOptions getInstance(CompilerContext context) {
         CompilerOptions options = context.get(OPTIONS_KEY);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/DefaultValueLiteral.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/DefaultValueLiteral.java
@@ -24,8 +24,8 @@ package org.wso2.ballerinalang.compiler.util;
  * @since 0.985.0
  */
 public class DefaultValueLiteral {
-    private Object defaultValue;
-    private int literalTypeTag;
+    private final Object defaultValue;
+    private final int literalTypeTag;
 
     public DefaultValueLiteral(Object defaultValue, int literalTypeTag) {
         this.defaultValue = defaultValue;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirs.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirs.java
@@ -39,13 +39,13 @@ import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BLANG_SOU
  */
 public final class ProjectDirs {
 
-    private static PathMatcher sourceFileMatcher = FileSystems.getDefault().getPathMatcher(
+    private static final PathMatcher sourceFileMatcher = FileSystems.getDefault().getPathMatcher(
             "glob:*" + BLANG_SOURCE_EXT);
 
-    private static PathMatcher testFileMatcher = FileSystems.getDefault().getPathMatcher(
+    private static final PathMatcher testFileMatcher = FileSystems.getDefault().getPathMatcher(
             "glob:../src/*/tests/**" + BLANG_SOURCE_EXT);
 
-    private static PathMatcher testResourceFileMatcher = FileSystems.getDefault().getPathMatcher(
+    private static final PathMatcher testResourceFileMatcher = FileSystems.getDefault().getPathMatcher(
             "glob:../src/*/tests/resources/**" + BLANG_SOURCE_EXT);
 
     private ProjectDirs() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirs.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirs.java
@@ -39,20 +39,20 @@ import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BLANG_SOU
  */
 public final class ProjectDirs {
 
-    private static final PathMatcher sourceFileMatcher = FileSystems.getDefault().getPathMatcher(
+    private static final PathMatcher SOURCE_FILE_MATCHER = FileSystems.getDefault().getPathMatcher(
             "glob:*" + BLANG_SOURCE_EXT);
 
-    private static final PathMatcher testFileMatcher = FileSystems.getDefault().getPathMatcher(
+    private static final PathMatcher TEST_FILE_MATCHER = FileSystems.getDefault().getPathMatcher(
             "glob:../src/*/tests/**" + BLANG_SOURCE_EXT);
 
-    private static final PathMatcher testResourceFileMatcher = FileSystems.getDefault().getPathMatcher(
+    private static final PathMatcher TEST_RESOURCE_FILE_MATCHER = FileSystems.getDefault().getPathMatcher(
             "glob:../src/*/tests/resources/**" + BLANG_SOURCE_EXT);
 
     private ProjectDirs() {
     }
 
     public static boolean isSourceFile(Path path) {
-        return !Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS) && sourceFileMatcher.matches(path);
+        return !Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS) && SOURCE_FILE_MATCHER.matches(path);
     }
 
     public static Path getLastComp(Path path) {
@@ -124,7 +124,7 @@ public final class ProjectDirs {
         Path pkgPath = sourceRoot.resolve(pkg);
         Path relativizePath = pkgPath.relativize(sourcePath);
         // Bal files should be inside tests directory but not in test resources
-        return testFileMatcher.matches(relativizePath) && !testResourceFileMatcher.matches(relativizePath);
+        return TEST_FILE_MATCHER.matches(relativizePath) && !TEST_RESOURCE_FILE_MATCHER.matches(relativizePath);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/diagnotic/DiagnosticPos.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/diagnotic/DiagnosticPos.java
@@ -34,9 +34,9 @@ import org.ballerinalang.model.elements.PackageID;
 @Deprecated
 public class DiagnosticPos implements Location {
 
-    private LineRange lineRange;
-    private TextRange textRange;
-    private PackageID packageID;
+    private final LineRange lineRange;
+    private final TextRange textRange;
+    private final PackageID packageID;
 
     public DiagnosticPos(String filePath, PackageID pkgId, int startLine, int endLine,
                          int startColumn, int endColumn) {

--- a/compiler/ballerina-lang/src/test/java/org/ballerinalang/toml/ManifestProcessorTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/ballerinalang/toml/ManifestProcessorTest.java
@@ -35,7 +35,7 @@ import java.util.Locale;
  */
 public class ManifestProcessorTest {
     private static final String OS = System.getProperty("os.name").toLowerCase(Locale.getDefault());
-    private String validProjectBlock = """
+    private final String validProjectBlock = """
             [project]
             org-name = "foo"
             version = "1.0.0"

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/diagnostics/DiagnosticMessageHelper.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/diagnostics/DiagnosticMessageHelper.java
@@ -30,7 +30,7 @@ import java.util.ResourceBundle;
  */
 public final class DiagnosticMessageHelper {
 
-    private static ResourceBundle messages = ResourceBundle.getBundle(
+    private static final ResourceBundle messages = ResourceBundle.getBundle(
             "syntax_diagnostic_message", Locale.getDefault());
 
     private DiagnosticMessageHelper() {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/diagnostics/DiagnosticMessageHelper.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/diagnostics/DiagnosticMessageHelper.java
@@ -30,7 +30,7 @@ import java.util.ResourceBundle;
  */
 public final class DiagnosticMessageHelper {
 
-    private static final ResourceBundle messages = ResourceBundle.getBundle(
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(
             "syntax_diagnostic_message", Locale.getDefault());
 
     private DiagnosticMessageHelper() {
@@ -38,7 +38,7 @@ public final class DiagnosticMessageHelper {
 
     public static String getDiagnosticMessage(DiagnosticCode diagnosticCode, Object... args) {
         String msgKey = diagnosticCode.messageKey();
-        String msg = messages.getString(msgKey);
+        String msg = MESSAGES.getString(msgKey);
         return MessageFormat.format(msg, args);
     }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/InputReader.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/InputReader.java
@@ -33,8 +33,8 @@ import java.nio.charset.StandardCharsets;
 public class InputReader {
 
     private static final int BUFFER_SIZE = 10;
-    private CharacterBuffer charsAhead = new CharacterBuffer(BUFFER_SIZE);
-    private Reader reader;
+    private final CharacterBuffer charsAhead = new CharacterBuffer(BUFFER_SIZE);
+    private final Reader reader;
     private int currentChar;
 
     InputReader(InputStream inputStream) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/Result.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/Result.java
@@ -40,7 +40,7 @@ public class Result {
     /**
      * List of solutions to recover from the error.
      */
-    private ArrayDeque<AbstractParserErrorHandler.Solution> fixes;
+    private final ArrayDeque<AbstractParserErrorHandler.Solution> fixes;
 
     /**
      * Represent the end solution to be applied to the next immediate token, to recover from the error.

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/TokenReader.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/TokenReader.java
@@ -32,8 +32,8 @@ public class TokenReader extends AbstractTokenReader {
 
     private static final int BUFFER_SIZE = 20;
 
-    private AbstractLexer lexer;
-    private TokenBuffer tokensAhead = new TokenBuffer(BUFFER_SIZE);
+    private final AbstractLexer lexer;
+    private final TokenBuffer tokensAhead = new TokenBuffer(BUFFER_SIZE);
     private STToken currentToken = null;
 
     TokenReader(AbstractLexer lexer) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/incremental/IncrementalParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/incremental/IncrementalParser.java
@@ -64,15 +64,15 @@ public class IncrementalParser extends BallerinaParser {
         return node;
     }
 
-    private Predicate<SyntaxKind> isModelLevelDeclaration =
+    private final Predicate<SyntaxKind> isModelLevelDeclaration =
             kind -> SyntaxKind.IMPORT_DECLARATION.compareTo(kind) <= 0 &&
                     SyntaxKind.ENUM_DECLARATION.compareTo(kind) >= 0;
 
-    private Predicate<SyntaxKind> isFunctionBody = kind ->
+    private final Predicate<SyntaxKind> isFunctionBody = kind ->
             kind == SyntaxKind.FUNCTION_BODY_BLOCK ||
             kind == SyntaxKind.EXTERNAL_FUNCTION_BODY ||
             kind == SyntaxKind.EXPRESSION_FUNCTION_BODY;
 
-    private Predicate<SyntaxKind> isStatement = kind -> SyntaxKind.BLOCK_STATEMENT.compareTo(kind) <= 0 &&
+    private final Predicate<SyntaxKind> isStatement = kind -> SyntaxKind.BLOCK_STATEMENT.compareTo(kind) <= 0 &&
             SyntaxKind.INVALID_EXPRESSION_STATEMENT.compareTo(kind) >= 0;
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/incremental/UnmodifiedSubtreeSupplier.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/incremental/UnmodifiedSubtreeSupplier.java
@@ -25,7 +25,7 @@ import io.ballerina.compiler.internal.parser.tree.STNode;
  * @since 1.3.0
  */
 public class UnmodifiedSubtreeSupplier {
-    private HybridNodeStorage hybridNodeStorage;
+    private final HybridNodeStorage hybridNodeStorage;
 
     public UnmodifiedSubtreeSupplier(HybridNodeStorage hybridNodeStorage) {
         this.hybridNodeStorage = hybridNodeStorage;

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNodeDiagnostic.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNodeDiagnostic.java
@@ -26,8 +26,8 @@ import io.ballerina.tools.diagnostics.DiagnosticCode;
  * @since 2.0.0
  */
 public class STNodeDiagnostic extends IRDiagnostic {
-    private DiagnosticCode diagnosticCode;
-    private Object[] args;
+    private final DiagnosticCode diagnosticCode;
+    private final Object[] args;
 
     STNodeDiagnostic(DiagnosticCode diagnosticCode, Object... args) {
         this.diagnosticCode = diagnosticCode;

--- a/compiler/ballerina-tools-api/src/main/java/io/ballerina/tools/text/CharReader.java
+++ b/compiler/ballerina-tools-api/src/main/java/io/ballerina/tools/text/CharReader.java
@@ -26,9 +26,9 @@ import java.util.Arrays;
  */
 public class CharReader {
 
-    private char[] charBuffer;
+    private final char[] charBuffer;
     private int offset = 0;
-    private int charBufferLength;
+    private final int charBufferLength;
 
     private int lexemeStartPos;
 

--- a/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/TreeGenConfig.java
+++ b/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/TreeGenConfig.java
@@ -52,10 +52,10 @@ public class TreeGenConfig {
     public static final String SYNTAX_NODE_METADATA_KEY = "syntax.node.metadata";
 
     private final Properties props;
-    private static final TreeGenConfig instance = new TreeGenConfig(loadConfig());
+    private static final TreeGenConfig INSTANCE = new TreeGenConfig(loadConfig());
 
     static TreeGenConfig getInstance() {
-        return instance;
+        return INSTANCE;
     }
 
     private TreeGenConfig(Properties props) {

--- a/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/TreeGenConfig.java
+++ b/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/TreeGenConfig.java
@@ -52,7 +52,7 @@ public class TreeGenConfig {
     public static final String SYNTAX_NODE_METADATA_KEY = "syntax.node.metadata";
 
     private final Properties props;
-    private static TreeGenConfig instance = new TreeGenConfig(loadConfig());
+    private static final TreeGenConfig instance = new TreeGenConfig(loadConfig());
 
     static TreeGenConfig getInstance() {
         return instance;

--- a/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/model/json/SyntaxNode.java
+++ b/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/model/json/SyntaxNode.java
@@ -27,7 +27,7 @@ import java.util.List;
  */
 public class SyntaxNode {
     private String name;
-    private List<SyntaxNodeAttribute> attributes;
+    private final List<SyntaxNodeAttribute> attributes;
     private String kind;
     private String base;
     private String type;

--- a/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/model/json/SyntaxNodeAttribute.java
+++ b/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/model/json/SyntaxNodeAttribute.java
@@ -25,10 +25,10 @@ import io.ballerinalang.compiler.internal.treegen.model.OccurrenceKind;
  * @since 1.3.0
  */
 public class SyntaxNodeAttribute {
-    private String name;
-    private String type;
-    private String occurrences;
-    private boolean isOptional;
+    private final String name;
+    private final String type;
+    private final String occurrences;
+    private final boolean isOptional;
 
     public SyntaxNodeAttribute(String name, String type, String occurrences, boolean isOptional) {
         this.name = name;

--- a/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/model/json/SyntaxTree.java
+++ b/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/model/json/SyntaxTree.java
@@ -25,10 +25,10 @@ import java.util.List;
  * @since 1.3.0
  */
 public class SyntaxTree {
-    private String root;
-    private List<SyntaxNode> nodes;
-    private String type;
-    private List<SyntaxNodeAttribute> fields;
+    private final String root;
+    private final List<SyntaxNode> nodes;
+    private final String type;
+    private final List<SyntaxNodeAttribute> fields;
 
     public SyntaxTree(String root,
                       List<SyntaxNode> nodes,

--- a/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/StackTrace.java
+++ b/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/StackTrace.java
@@ -115,8 +115,8 @@ public final class StackTrace {
 
         BArray callStack;
 
-        private ObjectType type;
-        private BTypedesc typedesc;
+        private final ObjectType type;
+        private final BTypedesc typedesc;
 
         public CallStack(ObjectType type) {
             this.type = type;

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachArrayTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachArrayTests.java
@@ -37,12 +37,12 @@ public class ForeachArrayTests {
 
     private CompileResult program;
 
-    private int[] iValues = {1, -3, 5, -30, 4, 11, 25, 10};
-    private double[] fValues = {1.123, -3.35244, 5.23, -30.45, 4.32, 11.56, 25.967, 10.345};
-    private String[] sValues = {"foo", "bar", "bax", "baz"};
-    private boolean[] bValues = {true, false, false, false, true, false};
-    private String[] jValues = {"{\"name\":\"bob\", \"age\":10}", "{\"name\":\"tom\", \"age\":16}"};
-    private String[] tValues = {"name=bob,age=10", "name=tom,age=16"};
+    private final int[] iValues = {1, -3, 5, -30, 4, 11, 25, 10};
+    private final double[] fValues = {1.123, -3.35244, 5.23, -30.45, 4.32, 11.56, 25.967, 10.345};
+    private final String[] sValues = {"foo", "bar", "bax", "baz"};
+    private final boolean[] bValues = {true, false, false, false, true, false};
+    private final String[] jValues = {"{\"name\":\"bob\", \"age\":10}", "{\"name\":\"tom\", \"age\":16}"};
+    private final String[] tValues = {"name=bob,age=10", "name=tom,age=16"};
 
     @BeforeClass
     public void setup() {

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachOnFailTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachOnFailTests.java
@@ -37,13 +37,6 @@ public class ForeachOnFailTests {
 
     private CompileResult program;
 
-    private int[] iValues = {1, -3, 5, -30, 4, 11, 25, 10};
-    private double[] fValues = {1.123, -3.35244, 5.23, -30.45, 4.32, 11.56, 25.967, 10.345};
-    private String[] sValues = {"foo", "bar", "bax", "baz"};
-    private boolean[] bValues = {true, false, false, false, true, false};
-    private String[] jValues = {"{\"name\":\"bob\", \"age\":10}", "{\"name\":\"tom\", \"age\":16}"};
-    private String[] tValues = {"name=bob,age=10", "name=tom,age=16"};
-
     @BeforeClass
     public void setup() {
         program = BCompileUtil.compile("test-src/statements/foreach/foreach-on-fail.bal");

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachXMLTypedBindingPatternsTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachXMLTypedBindingPatternsTests.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class ForeachXMLTypedBindingPatternsTests {
 
     private CompileResult program;
-    private String expectedXml1 = """
+    private final String expectedXml1 = """
             0:<p:person xmlns:p="foo" xmlns:q="bar">
                     <p:name>bob</p:name>
                     <p:address>
@@ -42,7 +42,7 @@ public class ForeachXMLTypedBindingPatternsTests {
                     </p:address>
                     <q:ID>1131313</q:ID>
                 </p:person>\s""";
-    private String expectedXml2 = """
+    private final String expectedXml2 = """
             0:<p:name xmlns:p="foo">bob</p:name> \
             1:<p:address xmlns:p="foo">
                         <p:city>NY</p:city>

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/visitor/Array.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/visitor/Array.java
@@ -24,7 +24,7 @@ package org.ballerinalang.langserver.commons.toml.visitor;
  */
 public class Array extends KeyValuePair {
 
-    private String qName;
+    private final String qName;
 
     public Array(String name, String qName, ValueType valueType) {
         super(name, valueType);

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/visitor/KeyValuePair.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/visitor/KeyValuePair.java
@@ -26,10 +26,10 @@ import org.ballerinalang.langserver.commons.toml.common.TomlSyntaxTreeUtil;
  */
 public class KeyValuePair implements TomlNode {
 
-    private String key;
-    private String defaultValue;
-    private int id;
-    private ValueType type;
+    private final String key;
+    private final String defaultValue;
+    private final int id;
+    private final ValueType type;
 
     public KeyValuePair(String key, String defaultValue, int id, ValueType type) {
         this.key = key;

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/visitor/Table.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/visitor/Table.java
@@ -24,7 +24,7 @@ package org.ballerinalang.langserver.commons.toml.visitor;
  */
 public class Table implements TomlNode {
 
-    private String name;
+    private final String name;
 
     public Table(String name) {
         this.name = name;

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/visitor/TableArray.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/toml/visitor/TableArray.java
@@ -24,7 +24,7 @@ package org.ballerinalang.langserver.commons.toml.visitor;
  */
 public class TableArray implements TomlNode {
 
-    private String name;
+    private final String name;
 
     public TableArray(String name) {
         this.name = name;

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/trace/Message.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/trace/Message.java
@@ -22,13 +22,13 @@ package org.ballerinalang.langserver.commons.trace;
  */
 public class Message {
     private String id;
-    private String direction;
-    private String headers;
-    private String httpMethod;
-    private String path;
-    private String contentType;
-    private String payload;
-    private String headerType;
+    private final String direction;
+    private final String headers;
+    private final String httpMethod;
+    private final String path;
+    private final String contentType;
+    private final String payload;
+    private final String headerType;
 
     public Message(String id, String direction, String headers, String httpMethod, String path, String contentType,
             String payload, String headerType) {

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/trace/TraceRecord.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/trace/TraceRecord.java
@@ -24,15 +24,15 @@ import java.util.UUID;
  * Model class for trace log.
  */
 public class TraceRecord {
-    private Message message;
-    private String rawMessage;
-    private String id;
-    private String millis;
-    private String sequence;
-    private String logger;
-    private String sourceClass;
-    private String sourceMethod;
-    private String thread;
+    private final Message message;
+    private final String rawMessage;
+    private final String id;
+    private final String millis;
+    private final String sequence;
+    private final String logger;
+    private final String sourceClass;
+    private final String sourceMethod;
+    private final String thread;
 
     public TraceRecord(Message message, JsonObject record, String rawMessage) {
         this.message = message;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
@@ -71,10 +71,10 @@ public class LSPackageLoader {
     public static final LanguageServerContext.Key<LSPackageLoader> LS_PACKAGE_LOADER_KEY =
             new LanguageServerContext.Key<>();
 
-    private List<ModuleInfo> distRepoPackages = new ArrayList<>();
+    private final List<ModuleInfo> distRepoPackages = new ArrayList<>();
     private final List<ModuleInfo> remoteRepoPackages = new ArrayList<>();
     private final List<ModuleInfo> localRepoPackages = new ArrayList<>();
-    private List<ModuleInfo> centralPackages = new ArrayList<>();
+    private final List<ModuleInfo> centralPackages = new ArrayList<>();
     private final LSClientLogger clientLogger;
 
     ExtendedLanguageClient languageClient;
@@ -83,7 +83,7 @@ public class LSPackageLoader {
 
     private boolean initialized = false;
 
-    private CentralPackageDescriptorLoader centralPackageDescriptorLoader;
+    private final CentralPackageDescriptorLoader centralPackageDescriptorLoader;
 
     public static LSPackageLoader getInstance(LanguageServerContext context) {
         LSPackageLoader lsPackageLoader = context.get(LS_PACKAGE_LOADER_KEY);
@@ -355,12 +355,12 @@ public class LSPackageLoader {
      */
     public static class ModuleInfo {
 
-        private PackageOrg packageOrg;
+        private final PackageOrg packageOrg;
         private PackageName packageName;
-        private PackageVersion packageVersion;
-        private Path sourceRoot;
+        private final PackageVersion packageVersion;
+        private final Path sourceRoot;
 
-        private String moduleIdentifier;
+        private final String moduleIdentifier;
 
         private boolean isModuleFromCurrentPackage = false;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/FailStatementResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/FailStatementResolver.java
@@ -34,7 +34,7 @@ import java.util.Optional;
  */
 public class FailStatementResolver extends NodeTransformer<Optional<Node>> {
     
-    private Diagnostic diagnostic;
+    private final Diagnostic diagnostic;
     
     public FailStatementResolver(Diagnostic diagnostic) {
         this.diagnostic = diagnostic;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
@@ -97,7 +97,7 @@ import java.util.Optional;
 public class FunctionCallExpressionTypeFinder extends NodeVisitor {
 
     private final SemanticModel semanticModel;
-    private FunctionCallExpressionNode functionCallExpr;
+    private final FunctionCallExpressionNode functionCallExpr;
     private TypeSymbol returnTypeSymbol;
     private boolean resultFound = false;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/RecordField.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/RecordField.java
@@ -57,8 +57,8 @@ public class RecordField {
      * @since 2201.8.0
      */
     public static class RecordFieldIdentifier {
-        private String name;
-        private TypeSymbol typeSymbol;
+        private final String name;
+        private final TypeSymbol typeSymbol;
 
         public RecordFieldIdentifier(String name, TypeSymbol typeSymbol) {
             this.name = name;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ResourcePathCompletionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ResourcePathCompletionUtil.java
@@ -290,7 +290,7 @@ public final class ResourcePathCompletionUtil {
     private static class ResourceAccessPathPart {
 
         private String computedPathInsertText;
-        private String computedPathSignature;
+        private final String computedPathSignature;
 
         private String namedPathSignature;
         private String namedPathInsertText;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
@@ -75,8 +75,6 @@ public class ServiceTemplateGenerator {
     private static final LanguageServerContext.Key<ServiceTemplateGenerator> SERVICE_TEMPLATE_GENERATOR_KEY =
             new LanguageServerContext.Key<>();
 
-    private boolean isInitialized = false;
-
     private ServiceTemplateGenerator(LanguageServerContext context) {
         context.put(SERVICE_TEMPLATE_GENERATOR_KEY, this);
     }
@@ -178,10 +176,6 @@ public class ServiceTemplateGenerator {
         String currentModuleName = currentModule.get().descriptor().name().toString();
         String currentVersion = currentModule.get().packageInstance().descriptor().version().value().toString();
         return CodeActionModuleId.from(currentOrg, currentModuleName, currentVersion);
-    }
-
-    public boolean initialized() {
-        return this.isInitialized;
     }
 
     public static Predicate<Symbol> listenerPredicate() {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/AnnotationAttachmentMetaInfo.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/AnnotationAttachmentMetaInfo.java
@@ -28,13 +28,13 @@ import java.util.Queue;
  */
 public class AnnotationAttachmentMetaInfo {
 
-    private String attachmentName;
+    private final String attachmentName;
     
-    private Queue<String> fieldQueue;
+    private final Queue<String> fieldQueue;
     
-    private String packageAlias;
+    private final String packageAlias;
     
-    private AnnotationNodeKind attachmentPoint;
+    private final AnnotationNodeKind attachmentPoint;
 
     public AnnotationAttachmentMetaInfo(String attachmentName, Queue<String> fieldQueue, String packageAlias,
                                         AnnotationNodeKind attachmentPoint) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/DocumentSymbolContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/DocumentSymbolContextImpl.java
@@ -38,9 +38,9 @@ public class DocumentSymbolContextImpl extends AbstractDocumentServiceContext im
     private Boolean labelSupport;
     private SymbolTagSupportCapabilities supportedTags;
     private Boolean hierarchicalDocumentSymbolSupport;
-    private LSClientCapabilities clientCapabilities;
-    private DocumentSymbolParams params;
-    private DocumentSymbolCapabilities documentSymbolClientCapabilities;
+    private final LSClientCapabilities clientCapabilities;
+    private final DocumentSymbolParams params;
+    private final DocumentSymbolCapabilities documentSymbolClientCapabilities;
     boolean deprecatedTagSupport;
 
     DocumentSymbolContextImpl(LSOperation operation, String fileUri, WorkspaceManager wsManager,
@@ -106,8 +106,8 @@ public class DocumentSymbolContextImpl extends AbstractDocumentServiceContext im
      */
     protected static class DocumentSymbolContextBuilder extends AbstractContextBuilder<DocumentSymbolContextBuilder> {
 
-        private DocumentSymbolParams params;
-        private LSClientCapabilities clientCapabilities;
+        private final DocumentSymbolParams params;
+        private final LSClientCapabilities clientCapabilities;
 
         public DocumentSymbolContextBuilder(DocumentSymbolParams params,
                                             LanguageServerContext serverContext,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/LanguageServerContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/LanguageServerContextImpl.java
@@ -28,8 +28,8 @@ import java.util.Map;
  * @since 2.0.0
  */
 public class LanguageServerContextImpl implements LanguageServerContext {
-    private Map<LanguageServerContext.Key<?>, Object> props = new HashMap<>();
-    private Map<Class<?>, Object> objects = new HashMap<>();
+    private final Map<LanguageServerContext.Key<?>, Object> props = new HashMap<>();
+    private final Map<Class<?>, Object> objects = new HashMap<>();
 
     public LanguageServerContextImpl() {
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolResolver.java
@@ -64,8 +64,8 @@ import java.util.stream.Collectors;
  */
 public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSymbol>> {
 
-    private List<DocumentSymbol> documentSymbolStore;
-    private DocumentSymbolContext context;
+    private final List<DocumentSymbol> documentSymbolStore;
+    private final DocumentSymbolContext context;
 
     DocumentSymbolResolver(DocumentSymbolContext context) {
         this.context = context;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaRecordRequest.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaRecordRequest.java
@@ -25,11 +25,11 @@ package org.ballerinalang.langserver.extensions.ballerina.connector;
  */
 public class BallerinaRecordRequest {
 
-    private String org;
-    private String module;
-    private String version = "";
-    private String name;
-    private Boolean beta;
+    private final String org;
+    private final String module;
+    private final String version;
+    private final String name;
+    private final Boolean beta;
 
     public BallerinaRecordRequest(String org, String module, String version, String name, Boolean beta) {
         this.org = org;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaRecordResponse.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaRecordResponse.java
@@ -32,7 +32,7 @@ public class BallerinaRecordResponse {
     private final String version;
     private final String name;
     private final String error;
-    private JsonElement ast;
+    private final JsonElement ast;
     private final Boolean beta;
 
     public BallerinaRecordResponse(String org, String module, String version, String name,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/FindNodes.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/FindNodes.java
@@ -31,10 +31,10 @@ import java.util.List;
  */
 public class FindNodes extends NodeVisitor {
 
-    private List<FunctionDefinitionNode> functionDefinitionNodeList;
-    private List<ClassDefinitionNode> classDefinitionNodeList;
-    private List<ServiceDeclarationNode> serviceDeclarationNodeList;
-    private List<ImportDeclarationNode> importDeclarationNodesList;
+    private final List<FunctionDefinitionNode> functionDefinitionNodeList;
+    private final List<ClassDefinitionNode> classDefinitionNodeList;
+    private final List<ServiceDeclarationNode> serviceDeclarationNodeList;
+    private final List<ImportDeclarationNode> importDeclarationNodesList;
 
     public FindNodes() {
         this.functionDefinitionNodeList = new ArrayList<>();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
@@ -46,12 +46,12 @@ import java.util.Optional;
  */
 public class UnusedSymbolsVisitor extends NodeVisitor {
 
-    private Map<String, ImportDeclarationNode> unusedImports = new HashMap<>();
-    private Map<String, ImportDeclarationNode> usedImports = new HashMap<>();
-    private Map<LineRange, ASTModification> deleteRanges;
-    private Map<LineRange, ASTModification> toBeDeletedRanges = new HashMap<>();
-    private SemanticModel semanticModel;
-    private Document srcFile;
+    private final Map<String, ImportDeclarationNode> unusedImports = new HashMap<>();
+    private final Map<String, ImportDeclarationNode> usedImports = new HashMap<>();
+    private final Map<LineRange, ASTModification> deleteRanges;
+    private final Map<LineRange, ASTModification> toBeDeletedRanges = new HashMap<>();
+    private final SemanticModel semanticModel;
+    private final Document srcFile;
 
     public UnusedSymbolsVisitor(Document srcFile, SemanticModel semanticModel,
                                 Map<LineRange, ASTModification> deleteRanges) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/packages/PackageObject.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/packages/PackageObject.java
@@ -25,7 +25,7 @@ public class PackageObject {
     private final String name;
     private final String filePath;
 
-    private List<ModuleObject> modules = new ArrayList<>();
+    private final List<ModuleObject> modules = new ArrayList<>();
 
     protected PackageObject(String name, String filePath) {
         this.name = name;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/DocumentationReferenceFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/DocumentationReferenceFinder.java
@@ -40,7 +40,7 @@ import java.util.Optional;
  */
 public class DocumentationReferenceFinder extends NodeTransformer<List<NodeLocation>> {
 
-    private Symbol symbol;
+    private final Symbol symbol;
 
     public DocumentationReferenceFinder(Symbol symbol) {
         this.symbol = symbol;

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/docsymbol/DocumentSymbolTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/docsymbol/DocumentSymbolTest.java
@@ -47,7 +47,7 @@ public class DocumentSymbolTest {
 
     private final Path sourcesPath = new File(getClass().getClassLoader().getResource("docsymbol").getFile()).toPath();
 
-    private static final Logger log = LoggerFactory.getLogger(DocumentSymbolTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DocumentSymbolTest.class);
 
     @BeforeClass
     public void init() throws Exception {
@@ -76,7 +76,7 @@ public class DocumentSymbolTest {
 
     @DataProvider(name = "document-data-provider")
     public Object[][] documentSymbolDataProvider() {
-        log.info("Test textDocument/symbol");
+        LOG.info("Test textDocument/symbol");
         return new Object[][] {
                 {"documentSymbol.json", "docSymbol.bal"},
         };

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/docsymbol/DocumentSymbolTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/docsymbol/DocumentSymbolTest.java
@@ -45,7 +45,7 @@ public class DocumentSymbolTest {
     
     private Endpoint serviceEndpoint;
 
-    private Path sourcesPath = new File(getClass().getClassLoader().getResource("docsymbol").getFile()).toPath();
+    private final Path sourcesPath = new File(getClass().getClassLoader().getResource("docsymbol").getFile()).toPath();
 
     private static final Logger log = LoggerFactory.getLogger(DocumentSymbolTest.class);
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/connector/ConnectorTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/connector/ConnectorTest.java
@@ -31,7 +31,7 @@ import java.nio.file.Path;
  */
 public class ConnectorTest {
     private Endpoint serviceEndpoint;
-    private Path testConnectorFilePath = FileUtils.RES_DIR.resolve("extensions").resolve("connector")
+    private final Path testConnectorFilePath = FileUtils.RES_DIR.resolve("extensions").resolve("connector")
             .resolve("TestConnector").resolve("main.bal");
 
     @BeforeClass

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeModifyTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeModifyTest.java
@@ -40,13 +40,13 @@ public class SyntaxTreeModifyTest {
     private static final String OS = System.getProperty("os.name").toLowerCase();
     private Endpoint serviceEndpoint;
 
-    private Path mainFile = FileUtils.RES_DIR.resolve("extensions")
+    private final Path mainFile = FileUtils.RES_DIR.resolve("extensions")
             .resolve("document")
             .resolve("ast")
             .resolve("modify")
             .resolve("main.bal");
 
-    private Path mainEmptyFile = FileUtils.RES_DIR.resolve("extensions")
+    private final Path mainEmptyFile = FileUtils.RES_DIR.resolve("extensions")
             .resolve("document")
             .resolve("ast")
             .resolve("modify")
@@ -58,55 +58,55 @@ public class SyntaxTreeModifyTest {
 //            .resolve("modify")
 //            .resolve("mainNats.bal");
 
-    private Path emptyFile = FileUtils.RES_DIR.resolve("extensions")
+    private final Path emptyFile = FileUtils.RES_DIR.resolve("extensions")
             .resolve("document")
             .resolve("ast")
             .resolve("modify")
             .resolve("empty.bal");
 
-    private Path mainHttpCallFile = FileUtils.RES_DIR.resolve("extensions")
+    private final Path mainHttpCallFile = FileUtils.RES_DIR.resolve("extensions")
             .resolve("document")
             .resolve("ast")
             .resolve("modify")
             .resolve("mainHttpCall.bal");
 
-    private Path mainHttpCallWithPrintFile = FileUtils.RES_DIR.resolve("extensions")
+    private final Path mainHttpCallWithPrintFile = FileUtils.RES_DIR.resolve("extensions")
             .resolve("document")
             .resolve("ast")
             .resolve("modify")
             .resolve("mainHttpCallWithPrint.bal");
 
-    private Path removeImport = FileUtils.RES_DIR.resolve("extensions")
+    private final Path removeImport = FileUtils.RES_DIR.resolve("extensions")
             .resolve("document")
             .resolve("ast")
             .resolve("modify")
             .resolve("removeImport.bal");
 
-    private Path removeImportExpected = FileUtils.RES_DIR.resolve("extensions")
+    private final Path removeImportExpected = FileUtils.RES_DIR.resolve("extensions")
             .resolve("document")
             .resolve("ast")
             .resolve("modify")
             .resolve("removeImportExpected.bal");
 
-    private Path notRemoveIgnoredImports = FileUtils.RES_DIR.resolve("extensions")
+    private final Path notRemoveIgnoredImports = FileUtils.RES_DIR.resolve("extensions")
             .resolve("document")
             .resolve("ast")
             .resolve("modify")
             .resolve("notRemoveIgnoredImports.bal");
 
-    private Path notRemoveIgnoredImportsExpected = FileUtils.RES_DIR.resolve("extensions")
+    private final Path notRemoveIgnoredImportsExpected = FileUtils.RES_DIR.resolve("extensions")
             .resolve("document")
             .resolve("ast")
             .resolve("modify")
             .resolve("notRemoveIgnoredImportsExpected.bal");
 
-    private Path notRemoveUsedImports = FileUtils.RES_DIR.resolve("extensions")
+    private final Path notRemoveUsedImports = FileUtils.RES_DIR.resolve("extensions")
             .resolve("document")
             .resolve("ast")
             .resolve("modify")
             .resolve("notRemoveUsedImports.bal");
 
-    private Path notRemoveUsedImportsExpected = FileUtils.RES_DIR.resolve("extensions")
+    private final Path notRemoveUsedImportsExpected = FileUtils.RES_DIR.resolve("extensions")
             .resolve("document")
             .resolve("ast")
             .resolve("modify")

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/VisibleEndpointTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/VisibleEndpointTest.java
@@ -35,12 +35,12 @@ public class VisibleEndpointTest {
 
     private Endpoint serviceEndpoint;
 
-    private Path nestedVisibleEPsFile = FileUtils.RES_DIR.resolve("extensions")
+    private final Path nestedVisibleEPsFile = FileUtils.RES_DIR.resolve("extensions")
             .resolve("document")
             .resolve("sources")
             .resolve("nestedVisibleEndpoints.bal");
 
-    private Path transactionVisibleEPsFile = FileUtils.RES_DIR.resolve("extensions")
+    private final Path transactionVisibleEPsFile = FileUtils.RES_DIR.resolve("extensions")
             .resolve("document")
             .resolve("sources")
             .resolve("visibleEndpointsInTransactions.bal");

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/implementation/GotoImplementationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/implementation/GotoImplementationTest.java
@@ -41,8 +41,8 @@ import java.nio.file.Path;
  */
 public class GotoImplementationTest {
     private Endpoint serviceEndpoint;
-    private final String configRoot = "implementation" + CommonUtil.FILE_SEPARATOR + "expected";
-    private static final Logger log = LoggerFactory.getLogger(GotoImplementationTest.class);
+    private static final String CONFIG_ROOT = "implementation" + CommonUtil.FILE_SEPARATOR + "expected";
+    private static final Logger LOG = LoggerFactory.getLogger(GotoImplementationTest.class);
 
     @BeforeClass
     public void init() {
@@ -54,7 +54,7 @@ public class GotoImplementationTest {
         Path sourcePath = FileUtils.RES_DIR.resolve(source);
         try {
             TestUtil.openDocument(serviceEndpoint, sourcePath);
-            JsonObject configJsonObject = FileUtils.fileContentAsObject(configRoot + CommonUtil.FILE_SEPARATOR
+            JsonObject configJsonObject = FileUtils.fileContentAsObject(CONFIG_ROOT + CommonUtil.FILE_SEPARATOR
                     + configPath);
             JsonObject position = configJsonObject.getAsJsonObject("position");
             Position cursor = new Position(position.get("line").getAsInt(), position.get("col").getAsInt());
@@ -73,7 +73,7 @@ public class GotoImplementationTest {
 
     @DataProvider(name = "goto-impl-data-provider")
     public Object[][] dataProvider() {
-        log.info("Test textDocument/implementation");
+        LOG.info("Test textDocument/implementation");
         String sourcePath1 = "implementation" + CommonUtil.FILE_SEPARATOR + "source" + CommonUtil.FILE_SEPARATOR
                 + "gotoImplProject" + CommonUtil.FILE_SEPARATOR + "src" + CommonUtil.FILE_SEPARATOR  + "pkg1"
                 + CommonUtil.FILE_SEPARATOR + "main.bal";

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/implementation/GotoImplementationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/implementation/GotoImplementationTest.java
@@ -41,7 +41,7 @@ import java.nio.file.Path;
  */
 public class GotoImplementationTest {
     private Endpoint serviceEndpoint;
-    private String configRoot = "implementation" + CommonUtil.FILE_SEPARATOR + "expected";
+    private final String configRoot = "implementation" + CommonUtil.FILE_SEPARATOR + "expected";
     private static final Logger log = LoggerFactory.getLogger(GotoImplementationTest.class);
 
     @BeforeClass

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
@@ -51,7 +51,7 @@ public class LSPackageLoaderTest extends AbstractLSTest {
 
     private final Path testRoot = FileUtils.RES_DIR.resolve("lspackageloader");
     private static final Map<String, String> REMOTE_PROJECTS = Map.of("project3", "main.bal");
-    private List<LSPackageLoader.ModuleInfo> remoteRepoPackages = new ArrayList<>(getRemotePackages());
+    private final List<LSPackageLoader.ModuleInfo> remoteRepoPackages = new ArrayList<>(getRemotePackages());
 
     @Test(dataProvider = "data-provider")
     public void test(String source) throws IOException, EventSyncException, WorkspaceDocumentException {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/AbstractSignatureHelpTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/AbstractSignatureHelpTest.java
@@ -49,7 +49,7 @@ public abstract class AbstractSignatureHelpTest {
 
     private Endpoint serviceEndpoint;
 
-    private Path testRoot = new File(getClass().getClassLoader().getResource("signature").getFile()).toPath();
+    private final Path testRoot = new File(getClass().getClassLoader().getResource("signature").getFile()).toPath();
 
     private static final Logger log = LoggerFactory.getLogger(AbstractSignatureHelpTest.class);
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/AbstractSignatureHelpTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/AbstractSignatureHelpTest.java
@@ -45,13 +45,13 @@ import java.util.stream.Stream;
  */
 public abstract class AbstractSignatureHelpTest {
 
-    private final String configDir = "config";
+    private static final String CONFIG_DIR = "config";
 
     private Endpoint serviceEndpoint;
 
     private final Path testRoot = new File(getClass().getClassLoader().getResource("signature").getFile()).toPath();
 
-    private static final Logger log = LoggerFactory.getLogger(AbstractSignatureHelpTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractSignatureHelpTest.class);
 
     @BeforeClass
     public void init() throws Exception {
@@ -62,7 +62,7 @@ public abstract class AbstractSignatureHelpTest {
     public void test(String config, String source)
             throws WorkspaceDocumentException, IOException, InterruptedException {
         String configJsonPath =
-                "signature" + File.separator + source + File.separator + configDir + File.separator + config;
+                "signature" + File.separator + source + File.separator + CONFIG_DIR + File.separator + config;
         JsonObject configJsonObject = FileUtils.fileContentAsObject(configJsonPath);
         JsonObject expected = configJsonObject.get("expected").getAsJsonObject();
         Path sourcePath = testRoot.resolve(configJsonObject.get("source").getAsString());
@@ -104,7 +104,7 @@ public abstract class AbstractSignatureHelpTest {
         }
         List<String> skippedTests = this.skipList();
         try (Stream<Path> configPaths = Files.walk(
-                this.testRoot.resolve(this.getTestResourceDir()).resolve(this.configDir))) {
+                this.testRoot.resolve(this.getTestResourceDir()).resolve(this.CONFIG_DIR))) {
             return configPaths.filter(path -> {
                         File file = path.toFile();
                         return file.isFile() && file.getName().endsWith(".json")

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/BFunction.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/BFunction.java
@@ -36,7 +36,7 @@ public abstract class BFunction {
     private String functionName;
     private Class<?> declaringClass;
     private List<JParameter> parameters = new LinkedList<>();
-    private List<JError> throwables = new LinkedList<>();
+    private final List<JError> throwables = new LinkedList<>();
     private boolean isStatic = true;
     private String returnType;
     private String errorType = null;

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JConstructor.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JConstructor.java
@@ -38,20 +38,20 @@ import static org.ballerinalang.bindgen.utils.BindgenUtils.getAlias;
  */
 public class JConstructor extends BFunction  {
 
-    private Class<?> parentClass;
+    private final Class<?> parentClass;
     private String exceptionName;
     private String shortClassName;
     private String exceptionConstName;
-    private Constructor<?> constructor;
+    private final Constructor<?> constructor;
 
     private boolean returnError = false;
     private boolean hasException = false; // identifies if the Ballerina returns should have an error declared
     private boolean handleException = false; // identifies if the Java constructor throws an error
     private boolean javaArraysModule = false;
 
-    private List<JParameter> parameters = new ArrayList<>();
-    private StringBuilder paramTypes = new StringBuilder();
-    private Set<String> importedPackages = new HashSet<>();
+    private final List<JParameter> parameters = new ArrayList<>();
+    private final StringBuilder paramTypes = new StringBuilder();
+    private final Set<String> importedPackages = new HashSet<>();
 
     JConstructor(Constructor<?> c, BindgenEnv env, JClass jClass, String constructorName) {
         super(BFunctionKind.CONSTRUCTOR, env);

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JField.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JField.java
@@ -38,12 +38,12 @@ import static org.ballerinalang.bindgen.utils.BindgenUtils.isStaticField;
  */
 public class JField extends BFunction {
 
-    private String fieldName;
-    private String fieldType;
+    private final String fieldName;
+    private final String fieldType;
     private String fieldMethodName;
 
     private boolean isArray;
-    private boolean isStatic;
+    private final boolean isStatic;
     private boolean isString;
     private boolean isStringArray;
     private boolean isObject = true;
@@ -51,7 +51,7 @@ public class JField extends BFunction {
     private boolean returnError = false;
     private boolean javaArraysModule = false;
 
-    private JParameter fieldObj;
+    private final JParameter fieldObj;
 
     JField(Field field, BFunction.BFunctionKind fieldKind, BindgenEnv env, JClass jClass) {
         super(fieldKind, env);

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JMethod.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JMethod.java
@@ -48,8 +48,8 @@ import static org.ballerinalang.bindgen.utils.BindgenUtils.isStaticMethod;
  */
 public class JMethod extends BFunction {
 
-    private BindgenEnv env;
-    private boolean isStatic;
+    private final BindgenEnv env;
+    private final boolean isStatic;
     private boolean hasReturn = false;
     private boolean returnError = false;
     private boolean objectReturn = false;
@@ -59,17 +59,17 @@ public class JMethod extends BFunction {
     private boolean isStringReturn = false;
     private boolean isStringArrayReturn = false;
     private boolean javaArraysModule = false;
-    private boolean isOptionalReturnTypes;
-    private String parentPrefix;
+    private final boolean isOptionalReturnTypes;
+    private final String parentPrefix;
 
-    private Class<?> parentClass;
-    private Method method;
+    private final Class<?> parentClass;
+    private final Method method;
     private String methodName;
-    private String unescapedMethodName;
+    private final String unescapedMethodName;
     private String returnType;
     private String exceptionName;
     private String returnTypeJava;
-    private String javaMethodName;
+    private final String javaMethodName;
     private String exceptionConstName;
     private String returnComponentType;
 

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JParameter.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JParameter.java
@@ -40,21 +40,21 @@ import static org.ballerinalang.bindgen.utils.BindgenUtils.getPrimitiveArrayType
  */
 public class JParameter {
 
-    private BindgenEnv env;
-    private String type;
-    private String externalType;
+    private final BindgenEnv env;
+    private final String type;
+    private final String externalType;
     private String shortTypeName;
     private String componentType;
     private String fieldName;
 
-    private Class<?> parentClass;
-    private Class<?> parameterClass;
+    private final Class<?> parentClass;
+    private final Class<?> parameterClass;
 
     private Boolean isObj = false;
     private Boolean isString = false;
     private Boolean isObjArray = false;
     private Boolean isOptional = false;
-    private boolean modulesFlag;
+    private final boolean modulesFlag;
     private Boolean isStringArray = false;
     private Boolean isPrimitiveArray = false;
 

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenEnv.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenEnv.java
@@ -60,14 +60,14 @@ public class BindgenEnv {
 
     // Flag depicting whether the current class being generated is a direct class or a dependent class
     private boolean directJavaClass = true;
-    private Set<String> classPaths = new HashSet<>();
-    private Map<String, String> aliases = new HashMap<>();
-    private Set<String> classListForLooping = new HashSet<>();
-    private Set<String> allJavaClasses = new HashSet<>();
-    private Set<JError> exceptionList = new HashSet<>();
-    private Map<String, String> failedClassGens = new HashMap<>();
-    private List<String> failedMethodGens = new ArrayList<>();
-    private Set<String> superClasses = new HashSet<>();
+    private final Set<String> classPaths = new HashSet<>();
+    private final Map<String, String> aliases = new HashMap<>();
+    private final Set<String> classListForLooping = new HashSet<>();
+    private final Set<String> allJavaClasses = new HashSet<>();
+    private final Set<JError> exceptionList = new HashSet<>();
+    private final Map<String, String> failedClassGens = new HashMap<>();
+    private final List<String> failedMethodGens = new ArrayList<>();
+    private final Set<String> superClasses = new HashSet<>();
 
     public void setModulesFlag(boolean modulesFlag) {
         this.modulesFlag = modulesFlag;

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenMvnResolver.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenMvnResolver.java
@@ -50,8 +50,8 @@ import static org.wso2.ballerinalang.compiler.util.ProjectDirs.isModuleExist;
  */
 public class BindgenMvnResolver {
 
-    private PrintStream outStream;
-    private BindgenEnv env;
+    private final PrintStream outStream;
+    private final BindgenEnv env;
 
     public BindgenMvnResolver(PrintStream outStream, BindgenEnv env) {
         this.outStream = outStream;

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/AbstractTestResource.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/AbstractTestResource.java
@@ -22,6 +22,7 @@ package org.ballerinalang.bindgen;
  *
  * @since 2.0.0
  */
+@SuppressWarnings("all")
 abstract class AbstractTestResource {
 
     AbstractTestResource() {

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/BindgenCommandTest.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/BindgenCommandTest.java
@@ -47,7 +47,7 @@ import java.util.Objects;
 public class BindgenCommandTest extends BindgenCommandBaseTest {
 
     private Path testResources;
-    private String newLine = System.lineSeparator();
+    private final String newLine = System.lineSeparator();
 
     @Override
     @BeforeClass
@@ -333,9 +333,9 @@ public class BindgenCommandTest extends BindgenCommandBaseTest {
 
     static class Copy extends SimpleFileVisitor<Path> {
 
-        private Path fromPath;
-        private Path toPath;
-        private StandardCopyOption copyOption;
+        private final Path fromPath;
+        private final Path toPath;
+        private final StandardCopyOption copyOption;
 
         private Copy(Path fromPath, Path toPath, StandardCopyOption copyOption) {
             this.fromPath = fromPath;

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/FieldsTestResource.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/FieldsTestResource.java
@@ -32,6 +32,7 @@ import java.util.Set;
  *
  * @since 2.0.0
  */
+@SuppressWarnings("all")
 public class FieldsTestResource implements InterfaceTestResource {
 
     // Instance primitive fields

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/MavenSupportTest.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/MavenSupportTest.java
@@ -142,9 +142,9 @@ public class MavenSupportTest extends BindgenCommandBaseTest {
 
     static class Copy extends SimpleFileVisitor<Path> {
 
-        private Path fromPath;
-        private Path toPath;
-        private StandardCopyOption copyOption;
+        private final Path fromPath;
+        private final Path toPath;
+        private final StandardCopyOption copyOption;
 
         private Copy(Path fromPath, Path toPath, StandardCopyOption copyOption) {
             this.fromPath = fromPath;

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/MethodsTestResource.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/MethodsTestResource.java
@@ -31,6 +31,7 @@ import java.util.Set;
  *
  * @since 2.0.0
  */
+@SuppressWarnings("all")
 public class MethodsTestResource extends AbstractTestResource implements InterfaceTestResource {
 
     // Different instance method combinations

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -87,17 +87,17 @@ class AIDataMapperCodeActionUtil {
     private static final int MAXIMUM_CACHE_SIZE = 100;
     private static final int RIGHT_SYMBOL_INDEX = 1;
     private static final int LEFT_SYMBOL_INDEX = 0;
-    private Cache<Integer, String> mappingCache =
+    private final Cache<Integer, String> mappingCache =
             CacheBuilder.newBuilder().maximumSize(MAXIMUM_CACHE_SIZE).build();
-    private HashMap<String, String> isOptionalMap = new HashMap<>();
-    private HashMap<String, String> leftFieldMap = new HashMap<>();
-    private HashMap<String, String> responseFieldMap = new HashMap<>();
+    private final HashMap<String, String> isOptionalMap = new HashMap<>();
+    private final HashMap<String, String> leftFieldMap = new HashMap<>();
+    private final HashMap<String, String> responseFieldMap = new HashMap<>();
     private HashMap<String, String> restFieldMap = new HashMap<>();
     private HashMap<String, Map<String, RecordFieldSymbol>> spreadFieldMap = new HashMap<>();
-    private HashMap<String, String> spreadFieldResponseMap = new HashMap<>();
-    private ArrayList<String> leftReadOnlyFields = new ArrayList<>();
+    private final HashMap<String, String> spreadFieldResponseMap = new HashMap<>();
+    private final ArrayList<String> leftReadOnlyFields = new ArrayList<>();
     private ArrayList<String> rightSpecificFieldList = new ArrayList<>();
-    private ArrayList<String> optionalRightRecordFields = new ArrayList<>();
+    private final ArrayList<String> optionalRightRecordFields = new ArrayList<>();
 
     private static final String SCHEMA = "schema";
     private static final String ID = "id";

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/DataMapperNodeVisitor.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/DataMapperNodeVisitor.java
@@ -52,7 +52,7 @@ public class DataMapperNodeVisitor extends NodeVisitor {
     public final HashMap<String, String> restFields;
     public final HashMap<String, Map<String, RecordFieldSymbol>> spreadFields;
     public final ArrayList<String> specificFieldList;
-    private String rhsSymbolName;
+    private final String rhsSymbolName;
     private SemanticModel model;
 
     public DataMapperNodeVisitor(String rhsSymbolName) {

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/utils/HttpClientRequest.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/utils/HttpClientRequest.java
@@ -91,7 +91,7 @@ public final class HttpClientRequest {
     }
 
     private static HttpResponse buildResponse(HttpURLConnection conn) throws IOException {
-        return buildResponse(conn, defaultResponseBuilder);
+        return buildResponse(conn, DEFAULT_RESPONSE_BUILDER);
     }
 
     private static HttpResponse buildResponse(HttpURLConnection conn,
@@ -129,7 +129,7 @@ public final class HttpClientRequest {
         return httpResponse;
     }
 
-    private static final CheckedFunction<BufferedReader, String> defaultResponseBuilder = ((bufferedReader) -> {
+    private static final CheckedFunction<BufferedReader, String> DEFAULT_RESPONSE_BUILDER = ((bufferedReader) -> {
         String line;
         StringBuilder sb = new StringBuilder();
         while ((line = bufferedReader.readLine()) != null) {

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/utils/HttpClientRequest.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/utils/HttpClientRequest.java
@@ -129,7 +129,7 @@ public final class HttpClientRequest {
         return httpResponse;
     }
 
-    private static CheckedFunction<BufferedReader, String> defaultResponseBuilder = ((bufferedReader) -> {
+    private static final CheckedFunction<BufferedReader, String> defaultResponseBuilder = ((bufferedReader) -> {
         String line;
         StringBuilder sb = new StringBuilder();
         while ((line = bufferedReader.readLine()) != null) {

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/utils/HttpResponse.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/utils/HttpResponse.java
@@ -19,8 +19,8 @@ package org.ballerinalang.datamapper.utils;
  * This class is a simple representation of an HTTP response.
  */
 public class HttpResponse {
-    private String data;
-    private int responseCode;
+    private final String data;
+    private final int responseCode;
 
     /**
      * This method set data and response code of a HTTP request response.

--- a/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/DataMapperTestUtils.java
+++ b/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/DataMapperTestUtils.java
@@ -43,10 +43,10 @@ import java.util.List;
  */
 public final class DataMapperTestUtils {
 
-    private static final Path sourcesPath = new File(DataMapperTestUtils.class.getClassLoader()
+    private static final Path SOURCES_PATH = new File(DataMapperTestUtils.class.getClassLoader()
             .getResource("codeaction").getFile()).toPath();
-    private static final LanguageServerContext serverContext = new LanguageServerContextImpl();
-    private static final WorkspaceManager workspaceManager = new BallerinaWorkspaceManager(serverContext);
+    private static final LanguageServerContext SERVER_CONTEXT = new LanguageServerContextImpl();
+    private static final WorkspaceManager WORKSPACE_MANAGER = new BallerinaWorkspaceManager(SERVER_CONTEXT);
 
     private DataMapperTestUtils() {
     }
@@ -77,12 +77,12 @@ public final class DataMapperTestUtils {
             throws IOException, WorkspaceDocumentException {
 
         // Read expected results
-        Path sourcePath = sourcesPath.resolve("source").resolve(source);
+        Path sourcePath = SOURCES_PATH.resolve("source").resolve(source);
         TestUtil.openDocument(serviceEndpoint, sourcePath);
 
         // Filter diagnostics for the cursor position
         List<io.ballerina.tools.diagnostics.Diagnostic> diagnostics
-                = TestUtil.compileAndGetDiagnostics(sourcePath, workspaceManager, serverContext);
+                = TestUtil.compileAndGetDiagnostics(sourcePath, WORKSPACE_MANAGER, SERVER_CONTEXT);
         List<Diagnostic> diags = new ArrayList<>(CodeActionUtil.toDiagnostics(diagnostics));
         Position pos = new Position(configJsonObject.get("line").getAsInt(),
                 configJsonObject.get("character").getAsInt());

--- a/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/DataMapperTestUtils.java
+++ b/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/DataMapperTestUtils.java
@@ -43,8 +43,8 @@ import java.util.List;
  */
 public final class DataMapperTestUtils {
 
-    private static Path sourcesPath = new File(DataMapperTestUtils.class.getClassLoader().getResource("codeaction")
-            .getFile()).toPath();
+    private static final Path sourcesPath = new File(DataMapperTestUtils.class.getClassLoader()
+            .getResource("codeaction").getFile()).toPath();
     private static final LanguageServerContext serverContext = new LanguageServerContextImpl();
     private static final WorkspaceManager workspaceManager = new BallerinaWorkspaceManager(serverContext);
 

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -75,9 +75,9 @@ import java.util.stream.Collectors;
  */
 public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
     private SemanticModel semanticModel;
-    private List<JsonObject> visibleEpsForEachBlock;
-    private List<JsonObject> visibleEpsForModule;
-    private List<JsonObject> visibleEpsForClass;
+    private final List<JsonObject> visibleEpsForEachBlock;
+    private final List<JsonObject> visibleEpsForModule;
+    private final List<JsonObject> visibleEpsForClass;
 
 
     public SyntaxTreeMapGenerator(SemanticModel semanticModel) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -86,7 +86,7 @@ import static java.net.HttpURLConnection.HTTP_OK;
  */
 public final class BallerinaDocGenerator {
 
-    private static final Logger log = LoggerFactory.getLogger(BallerinaDocGenerator.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BallerinaDocGenerator.class);
     private static PrintStream out = System.out;
 
     public static final String API_DOCS_JSON = "api-docs.json";
@@ -106,7 +106,7 @@ public final class BallerinaDocGenerator {
     private static final String CENTRAL_REGISTRY_PATH = "/registry";
     private static final String CENTRAL_DOC_UI_PATH = "/docs/doc-ui";
 
-    private static final Gson gson = new GsonBuilder().registerTypeHierarchyAdapter(Path.class, new PathToJson())
+    private static final Gson GSON = new GsonBuilder().registerTypeHierarchyAdapter(Path.class, new PathToJson())
             .excludeFieldsWithoutExposeAnnotation().create();
 
     private BallerinaDocGenerator() {
@@ -122,7 +122,7 @@ public final class BallerinaDocGenerator {
         // get all the files from a directory
         File[] orgFileList = directory.listFiles();
         if (orgFileList == null) {
-            log.error(String.format("docerina: API documentation generation failed. Could not find any packages"
+            LOG.error(String.format("docerina: API documentation generation failed. Could not find any packages"
                     + " in given path %s", apiDocsRoot));
             return;
         }
@@ -146,9 +146,9 @@ public final class BallerinaDocGenerator {
                         Path docJsonPath = Paths.get(versionFile.getAbsolutePath(), API_DOCS_JSON);
                         if (docJsonPath.toFile().exists()) {
                             try (BufferedReader br = Files.newBufferedReader(docJsonPath, StandardCharsets.UTF_8)) {
-                                ApiDocsJson apiDocsJson = gson.fromJson(br, ApiDocsJson.class);
+                                ApiDocsJson apiDocsJson = GSON.fromJson(br, ApiDocsJson.class);
                                 if (apiDocsJson.docsData.modules.isEmpty()) {
-                                    log.warn("No packages found at: " + docJsonPath.toString());
+                                    LOG.warn("No packages found at: " + docJsonPath.toString());
                                     continue;
                                 }
                                 apiDocsJson.docsData.modules.forEach(mod -> {
@@ -156,7 +156,7 @@ public final class BallerinaDocGenerator {
                                         mod.resources
                                                 .addAll(getResourcePaths(Paths.get(orgFile.getAbsolutePath())));
                                     } catch (IOException e) {
-                                        log.error(String.format("API documentation generation failed. Cause: %s"
+                                        LOG.error(String.format("API documentation generation failed. Cause: %s"
                                                 , e.getMessage()), e);
                                         return;
                                     }
@@ -178,7 +178,7 @@ public final class BallerinaDocGenerator {
 
                                 }
                             } catch (IOException e) {
-                                log.error(String.format("API documentation generation failed. Cause: %s",
+                                LOG.error(String.format("API documentation generation failed. Cause: %s",
                                         e.getMessage()), e);
                                 return;
                             }
@@ -192,21 +192,21 @@ public final class BallerinaDocGenerator {
         writeAPIDocs(moduleLib, apiDocsRoot, true, false);
 
         // Create the central Ballerina library index JSON.
-        String stdIndexJson = gson.toJson(centralLib);
+        String stdIndexJson = GSON.toJson(centralLib);
         File stdIndexJsonFile = apiDocsRoot.resolve(CENTRAL_STDLIB_INDEX_JSON).toFile();
         try (Writer writer = new OutputStreamWriter(new FileOutputStream(stdIndexJsonFile), StandardCharsets.UTF_8)) {
             writer.write(new String(stdIndexJson.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
         } catch (IOException e) {
-            log.error("Failed to create {} file.", CENTRAL_STDLIB_INDEX_JSON, e);
+            LOG.error("Failed to create {} file.", CENTRAL_STDLIB_INDEX_JSON, e);
         }
 
         // Create the central Ballerina library search JSON.
-        String stdSearchJson = gson.toJson(genSearchJson(moduleLib));
+        String stdSearchJson = GSON.toJson(genSearchJson(moduleLib));
         File stdSearchJsonFile = apiDocsRoot.resolve(CENTRAL_STDLIB_SEARCH_JSON).toFile();
         try (Writer writer = new OutputStreamWriter(new FileOutputStream(stdSearchJsonFile), StandardCharsets.UTF_8)) {
             writer.write(new String(stdSearchJson.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
         } catch (IOException e) {
-            log.error("Failed to create {} file.", CENTRAL_STDLIB_SEARCH_JSON, e);
+            LOG.error("Failed to create {} file.", CENTRAL_STDLIB_SEARCH_JSON, e);
         }
     }
 
@@ -236,14 +236,14 @@ public final class BallerinaDocGenerator {
                 byte[] iconByteArray = Files.readAllBytes(iconPath);
                 Files.write(output, iconByteArray);
             } catch (IOException e) {
-                log.error("Failed to copy icon to the API docs.", e);
+                LOG.error("Failed to copy icon to the API docs.", e);
             }
         }
     }
 
     private static void writeAPIDocs(ModuleLibrary moduleLib, Path output, boolean isMerge, boolean excludeUI) {
         if (moduleLib.modules.isEmpty()) {
-            log.error("No modules found to create docs.");
+            LOG.error("No modules found to create docs.");
             return;
         }
         if (!isMerge && excludeUI) {
@@ -315,14 +315,14 @@ public final class BallerinaDocGenerator {
                     try {
                         FileUtils.copyDirectory(sourceDir, output.toFile());
                     } catch (IOException ex) {
-                        log.error("Failed to copy the API doc UI", ex);
+                        LOG.error("Failed to copy the API doc UI", ex);
                     }
                 } else {
                     try {
                         FileUtils.copyInputStreamToFile(BallerinaDocGenerator.class
                                 .getResourceAsStream("/doc-ui/index.html"), output.resolve("index.html").toFile());
                     } catch (IOException ex) {
-                        log.error("Failed to copy the API doc UI", ex);
+                        LOG.error("Failed to copy the API doc UI", ex);
                     }
                 }
             }
@@ -371,12 +371,12 @@ public final class BallerinaDocGenerator {
                             outputStream.write(buffer, 0, length);
                         }
                     } catch (IOException e) {
-                        log.error("Unable to write to the file" , e);
+                        LOG.error("Unable to write to the file" , e);
                     }
                 }
             }
         } catch (IOException e) {
-            log.error("Error occurred when unzipping file", e);
+            LOG.error("Error occurred when unzipping file", e);
         }
     }
 
@@ -390,7 +390,7 @@ public final class BallerinaDocGenerator {
                 try {
                     FileUtils.copyFileToDirectory(resourcePath.toFile(), resourcesDirFile);
                 } catch (IOException e) {
-                    log.error(String.format("docerina: failed to copy [resource] %s into [resources directory] "
+                    LOG.error(String.format("docerina: failed to copy [resource] %s into [resources directory] "
                                     + "%s. Cause: %s", resourcePath.toString(), resourcesDirFile.toString(),
                             e.getMessage()), e);
                 }
@@ -419,7 +419,7 @@ public final class BallerinaDocGenerator {
         try {
             Files.createDirectories(destination);
         } catch (IOException e) {
-            log.error("API documentation generation failed when creating directory:", e);
+            LOG.error("API documentation generation failed when creating directory:", e);
         }
 
         ApiDocsJson apiDocsJson = new ApiDocsJson();
@@ -432,22 +432,22 @@ public final class BallerinaDocGenerator {
 
         if (jsFile.exists()) {
             if (!jsFile.delete()) {
-                log.error("docerina: failed to delete {}", jsFile.toString());
+                LOG.error("docerina: failed to delete {}", jsFile.toString());
             }
         }
         if (jsonFile.exists()) {
             if (!jsonFile.delete()) {
-                log.error("docerina: failed to delete {}", jsonFile.toString());
+                LOG.error("docerina: failed to delete {}", jsonFile.toString());
             }
         }
-        String json = gson.toJson(apiDocsJson);
+        String json = GSON.toJson(apiDocsJson);
         if (!excludeUI) {
             try (Writer writer = new OutputStreamWriter(new FileOutputStream(jsFile),
                     StandardCharsets.UTF_8)) {
                 String js = "var apiDocsJson = " + json + ";";
                 writer.write(new String(js.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
             } catch (IOException e) {
-                log.error("Failed to create {} file.", API_DOCS_JS, e);
+                LOG.error("Failed to create {} file.", API_DOCS_JS, e);
             }
         }
 
@@ -455,7 +455,7 @@ public final class BallerinaDocGenerator {
                 StandardCharsets.UTF_8)) {
             writer.write(new String(json.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
         } catch (IOException e) {
-            log.error("Failed to create {} file.", API_DOCS_JSON, e);
+            LOG.error("Failed to create {} file.", API_DOCS_JSON, e);
         }
     }
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -106,7 +106,7 @@ public final class BallerinaDocGenerator {
     private static final String CENTRAL_REGISTRY_PATH = "/registry";
     private static final String CENTRAL_DOC_UI_PATH = "/docs/doc-ui";
 
-    private static Gson gson = new GsonBuilder().registerTypeHierarchyAdapter(Path.class, new PathToJson())
+    private static final Gson gson = new GsonBuilder().registerTypeHierarchyAdapter(Path.class, new PathToJson())
             .excludeFieldsWithoutExposeAnnotation().create();
 
     private BallerinaDocGenerator() {

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/options/ForceFormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/options/ForceFormattingOptions.java
@@ -23,7 +23,7 @@ package org.ballerinalang.formatter.core.options;
  * @since 2201.3.0
  */
 public class ForceFormattingOptions {
-    private boolean forceFormatRecordFields;
+    private final boolean forceFormatRecordFields;
 
     private ForceFormattingOptions(boolean forceFormatRecordFields) {
         this.forceFormatRecordFields = forceFormatRecordFields;

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/options/ImportFormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/options/ImportFormattingOptions.java
@@ -28,9 +28,9 @@ import static org.ballerinalang.formatter.core.FormatterUtils.getDefaultBoolean;
  */
 public class ImportFormattingOptions {
 
-    private boolean groupImports;
-    private boolean sortImports;
-    private boolean removeUnusedImports;
+    private final boolean groupImports;
+    private final boolean sortImports;
+    private final boolean removeUnusedImports;
 
     private ImportFormattingOptions(boolean groupImports, boolean sortImports, boolean removeUnusedImports) {
         this.groupImports = groupImports;

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/options/IndentFormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/options/IndentFormattingOptions.java
@@ -63,7 +63,7 @@ public class IndentFormattingOptions {
         private static final String CONTINUATION_INDENT_SIZE = "continuationIndentSize";
         private int indentSize = getDefaultInt(FormatSection.INDENT, INDENT_SIZE);
         private int continuationIndentSize = getDefaultInt(FormatSection.INDENT, CONTINUATION_INDENT_SIZE);
-        private String wsCharacter = " ";
+        private static final String wsCharacter = " ";
 
         public IndentFormattingOptionsBuilder setIndentSize(int indentSize) {
             this.indentSize = indentSize;

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/options/IndentFormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/options/IndentFormattingOptions.java
@@ -63,7 +63,7 @@ public class IndentFormattingOptions {
         private static final String CONTINUATION_INDENT_SIZE = "continuationIndentSize";
         private int indentSize = getDefaultInt(FormatSection.INDENT, INDENT_SIZE);
         private int continuationIndentSize = getDefaultInt(FormatSection.INDENT, CONTINUATION_INDENT_SIZE);
-        private static final String wsCharacter = " ";
+        private static final String WS_CHARACTER = " ";
 
         public IndentFormattingOptionsBuilder setIndentSize(int indentSize) {
             this.indentSize = indentSize;
@@ -76,7 +76,7 @@ public class IndentFormattingOptions {
         }
 
         public IndentFormattingOptions build() {
-            return new IndentFormattingOptions(indentSize, continuationIndentSize, wsCharacter);
+            return new IndentFormattingOptions(indentSize, continuationIndentSize, WS_CHARACTER);
         }
 
         public IndentFormattingOptions build(Map<String, Object> configs) throws FormatterException {

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/FormatterTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/FormatterTest.java
@@ -49,7 +49,7 @@ public abstract class FormatterTest {
     // TODO: Add test cases for syntax error scenarios as well
 
     private final Path resourceDirectory = Paths.get("src").resolve("test").resolve("resources").toAbsolutePath();
-    private Path buildDirectory = Paths.get("build").toAbsolutePath().normalize();
+    private final Path buildDirectory = Paths.get("build").toAbsolutePath().normalize();
     private static final String ASSERT_DIR = "assert";
     private static final String SOURCE_DIR = "source";
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/JsonToRecordRequest.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/JsonToRecordRequest.java
@@ -31,7 +31,7 @@ public class JsonToRecordRequest {
     private boolean forceFormatRecordFields;
     private String filePathUri;
 
-    private boolean isNullAsOptional;
+    private final boolean isNullAsOptional;
 
     public JsonToRecordRequest(String jsonString, String recordName, boolean isRecordTypeDesc, boolean isClosed,
                                boolean forceFormatRecordFields, String filePathUri, boolean isNullAsOptional) {

--- a/misc/maven-resolver/src/main/java/org/ballerinalang/maven/MavenResolver.java
+++ b/misc/maven-resolver/src/main/java/org/ballerinalang/maven/MavenResolver.java
@@ -57,7 +57,7 @@ import java.util.List;
  */
 public class MavenResolver {
     org.ballerinalang.maven.Dependency rootNode = null;
-    private List<RemoteRepository> repositories;
+    private final List<RemoteRepository> repositories;
     RepositorySystem system;
     DefaultRepositorySystemSession session;
 

--- a/misc/maven-resolver/src/main/java/org/ballerinalang/maven/TransferListener.java
+++ b/misc/maven-resolver/src/main/java/org/ballerinalang/maven/TransferListener.java
@@ -32,10 +32,10 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class TransferListener extends AbstractTransferListener {
     private static final String JAR_EXTENSION = "jar";
-    private PrintStream out;
-    private Map<TransferResource, Long> downloads = new ConcurrentHashMap<>();
-    private Map<String, ProgressBar> progressBars = new ConcurrentHashMap<>();
-    private Map<String, Long> progresses = new ConcurrentHashMap<>();
+    private final PrintStream out;
+    private final Map<TransferResource, Long> downloads = new ConcurrentHashMap<>();
+    private final Map<String, ProgressBar> progressBars = new ConcurrentHashMap<>();
+    private final Map<String, Long> progresses = new ConcurrentHashMap<>();
 
     public TransferListener() {
         this(System.out);

--- a/misc/maven-resolver/src/main/java/org/ballerinalang/maven/bala/client/TransferListenerForClient.java
+++ b/misc/maven-resolver/src/main/java/org/ballerinalang/maven/bala/client/TransferListenerForClient.java
@@ -30,10 +30,10 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class TransferListenerForClient extends AbstractTransferListener {
     private static final String BALA_EXTENSION = "bala";
-    private PrintStream out;
-    private Map<TransferResource, Long> downloads = new ConcurrentHashMap<>();
-    private Map<String, ProgressBar> progressBars = new ConcurrentHashMap<>();
-    private Map<String, Long> progresses = new ConcurrentHashMap<>();
+    private final PrintStream out;
+    private final Map<TransferResource, Long> downloads = new ConcurrentHashMap<>();
+    private final Map<String, ProgressBar> progressBars = new ConcurrentHashMap<>();
+    private final Map<String, Long> progresses = new ConcurrentHashMap<>();
 
     public TransferListenerForClient() {
         this(System.out);

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
@@ -89,7 +89,7 @@ public class TestProcessor {
     private static final String FILE_NAME_PERIOD_SEPARATOR = "$$$";
     private static final String MODULE_DELIMITER = "§";
 
-    private TesterinaRegistry registry = TesterinaRegistry.getInstance();
+    private final TesterinaRegistry registry = TesterinaRegistry.getInstance();
 
     private JarResolver jarResolver;
 

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TesterinaRegistry.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TesterinaRegistry.java
@@ -36,17 +36,17 @@ public class TesterinaRegistry {
     private List<String> groups = new ArrayList<>();
     private boolean shouldIncludeGroups;
     private Map<String, TestSuite> testSuites = new HashMap<>();
-    private Map<String, String> mockFunctionSourceMap = new HashMap<>();
+    private final Map<String, String> mockFunctionSourceMap = new HashMap<>();
 
     // This is use to keep track of packages that are already inited.
-    private List<String> initializedPackages = new ArrayList<>();
+    private final List<String> initializedPackages = new ArrayList<>();
     /**
      * This is required to stop the annotation processor from processing annotations upon the compilation of the
      * service skeleton. This flag will make sure that @{@link TestProcessor}'s methods will skip the
      * annotation processing once the test suites are compiled.
      */
     private boolean testSuitesCompiled;
-    private static TesterinaRegistry instance = new TesterinaRegistry();
+    private static final TesterinaRegistry instance = new TesterinaRegistry();
 
     public static TesterinaRegistry getInstance() {
         return instance;

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TesterinaRegistry.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TesterinaRegistry.java
@@ -46,10 +46,10 @@ public class TesterinaRegistry {
      * annotation processing once the test suites are compiled.
      */
     private boolean testSuitesCompiled;
-    private static final TesterinaRegistry instance = new TesterinaRegistry();
+    private static final TesterinaRegistry INSTANCE = new TesterinaRegistry();
 
     public static TesterinaRegistry getInstance() {
-        return instance;
+        return INSTANCE;
     }
 
     public Map<String, TestSuite> getTestSuites() {

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/io/StringUtils.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/io/StringUtils.java
@@ -51,18 +51,18 @@ import java.util.regex.PatternSyntaxException;
 public final class StringUtils {
 
     private static final String CHAR_PREFIX = "$";
-    private static final List<String> specialCharacters = new ArrayList<>(
+    private static final List<String> SPECIAL_CHARACTERS = new ArrayList<>(
             Arrays.asList(",", "\\n", "\\r", "\\t", "\n", "\r", "\t", "\"", "\\", "!", "`"));
-    private static final List<String> bracketCharacters = new ArrayList<>(Arrays.asList("{", "}", "[", "]", "(", ")"));
-    private static final List<String> regexSpecialCharacters = new ArrayList<>(
+    private static final List<String> BRACKET_CHARACTERS = new ArrayList<>(Arrays.asList("{", "}", "[", "]", "(", ")"));
+    private static final List<String> REGEX_SPECIAL_CHARACTERS = new ArrayList<>(
             Arrays.asList("{", "}", "[", "]", "(", ")", "+", "^", "|"));
 
     private StringUtils() {
     }
 
     public static Object matchWildcard(BString functionName, BString functionPattern) {
-        Object encodedFunctionPattern = encode(functionPattern.getValue(), regexSpecialCharacters);
-        Object encodedFunctionName = encode(functionName.getValue(), regexSpecialCharacters);
+        Object encodedFunctionPattern = encode(functionPattern.getValue(), REGEX_SPECIAL_CHARACTERS);
+        Object encodedFunctionName = encode(functionName.getValue(), REGEX_SPECIAL_CHARACTERS);
 
         if (encodedFunctionPattern instanceof BError) {
             return encodedFunctionPattern;
@@ -84,13 +84,13 @@ public final class StringUtils {
     public static Object escapeSpecialCharacters(BString key) {
         Object updatedKeyOrError = key.getValue();
         if (!isBalanced((String) updatedKeyOrError)) {
-            updatedKeyOrError = encode((String) updatedKeyOrError, bracketCharacters);
+            updatedKeyOrError = encode((String) updatedKeyOrError, BRACKET_CHARACTERS);
         }
 
         if (updatedKeyOrError instanceof BError) {
             return updatedKeyOrError;
         }
-        updatedKeyOrError = encode((String) updatedKeyOrError, specialCharacters);
+        updatedKeyOrError = encode((String) updatedKeyOrError, SPECIAL_CHARACTERS);
 
         if (updatedKeyOrError instanceof BError) {
             return updatedKeyOrError;

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/io/StringUtils.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/io/StringUtils.java
@@ -51,12 +51,11 @@ import java.util.regex.PatternSyntaxException;
 public final class StringUtils {
 
     private static final String CHAR_PREFIX = "$";
-    private static List<String> specialCharacters = new ArrayList<>(Arrays.asList(",", "\\n", "\\r", "\\t", "\n", "\r",
-            "\t",
-            "\"", "\\", "!", "`"));
-    private static List<String> bracketCharacters = new ArrayList<>(Arrays.asList("{", "}", "[", "]", "(", ")"));
-    private static List<String> regexSpecialCharacters = new ArrayList<>(Arrays.asList("{", "}", "[", "]", "(", ")",
-            "+", "^", "|"));
+    private static final List<String> specialCharacters = new ArrayList<>(
+            Arrays.asList(",", "\\n", "\\r", "\\t", "\n", "\r", "\t", "\"", "\\", "!", "`"));
+    private static final List<String> bracketCharacters = new ArrayList<>(Arrays.asList("{", "}", "[", "]", "(", ")"));
+    private static final List<String> regexSpecialCharacters = new ArrayList<>(
+            Arrays.asList("{", "}", "[", "]", "(", ")", "+", "^", "|"));
 
     private StringUtils() {
     }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
@@ -47,10 +47,10 @@ import java.util.Map;
  */
 public class GenericMockObjectValue implements ObjectValue {
 
-    private ObjectValue mockObj;
+    private final ObjectValue mockObj;
 
-    private ObjectType type;
-    private BTypedesc typedesc;
+    private final ObjectType type;
+    private final BTypedesc typedesc;
 
     public GenericMockObjectValue(ObjectType type, ObjectValue mockObj) {
         this.type = type;

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/MockRegistry.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/MockRegistry.java
@@ -30,10 +30,10 @@ import java.util.Map;
 public class MockRegistry {
 
     public static final String ANY = "__ANY__";
-    private static final MockRegistry instance = new MockRegistry();
+    private static final MockRegistry INSTANCE = new MockRegistry();
 
     public static MockRegistry getInstance() {
-        return instance;
+        return INSTANCE;
     }
     private final Map<String, Object> casesMap = new HashMap<>();
     private final Map<String, Integer> memberFuncHitsMap = new HashMap<>();

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/MockRegistry.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/MockRegistry.java
@@ -30,13 +30,13 @@ import java.util.Map;
 public class MockRegistry {
 
     public static final String ANY = "__ANY__";
-    private static MockRegistry instance = new MockRegistry();
+    private static final MockRegistry instance = new MockRegistry();
 
     public static MockRegistry getInstance() {
         return instance;
     }
-    private Map<String, Object> casesMap = new HashMap<>();
-    private Map<String, Integer> memberFuncHitsMap = new HashMap<>();
+    private final Map<String, Object> casesMap = new HashMap<>();
+    private final Map<String, Integer> memberFuncHitsMap = new HashMap<>();
 
     /**
      * Register a case for object mocking when a sequence of return value is provided.

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/ModuleCoverage.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/ModuleCoverage.java
@@ -34,7 +34,7 @@ public class ModuleCoverage {
     private int coveredLines;
     private int missedLines;
     private float coveragePercentage;
-    private List<SourceFile> sourceFiles = new ArrayList<>();
+    private final List<SourceFile> sourceFiles = new ArrayList<>();
 
     /**
      * Adds the code snippet from the source file highlighted with covered and missed lines.
@@ -211,9 +211,9 @@ public class ModuleCoverage {
      * Inner class for the SourceFile in Json.
      */
     private static class SourceFile {
-        private String name;
-        private List<Integer> coveredLines;
-        private List<Integer> missedLines;
+        private final String name;
+        private final List<Integer> coveredLines;
+        private final List<Integer> missedLines;
         private List<Integer> emptyLines;
         private float coveragePercentage;
         private String sourceCode;

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/ModuleStatus.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/ModuleStatus.java
@@ -31,7 +31,7 @@ public class ModuleStatus {
     private int passed;
     private int failed;
     private int skipped;
-    private List<Test> tests = new ArrayList<>();
+    private final List<Test> tests = new ArrayList<>();
 
     private static ModuleStatus instance = new ModuleStatus();
 
@@ -84,8 +84,8 @@ public class ModuleStatus {
      * Inner class for individual Test object.
      */
     private static class Test {
-        private String name;
-        private Status status;
+        private final String name;
+        private final Status status;
         private String failureMessage = "";
 
         public Test(String name, Status status, String failureMessage) {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/NormalizedCoverageClass.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/NormalizedCoverageClass.java
@@ -33,9 +33,9 @@ import java.util.Collection;
  */
 public class NormalizedCoverageClass implements IClassCoverage {
     private final IClassCoverage oldClassCoverage;
-    private String normalizedPackageName;
-    private String normalizedClassName;
-    private Collection<IMethodCoverage> updatedMethods = new ArrayList<>();
+    private final String normalizedPackageName;
+    private final String normalizedClassName;
+    private final Collection<IMethodCoverage> updatedMethods = new ArrayList<>();
 
     public NormalizedCoverageClass(IClassCoverage oldClassCoverage, String normalizedPackageName,
                                    String normalizedClassName) {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedSourceFile.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedSourceFile.java
@@ -33,7 +33,7 @@ public class PartialCoverageModifiedSourceFile implements ISourceFileCoverage {
 
     private final ISourceFileCoverage oldSourceFile;
     private final List<ILine> modifiedLines;
-    private String normalizedPackageName;
+    private final String normalizedPackageName;
 
     public PartialCoverageModifiedSourceFile(ISourceFileCoverage oldSourcefile, List<ILine> modifiedLines,
                                              String normalizedPackageName) {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestGroup.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestGroup.java
@@ -30,8 +30,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class TestGroup {
     private int testCount;
     private int executedCount;
-    private List<String> beforeGroupsFunctions;
-    private Map<String, AtomicBoolean> afterGroupsFunctions;
+    private final List<String> beforeGroupsFunctions;
+    private final Map<String, AtomicBoolean> afterGroupsFunctions;
 
     public TestGroup() {
         this.testCount = 0;

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestSuite.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestSuite.java
@@ -37,8 +37,8 @@ public class TestSuite {
     private String version;
     private String packageName;
     private String moduleName;
-    private String packageId;
-    private String testPackageId;
+    private final String packageId;
+    private final String testPackageId;
     private String executeFilePath;
 
     private String initFunctionName;
@@ -52,14 +52,14 @@ public class TestSuite {
     private String sourceRootPath;
     private String sourceFileName;
 
-    private Map<String, String> testUtilityFunctions = new HashMap<>();
-    private List<String> beforeSuiteFunctionNames = new ArrayList<>();
-    private Map<String, AtomicBoolean> afterSuiteFunctionNames = new TreeMap<>();
-    private List<String> beforeEachFunctionNames = new ArrayList<>();
-    private List<String> afterEachFunctionNames = new ArrayList<>();
+    private final Map<String, String> testUtilityFunctions = new HashMap<>();
+    private final List<String> beforeSuiteFunctionNames = new ArrayList<>();
+    private final Map<String, AtomicBoolean> afterSuiteFunctionNames = new TreeMap<>();
+    private final List<String> beforeEachFunctionNames = new ArrayList<>();
+    private final List<String> afterEachFunctionNames = new ArrayList<>();
     private List<Test> tests = new ArrayList<>();
-    private Map<String, TestGroup> groups = new TreeMap<>();
-    private List<String> testExecutionDependencies = new ArrayList<>();
+    private final Map<String, TestGroup> groups = new TreeMap<>();
+    private final List<String> testExecutionDependencies = new ArrayList<>();
 
     private boolean isReportRequired;
     private boolean isSingleDDTExecution;

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TesterinaReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TesterinaReport.java
@@ -31,8 +31,8 @@ import java.util.Map;
  */
 public class TesterinaReport {
 
-    private PrintStream outStream;
-    private Map<String, TestSummary> testReportOfPackage = new HashMap<>();
+    private final PrintStream outStream;
+    private final Map<String, TestSummary> testReportOfPackage = new HashMap<>();
     private boolean failure;
     private boolean isReportRequired;
 

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TesterinaResult.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TesterinaResult.java
@@ -22,10 +22,10 @@ package org.ballerinalang.test.runtime.entity;
  * {@link TesterinaResult} represents the result of the Testerina test.
  */
 public class TesterinaResult {
-    private String testFunctionName;
-    private boolean isPassed;
-    private boolean isSkipped;
-    private String assertFailureMessage;
+    private final String testFunctionName;
+    private final boolean isPassed;
+    private final boolean isSkipped;
+    private final String assertFailureMessage;
 
     public TesterinaResult(String testFunctionName, boolean isPassed, boolean isSkipped, String assertFailureMessage) {
         this.testFunctionName = testFunctionName;

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/api/Toml.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/api/Toml.java
@@ -54,7 +54,7 @@ import java.util.Optional;
  */
 public class Toml {
 
-    private TomlTableNode rootNode;
+    private final TomlTableNode rootNode;
 
     /**
      * Creates new Root TOML Node from AST.

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/InputReader.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/InputReader.java
@@ -33,8 +33,8 @@ import java.nio.charset.StandardCharsets;
 public class InputReader {
 
     private static final int BUFFER_SIZE = 10;
-    private CharacterBuffer charsAhead = new CharacterBuffer(BUFFER_SIZE);
-    private Reader reader;
+    private final CharacterBuffer charsAhead = new CharacterBuffer(BUFFER_SIZE);
+    private final Reader reader;
     private int currentChar;
 
     InputReader(InputStream inputStream) {

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/TokenReader.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/TokenReader.java
@@ -29,8 +29,8 @@ public class TokenReader extends AbstractTokenReader {
 
     private static final int BUFFER_SIZE = 20;
 
-    private AbstractLexer lexer;
-    private TokenBuffer tokensAhead = new TokenBuffer(BUFFER_SIZE);
+    private final AbstractLexer lexer;
+    private final TokenBuffer tokensAhead = new TokenBuffer(BUFFER_SIZE);
     private STToken currentToken = null;
 
     TokenReader(AbstractLexer lexer) {

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/tree/STNodeDiagnostic.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/internal/parser/tree/STNodeDiagnostic.java
@@ -25,8 +25,8 @@ import io.ballerina.tools.diagnostics.DiagnosticCode;
  * @since 2.0.0
  */
 public class STNodeDiagnostic {
-    private DiagnosticCode diagnosticCode;
-    private Object[] args;
+    private final DiagnosticCode diagnosticCode;
+    private final Object[] args;
 
     STNodeDiagnostic(DiagnosticCode diagnosticCode, Object... args) {
         this.diagnosticCode = diagnosticCode;

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTransformer.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTransformer.java
@@ -61,7 +61,7 @@ import java.util.Optional;
  */
 public class TomlTransformer extends NodeTransformer<TomlNode> {
 
-    private DiagnosticLog dlog;
+    private final DiagnosticLog dlog;
 
     public TomlTransformer() {
         this.dlog = DiagnosticLog.getInstance();

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -77,7 +77,7 @@ import static org.testng.Assert.assertTrue;
  */
 public class LangLibFunctionTest {
 
-    private static final List<String> valueLangLib = List.of("clone", "cloneReadOnly", "cloneWithType",
+    private static final List<String> VALUE_LANG_LIB = List.of("clone", "cloneReadOnly", "cloneWithType",
             "isReadOnly", "toString", "toBalString", "toJson", "toJsonString",
             "fromJsonString", "fromJsonFloatString", "fromJsonDecimalString",
             "fromJsonWithType", "fromJsonStringWithType", "mergeJson");

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -77,7 +77,7 @@ import static org.testng.Assert.assertTrue;
  */
 public class LangLibFunctionTest {
 
-    private static List<String> valueLangLib = List.of("clone", "cloneReadOnly", "cloneWithType",
+    private static final List<String> valueLangLib = List.of("clone", "cloneReadOnly", "cloneWithType",
             "isReadOnly", "toString", "toBalString", "toJson", "toJsonString",
             "fromJsonString", "fromJsonFloatString", "fromJsonDecimalString",
             "fromJsonWithType", "fromJsonStringWithType", "mergeJson");

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -364,8 +364,8 @@ public class SymbolBIRTest {
     }
 
     static class SymbolInfo {
-        private String name;
-        private SymbolKind kind;
+        private final String name;
+        private final SymbolKind kind;
 
         SymbolInfo(String name, SymbolKind kind) {
             this.name = name;

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
@@ -54,10 +54,11 @@ import static io.ballerina.projects.util.ProjectConstants.DIST_CACHE_DIRECTORY;
  */
 public final class BCompileUtil {
 
-    private static final Path testSourcesDirectory = Paths.get("src/test/resources").toAbsolutePath().normalize();
-    private static final Path testBuildDirectory = Paths.get("build").toAbsolutePath().normalize();
+    private static final Path TEST_SOURCES_DIRECTORY = Paths.get("src/test/resources").toAbsolutePath()
+            .normalize();
+    private static final Path TEST_BUILD_DIRECTORY = Paths.get("build").toAbsolutePath().normalize();
 
-    private static final Logger logger = LoggerFactory.getLogger(BCompileUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BCompileUtil.class);
 
     private BCompileUtil() {}
 
@@ -69,7 +70,7 @@ public final class BCompileUtil {
     public static Project loadProject(String sourceFilePath, BuildOptions buildOptions) {
         Path sourcePath = Paths.get(sourceFilePath);
         String sourceFileName = sourcePath.getFileName().toString();
-        Path sourceRoot = testSourcesDirectory.resolve(sourcePath.getParent());
+        Path sourceRoot = TEST_SOURCES_DIRECTORY.resolve(sourcePath.getParent());
 
         Path projectPath = Paths.get(sourceRoot.toString(), sourceFileName);
 
@@ -152,7 +153,7 @@ public final class BCompileUtil {
     }
 
     public static CompileResult compileAndCacheBala(String sourceFilePath) {
-        return compileAndCacheBala(sourceFilePath, testBuildDirectory.resolve(DIST_CACHE_DIRECTORY));
+        return compileAndCacheBala(sourceFilePath, TEST_BUILD_DIRECTORY.resolve(DIST_CACHE_DIRECTORY));
     }
 
     public static CompileResult compileAndCacheBala(String sourceFilePath, Path repoPath) {
@@ -163,7 +164,7 @@ public final class BCompileUtil {
                                              ProjectEnvironmentBuilder projectEnvironmentBuilder) {
         Path sourcePath = Paths.get(sourceFilePath);
         String sourceFileName = sourcePath.getFileName().toString();
-        Path sourceRoot = testSourcesDirectory.resolve(sourcePath.getParent());
+        Path sourceRoot = TEST_SOURCES_DIRECTORY.resolve(sourcePath.getParent());
         Path projectPath = Paths.get(sourceRoot.toString(), sourceFileName);
 
         return compileAndCacheBala(projectPath, repoPath, projectEnvironmentBuilder);
@@ -210,7 +211,7 @@ public final class BCompileUtil {
     private static JBallerinaBackend jBallerinaBackend(Package currentPackage) {
         PackageCompilation packageCompilation = currentPackage.getCompilation();
         if (packageCompilation.diagnosticResult().errorCount() > 0) {
-            logger.error("compilation failed with errors: " + currentPackage.project().sourceRoot());
+            LOGGER.error("compilation failed with errors: " + currentPackage.project().sourceRoot());
         }
         return JBallerinaBackend.from(packageCompilation, JvmTarget.JAVA_17);
     }
@@ -228,7 +229,7 @@ public final class BCompileUtil {
                                                 String org,
                                                 String pkgName,
                                                 String version) throws IOException {
-        Path targetPath = balaCachePath(org, pkgName, version, testBuildDirectory.resolve(DIST_CACHE_DIRECTORY))
+        Path targetPath = balaCachePath(org, pkgName, version, TEST_BUILD_DIRECTORY.resolve(DIST_CACHE_DIRECTORY))
                 .resolve("any");
         if (Files.isDirectory(targetPath)) {
             ProjectUtils.deleteDirectory(targetPath);
@@ -280,7 +281,7 @@ public final class BCompileUtil {
             return balaDirPath;
         } catch (IOException e) {
             throw new RuntimeException("error while creating the bala distribution cache directory at " +
-                    testBuildDirectory, e);
+                    TEST_BUILD_DIRECTORY, e);
         }
     }
 
@@ -294,7 +295,7 @@ public final class BCompileUtil {
         }
 
         private static TestCompilationCache from(Project project) {
-            Path testCompilationCachePath = testBuildDirectory.resolve(DIST_CACHE_DIRECTORY);
+            Path testCompilationCachePath = TEST_BUILD_DIRECTORY.resolve(DIST_CACHE_DIRECTORY);
             return new TestCompilationCache(project, testCompilationCachePath);
         }
     }

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
@@ -304,8 +304,8 @@ public final class BCompileUtil {
      */
     public static class BIRCompileResult {
 
-        private BIRNode.BIRPackage expectedBIR;
-        private byte[] actualBIRBinary;
+        private final BIRNode.BIRPackage expectedBIR;
+        private final byte[] actualBIRBinary;
 
         BIRCompileResult(BIRNode.BIRPackage expectedBIR, byte[] actualBIRBinary) {
             this.expectedBIR = expectedBIR;

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/agent/BallerinaServerAgent.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/agent/BallerinaServerAgent.java
@@ -38,7 +38,7 @@ import java.util.Map;
  */
 public final class BallerinaServerAgent {
 
-    private static PrintStream outStream = System.err;
+    private static final PrintStream outStream = System.err;
 
     /**
      * Argument name for exist status.

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/agent/BallerinaServerAgent.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/agent/BallerinaServerAgent.java
@@ -38,7 +38,7 @@ import java.util.Map;
  */
 public final class BallerinaServerAgent {
 
-    private static final PrintStream outStream = System.err;
+    private static final PrintStream OUT_STREAM = System.err;
 
     /**
      * Argument name for exist status.
@@ -88,9 +88,9 @@ public final class BallerinaServerAgent {
      * @param instrumentation   instance for any instrumentation purposes
      */
     public static void premain(String args, Instrumentation instrumentation) {
-        outStream.println("*******************************************************");
-        outStream.println("Initializing Ballerina server agent with arguments - " + args);
-        outStream.println("*******************************************************");
+        OUT_STREAM.println("*******************************************************");
+        OUT_STREAM.println("Initializing Ballerina server agent with arguments - " + args);
+        OUT_STREAM.println("*******************************************************");
 
         Map<String, String> inputArgs = decodeAgentArgs(args);
 
@@ -100,7 +100,7 @@ public final class BallerinaServerAgent {
         agentHost = getValue(AGENT_HOST, DEFAULT_AGENT_HOST, inputArgs);
         agentPort = (int) getValue(AGENT_PORT, DEFAULT_AGENT_PORT, inputArgs);
 
-        outStream.println("timeout - " + timeout + " exitStatus - " + exitStatus
+        OUT_STREAM.println("timeout - " + timeout + " exitStatus - " + exitStatus
                 + " killStatus - " + killStatus + " host - " + agentHost + " port - " + agentPort);
 
         if (agentPort == -1) {
@@ -126,7 +126,7 @@ public final class BallerinaServerAgent {
                         cc.detach();
                         return byteCode;
                     } catch (Throwable ex) {
-                        outStream.println("Error injecting the start agent code to the server, error - "
+                        OUT_STREAM.println("Error injecting the start agent code to the server, error - "
                                 + ex.getMessage());
                     }
                 }
@@ -142,13 +142,13 @@ public final class BallerinaServerAgent {
      * Start the agent server for managing the server.
      */
     public static void startAgentServer() {
-        outStream.println("Starting Ballerina agent on host - " + agentHost + ", port - " + agentPort);
+        OUT_STREAM.println("Starting Ballerina agent on host - " + agentHost + ", port - " + agentPort);
         new Thread(() -> {
             try {
                 WebServer ws = new WebServer(agentHost, agentPort);
 
                 // Post endpoint to check the status TODO we may be able to remove this
-                ws.post("/status", () -> outStream.println("status check"));
+                ws.post("/status", () -> OUT_STREAM.println("status check"));
 
                 // Post endpoint to shutdown the server
                 ws.post("/shutdown", BallerinaServerAgent::shutdownServer);
@@ -159,14 +159,14 @@ public final class BallerinaServerAgent {
                 // Start the server
                 ws.start();
             } catch (Throwable e) {
-                outStream.println("Error initializing agent server, error - " + e.getMessage());
+                OUT_STREAM.println("Error initializing agent server, error - " + e.getMessage());
             }
         }).start();
-        outStream.println("Ballerina agent started on host - " + agentHost + ", port - " + agentPort);
+        OUT_STREAM.println("Ballerina agent started on host - " + agentHost + ", port - " + agentPort);
     }
 
     private static void shutdownServer() {
-        outStream.println("Shutting down Ballerina server with agent port - " + agentPort);
+        OUT_STREAM.println("Shutting down Ballerina server with agent port - " + agentPort);
         new Thread(() -> Runtime.getRuntime().exit(exitStatus)).start();
 
         if (timeout <= 0) {
@@ -192,7 +192,7 @@ public final class BallerinaServerAgent {
     }
 
     private static void killServer() {
-        outStream.println("Killing Ballerina server with agent port - " + agentPort);
+        OUT_STREAM.println("Killing Ballerina server with agent port - " + agentPort);
         Thread killThread = new Thread(() -> Runtime.getRuntime().halt(killStatus));
         killThread.setDaemon(true);
         killThread.start();

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BMainInstance.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BMainInstance.java
@@ -49,11 +49,11 @@ public class BMainInstance implements BMain {
     private static final Logger log = LoggerFactory.getLogger(BMainInstance.class);
     private static final String JAVA_OPTS = "JAVA_OPTS";
     private String agentArgs = "";
-    private BalServer balServer;
+    private final BalServer balServer;
 
     private static class StreamGobbler extends Thread {
-        private InputStream inputStream;
-        private PrintStream printStream;
+        private final InputStream inputStream;
+        private final PrintStream printStream;
 
         public StreamGobbler(InputStream inputStream, PrintStream printStream) {
             this.inputStream = inputStream;

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BMainInstance.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BMainInstance.java
@@ -46,7 +46,7 @@ import java.util.stream.Stream;
  * @since 0.982.0
  */
 public class BMainInstance implements BMain {
-    private static final Logger log = LoggerFactory.getLogger(BMainInstance.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BMainInstance.class);
     private static final String JAVA_OPTS = "JAVA_OPTS";
     private String agentArgs = "";
     private final BalServer balServer;

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
@@ -49,18 +49,18 @@ public class BServerInstance implements BServer {
     private static final Logger log = LoggerFactory.getLogger(BServerInstance.class);
     private static final String JAVA_OPTS = "JAVA_OPTS";
     private static final String agentHost = "localhost";
-    private BalServer balServer;
+    private final BalServer balServer;
     private int agentPort;
     private String agentArgs;
     private boolean agentsAdded = false;
     private Process process;
     private ServerLogReader serverInfoLogReader;
     private ServerLogReader serverErrorLogReader;
-    private Set<LogLeecher> tmpInfoLeechers = ConcurrentHashMap.newKeySet();
-    private Set<LogLeecher> tmpErrorLeechers = ConcurrentHashMap.newKeySet();
+    private final Set<LogLeecher> tmpInfoLeechers = ConcurrentHashMap.newKeySet();
+    private final Set<LogLeecher> tmpErrorLeechers = ConcurrentHashMap.newKeySet();
     private int[] requiredPorts;
 
-    private static InetAddress address;
+    private static final InetAddress address;
 
     static {
         try {

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
@@ -46,9 +46,9 @@ import static org.ballerinalang.test.context.Constant.BALLERINA_AGENT_PATH;
  * @since 0.982.0
  */
 public class BServerInstance implements BServer {
-    private static final Logger log = LoggerFactory.getLogger(BServerInstance.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BServerInstance.class);
     private static final String JAVA_OPTS = "JAVA_OPTS";
-    private static final String agentHost = "localhost";
+    private static final String AGENT_HOST = "localhost";
     private final BalServer balServer;
     private int agentPort;
     private String agentArgs;
@@ -60,11 +60,11 @@ public class BServerInstance implements BServer {
     private final Set<LogLeecher> tmpErrorLeechers = ConcurrentHashMap.newKeySet();
     private int[] requiredPorts;
 
-    private static final InetAddress address;
+    private static final InetAddress ADDRESS;
 
     static {
         try {
-            address = InetAddress.getByName(agentHost);
+            ADDRESS = InetAddress.getByName(AGENT_HOST);
         } catch (UnknownHostException e) {
             throw new RuntimeException(e);
         }
@@ -93,7 +93,7 @@ public class BServerInstance implements BServer {
             throw new BallerinaTestException("Cannot start server, Ballerina agent not provided");
         }
 
-        agentArgs = "-javaagent:" + balAgent + "=host=" + agentHost + ",port=" + agentPort
+        agentArgs = "-javaagent:" + balAgent + "=host=" + AGENT_HOST + ",port=" + agentPort
                 + ",exitStatus=1,timeout=15000,killStatus=5 ";
 
         // add jacoco agent
@@ -226,7 +226,7 @@ public class BServerInstance implements BServer {
      */
     @Override
     public void shutdownServer() throws BallerinaTestException {
-        log.info("Stopping server..");
+        LOG.info("Stopping server..");
         Map<String, String> headers = new HashMap<>();
         headers.put("Content-Type", "text/plain");
         try {
@@ -236,7 +236,7 @@ public class BServerInstance implements BServer {
                 throw new BallerinaTestException("Error shutting down the server, invalid response - "
                         + response.getData());
             }
-            cleanupServer(address);
+            cleanupServer(ADDRESS);
         } catch (IOException e) {
             throw new BallerinaTestException("Error shutting down the server, error - " + e.getMessage(), e);
         }
@@ -249,7 +249,7 @@ public class BServerInstance implements BServer {
      */
     @Override
     public void killServer() throws BallerinaTestException {
-        log.info("Stopping server..");
+        LOG.info("Stopping server..");
         Map<String, String> headers = new HashMap<>();
         headers.put("Content-Type", "text/plain");
         try {
@@ -259,7 +259,7 @@ public class BServerInstance implements BServer {
                 throw new BallerinaTestException("Error killing the server, invalid response - "
                         + response.getData());
             }
-            cleanupServer(address);
+            cleanupServer(ADDRESS);
         } catch (IOException e) {
             throw new BallerinaTestException("Error shutting down the server, error - " + e.getMessage(), e);
         }
@@ -268,7 +268,7 @@ public class BServerInstance implements BServer {
     private void cleanupServer(InetAddress address) {
         //wait until port to close
         Utils.waitForPortsToClose(requiredPorts, 30000, address);
-        log.info("Server Stopped Successfully");
+        LOG.info("Server Stopped Successfully");
     }
 
     private synchronized void addJavaAgents(Map<String, String> envProperties) {
@@ -482,9 +482,9 @@ public class BServerInstance implements BServer {
             this.requiredPorts = ArrayUtils.addAll(this.requiredPorts, agentPort);
 
             //Check whether agent port is available.
-            Utils.checkPortsAvailability(this.requiredPorts, address);
+            Utils.checkPortsAvailability(this.requiredPorts, ADDRESS);
 
-            log.info("Starting Ballerina server..");
+            LOG.info("Starting Ballerina server..");
 
             List<String> runCmdSet = new ArrayList<>();
             runCmdSet.add("java");
@@ -513,11 +513,11 @@ public class BServerInstance implements BServer {
             serverErrorLogReader = new ServerLogReader("errorStream", process.getErrorStream());
             tmpErrorLeechers.forEach(leecher -> serverErrorLogReader.addLeecher(leecher));
             serverErrorLogReader.start();
-            log.info("Waiting for port " + agentPort + " to open");
+            LOG.info("Waiting for port " + agentPort + " to open");
             long timeout = 1000L * 60 * 10;
             //TODO: Need to reduce the timeout after build time improvements
-            Utils.waitForPortsToOpen(new int[]{agentPort}, timeout, false, address);
-            log.info("Server Started Successfully.");
+            Utils.waitForPortsToOpen(new int[]{agentPort}, timeout, false, ADDRESS);
+            LOG.info("Server Started Successfully.");
         } catch (IOException e) {
             throw new BallerinaTestException("Error starting services", e);
         }

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/ServerLogReader.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/ServerLogReader.java
@@ -36,11 +36,11 @@ public class ServerLogReader implements Runnable {
     private static final String STREAM_TYPE_IN = "inputStream";
     private static final String STREAM_TYPE_ERROR = "errorStream";
     private final Logger log = LoggerFactory.getLogger(ServerLogReader.class);
-    private String streamType;
-    private InputStream inputStream;
+    private final String streamType;
+    private final InputStream inputStream;
     private volatile boolean running = true;
 
-    private Set<LogLeecher> leechers = ConcurrentHashMap.newKeySet();
+    private final Set<LogLeecher> leechers = ConcurrentHashMap.newKeySet();
 
     /**
      * Initialize the reader with reader name and stream to read.

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/listener/JBallerinaTestInitializer.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/listener/JBallerinaTestInitializer.java
@@ -33,7 +33,7 @@ import static org.ballerinalang.test.util.TestConstant.ENABLE_JBALLERINA_TESTS;
  */
 public class JBallerinaTestInitializer implements ITestListener {
 
-    private static Logger log = LoggerFactory.getLogger(JBallerinaTestInitializer.class);
+    private static final Logger log = LoggerFactory.getLogger(JBallerinaTestInitializer.class);
 
     @Override
     public void onStart(ITestContext context) {

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/listener/JBallerinaTestInitializer.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/listener/JBallerinaTestInitializer.java
@@ -33,13 +33,13 @@ import static org.ballerinalang.test.util.TestConstant.ENABLE_JBALLERINA_TESTS;
  */
 public class JBallerinaTestInitializer implements ITestListener {
 
-    private static final Logger log = LoggerFactory.getLogger(JBallerinaTestInitializer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(JBallerinaTestInitializer.class);
 
     @Override
     public void onStart(ITestContext context) {
         String property = context.getCurrentXmlTest().getParameter(ENABLE_JBALLERINA_TESTS);
         if (Boolean.parseBoolean(property)) {
-            log.info("JBallerina tests initialized...");
+            LOG.info("JBallerina tests initialized...");
             System.setProperty(ENABLE_JBALLERINA_TESTS, "true");
         }
     }
@@ -48,7 +48,7 @@ public class JBallerinaTestInitializer implements ITestListener {
     public void onFinish(ITestContext context) {
         String property = context.getCurrentXmlTest().getParameter(ENABLE_JBALLERINA_TESTS);
         if (Boolean.parseBoolean(property)) {
-            log.info("JBallerina tests disabled...");
+            LOG.info("JBallerina tests disabled...");
             System.clearProperty(ENABLE_JBALLERINA_TESTS);
         }
     }

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/HttpClientRequest.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/HttpClientRequest.java
@@ -314,7 +314,7 @@ public final class HttpClientRequest {
         return httpResponse;
     }
 
-    private static CheckedFunction<BufferedReader, String> defaultResponseBuilder = ((bufferedReader) -> {
+    private static final CheckedFunction<BufferedReader, String> defaultResponseBuilder = ((bufferedReader) -> {
         String line;
         StringBuilder sb = new StringBuilder();
         while ((line = bufferedReader.readLine()) != null) {
@@ -323,7 +323,7 @@ public final class HttpClientRequest {
         return sb.toString();
     });
 
-    private static CheckedFunction<BufferedReader, String> preserveNewLineResponseBuilder = ((bufferedReader) -> {
+    private static final CheckedFunction<BufferedReader, String> preserveNewLineResponseBuilder = ((bufferedReader) -> {
         String line;
         StringBuilder sb = new StringBuilder();
         while ((line = bufferedReader.readLine()) != null) {

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/HttpClientRequest.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/HttpClientRequest.java
@@ -185,19 +185,19 @@ public final class HttpClientRequest {
     private static HttpResponse executeRequestWithoutRequestBody(String method, String requestUrl, Map<String
             , String> headers) throws IOException {
         return executeRequestWithoutRequestBody(method, requestUrl, headers, DEFAULT_READ_TIMEOUT,
-                defaultResponseBuilder);
+                DEFAULT_RESPONSE_BUILDER);
     }
 
     private static HttpResponse executeRequestWithoutRequestBody(String method, String requestUrl, Map<String
             , String> headers, boolean throwError) throws IOException {
         return executeRequestWithoutRequestBody(method, requestUrl, headers, DEFAULT_READ_TIMEOUT,
-                defaultResponseBuilder, throwError);
+                DEFAULT_RESPONSE_BUILDER, throwError);
     }
 
     private static HttpResponse executeRequestAndPreserveNewline(String method, String requestUrl, Map<String
             , String> headers) throws IOException {
         return executeRequestWithoutRequestBody(method, requestUrl, headers, DEFAULT_READ_TIMEOUT,
-                                                preserveNewLineResponseBuilder);
+                PRESERVE_NEW_LINE_RESPONSE_BUILDER);
     }
 
     private static HttpResponse executeRequestWithoutRequestBody(String method, String requestUrl,
@@ -270,7 +270,7 @@ public final class HttpClientRequest {
     }
 
     private static HttpResponse buildResponse(HttpURLConnection conn) throws IOException {
-        return buildResponse(conn, defaultResponseBuilder, false);
+        return buildResponse(conn, DEFAULT_RESPONSE_BUILDER, false);
     }
 
     private static HttpResponse buildResponse(HttpURLConnection conn,
@@ -314,7 +314,7 @@ public final class HttpClientRequest {
         return httpResponse;
     }
 
-    private static final CheckedFunction<BufferedReader, String> defaultResponseBuilder = ((bufferedReader) -> {
+    private static final CheckedFunction<BufferedReader, String> DEFAULT_RESPONSE_BUILDER = ((bufferedReader) -> {
         String line;
         StringBuilder sb = new StringBuilder();
         while ((line = bufferedReader.readLine()) != null) {
@@ -323,15 +323,16 @@ public final class HttpClientRequest {
         return sb.toString();
     });
 
-    private static final CheckedFunction<BufferedReader, String> preserveNewLineResponseBuilder = ((bufferedReader) -> {
-        String line;
-        StringBuilder sb = new StringBuilder();
-        while ((line = bufferedReader.readLine()) != null) {
-            sb.append(line);
-            sb.append(System.lineSeparator());
-        }
-        return sb.toString();
-    });
+    private static final CheckedFunction<BufferedReader, String> PRESERVE_NEW_LINE_RESPONSE_BUILDER =
+            ((bufferedReader) -> {
+                String line;
+                StringBuilder sb = new StringBuilder();
+                while ((line = bufferedReader.readLine()) != null) {
+                    sb.append(line);
+                    sb.append(System.lineSeparator());
+                }
+                return sb.toString();
+            });
 
     /**
      * This is a custom functional interface which allows defining a method that throws an IOException.

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/client/ResponseHandler.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/client/ResponseHandler.java
@@ -32,7 +32,7 @@ public class ResponseHandler extends ChannelInboundHandlerAdapter {
 
     private CountDownLatch latch;
     private CountDownLatch waitForConnectionClosureLatch;
-    private LinkedList<FullHttpResponse> fullHttpResponses = new LinkedList<>();
+    private final LinkedList<FullHttpResponse> fullHttpResponses = new LinkedList<>();
     private String channelEventMsg;
 
     @Override

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/data/streaming/TableDataStreamingTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/data/streaming/TableDataStreamingTestCase.java
@@ -174,18 +174,19 @@ public class TableDataStreamingTestCase extends BaseTest {
     /**
      * This reads a buffered stream and returns the number of characters.
      */
-    private static HttpClientRequest.CheckedFunction<BufferedReader, String> responseBuilder = ((bufferedReader) -> {
-        int count = 0;
-        while (bufferedReader.read() != -1) {
-            count++;
-        }
-        return String.valueOf(count);
-    });
+    private static final HttpClientRequest.CheckedFunction<BufferedReader, String> responseBuilder =
+            (bufferedReader -> {
+                int count = 0;
+                while (bufferedReader.read() != -1) {
+                    count++;
+                }
+                return String.valueOf(count);
+            });
 
     /**
      * This reads a buffered stream and returns the number of characters.
      */
-    private static HttpClientRequest.CheckedFunction<BufferedReader, String> slowResponseBuilder =
+    private static final HttpClientRequest.CheckedFunction<BufferedReader, String> slowResponseBuilder =
             ((bufferedReader) -> {
                 int count = 0;
                 while (bufferedReader.read() != -1) {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/data/streaming/TableDataStreamingTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/data/streaming/TableDataStreamingTestCase.java
@@ -77,8 +77,8 @@ public class TableDataStreamingTestCase extends BaseTest {
     @Test(groups = {"brokenOnXMLChange"},
             description = "Tests streaming a large amount of data from a table, converted to XML")
     public void testStreamingLargeXml() throws Exception {
-        HttpResponse response = HttpClientRequest
-                .doGet(serverInstance.getServiceURLHttp(servicePort, "dataService/getXmlData"), 60000, responseBuilder);
+        HttpResponse response = HttpClientRequest.doGet(
+                serverInstance.getServiceURLHttp(servicePort, "dataService/getXmlData"), 60000, RESPONSE_BUILDER);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200);
         Assert.assertEquals(Integer.parseInt(response.getData()), 211288909);
@@ -88,7 +88,7 @@ public class TableDataStreamingTestCase extends BaseTest {
     public void testStreamingLargeJson() throws Exception {
         HttpResponse response = HttpClientRequest
                 .doGet(serverInstance.getServiceURLHttp(servicePort, "dataService/getJsonData"), 60000,
-                        responseBuilder);
+                        RESPONSE_BUILDER);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200);
         Assert.assertEquals(Integer.parseInt(response.getData()), 208788890);
@@ -98,7 +98,7 @@ public class TableDataStreamingTestCase extends BaseTest {
     public void testStreamingLargeJsonAppended() throws Exception {
         HttpResponse response = HttpClientRequest
                 .doGet(serverInstance.getServiceURLHttp(servicePort, "dataService/getJsonDataAppended"), 60000,
-                        responseBuilder);
+                        RESPONSE_BUILDER);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200);
         Assert.assertEquals(Integer.parseInt(response.getData()), 208788925);
@@ -108,7 +108,7 @@ public class TableDataStreamingTestCase extends BaseTest {
     public void getJosnViaSetJsonPayloadMethod() throws Exception {
         HttpResponse response = HttpClientRequest
                 .doGet(serverInstance.getServiceURLHttp(servicePort, "dataService/getJosnViaSetJsonPayloadMethod"),
-                        60000, responseBuilder);
+                        60000, RESPONSE_BUILDER);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200);
         Assert.assertEquals(Integer.parseInt(response.getData()), 208788890);
@@ -118,7 +118,7 @@ public class TableDataStreamingTestCase extends BaseTest {
     public void getJosnViaGetJsonStringMethod() throws Exception {
         HttpResponse response = HttpClientRequest
                 .doGet(serverInstance.getServiceURLHttp(servicePort, "dataService/getJosnViaGetJsonStringMethod"),
-                        60000, responseBuilder);
+                        60000, RESPONSE_BUILDER);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200);
         Assert.assertEquals(Integer.parseInt(response.getData()), 20840);
@@ -127,7 +127,7 @@ public class TableDataStreamingTestCase extends BaseTest {
     @Test(groups = {"brokenOnXMLChange"}, description = "Tests the outbound throttling scenario with a slow client")
     public void testStreamingLargeXMLWithSlowClient() throws Exception {
         HttpResponse response = HttpClientRequest.doGet(
-                serverInstance.getServiceURLHttp(servicePort, "dataService/getXmlData"), 60000, slowResponseBuilder);
+                serverInstance.getServiceURLHttp(servicePort, "dataService/getXmlData"), 60000, SLOW_RESPONSE_BUILDER);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200);
         Assert.assertEquals(Integer.parseInt(response.getData()), 211288909);
@@ -136,7 +136,7 @@ public class TableDataStreamingTestCase extends BaseTest {
     @Test(description = "Tests the outbound throttling scenario with a slow client")
     public void testStreamingLargeJsonWithSlowClient() throws Exception {
         HttpResponse response = HttpClientRequest.doGet(
-                serverInstance.getServiceURLHttp(servicePort, "dataService/getJsonData"), 60000, slowResponseBuilder);
+                serverInstance.getServiceURLHttp(servicePort, "dataService/getJsonData"), 60000, SLOW_RESPONSE_BUILDER);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200);
         Assert.assertEquals(Integer.parseInt(response.getData()), 208788890);
@@ -174,7 +174,7 @@ public class TableDataStreamingTestCase extends BaseTest {
     /**
      * This reads a buffered stream and returns the number of characters.
      */
-    private static final HttpClientRequest.CheckedFunction<BufferedReader, String> responseBuilder =
+    private static final HttpClientRequest.CheckedFunction<BufferedReader, String> RESPONSE_BUILDER =
             (bufferedReader -> {
                 int count = 0;
                 while (bufferedReader.read() != -1) {
@@ -186,7 +186,7 @@ public class TableDataStreamingTestCase extends BaseTest {
     /**
      * This reads a buffered stream and returns the number of characters.
      */
-    private static final HttpClientRequest.CheckedFunction<BufferedReader, String> slowResponseBuilder =
+    private static final HttpClientRequest.CheckedFunction<BufferedReader, String> SLOW_RESPONSE_BUILDER =
             ((bufferedReader) -> {
                 int count = 0;
                 while (bufferedReader.read() != -1) {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/util/SQLDBUtils.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/util/SQLDBUtils.java
@@ -124,7 +124,7 @@ public final class SQLDBUtils {
      * This class represents a file based database used for testing data clients.
      */
     public static class FileBasedTestDatabase extends TestDatabase {
-        private String dbDirectory;
+        private final String dbDirectory;
 
         public FileBasedTestDatabase(DBType dbType, String databaseScript, String dbDirectory, String dbName) {
             this.dbDirectory = dbDirectory;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Errors.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Errors.java
@@ -45,7 +45,7 @@ import static io.ballerina.runtime.api.creators.TypeCreator.createErrorType;
  */
 public final class Errors {
 
-    private static final Module errorModule = new Module("testorg", "errors.error_utils", "1");
+    private static final Module ERROR_MODULE = new Module("testorg", "errors.error_utils", "1");
 
     private Errors() {
     }
@@ -53,7 +53,7 @@ public final class Errors {
     public static BError getError(BString errorName) {
         BMap<BString, Object> errorDetails = ValueCreator.createMapValue();
         errorDetails.put(StringUtils.fromString("cause"), StringUtils.fromString("Person age cannot be negative"));
-        return ErrorCreator.createError(errorModule, errorName.getValue(), StringUtils.fromString("Invalid age"),
+        return ErrorCreator.createError(ERROR_MODULE, errorName.getValue(), StringUtils.fromString("Invalid age"),
                                         ErrorCreator.createError(StringUtils.fromString("Invalid data given")),
                                         errorDetails);
     }
@@ -74,7 +74,7 @@ public final class Errors {
     public static BError getDistinctErrorNegative(BString errorName) {
         BMap<BString, Object> errorDetails = ValueCreator.createMapValue();
         errorDetails.put(StringUtils.fromString("detail"), "detail error message");
-        return ErrorCreator.createError(errorModule, errorName.getValue(), StringUtils.fromString("msg"),
+        return ErrorCreator.createError(ERROR_MODULE, errorName.getValue(), StringUtils.fromString("msg"),
                 null, errorDetails);
     }
 
@@ -95,11 +95,11 @@ public final class Errors {
         String typeIdName = "RuntimeError";
         BMap<BString, Object> errorDetails = ValueCreator.createMapValue();
         errorDetails.put(StringUtils.fromString("detail"), "this is runtime failure");
-        return ErrorCreator.createDistinctError(typeIdName, errorModule, msg, errorDetails);
+        return ErrorCreator.createDistinctError(typeIdName, ERROR_MODULE, msg, errorDetails);
     }
 
     public static BError getDistinctErrorWithNullDetailNegative(BString errorName) {
-        return ErrorCreator.createError(errorModule, errorName.getValue(), StringUtils.fromString("msg"),
+        return ErrorCreator.createError(ERROR_MODULE, errorName.getValue(), StringUtils.fromString("msg"),
                 null, null);
     }
 
@@ -115,12 +115,12 @@ public final class Errors {
     public static BError getDistinctErrorWithEmptyDetailNegative2(BString msg) {
         String typeIdName = "RuntimeError";
         BMap<BString, Object> errorDetails = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL);
-        return ErrorCreator.createDistinctError(typeIdName, errorModule, msg, errorDetails);
+        return ErrorCreator.createDistinctError(typeIdName, ERROR_MODULE, msg, errorDetails);
     }
 
     public static BError getDistinctErrorWithNullDetailNegative2(BString msg) {
         String typeIdName = "RuntimeError";
-        return ErrorCreator.createDistinctError(typeIdName, errorModule, msg, (BMap<BString, Object>) null);
+        return ErrorCreator.createDistinctError(typeIdName, ERROR_MODULE, msg, (BMap<BString, Object>) null);
     }
 
     public static BError getErrorWithEmptyDetailNegative2(BString msg) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Errors.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Errors.java
@@ -45,7 +45,7 @@ import static io.ballerina.runtime.api.creators.TypeCreator.createErrorType;
  */
 public final class Errors {
 
-    private static Module errorModule = new Module("testorg", "errors.error_utils", "1");
+    private static final Module errorModule = new Module("testorg", "errors.error_utils", "1");
 
     private Errors() {
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/ClassWithDefaultConstructor.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/ClassWithDefaultConstructor.java
@@ -26,7 +26,7 @@ import io.ballerina.runtime.api.values.BString;
  * @since 1.0.0
  */
 public class ClassWithDefaultConstructor extends AbstractClass {
-    private int a;
+    private final int a;
 
     public ClassWithDefaultConstructor() {
         a = 11;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/ClassWithTwoParamConstructor.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/ClassWithTwoParamConstructor.java
@@ -23,7 +23,7 @@ package org.ballerinalang.nativeimpl.jvm.tests;
  * @since 1.0.0
  */
 public class ClassWithTwoParamConstructor {
-    private String str;
+    private final String str;
 
     public ClassWithTwoParamConstructor(String prefix, String name) {
         this.str = prefix + name;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
@@ -81,12 +81,12 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class StaticMethods {
 
-    private static final BArrayType intArrayType = new BArrayType(PredefinedTypes.TYPE_INT);
-    private static final BArrayType jsonArrayType = new BArrayType(PredefinedTypes.TYPE_JSON);
-    private static final BTupleType tupleType = new BTupleType(
+    private static final BArrayType INT_ARRAY_TYPE = new BArrayType(PredefinedTypes.TYPE_INT);
+    private static final BArrayType JSON_ARRAY_TYPE = new BArrayType(PredefinedTypes.TYPE_JSON);
+    private static final BTupleType TUPLE_TYPE = new BTupleType(
             Arrays.asList(PredefinedTypes.TYPE_INT, PredefinedTypes.TYPE_FLOAT, PredefinedTypes.TYPE_STRING,
                           PredefinedTypes.TYPE_INT, PredefinedTypes.TYPE_STRING));
-    private static final Module errorModule = new Module("testorg", "distinct_error.errors", "1");
+    private static final Module ERROR_MODULE = new Module("testorg", "distinct_error.errors", "1");
 
     private StaticMethods() {
     }
@@ -132,7 +132,7 @@ public final class StaticMethods {
 
     // This scenario is for map value to be passed to interop and return array value.
     public static ArrayValue getArrayValueFromMap(BString key, MapValue<?, ?> mapValue) {
-        ArrayValue arrayValue = (ArrayValue) ValueCreator.createArrayValue(intArrayType);
+        ArrayValue arrayValue = (ArrayValue) ValueCreator.createArrayValue(INT_ARRAY_TYPE);
         arrayValue.add(0, 1);
         long fromMap = (long) mapValue.get(key);
         arrayValue.add(1, fromMap);
@@ -276,7 +276,7 @@ public final class StaticMethods {
 
     public static ArrayValue getArrayValueFromMapWhichThrowsCheckedException(BString key, MapValue<?, ?> mapValue)
             throws JavaInteropTestCheckedException {
-        ArrayValue arrayValue = (ArrayValue) ValueCreator.createArrayValue(intArrayType);
+        ArrayValue arrayValue = (ArrayValue) ValueCreator.createArrayValue(INT_ARRAY_TYPE);
         arrayValue.add(0, 1);
         long fromMap = mapValue.getIntValue(key);
         arrayValue.add(1, fromMap);
@@ -320,7 +320,7 @@ public final class StaticMethods {
         } else if (flag == 1) {
             BMap<BString, Object> errorDetails = ValueCreator.createMapValue();
             errorDetails.put(StringUtils.fromString("detail"), "detail error message");
-            return ErrorCreator.createError(errorModule, errorName.getValue(), StringUtils.fromString("error msg"),
+            return ErrorCreator.createError(ERROR_MODULE, errorName.getValue(), StringUtils.fromString("error msg"),
                     null, errorDetails);
         } else {
             return ErrorCreator.createError(StringUtils.fromString("Invalid data given"));
@@ -423,7 +423,7 @@ public final class StaticMethods {
 
     public static TupleValueImpl mockedNativeFuncWithOptionalParams(long a, double b, String c,
                                                                     long d, String e) {
-        TupleValueImpl tuple = (TupleValueImpl) ValueCreator.createTupleValue(tupleType);
+        TupleValueImpl tuple = (TupleValueImpl) ValueCreator.createTupleValue(TUPLE_TYPE);
         tuple.add(0, Long.valueOf(a));
         tuple.add(1, Double.valueOf(b));
         tuple.add(2, (Object) c);
@@ -450,7 +450,7 @@ public final class StaticMethods {
     }
 
     public static ArrayValue getJsonArray() {
-        ArrayValue array = (ArrayValue) ValueCreator.createArrayValue(jsonArrayType);
+        ArrayValue array = (ArrayValue) ValueCreator.createArrayValue(JSON_ARRAY_TYPE);
         array.add(0, (Object) StringUtils.fromString("John"));
         return array;
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
@@ -86,7 +86,7 @@ public final class StaticMethods {
     private static final BTupleType tupleType = new BTupleType(
             Arrays.asList(PredefinedTypes.TYPE_INT, PredefinedTypes.TYPE_FLOAT, PredefinedTypes.TYPE_STRING,
                           PredefinedTypes.TYPE_INT, PredefinedTypes.TYPE_STRING));
-    private static Module errorModule = new Module("testorg", "distinct_error.errors", "1");
+    private static final Module errorModule = new Module("testorg", "distinct_error.errors", "1");
 
     private StaticMethods() {
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsTests.java
@@ -44,7 +44,7 @@ import static io.ballerina.runtime.api.utils.TypeUtils.getType;
 public class IterableOperationsTests {
 
     private CompileResult basic, negative;
-    private static BString[] values = BStringUtils.getBStringArray(new String[]{"Hello", "World..!", "I", "am",
+    private static final BString[] values = BStringUtils.getBStringArray(new String[]{"Hello", "World..!", "I", "am",
             "Ballerina.!!!"});
 
     @BeforeClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsTests.java
@@ -44,7 +44,7 @@ import static io.ballerina.runtime.api.utils.TypeUtils.getType;
 public class IterableOperationsTests {
 
     private CompileResult basic, negative;
-    private static final BString[] values = BStringUtils.getBStringArray(new String[]{"Hello", "World..!", "I", "am",
+    private static final BString[] VALUES = BStringUtils.getBStringArray(new String[]{"Hello", "World..!", "I", "am",
             "Ballerina.!!!"});
 
     @BeforeClass
@@ -179,25 +179,25 @@ public class IterableOperationsTests {
 
     @Test
     public void testBasicArray1() {
-        BArray sarray = ValueCreator.createArrayValue(values);
+        BArray sarray = ValueCreator.createArrayValue(VALUES);
         Object returns = BRunUtil.invoke(basic, "testBasicArray1", new Object[]{sarray});
         Assert.assertNotNull(returns);
         Assert.assertNotNull(returns);
         StringBuilder sb = new StringBuilder();
-        Arrays.stream(values).forEach(s -> sb.append(s.getValue().toUpperCase(Locale.getDefault())).append(":").
+        Arrays.stream(VALUES).forEach(s -> sb.append(s.getValue().toUpperCase(Locale.getDefault())).append(":").
                 append(s.getValue().toLowerCase(Locale.getDefault())).append(" "));
         Assert.assertEquals(returns.toString(), sb.toString().trim());
     }
 
     @Test
     public void testBasicArray2() {
-        BArray sarray = ValueCreator.createArrayValue(values);
+        BArray sarray = ValueCreator.createArrayValue(VALUES);
         Object returns = BRunUtil.invoke(basic, "testBasicArray2", new Object[]{sarray});
         Assert.assertNotNull(returns);
         Assert.assertNotNull(returns);
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < values.length; i++) {
-            sb.append(i).append(values[i]).append(" ");
+        for (int i = 0; i < VALUES.length; i++) {
+            sb.append(i).append(VALUES[i]).append(" ");
         }
         Assert.assertEquals(returns.toString(), sb.toString().trim());
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsWithVarMutabilityTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsWithVarMutabilityTests.java
@@ -40,7 +40,7 @@ import java.util.Locale;
 public class IterableOperationsWithVarMutabilityTests {
 
     private CompileResult compileResult;
-    private static final BString[] values = BStringUtils.getBStringArray(new String[]{"Hello", "World..!", "I", "am",
+    private static final BString[] VALUES = BStringUtils.getBStringArray(new String[]{"Hello", "World..!", "I", "am",
             "Ballerina.!!!"});
 
     @BeforeClass
@@ -66,21 +66,21 @@ public class IterableOperationsWithVarMutabilityTests {
 
     @Test
     public void testBasicArray1() {
-        BArray array = ValueCreator.createArrayValue(values);
+        BArray array = ValueCreator.createArrayValue(VALUES);
         Object returns = BRunUtil.invoke(compileResult, "testBasicArray1", new Object[]{array});
         StringBuilder sb = new StringBuilder();
-        Arrays.stream(values).forEach(s -> sb.append(s.getValue().toUpperCase(Locale.getDefault())).append(":").
+        Arrays.stream(VALUES).forEach(s -> sb.append(s.getValue().toUpperCase(Locale.getDefault())).append(":").
                 append(s.getValue().toLowerCase(Locale.getDefault())).append(" "));
         Assert.assertEquals(returns.toString(), sb.toString().trim());
     }
 
     @Test
     public void testBasicArray2() {
-        BArray array = ValueCreator.createArrayValue(values);
+        BArray array = ValueCreator.createArrayValue(VALUES);
         Object returns = BRunUtil.invoke(compileResult, "testBasicArray2", new Object[]{array});
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < values.length; i++) {
-            sb.append(i).append(values[i]).append(" ");
+        for (int i = 0; i < VALUES.length; i++) {
+            sb.append(i).append(VALUES[i]).append(" ");
         }
         Assert.assertEquals(returns.toString(), sb.toString().trim());
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsWithVarMutabilityTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsWithVarMutabilityTests.java
@@ -40,7 +40,7 @@ import java.util.Locale;
 public class IterableOperationsWithVarMutabilityTests {
 
     private CompileResult compileResult;
-    private static BString[] values = BStringUtils.getBStringArray(new String[]{"Hello", "World..!", "I", "am",
+    private static final BString[] values = BStringUtils.getBStringArray(new String[]{"Hello", "World..!", "I", "am",
             "Ballerina.!!!"});
 
     @BeforeClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/object/ObjectConstructorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/object/ObjectConstructorTest.java
@@ -36,14 +36,14 @@ import static org.ballerinalang.test.BAssertUtil.validateError;
 public class ObjectConstructorTest {
 
     private CompileResult compiledConstructedObjects, closures, annotations, multiLevelClosures;
-    private static final String path = "test-src/expressions/object/";
+    private static final String PATH = "test-src/expressions/object/";
 
     @BeforeClass
     public void setup() {
-        compiledConstructedObjects = BCompileUtil.compile(path + "object_constructor_expression.bal");
-        closures = BCompileUtil.compile(path + "object_closures.bal");
-        multiLevelClosures = BCompileUtil.compile(path + "object_multilevel_closures.bal");
-        annotations = BCompileUtil.compile(path + "object_closures_annotations.bal");
+        compiledConstructedObjects = BCompileUtil.compile(PATH + "object_constructor_expression.bal");
+        closures = BCompileUtil.compile(PATH + "object_closures.bal");
+        multiLevelClosures = BCompileUtil.compile(PATH + "object_multilevel_closures.bal");
+        annotations = BCompileUtil.compile(PATH + "object_closures_annotations.bal");
     }
 
     @DataProvider(name = "ObjectCtorTestFunctionList")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/object/ObjectConstructorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/object/ObjectConstructorTest.java
@@ -36,7 +36,7 @@ import static org.ballerinalang.test.BAssertUtil.validateError;
 public class ObjectConstructorTest {
 
     private CompileResult compiledConstructedObjects, closures, annotations, multiLevelClosures;
-    private static String path = "test-src/expressions/object/";
+    private static final String path = "test-src/expressions/object/";
 
     @BeforeClass
     public void setup() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/primitivetypes/UnionsWithPrimitiveTypesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/primitivetypes/UnionsWithPrimitiveTypesTest.java
@@ -39,14 +39,14 @@ import java.io.IOException;
  */
 public class UnionsWithPrimitiveTypesTest {
     private CompileResult result;
-    private boolean aBoolean = true;
-    private byte aByte = 8;
-    private short aShort = 567;
-    private char aChar = 'A';
-    private int anInt = 345866;
-    private long aLong = 42343242;
-    private float aFloat = 234242423.0f;
-    private double aDouble = 8781233342322.324234;
+    private final boolean aBoolean = true;
+    private final byte aByte = 8;
+    private final short aShort = 567;
+    private final char aChar = 'A';
+    private final int anInt = 345866;
+    private final long aLong = 42343242;
+    private final float aFloat = 234242423.0f;
+    private final double aDouble = 8781233342322.324234;
 
     @BeforeClass
     public void setup() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ForeachArrayTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ForeachArrayTests.java
@@ -39,11 +39,11 @@ public class ForeachArrayTests {
 
     private CompileResult program;
 
-    private int[] iValues = {1, -3, 5, -30, 4, 11, 25, 10};
-    private double[] fValues = {1.123, -3.35244, 5.23, -30.45, 4.32, 11.56, 25.967, 10.345};
-    private String[] sValues = {"foo", "bar", "bax", "baz"};
-    private boolean[] bValues = {true, false, false, false, true, false};
-    private String[] tValues = {"name=bob,age=10", "name=tom,age=16"};
+    private final int[] iValues = {1, -3, 5, -30, 4, 11, 25, 10};
+    private final double[] fValues = {1.123, -3.35244, 5.23, -30.45, 4.32, 11.56, 25.967, 10.345};
+    private final String[] sValues = {"foo", "bar", "bax", "baz"};
+    private final boolean[] bValues = {true, false, false, false, true, false};
+    private final String[] tValues = {"name=bob,age=10", "name=tom,age=16"};
 
     @BeforeClass
     public void setup() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ForeachMapTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ForeachMapTests.java
@@ -37,7 +37,7 @@ import java.util.Map;
 public class ForeachMapTests {
 
     private CompileResult program;
-    private Map<String, String> values = new LinkedHashMap<>();
+    private final Map<String, String> values = new LinkedHashMap<>();
 
     @BeforeClass
     public void setup() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/TestThreadPool.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/TestThreadPool.java
@@ -29,9 +29,9 @@ import java.util.concurrent.Executors;
  */
 public class TestThreadPool {
 
-    private static TestThreadPool instance = new TestThreadPool();
+    private static final TestThreadPool instance = new TestThreadPool();
 
-    private ExecutorService executorService = Executors.newFixedThreadPool(500);
+    private final ExecutorService executorService = Executors.newFixedThreadPool(500);
 
     private TestThreadPool() {
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/TestThreadPool.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/TestThreadPool.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Executors;
  */
 public class TestThreadPool {
 
-    private static final TestThreadPool instance = new TestThreadPool();
+    private static final TestThreadPool INSTANCE = new TestThreadPool();
 
     private final ExecutorService executorService = Executors.newFixedThreadPool(500);
 
@@ -37,7 +37,7 @@ public class TestThreadPool {
     }
 
     public static TestThreadPool getInstance() {
-        return instance;
+        return INSTANCE;
     }
 
     public ExecutorService getExecutor() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArraySizeDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArraySizeDefinitionTest.java
@@ -31,11 +31,11 @@ import org.testng.annotations.Test;
  */
 public class ArraySizeDefinitionTest {
 
-    private String sizeMismatchError = "size mismatch in closed array. expected '2', but found '3'";
-    private String invalidReferenceExpressionError = "invalid reference expression " +
+    private final String sizeMismatchError = "size mismatch in closed array. expected '2', but found '3'";
+    private final String invalidReferenceExpressionError = "invalid reference expression " +
             "'intLength' as array size: expected a constant reference expression";
-    private String incompatibleTypeError = "incompatible types: expected 'int', found 'string'";
-    private String undefinedSymbolError = "undefined symbol 'length'";
+    private final String incompatibleTypeError = "incompatible types: expected 'int', found 'string'";
+    private final String undefinedSymbolError = "undefined symbol 'length'";
     private static final String INVALID_ARRAY_LENGTH_ERROR =
             "invalid array length: array length should be a non-negative integer";
     private static final String SIZE_LIMIT_ERROR = "array length greater that '2147483637' not yet supported";

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtErrorMatchPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtErrorMatchPatternTest.java
@@ -32,9 +32,9 @@ import org.testng.annotations.Test;
  */
 public class MatchStmtErrorMatchPatternTest {
     private CompileResult result, restPatternResult, resultNegative, moduleResult;
-    private String patternNotMatched = "pattern will not be matched";
-    private String unreachablePattern = "unreachable pattern";
-    private String unnecessaryCondition = "unnecessary condition: expression will always evaluate to 'true'";
+    private final String patternNotMatched = "pattern will not be matched";
+    private final String unreachablePattern = "unreachable pattern";
+    private final String unnecessaryCondition = "unnecessary condition: expression will always evaluate to 'true'";
 
     @BeforeClass
     public void setup() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtListMatchPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtListMatchPatternTest.java
@@ -34,9 +34,9 @@ import org.testng.annotations.Test;
 public class MatchStmtListMatchPatternTest {
 
     private CompileResult result, resultNegative, resultSemanticsNegative, restMatchPatternResult;
-    private String patternNotMatched = "pattern will not be matched";
-    private String unreachablePattern = "unreachable pattern";
-    private String unreachableCode = "unreachable code";
+    private final String patternNotMatched = "pattern will not be matched";
+    private final String unreachablePattern = "unreachable pattern";
+    private final String unreachableCode = "unreachable code";
 
     @BeforeClass
     public void setup() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtMappingMatchPatternNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtMappingMatchPatternNegativeTest.java
@@ -31,8 +31,8 @@ import org.testng.annotations.Test;
 public class MatchStmtMappingMatchPatternNegativeTest {
 
     private CompileResult negativeResult, warningResult;
-    private String patternNotMatched = "pattern will not be matched";
-    private String unreachablePattern = "unreachable pattern";
+    private final String patternNotMatched = "pattern will not be matched";
+    private final String unreachablePattern = "unreachable pattern";
 
     @BeforeClass
     public void setup() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/varbindingpatternmatchpattern/ErrorBindingPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/varbindingpatternmatchpattern/ErrorBindingPatternTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
  */
 public class ErrorBindingPatternTest {
     private CompileResult result, restPatternResult, resultNegative;
-    private String patternNotMatched = "pattern will not be matched";
+    private final String patternNotMatched = "pattern will not be matched";
 
     @BeforeClass
     public void setup() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/varbindingpatternmatchpattern/ListBindingPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/varbindingpatternmatchpattern/ListBindingPatternTest.java
@@ -33,9 +33,9 @@ import org.testng.annotations.Test;
  */
 public class ListBindingPatternTest {
     private CompileResult result, restMatchPatternResult, resultNegative;
-    private String patternNotMatched = "pattern will not be matched";
-    private String unreachablePattern = "unreachable pattern";
-    private String unreachableCode = "unreachable code";
+    private final String patternNotMatched = "pattern will not be matched";
+    private final String unreachablePattern = "unreachable pattern";
+    private final String unreachableCode = "unreachable code";
 
     @BeforeClass
     public void setup() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/varbindingpatternmatchpattern/MappingBindingPatternNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/varbindingpatternmatchpattern/MappingBindingPatternNegativeTest.java
@@ -33,8 +33,8 @@ import org.testng.annotations.Test;
 @Test
 public class MappingBindingPatternNegativeTest {
     private CompileResult warningResult, negativeResult;
-    private String patternNotMatched = "pattern will not be matched";
-    private String unreachablePattern = "unreachable pattern";
+    private final String patternNotMatched = "pattern will not be matched";
+    private final String unreachablePattern = "unreachable pattern";
 
     @BeforeClass
     public void setup() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/utils/interop/Utils.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/utils/interop/Utils.java
@@ -35,14 +35,14 @@ public final class Utils {
 
     private static final int CORE_THREAD_POOL_SIZE = 1;
 
-    private static final ScheduledExecutorService executor = Executors.newScheduledThreadPool(CORE_THREAD_POOL_SIZE);
+    private static final ScheduledExecutorService EXECUTOR = Executors.newScheduledThreadPool(CORE_THREAD_POOL_SIZE);
 
     private Utils() {
     }
 
     public static void sleep(Environment env, long delayMillis) {
         Future balFuture = env.markAsync();
-        executor.schedule(() -> balFuture.complete(null), delayMillis, TimeUnit.MILLISECONDS);
+        EXECUTOR.schedule(() -> balFuture.complete(null), delayMillis, TimeUnit.MILLISECONDS);
     }
 
     public static void print(Object... values) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/utils/interop/Utils.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/utils/interop/Utils.java
@@ -35,7 +35,7 @@ public final class Utils {
 
     private static final int CORE_THREAD_POOL_SIZE = 1;
 
-    private static ScheduledExecutorService executor = Executors.newScheduledThreadPool(CORE_THREAD_POOL_SIZE);
+    private static final ScheduledExecutorService executor = Executors.newScheduledThreadPool(CORE_THREAD_POOL_SIZE);
 
     private Utils() {
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/utils/RuntimeApi.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/utils/RuntimeApi.java
@@ -40,9 +40,9 @@ import java.util.HashMap;
  */
 public final class RuntimeApi {
 
-    private static final Module objectModule = new Module("testorg", "runtime_api", "1");
-    private static final Module recordModule = new Module("testorg", "runtime_api", "1");
-    private static final Module errorModule = new Module("testorg", "runtime_api", "1");
+    private static final Module OBJECT_MODULE = new Module("testorg", "runtime_api", "1");
+    private static final Module RECORD_MODULE = new Module("testorg", "runtime_api", "1");
+    private static final Module ERROR_MODULE = new Module("testorg", "runtime_api", "1");
 
     private RuntimeApi() {
     }
@@ -53,7 +53,7 @@ public final class RuntimeApi {
         address.put("city", StringUtils.fromString("Colombo"));
         address.put("country", StringUtils.fromString("Sri Lanka"));
         address.put("postalCode", 10250);
-        return ValueCreator.createRecordValue(recordModule, recordName.getValue(), address);
+        return ValueCreator.createRecordValue(RECORD_MODULE, recordName.getValue(), address);
     }
 
     public static BMap<BString, Object> getTestRecord(BString recordName) {
@@ -61,25 +61,25 @@ public final class RuntimeApi {
         address.put("city", StringUtils.fromString("Kandy"));
         address.put("country", StringUtils.fromString("Sri Lanka"));
         address.put("postalCode", 10250);
-        return ValueCreator.createRecordValue(recordModule, recordName.getValue(), address);
+        return ValueCreator.createRecordValue(RECORD_MODULE, recordName.getValue(), address);
     }
 
     public static BObject getObject(BString objectName) {
         BMap<BString, Object> address = getRecord(StringUtils.fromString("Address"));
-        return ValueCreator.createObjectValue(objectModule, objectName.getValue(), StringUtils.fromString("Waruna"),
+        return ValueCreator.createObjectValue(OBJECT_MODULE, objectName.getValue(), StringUtils.fromString("Waruna"),
                 14, address);
     }
 
     public static BObject getTestObject(BString objectName) {
         BMap<BString, Object> address = getTestRecord(StringUtils.fromString("TestAddress"));
-        return ValueCreator.createObjectValue(objectModule, objectName.getValue(), StringUtils.fromString("Waruna"),
+        return ValueCreator.createObjectValue(OBJECT_MODULE, objectName.getValue(), StringUtils.fromString("Waruna"),
                 14,  address);
     }
 
     public static BError getError(BString errorName) {
         BMap<BString, Object> errorDetails = ValueCreator.createMapValue();
         errorDetails.put(StringUtils.fromString("cause"), StringUtils.fromString("Person age cannot be negative"));
-        return ErrorCreator.createError(errorModule, errorName.getValue(), StringUtils.fromString("Invalid age"),
+        return ErrorCreator.createError(ERROR_MODULE, errorName.getValue(), StringUtils.fromString("Invalid age"),
                 ErrorCreator.createError(StringUtils.fromString("Invalid data given")),
                 errorDetails);
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/utils/RuntimeApi.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/utils/RuntimeApi.java
@@ -42,7 +42,7 @@ public final class RuntimeApi {
 
     private static final Module objectModule = new Module("testorg", "runtime_api", "1");
     private static final Module recordModule = new Module("testorg", "runtime_api", "1");
-    private static Module errorModule = new Module("testorg", "runtime_api", "1");
+    private static final Module errorModule = new Module("testorg", "runtime_api", "1");
 
     private RuntimeApi() {
     }


### PR DESCRIPTION
## Purpose
> Fields that are not reassigned should be marked as final to make the intent clear. It also helps to later convert some classes to records and encapsulate public fields (use getters & setters).



## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
