### PR TITLE
[Refactoring] Simpler usage of TypeToken for Gson deserialization

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/NativeUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/NativeUtils.java
@@ -169,9 +169,7 @@ public class NativeUtils {
             if (mockedFunctionClassFile.isFile()) {
                 BufferedReader br = Files.newBufferedReader(mockedFunctionClassPath, StandardCharsets.UTF_8);
                 Gson gsonRead = new Gson();
-                Map<String, String[]> testFileMockedFunctionMapping = gsonRead.fromJson(br,
-                        new TypeToken<Map<String, String[]>>() {
-                        }.getType());
+                Map<String, String[]> testFileMockedFunctionMapping = gsonRead.fromJson(br, new TypeToken<>() { });
                 if (!testFileMockedFunctionMapping.isEmpty()) {
                     ReflectConfigClass originalTestFileRefConfClz;
                     for (Map.Entry<String, String[]> testFileMockedFunctionMappingEntry :

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
@@ -419,8 +419,7 @@ public class Utils {
      * @return converted list of strings
      */
     static List<String> getAsList(String arrayString) {
-        return new Gson().fromJson(arrayString, new TypeToken<List<String>>() {
-        }.getType());
+        return new Gson().fromJson(arrayString, new TypeToken<>() { });
     }
 
     /**

--- a/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/TreeGen.java
+++ b/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/TreeGen.java
@@ -38,7 +38,6 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -108,8 +107,7 @@ public class TreeGen {
     private static HashMap<String, SyntaxNodeMetadata> getNodeMetadataMap(TreeGenConfig config) {
         try (InputStreamReader reader =
                      new InputStreamReader(getNodeMetadataMapStream(config), StandardCharsets.UTF_8)) {
-            Type mapType = new TypeToken<HashMap<String, SyntaxNodeMetadata>>() { }.getType();
-            return new Gson().fromJson(reader, mapType);
+            return new Gson().fromJson(reader, new TypeToken<>() { });
         } catch (Throwable e) {
             throw new TreeGenException("Failed to parse syntax node metadata. Reason: " + e.getMessage(), e);
         }

--- a/language-server/modules/langserver-commons/src/test/java/org/ballerina/langserver/commons/toml/completion/SchemaVisitorTest.java
+++ b/language-server/modules/langserver-commons/src/test/java/org/ballerina/langserver/commons/toml/completion/SchemaVisitorTest.java
@@ -31,7 +31,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Map;
@@ -55,9 +54,7 @@ public class SchemaVisitorTest {
                 .resolve("schema_visitor").resolve("schema").resolve(schemaFile).toString());
 
         Gson gson = new Gson();
-        Type collectionType = new TypeToken<Map<String, Map<String, CompletionItem>>>() {
-        }.getType();
-        Map<String, Map<String, CompletionItem>> expectedMap = gson.fromJson(expected, collectionType);
+        Map<String, Map<String, CompletionItem>> expectedMap = gson.fromJson(expected, new TypeToken<>() { });
 
         Schema validationSchema = Schema.from(schemaString);
         TomlSchemaVisitor visitor = new TomlSchemaVisitor();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/example/BallerinaExampleService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/example/BallerinaExampleService.java
@@ -32,7 +32,6 @@ import org.eclipse.lsp4j.services.LanguageServer;
 
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
-import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -50,8 +49,7 @@ import java.util.concurrent.CompletableFuture;
 public class BallerinaExampleService implements ExtendedLanguageServerService {
     private static final String BBE_DEF_JSON = "index.json";
     private static final String EXAMPLES_DIR = "examples";
-    private static final Type EXAMPLE_CATEGORY_TYPE = new TypeToken<List<BallerinaExampleCategory>>() {
-    }.getType();
+    private static final TypeToken<List<BallerinaExampleCategory>> EXAMPLE_CATEGORY_TYPE = new TypeToken<>() { };
     private  LSClientLogger clientLogger;
 
     @Override

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -17,13 +17,13 @@
  */
 package org.ballerinalang.langserver.codeaction;
 
-import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
 import org.ballerinalang.langserver.AbstractLSTest;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.common.utils.PathUtil;
@@ -52,7 +52,6 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -161,9 +160,7 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
                                 .getAsJsonArray().get(0).getAsJsonObject().get("edits");
                     }
 
-                    Type type = new TypeToken<List<TextEdit>>() {
-                    }.getType();
-                    List<TextEdit> actualEdit = gson.fromJson(editsElement, type);
+                    List<TextEdit> actualEdit = gson.fromJson(editsElement, new TypeToken<>() { });
                     List<TextEdit> expEdit = expected.edits;
                     actual.edits = actualEdit;
                     if (!expEdit.equals(actualEdit)) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
@@ -40,7 +40,6 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -67,10 +66,8 @@ public abstract class CompletionTest extends AbstractLSTest {
         TestConfig testConfig = gson.fromJson(Files.newBufferedReader(configJsonPath), TestConfig.class);
         String response = getResponse(testConfig);
         JsonObject json = JsonParser.parseString(response).getAsJsonObject();
-        Type collectionType = new TypeToken<List<CompletionItem>>() {
-        }.getType();
         JsonArray resultList = json.getAsJsonObject("result").getAsJsonArray("left");
-        List<CompletionItem> responseItemList = gson.fromJson(resultList, collectionType);
+        List<CompletionItem> responseItemList = gson.fromJson(resultList, new TypeToken<>() { });
 
         boolean result = CompletionTestUtil.isSubList(testConfig.getItems(), responseItemList);
         if (!result) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/inlayhint/InlayHintTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/inlayhint/InlayHintTest.java
@@ -15,12 +15,12 @@
  */
 package org.ballerinalang.langserver.inlayhint;
 
-import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
 import org.ballerinalang.langserver.AbstractLSTest;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.util.FileUtils;
@@ -38,7 +38,6 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -71,13 +70,11 @@ public class InlayHintTest extends AbstractLSTest {
         inlayHintParams.setTextDocument(textDocumentIdentifier);
         Range range = testConfig.range;
 
-        Type collectionType = new TypeToken<List<InlayHint>>() {
-        }.getType();
         String response = getResponse(sourcePath.toString(), range, sourcePath.toString());
         JsonObject json = JsonParser.parseString(response).getAsJsonObject();
 
         JsonArray resultList = json.getAsJsonArray("result");
-        List<InlayHint> responseItemList = gson.fromJson(resultList, collectionType);
+        List<InlayHint> responseItemList = gson.fromJson(resultList, new TypeToken<>() { });
 
         if (responseItemList.size() != testConfig.getResult().size()) {
 //            updateConfig(configPath, testConfig, responseItemList);

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -437,9 +437,7 @@ class AIDataMapperCodeActionUtil {
             rightRecordJSON.addProperty(TYPE, "object");
             rightRecordJSON.add(PROPERTIES, rightSchema);
 
-            Map<String, Object> rightSchemaMap = new Gson().fromJson(rightSchema,
-                    new TypeToken<HashMap<String, Object>>() {
-                    }.getType());
+            Map<String, Object> rightSchemaMap = new Gson().fromJson(rightSchema, new TypeToken<>() { });
             this.isOptionalMap.clear();
             generateOptionalMap(rightSchemaMap, foundTypeRight);
 
@@ -452,9 +450,7 @@ class AIDataMapperCodeActionUtil {
             leftRecordJSON.addProperty(TYPE, "object");
             leftRecordJSON.add(PROPERTIES, leftSchema);
 
-            Map<String, Object> leftSchemaMap = new Gson().fromJson(leftSchema,
-                    new TypeToken<HashMap<String, Object>>() {
-                    }.getType());
+            Map<String, Object> leftSchemaMap = new Gson().fromJson(leftSchema, new TypeToken<>() { });
             this.leftFieldMap.clear();
             getLeftFields(leftSchemaMap, "");
         }
@@ -876,8 +872,7 @@ class AIDataMapperCodeActionUtil {
         try {
             Map<String, Object> responseMap = new Gson().fromJson(
                     JsonParser.parseString(mappingFromServer).getAsJsonObject(),
-                    new TypeToken<HashMap<String, Object>>() {
-                    }.getType());
+                    new TypeToken<>() { });
             getResponseKeys(responseMap, "");
             HashSet<String> unionKeys = new HashSet<>(this.responseFieldMap.keySet());
             unionKeys.addAll(this.leftFieldMap.keySet());

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
@@ -55,7 +55,7 @@ public class PartialCoverageModifiedCounter implements ICounter {
 
     /**
      * As implemented in Jacoco API.
-     * org.jacoco.core.internal.analysis.CounterImpl#getValue(org.jacoco.core.analysis.ICounter.CounterValue)
+     * {@link org.jacoco.core.internal.analysis.CounterImpl#getValue(org.jacoco.core.analysis.ICounter.CounterValue)}
      */
     @Override
     public double getValue(CounterValue value) {
@@ -101,7 +101,7 @@ public class PartialCoverageModifiedCounter implements ICounter {
     }
 
     /**
-     * As implemented in org.jacoco.core.internal.analysis.CounterImpl#getStatus().
+     * As implemented in {@link org.jacoco.core.internal.analysis.CounterImpl#getStatus()}.
      */
     @Override
     public int getStatus() {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
@@ -49,7 +49,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
@@ -168,7 +167,7 @@ public class CodeCoverageUtils {
     private static boolean isIncluded(String path, String includesInCoverage) {
         boolean isIncluded = false;
         if (includesInCoverage != null) {
-            List<String> includedPackages = Arrays.asList(includesInCoverage.split(":"));
+            String[] includedPackages = includesInCoverage.split(":");
             for (String packageName : includedPackages) {
                 packageName = packageName.replace(".", "/");
                 Pattern pattern = Pattern.compile(normalizeRegexPattern(packageName));


### PR DESCRIPTION
## Purpose
The `Gson.fromJson()` method expects either a `TypeToken` or a `java.lang.reflect.Type`.
The current approach to use `TypeToken`s and then convert them to `Type`s is suboptimal, since this requires to explicitly set the generic of the `TypeToken`.
This PR simplifies this in the following way:
It directly uses the `TypeToken` and does not convert it to a `Type`.

e.g. instead of writing:
```java
Type collectionType = new TypeToken<Map<String, Map<String, CompletionItem>>>() {
}.getType();
Map<String, Map<String, CompletionItem>> expectedMap = gson.fromJson(expected, collectionType);
```
this can be simplified to:
```java
Map<String, Map<String, CompletionItem>> expectedMap = gson.fromJson(expected, new TypeToken<>() { });
```

The generic of the `TypeToken` is then inferred from the variable type.


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
