### PR TITLE
Support navigation/references for init functions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -898,7 +898,6 @@ public class ReferenceFinder extends BaseVisitor {
     @Override
     public void visit(BLangTypeInit typeInit) {
         find(typeInit.userDefinedType);
-        find(typeInit.argsExpr);
         find(typeInit.initInvocation);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -899,6 +899,7 @@ public class ReferenceFinder extends BaseVisitor {
     public void visit(BLangTypeInit typeInit) {
         find(typeInit.userDefinedType);
         find(typeInit.argsExpr);
+        find(typeInit.initInvocation);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/references/ReferencesTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/references/ReferencesTest.java
@@ -124,6 +124,7 @@ public class ReferencesTest {
                 //  being set to lang.annotations.
                 {"ref_package_alias_config1.json"},
                 {"ref_retry_spec_config1.json"},
+                {"init_function_references.json"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/references/expected/init_function_references.json
+++ b/language-server/modules/langserver-core/src/test/resources/references/expected/init_function_references.json
@@ -1,0 +1,50 @@
+{
+  "source": {
+    "file": "projectls/class_def.bal"
+  },
+  "position": {
+    "line": 4,
+    "character": 16
+  },
+  "result": [
+    {
+      "uri": "projectls/class_def.bal",
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 16
+        },
+        "end": {
+          "line": 10,
+          "character": 19
+        }
+      }
+    },
+    {
+      "uri": "projectls/union_types.bal",
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 16
+        },
+        "end": {
+          "line": 6,
+          "character": 19
+        }
+      }
+    },
+    {
+      "uri": "projectls/class_def.bal",
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 13
+        },
+        "end": {
+          "line": 4,
+          "character": 17
+        }
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/references/sources/projectls/class_def.bal
+++ b/language-server/modules/langserver-core/src/test/resources/references/sources/projectls/class_def.bal
@@ -1,0 +1,11 @@
+class User {
+    private string uuid;
+    private string name;
+
+    function init(string uuid, string name) {
+        this.uuid = uuid;
+        this.name = name;
+    }
+}
+
+final User u1 = new User("123", "Alice");

--- a/language-server/modules/langserver-core/src/test/resources/references/sources/projectls/union_types.bal
+++ b/language-server/modules/langserver-core/src/test/resources/references/sources/projectls/union_types.bal
@@ -3,3 +3,5 @@ import projectls.lsmod2;
 
 
 public type RecUnion lsmod1:Mod1Rec|lsmod2:Mod2Rec;
+
+final User u2 = new User("123", "Bob");

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindAllReferencesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindAllReferencesTest.java
@@ -26,6 +26,7 @@ import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -142,5 +143,10 @@ public abstract class FindAllReferencesTest {
         for (Location expLocation : expLocations) {
             assertTrue(lineRanges.contains(expLocation.lineRange()));
         }
+    }
+
+    @AfterClass
+    public void tearDown() {
+        model = null;
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInClassObjectTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInClassObjectTest.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.semantic.api.test.allreferences;
 
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -54,7 +55,8 @@ public class FindRefsInClassObjectTest extends FindAllReferencesTest {
                         List.of(location(24, 13, 20))
                 },
                 {30, 13, location(30, 13, 17),
-                        List.of(location(30, 13, 17))
+                        List.of(location(30, 13, 17),
+                                location(52, 17, 20))
                 },
                 {34, 13, location(34, 13, 20),
                         List.of(location(34, 13, 20),
@@ -78,5 +80,10 @@ public class FindRefsInClassObjectTest extends FindAllReferencesTest {
     @Override
     public String getTestSourcePath() {
         return "test-src/find-all-ref/find_refs_in_class_object.bal";
+    }
+
+    @AfterClass
+    public void tearDown() {
+        super.tearDown();
     }
 }


### PR DESCRIPTION
## Purpose
$subject

Fixes #42985

## Approach
In the ReferenceFinder previously we weren't visiting the init function invocations.

## Samples
https://github.com/user-attachments/assets/2e5a7abd-fd39-4ba3-89cf-d0e228d050fe


## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
