### PR TITLE
Remove mime4j dependency from ballerina-lang

### DIFF
--- a/bvm/ballerina-profiler/build.gradle
+++ b/bvm/ballerina-profiler/build.gradle
@@ -18,6 +18,12 @@
 
 apply from: "$rootDir/gradle/javaProject.gradle"
 
+configurations {
+    runtimeClasspath {
+        transitive false
+    }
+}
+
 dependencies {
     implementation "org.ow2.asm:asm:${project.ow2AsmVersion}"
     implementation "org.ow2.asm:asm-commons:${project.ow2AsmCommonsVersion}"
@@ -30,20 +36,8 @@ dependencies {
 version = 1.0
 
 jar {
-    dependsOn(':identifier-util:jar')
-    dependsOn(':ballerina-runtime:jar')
-    from(sourceSets.main.output)
-    from(sourceSets.main.java) {
-        include "**/*.java"
-    }
-
-    from(configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }) {
-        exclude "META-INF/*.SF"
-        exclude "META-INF/*.DSA"
-        exclude "META-INF/*.RSA"
-    }
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     manifest {
         attributes 'Main-Class': 'io.ballerina.runtime.profiler.Main'
     }

--- a/bvm/ballerina-profiler/build.gradle
+++ b/bvm/ballerina-profiler/build.gradle
@@ -19,9 +19,7 @@
 apply from: "$rootDir/gradle/javaProject.gradle"
 
 configurations {
-    runtimeClasspath {
-        transitive false
-    }
+    runtimeClasspath.transitive = false
 }
 
 dependencies {

--- a/misc/ls-extensions/modules/bal-shell-service/build.gradle
+++ b/misc/ls-extensions/modules/bal-shell-service/build.gradle
@@ -22,6 +22,7 @@ apply from: "$rootDir/gradle/ballerinaLangLibLoad.gradle"
 configurations {
     compile.transitive = false
     compileClasspath.extendsFrom(compileOnly)
+    runtimeClasspath.transitive = false
 }
 
 dependencies {


### PR DESCRIPTION
## Purpose
$subject

Fixes #43098 

## Approach
There is a vulnerability in the mime4j package https://github.com/advisories/GHSA-jw7r-rxff-gv24 which comes as a transitive dependency from the `ballerina-profiler` and `ballerina-shell-service` modules. This PR removes them by packing the jar without transitive dependencies.

## Samples
https://github.com/ballerina-platform/ballerina-lang/actions/runs/10030529600/job/27719941501

## Remarks

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
