### PR TITLE
Fix compiler crashes when a constant reference expression is used in an annotation

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
@@ -130,10 +130,6 @@ public class ConstantValueResolver extends BLangNodeVisitor {
         return constantValueResolver;
     }
 
-    public void setCurrentPackageId(PackageID packageID) {
-        this.pkgID = packageID;
-    }
-
     public void resolve(List<BLangConstant> constants, PackageID packageID, SymbolEnv symEnv) {
         this.dlog.setCurrentPackageId(packageID);
         this.pkgID = packageID;
@@ -876,11 +872,11 @@ public class ConstantValueResolver extends BLangNodeVisitor {
         BTypeSymbol structureSymbol = recordType.tsymbol;
         for (BField field : recordType.fields.values()) {
             field.type = ImmutableTypeCloner.getImmutableType(pos, types, field.type, env,
-                    pkgID, env.scope.owner, symTable, anonymousModelHelper, names,
+                    env.enclPkg.packageID, env.scope.owner, symTable, anonymousModelHelper, names,
                     new HashSet<>());
             Name fieldName = field.symbol.name;
             field.symbol = new BVarSymbol(field.symbol.flags | Flags.READONLY, fieldName,
-                    pkgID, field.type, structureSymbol, pos, SOURCE);
+                    env.enclPkg.packageID, field.type, structureSymbol, pos, SOURCE);
             structureSymbol.scope.define(fieldName, field.symbol);
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
@@ -130,6 +130,10 @@ public class ConstantValueResolver extends BLangNodeVisitor {
         return constantValueResolver;
     }
 
+    public void setCurrentPackageId(PackageID packageID) {
+        this.pkgID = packageID;
+    }
+
     public void resolve(List<BLangConstant> constants, PackageID packageID, SymbolEnv symEnv) {
         this.dlog.setCurrentPackageId(packageID);
         this.pkgID = packageID;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -309,6 +309,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
     @Override
     public void visit(BLangPackage pkgNode, AnalyzerData data) {
         this.dlog.setCurrentPackageId(pkgNode.packageID);
+        this.constantValueResolver.setCurrentPackageId(pkgNode.packageID);
         if (pkgNode.completedPhases.contains(CompilerPhase.TYPE_CHECK)) {
             return;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -309,7 +309,6 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
     @Override
     public void visit(BLangPackage pkgNode, AnalyzerData data) {
         this.dlog.setCurrentPackageId(pkgNode.packageID);
-        this.constantValueResolver.setCurrentPackageId(pkgNode.packageID);
         if (pkgNode.completedPhases.contains(CompilerPhase.TYPE_CHECK)) {
             return;
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/annotation/AnnotationTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/annotation/AnnotationTests.java
@@ -80,6 +80,11 @@ public class AnnotationTests {
         BRunUtil.invoke(result, "testAnnotOnTupleFields");
     }
 
+    @Test
+    public void testConstAnnotationAccess() {
+        BRunUtil.invoke(result, "testConstAnnotationAccess");
+    }
+
     @Test(description = "Test the deprecated construct from external module")
     public void testDeprecation() {
         CompileResult result = BCompileUtil.compile("test-src/bala/test_bala/annotations/deprecation_annotation.bal");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_access.bal
@@ -403,6 +403,18 @@ type Student record {|
     string name;
 |};
 
+const Examples EXAMPLES = {
+    response: {}
+};
+
+@annot {
+    examples: EXAMPLES
+}
+type Teacher record {|
+    int id;
+    string name;
+|};
+
 function testConstTypeAnnotAccess() {
     Employee employee = {id: 1, name: "chirans"};
     typedesc<any> t = typeof employee;
@@ -419,6 +431,14 @@ function testConstTypeAnnotAccess() {
     AnnotationRecord1 config1 = <AnnotationRecord1> annot1;
     assertEquality({"response":{}}, config1.examples);
     assertTrue(config1.examples is readonly);
+
+    Teacher teacher = {id: 1, name: "James"};
+    typedesc<any> t1 = typeof teacher;
+    AnnotationRecord? annot2 = t1.@annot;
+    assertTrue(annot2 is AnnotationRecord);
+    AnnotationRecord config2 = <AnnotationRecord> annot2;
+    assertEquality({"response":{}}, config2.examples);
+    assertTrue(config2.examples is readonly);
 }
 
 function testListExprInConstAnnot() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/annotations/annotation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/annotations/annotation.bal
@@ -116,6 +116,52 @@ function testAnnotationsOnTypeRefTypes() {
     assertTrue('annotation is ());
 }
 
+@foo:annot {
+    examples: foo:EXAMPLES
+}
+type Student record {|
+    int id;
+    string name;
+|};
+
+public const foo:Examples EXAMPLES_2 = {
+    response: {}
+};
+
+@foo:annot {
+    examples: EXAMPLES_2
+}
+type Employee record {|
+    int id;
+    string name;
+|};
+
+function testConstAnnotationAccess() {
+    Employee employee = {id: 1, name: "chirans"};
+    typedesc<any> t = typeof employee;
+    foo:AnnotationRecord? annot = t.@foo:annot;
+    assertTrue(annot is foo:AnnotationRecord);
+    foo:AnnotationRecord config = <foo:AnnotationRecord> annot;
+    assertEquality({"response":{}}, config.examples);
+    assertTrue(config.examples is readonly);
+
+    Student student = {id: 2, name: "sachintha"};
+    typedesc<any> s = typeof student;
+    foo:AnnotationRecord? annot1 = s.@foo:annot;
+    assertTrue(annot1 is foo:AnnotationRecord);
+    foo:AnnotationRecord config1 = <foo:AnnotationRecord> annot1;
+    assertEquality({"response":{}}, config1.examples);
+    assertTrue(config1.examples is readonly);
+
+    foo:Teacher teacher = {id: 1, name: "James"};
+    typedesc<any> t1 = typeof teacher;
+    foo:AnnotationRecord? annot2 = t1.@foo:annot;
+    assertTrue(annot2 is foo:AnnotationRecord);
+    foo:AnnotationRecord config2 = <foo:AnnotationRecord> annot2;
+    assertEquality({"response":{}}, config2.examples);
+    assertTrue(config2.examples is readonly);
+}
+
 function assertTrue(anydata actual) {
     assertEquality(true, actual);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/annotations/annotation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/annotations/annotation.bal
@@ -125,7 +125,12 @@ type Student record {|
 |};
 
 public const foo:Examples EXAMPLES_2 = {
-    response: {}
+    response: {
+        headers: {
+            "h1": "h1",
+            "h2": "h2"
+        }
+    }
 };
 
 @foo:annot {
@@ -142,7 +147,7 @@ function testConstAnnotationAccess() {
     foo:AnnotationRecord? annot = t.@foo:annot;
     assertTrue(annot is foo:AnnotationRecord);
     foo:AnnotationRecord config = <foo:AnnotationRecord> annot;
-    assertEquality({"response":{}}, config.examples);
+    assertEquality({"response":{"headers": {"h1":"h1", "h2":"h2"}}}, config.examples);
     assertTrue(config.examples is readonly);
 
     Student student = {id: 2, name: "sachintha"};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/annotations.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/annotations.bal
@@ -49,3 +49,30 @@ public function testAnnotationsOnLocalTupleFields() returns [@annotOne {value: "
 public string gVar = "chiranS";
 
 public [@annotOne {value: gVar} int, @annotOne {value: "k"} int, string...] g1 =  [1, 2, "hello", "world"];
+
+public type Examples record {|
+    map<ExampleItem> response;
+|};
+
+public type ExampleItem record {
+    map<string> headers?;
+};
+
+public type AnnotationRecord record {|
+    string summary?;
+    Examples examples?;
+|};
+
+public const annotation AnnotationRecord annot on type;
+
+public const Examples EXAMPLES = {
+    response: {}
+};
+
+@annot {
+    examples: EXAMPLES
+}
+public type Teacher record {|
+    int id;
+    string name;
+|};


### PR DESCRIPTION
## Purpose
$subject

Fixes #42934

## Approach
Previously, when creating the `ConstantValueResolver`, the pkgId was not set, which caused the mentioned issue. This fix involves setting the pkgId when visiting the bLangPackage node in the Semantic Analyzer.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
