### PR TITLE
Reduce `BLangDiagnosticLocation` to create `LineRange` and `TextRange` only when needed

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLocation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLocation.java
@@ -33,38 +33,41 @@ import java.util.Objects;
  */
 public class BLangDiagnosticLocation implements Location {
 
-    private LineRange lineRange;
-    private TextRange textRange;
+    private String filePath;
+    private int startLine, endLine, startColumn, endColumn, startOffset, length;
 
     @Deprecated
     public BLangDiagnosticLocation(String filePath, int startLine, int endLine, int startColumn, int endColumn) {
-        this.lineRange = LineRange.from(filePath, LinePosition.from(startLine, startColumn),
-                LinePosition.from(endLine, endColumn));
-        this.textRange = TextRange.from(0, 0);
+        this(filePath, startLine, endLine, startColumn, endColumn, 0, 0);
     }
 
     public BLangDiagnosticLocation(String filePath, int startLine, int endLine, int startColumn, int endColumn,
                                    int startOffset, int length) {
-        this.lineRange = LineRange.from(filePath, LinePosition.from(startLine, startColumn),
-                LinePosition.from(endLine, endColumn));
-        this.textRange = TextRange.from(startOffset, length);
+        this.filePath = filePath;
+        this.startLine = startLine;
+        this.endLine = endLine;
+        this.startColumn = startColumn;
+        this.endColumn = endColumn;
+        this.startOffset = startOffset;
+        this.length = length;
     }
 
     @Override
     public LineRange lineRange() {
-        return lineRange;
+        return LineRange.from(filePath, LinePosition.from(startLine, startColumn),
+                LinePosition.from(endLine, endColumn));
     }
 
     @Override
     public TextRange textRange() {
-        return textRange;
+        return TextRange.from(startOffset, length);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof BLangDiagnosticLocation) {
             BLangDiagnosticLocation location = (BLangDiagnosticLocation) obj;
-            return lineRange.equals(location.lineRange) && textRange.equals(location.textRange);
+            return lineRange().equals(location.lineRange()) && textRange().equals(location.textRange());
         }
 
         return false;
@@ -72,11 +75,13 @@ public class BLangDiagnosticLocation implements Location {
 
     @Override
     public int hashCode() {
-        return Objects.hash(lineRange, textRange);
+        return Objects.hash(lineRange(), textRange());
     }
 
     @Override
     public String toString() {
-        return lineRange.toString() + textRange.toString();
+        // Desugar of lineRange().toString() + textRange().toString();
+        int endOffset = startOffset + length;
+        return "(" + startLine + "," + endLine + ")" + "(" + startOffset + "," + endOffset + ")";
     }
 }


### PR DESCRIPTION
## Purpose
Removed the caching for `LineRange` and `TextRange` fields in the `BLangDiagnosticLocation` and Create the objects only when needed since it consumes a considerable amount of Heap space when building https://github.com/ballerina-platform/module-ballerinax-health.hl7v2/tree/main/hl7v27

LineRange (30MB)
TextRange(10MB)

No significant performance drawbacks were noted. Below are the before and after results of --dump-build-time for building https://github.com/ballerina-platform/module-ballerinax-health.hl7v2/tree/main/hl7v27

#### Before

![Screenshot 2024-08-01 at 15 46 29](https://github.com/user-attachments/assets/a7ac209d-9148-44d4-ba9a-47a70f381ce9)

#### 
![Screenshot 2024-08-01 at 16 29 07](https://github.com/user-attachments/assets/e6e505dd-6781-4564-974b-411d8bee7c7d)

These values change +-2 sec for subsequent runs.

### nballerina repo build time

#### Before

![Screenshot 2024-08-01 at 17 25 26](https://github.com/user-attachments/assets/35b6b74c-5a45-4f28-9f7a-a1812d301c57)

#### After 
![Screenshot 2024-08-01 at 17 26 49](https://github.com/user-attachments/assets/27ac1f8f-1c11-4771-9ab3-e5f54e9365b6)

Part of https://github.com/ballerina-platform/ballerina-lang/issues/43125

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
