### PR TITLE
Add debouncing logic to the file watcher and improve error messages

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -211,7 +211,7 @@ public class RunCommand implements BLauncherCmd {
                 ProjectWatcher projectWatcher = new ProjectWatcher(
                         this, Paths.get(this.projectPath.toString()), outStream);
                 projectWatcher.watch();
-            } catch (IOException | InterruptedException e) {
+            } catch (IOException e) {
                 throw createLauncherException("unable to run in the watch mode:" + e.getMessage());
             }
             return;

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -212,7 +212,10 @@ public class RunCommand implements BLauncherCmd {
                         this, Paths.get(this.projectPath.toString()), outStream);
                 projectWatcher.watch();
             } catch (IOException e) {
-                throw createLauncherException("unable to run in the watch mode:" + e.getMessage());
+                throw createLauncherException("unable to watch the project:" + e.getMessage());
+            } catch (ProjectException e) {
+                CommandUtil.printError(this.errStream, e.getMessage(), runCmd, false);
+                CommandUtil.exitError(this.exitWhenFinish);
             }
             return;
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -577,59 +577,61 @@ public class JBallerinaBackend extends CompilerBackend {
     private void copyJar(ZipArchiveOutputStream outStream, JarLibrary jarLibrary,
                          HashMap<String, JarLibrary> copiedEntries, HashMap<String,
             StringBuilder> services) throws IOException {
-
-        ZipFile zipFile = new ZipFile(jarLibrary.path().toFile());
-        ZipArchiveEntryPredicate predicate = entry -> {
-            String entryName = entry.getName();
-            if (entryName.equals("META-INF/MANIFEST.MF")) {
-                return false;
-            }
-            if (entryName.equals("module-info.class")) {
-                return false;
-            }
-            if (entryName.startsWith("META-INF/services")) {
-                StringBuilder s = services.get(entryName);
-                if (s == null) {
-                    s = new StringBuilder();
-                    services.put(entryName, s);
+        if (Thread.currentThread().isInterrupted()) {
+            return;
+        }
+        try (ZipFile zipFile = new ZipFile(jarLibrary.path().toFile())) {
+            ZipArchiveEntryPredicate predicate = entry -> {
+                String entryName = entry.getName();
+                if (entryName.equals("META-INF/MANIFEST.MF")) {
+                    return false;
                 }
-                char c = '\n';
-
-                int len;
-                try (BufferedInputStream inStream = new BufferedInputStream(zipFile.getInputStream(entry))) {
-                    while ((len = inStream.read()) != -1) {
-                        c = (char) len;
-                        s.append(c);
+                if (entryName.equals("module-info.class")) {
+                    return false;
+                }
+                if (entryName.startsWith("META-INF/services")) {
+                    StringBuilder s = services.get(entryName);
+                    if (s == null) {
+                        s = new StringBuilder();
+                        services.put(entryName, s);
                     }
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    char c = '\n';
+
+                    int len;
+                    try (BufferedInputStream inStream = new BufferedInputStream(zipFile.getInputStream(entry))) {
+                        while ((len = inStream.read()) != -1) {
+                            c = (char) len;
+                            s.append(c);
+                        }
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                    if (c != '\n') {
+                        s.append('\n');
+                    }
+
+                    // Its not required to copy SPI entries in here as we'll be adding merged SPI related entries
+                    // separately. Therefore the predicate should be set as false.
+                    return false;
                 }
-                if (c != '\n') {
-                    s.append('\n');
+
+                // Skip already copied files or excluded extensions.
+                if (isCopiedEntry(entryName, copiedEntries)) {
+                    addConflictedJars(jarLibrary, copiedEntries, entryName);
+                    return false;
                 }
+                if (isExcludedEntry(entryName)) {
+                    return false;
+                }
+                // SPIs will be merged first and then put into jar separately.
+                copiedEntries.put(entryName, jarLibrary);
+                return true;
+            };
 
-                // Its not required to copy SPI entries in here as we'll be adding merged SPI related entries
-                // separately. Therefore the predicate should be set as false.
-                return false;
-            }
-
-            // Skip already copied files or excluded extensions.
-            if (isCopiedEntry(entryName, copiedEntries)) {
-                addConflictedJars(jarLibrary, copiedEntries, entryName);
-                return false;
-            }
-            if (isExcludedEntry(entryName)) {
-                return false;
-            }
-            // SPIs will be merged first and then put into jar separately.
-            copiedEntries.put(entryName, jarLibrary);
-            return true;
-        };
-
-        // Transfers selected entries from this zip file to the output stream, while preserving its compression and
-        // all the other original attributes.
-        zipFile.copyRawEntries(outStream, predicate);
-        zipFile.close();
+            // Transfers selected entries from this zip file to the output stream, while preserving its compression and
+            // all the other original attributes.
+            zipFile.copyRawEntries(outStream, predicate);
+        }
     }
 
     private static boolean isCopiedEntry(String entryName, HashMap<String, JarLibrary> copiedEntries) {


### PR DESCRIPTION
## Purpose
In windows file changes are notified twice by the OS,
1. the actual file change
2. the change of the last modified time

To avoid such unnecessary noise, I have added a debouncing logic to the ProjectWatcher.

Also, for non existing projects, I have improved the error message to match the `bal run` normal scenario.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
