### PR TITLE
[Refactoring] Exceptions in "throws" clauses should not be superfluous

### DIFF
--- a/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/handlers/help/HelpProvider.java
+++ b/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/handlers/help/HelpProvider.java
@@ -30,7 +30,6 @@ public interface HelpProvider {
      *
      * @param args   All the arguments given by requester.
      * @param output Builder to append output.
-     * @throws HelpProviderException If fetching help failed.
      */
-    void getTopic(String[] args, StringBuilder output) throws HelpProviderException;
+    void getTopic(String[] args, StringBuilder output);
 }

--- a/ballerina-shell/modules/shell-cli/src/test/java/io/ballerina/shell/cli/test/base/TestIntegrator.java
+++ b/ballerina-shell/modules/shell-cli/src/test/java/io/ballerina/shell/cli/test/base/TestIntegrator.java
@@ -95,7 +95,7 @@ public class TestIntegrator extends Thread {
                         testCase.getDescription());
                 stdoutStream.reset();
             }
-        } catch (IOException | InterruptedException ignored) {
+        } catch (IOException ignored) {
         }
     }
 
@@ -115,7 +115,7 @@ public class TestIntegrator extends Thread {
     /**
      * Send the data given to the specific stream.
      */
-    private void sendRequest(PrintStream stream, String string) throws InterruptedException {
+    private void sendRequest(PrintStream stream, String string) {
         // This is a workaround since with double `System.lineSeparator()` the tests fail on windows.
         stream.append(string).append("\n\n").flush();
     }

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/DualTreeParserTrial.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/DualTreeParserTrial.java
@@ -36,16 +36,9 @@ public abstract class DualTreeParserTrial extends TreeParserTrial {
     }
 
     @Override
-    public Collection<Node> parse(String source) throws ParserTrialFailedException {
-        try {
-            return parseSource(source);
-        } catch (ParserTrialFailedException e) {
-            if (source.endsWith(SEMICOLON)) {
-                return parseSource(source.substring(0, source.length() - 1));
-            }
-            throw e;
-        }
+    public Collection<Node> parse(String source) {
+        return parseSource(source);
     }
 
-    public abstract Collection<Node> parseSource(String source) throws ParserTrialFailedException;
+    public abstract Collection<Node> parseSource(String source);
 }

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/snippet/factory/SnippetFactory.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/snippet/factory/SnippetFactory.java
@@ -146,7 +146,7 @@ public abstract class SnippetFactory extends DiagnosticReporter {
      * @param node Root node to create snippet from.
      * @return Snippet that contains the node.
      */
-    public abstract Snippet createExpressionSnippet(Node node) throws SnippetException;
+    public abstract Snippet createExpressionSnippet(Node node);
 
     /**
      * Snippet creation helper interface.

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/AbstractEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/AbstractEvaluatorTest.java
@@ -49,7 +49,7 @@ public abstract class AbstractEvaluatorTest {
      *
      * @param fileName File containing test cases.
      */
-    protected void testEvaluate(String fileName) throws BallerinaShellException {
+    protected void testEvaluate(String fileName) {
         // Create evaluator
         TestInvoker invoker = new TestInvoker();
         Evaluator evaluator = new EvaluatorBuilder()

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ActionEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ActionEvaluatorTest.java
@@ -16,7 +16,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -31,22 +30,22 @@ public class ActionEvaluatorTest extends AbstractEvaluatorTest {
     private static final String VAR_EVALUATOR_TESTCASE = "testcases/evaluator/actions.var.json";
 
     @Test
-    public void testEvaluateStart() throws BallerinaShellException {
+    public void testEvaluateStart() {
         testEvaluate(START_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateRemote() throws BallerinaShellException {
+    public void testEvaluateRemote() {
         testEvaluate(REMOTE_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateResource() throws BallerinaShellException {
+    public void testEvaluateResource() {
         testEvaluate(RESOURCE_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateVar() throws BallerinaShellException {
+    public void testEvaluateVar() {
         testEvaluate(VAR_EVALUATOR_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/BasicTypeEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/BasicTypeEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -34,27 +33,27 @@ public class BasicTypeEvaluatorTest extends AbstractEvaluatorTest {
     private static final String MAPS_EVALUATOR_TESTCASE = "testcases/evaluator/values.maps.json";
 
     @Test
-    public void testEvaluateString() throws BallerinaShellException {
+    public void testEvaluateString() {
         testEvaluate(STRING_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateTuples() throws BallerinaShellException {
+    public void testEvaluateTuples() {
         testEvaluate(TUPLES_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateArrays() throws BallerinaShellException {
+    public void testEvaluateArrays() {
         testEvaluate(ARRAYS_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateTable() throws BallerinaShellException {
+    public void testEvaluateTable() {
         testEvaluate(TABLE_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateMaps() throws BallerinaShellException {
+    public void testEvaluateMaps() {
         testEvaluate(MAPS_EVALUATOR_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/BasicsEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/BasicsEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -38,48 +37,48 @@ public class BasicsEvaluatorTest extends AbstractEvaluatorTest {
     private static final String BASICS_ERRORS_TESTCASE = "testcases/evaluator/basics.errors.json";
 
     @Test
-    public void testBasicsModules() throws BallerinaShellException {
+    public void testBasicsModules() {
         // TODO: Improve after custom classpath support
         testEvaluate(BASICS_MODULES_TESTCASE);
     }
 
     @Test
-    public void testBasicsVariables() throws BallerinaShellException {
+    public void testBasicsVariables() {
         testEvaluate(BASICS_VARIABLES_TESTCASE);
     }
 
     @Test
-    public void testEvaluateBasicsVar() throws BallerinaShellException {
+    public void testEvaluateBasicsVar() {
         testEvaluate(BASICS_VAR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateBasicsFunctions() throws BallerinaShellException {
+    public void testEvaluateBasicsFunctions() {
         testEvaluate(BASICS_FUNCTIONS_TESTCASE);
     }
 
     @Test
-    public void testEvaluateBasicsReqParams() throws BallerinaShellException {
+    public void testEvaluateBasicsReqParams() {
         testEvaluate(BASICS_REQ_PARAMS_TESTCASE);
     }
 
     @Test
-    public void testEvaluateBasicsDefParams() throws BallerinaShellException {
+    public void testEvaluateBasicsDefParams() {
         testEvaluate(BASICS_DEF_PARAMS_TESTCASE);
     }
 
     @Test
-    public void testEvaluateBasicsRestParams() throws BallerinaShellException {
+    public void testEvaluateBasicsRestParams() {
         testEvaluate(BASICS_REST_PARAMS_TESTCASE);
     }
 
     @Test
-    public void testEvaluateBasicsQuoted() throws BallerinaShellException {
+    public void testEvaluateBasicsQuoted() {
         testEvaluate(BASICS_QUOTED_TESTCASE);
     }
 
     @Test
-    public void testEvaluateBasicsErrors() throws BallerinaShellException {
+    public void testEvaluateBasicsErrors() {
         testEvaluate(BASICS_ERRORS_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/BehaviorTypeEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/BehaviorTypeEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -30,7 +29,7 @@ public class BehaviorTypeEvaluatorTest extends AbstractEvaluatorTest {
     private static final String STREAM_EVALUATOR_TESTCASE = "testcases/evaluator/streams.streams.json";
 
     @Test
-    public void testEvaluateSteams() throws BallerinaShellException {
+    public void testEvaluateSteams() {
         testEvaluate(STREAM_EVALUATOR_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ConcurrencyEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ConcurrencyEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -31,7 +30,7 @@ public class ConcurrencyEvaluatorTest extends AbstractEvaluatorTest {
     private static final String LOCK_EVALUATOR_TESTCASE = "testcases/evaluator/concurrency.lock.json";
 
     @Test
-    public void testEvaluateLock() throws BallerinaShellException {
+    public void testEvaluateLock() {
         testEvaluate(LOCK_EVALUATOR_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ErrorsEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ErrorsEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -37,42 +36,42 @@ public class ErrorsEvaluatorTest extends AbstractEvaluatorTest {
     private static final String SINGLE_PLACE_EVALUATOR_TESTCASE = "testcases/evaluator/errors.single.place.json";
 
     @Test
-    public void testEvaluateErrorHandling() throws BallerinaShellException {
+    public void testEvaluateErrorHandling() {
         testEvaluate(HANDLING_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateFail() throws BallerinaShellException {
+    public void testEvaluateFail() {
         testEvaluate(FAIL_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateCheck() throws BallerinaShellException {
+    public void testEvaluateCheck() {
         testEvaluate(CHECK_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluatePanic() throws BallerinaShellException {
+    public void testEvaluatePanic() {
         testEvaluate(PANIC_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateCheckPanic() throws BallerinaShellException {
+    public void testEvaluateCheckPanic() {
         testEvaluate(CHECKPANIC_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateTrap() throws BallerinaShellException {
+    public void testEvaluateTrap() {
         testEvaluate(TRAP_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateUserDef() throws BallerinaShellException {
+    public void testEvaluateUserDef() {
         testEvaluate(USER_DEF_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateSinglePlace() throws BallerinaShellException {
+    public void testEvaluateSinglePlace() {
         // TODO: Test transaction on fail clause
         testEvaluate(SINGLE_PLACE_EVALUATOR_TESTCASE);
     }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/FileEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/FileEvaluatorTest.java
@@ -32,22 +32,22 @@ public class FileEvaluatorTest extends AbstractEvaluatorTest {
     private static final String RECURSIVE_EVALUATOR_TESTCASE = "testcases/evaluator/files.mu.recursive.json";
 
     @Test
-    public void testEvaluateFileBasic() throws Exception {
+    public void testEvaluateFileBasic() {
         testEvaluate(BASIC_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateFileUnordered() throws Exception {
+    public void testEvaluateFileUnordered() {
         testEvaluate(UNORDERED_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateFileMutuallyUsed() throws Exception {
+    public void testEvaluateFileMutuallyUsed() {
         testEvaluate(MU_USED_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateFileRecursive() throws Exception {
+    public void testEvaluateFileRecursive() {
         testEvaluate(RECURSIVE_EVALUATOR_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/FlowControlEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/FlowControlEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -34,27 +33,27 @@ public class FlowControlEvaluatorTest extends AbstractEvaluatorTest {
     private static final String FOREACH_EVALUATOR_TESTCASE = "testcases/evaluator/flow.control.foreach.json";
 
     @Test
-    public void testEvaluateElvis() throws BallerinaShellException {
+    public void testEvaluateElvis() {
         testEvaluate(ELVIS_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateIf() throws BallerinaShellException {
+    public void testEvaluateIf() {
         testEvaluate(IF_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateMatch() throws BallerinaShellException {
+    public void testEvaluateMatch() {
         testEvaluate(MATCH_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateWhile() throws BallerinaShellException {
+    public void testEvaluateWhile() {
         testEvaluate(WHILE_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateForEach() throws BallerinaShellException {
+    public void testEvaluateForEach() {
         testEvaluate(FOREACH_EVALUATOR_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/FunctionEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/FunctionEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -33,22 +32,22 @@ public class FunctionEvaluatorTest extends AbstractEvaluatorTest {
     private static final String POINTERS_EVALUATOR_TESTCASE = "testcases/evaluator/function.pointers.json";
 
     @Test
-    public void testEvaluateAnonFn() throws BallerinaShellException {
+    public void testEvaluateAnonFn() {
         testEvaluate(ANON_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateExprBody() throws BallerinaShellException {
+    public void testEvaluateExprBody() {
         testEvaluate(EXPR_BODY_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateIterations() throws BallerinaShellException {
+    public void testEvaluateIterations() {
         testEvaluate(ITERATION_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluatePointers() throws BallerinaShellException {
+    public void testEvaluatePointers() {
         testEvaluate(POINTERS_EVALUATOR_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/JavaInteropEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/JavaInteropEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -30,7 +29,7 @@ public class JavaInteropEvaluatorTest extends AbstractEvaluatorTest {
     private static final String JAVA_INTEROP_EVALUATOR_TESTCASE = "testcases/evaluator/java.interop.json";
 
     @Test
-    public void testEvaluateJavaInterop() throws BallerinaShellException {
+    public void testEvaluateJavaInterop() {
         testEvaluate(JAVA_INTEROP_EVALUATOR_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/JsonXmlEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/JsonXmlEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -40,57 +39,57 @@ public class JsonXmlEvaluatorTest extends AbstractEvaluatorTest {
     private static final String FUNCTION_EVALUATOR_TESTCASE = "testcases/evaluator/xml.function.json";
 
     @Test
-    public void testEvaluateJson() throws BallerinaShellException {
+    public void testEvaluateJson() {
         testEvaluate(JSON_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateJsonObjects() throws BallerinaShellException {
+    public void testEvaluateJsonObjects() {
         testEvaluate(JSON_OBJECTS_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateJsonArrays() throws BallerinaShellException {
+    public void testEvaluateJsonArrays() {
         testEvaluate(JSON_ARRAYS_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateJsonAccess() throws BallerinaShellException {
+    public void testEvaluateJsonAccess() {
         testEvaluate(JSON_ACCESS_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateJsonConvertMap() throws BallerinaShellException {
+    public void testEvaluateJsonConvertMap() {
         testEvaluate(JSON_CONV_MAP_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateXml() throws BallerinaShellException {
+    public void testEvaluateXml() {
         testEvaluate(XML_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateXmlLiteral() throws BallerinaShellException {
+    public void testEvaluateXmlLiteral() {
         testEvaluate(LITERAL_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateXmlAttribute() throws BallerinaShellException {
+    public void testEvaluateXmlAttribute() {
         testEvaluate(ATTRIBUTE_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateXmlNamespace() throws BallerinaShellException {
+    public void testEvaluateXmlNamespace() {
         testEvaluate(NAMESPACE_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateXmlAccess() throws BallerinaShellException {
+    public void testEvaluateXmlAccess() {
         testEvaluate(ACCESS_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateXmlFunction() throws BallerinaShellException {
+    public void testEvaluateXmlFunction() {
         testEvaluate(FUNCTION_EVALUATOR_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/MiscEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/MiscEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -32,17 +31,17 @@ public class MiscEvaluatorTest extends AbstractEvaluatorTest {
     private static final String LET_EVALUATOR_TESTCASE = "testcases/evaluator/values.let.json";
 
     @Test
-    public void testEvaluateEnum() throws BallerinaShellException {
+    public void testEvaluateEnum() {
         testEvaluate(ENUM_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateRawTemplate() throws BallerinaShellException {
+    public void testEvaluateRawTemplate() {
         testEvaluate(RAW_TEMP_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateLet() throws BallerinaShellException {
+    public void testEvaluateLet() {
         testEvaluate(LET_EVALUATOR_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ObjectEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/ObjectEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -37,42 +36,42 @@ public class ObjectEvaluatorTest extends AbstractEvaluatorTest {
     private static final String REF_EVALUATOR_TESTCASE = "testcases/evaluator/object.ref.json";
 
     @Test
-    public void testEvaluateClass() throws BallerinaShellException {
+    public void testEvaluateClass() {
         testEvaluate(CLASS_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateInit() throws BallerinaShellException {
+    public void testEvaluateInit() {
         testEvaluate(INIT_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateMethod() throws BallerinaShellException {
+    public void testEvaluateMethod() {
         testEvaluate(METHODS_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateAssign() throws BallerinaShellException {
+    public void testEvaluateAssign() {
         testEvaluate(ASSIGN_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateType() throws BallerinaShellException {
+    public void testEvaluateType() {
         testEvaluate(TYPE_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateConstructor() throws BallerinaShellException {
+    public void testEvaluateConstructor() {
         testEvaluate(CONSTRUCTOR_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateReadonly() throws BallerinaShellException {
+    public void testEvaluateReadonly() {
         testEvaluate(READONLY_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateRef() throws BallerinaShellException {
+    public void testEvaluateRef() {
         testEvaluate(REF_EVALUATOR_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/OperationsEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/OperationsEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -39,52 +38,52 @@ public class OperationsEvaluatorTest extends AbstractEvaluatorTest {
     private static final String CONV_OPERATION_TESTCASE = "testcases/evaluator/operations.conv.json";
 
     @Test
-    public void testEvaluateShift() throws BallerinaShellException {
+    public void testEvaluateShift() {
         testEvaluate(SHIFT_OPERATION_TESTCASE);
     }
 
     @Test
-    public void testEvaluateBitwise() throws BallerinaShellException {
+    public void testEvaluateBitwise() {
         testEvaluate(BITWISE_OPERATION_TESTCASE);
     }
 
     @Test
-    public void testEvaluateCompound() throws BallerinaShellException {
+    public void testEvaluateCompound() {
         testEvaluate(COMPOUND_OPERATION_TESTCASE);
     }
 
     @Test
-    public void testEvaluateEquality() throws BallerinaShellException {
+    public void testEvaluateEquality() {
         testEvaluate(EQUALITY_OPERATION_TESTCASE);
     }
 
     @Test
-    public void testEvaluateLength() throws BallerinaShellException {
+    public void testEvaluateLength() {
         testEvaluate(LENGTH_OPERATION_TESTCASE);
     }
 
     @Test
-    public void testEvaluateCast() throws BallerinaShellException {
+    public void testEvaluateCast() {
         testEvaluate(CAST_OPERATION_TESTCASE);
     }
 
     @Test
-    public void testEvaluateOptional() throws BallerinaShellException {
+    public void testEvaluateOptional() {
         testEvaluate(OPTIONAL_OPERATION_TESTCASE);
     }
 
     @Test
-    public void testEvaluateClone() throws BallerinaShellException {
+    public void testEvaluateClone() {
         testEvaluate(CLONE_OPERATION_TESTCASE);
     }
 
     @Test
-    public void testEvaluateImmutable() throws BallerinaShellException {
+    public void testEvaluateImmutable() {
         testEvaluate(IMMUTABLE_OPERATION_TESTCASE);
     }
 
     @Test
-    public void testEvaluateConvertTypes() throws BallerinaShellException {
+    public void testEvaluateConvertTypes() {
         testEvaluate(CONV_OPERATION_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/PatternEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/PatternEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -32,17 +31,17 @@ public class PatternEvaluatorTest extends AbstractEvaluatorTest {
     private static final String ARRAY_EVALUATOR_TESTCASE = "testcases/evaluator/pattern.array.json";
 
     @Test
-    public void testEvaluateTuple() throws BallerinaShellException {
+    public void testEvaluateTuple() {
         testEvaluate(TUPLE_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateRecord() throws BallerinaShellException {
+    public void testEvaluateRecord() {
         testEvaluate(RECORD_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateArray() throws BallerinaShellException {
+    public void testEvaluateArray() {
          testEvaluate(ARRAY_EVALUATOR_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/QueryEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/QueryEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -33,19 +32,19 @@ public class QueryEvaluatorTest extends AbstractEvaluatorTest {
     private static final String QUERY_ACTION_EVALUATOR_TESTCASE = "testcases/evaluator/query.action.json";
 
     @Test
-    public void testEvaluateQueryExpr() throws BallerinaShellException {
+    public void testEvaluateQueryExpr() {
         // TODO: (#28389) Compiler crashes for module-level query expression which uses var
         testEvaluate(QUERY_EXPR_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateQueryJoin() throws BallerinaShellException {
+    public void testEvaluateQueryJoin() {
         // TODO: (#28390) Module-level query expressions don't work
         testEvaluate(QUERY_JOIN_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateQueryAction() throws BallerinaShellException {
+    public void testEvaluateQueryAction() {
         testEvaluate(QUERY_ACTION_EVALUATOR_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/RecordEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/RecordEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -34,27 +33,27 @@ public class RecordEvaluatorTest extends AbstractEvaluatorTest {
     private static final String READONLY_TESTCASE = "testcases/evaluator/record.readonly.json";
 
     @Test
-    public void testRecordBasic() throws BallerinaShellException {
+    public void testRecordBasic() {
         testEvaluate(RECORD_TESTCASE);
     }
 
     @Test
-    public void testRecordAnon() throws BallerinaShellException {
+    public void testRecordAnon() {
         testEvaluate(ANON_TESTCASE);
     }
 
     @Test
-    public void testRecordOptional() throws BallerinaShellException {
+    public void testRecordOptional() {
         testEvaluate(OPTIONAL_TESTCASE);
     }
 
     @Test
-    public void testRecordRef() throws BallerinaShellException {
+    public void testRecordRef() {
         testEvaluate(REF_TESTCASE);
     }
 
     @Test
-    public void testRecordReadonly() throws BallerinaShellException {
+    public void testRecordReadonly() {
         testEvaluate(READONLY_TESTCASE);
     }
 }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/RegressionEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/RegressionEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -34,31 +33,31 @@ public class RegressionEvaluatorTest extends AbstractEvaluatorTest {
     private static final String IMPORT_CYCLIC_TYPE_TESTCASE = "testcases/evaluator/regression.cyclic.type.json";
 
     @Test
-    public void testEvaluateSameImport() throws BallerinaShellException {
+    public void testEvaluateSameImport() {
         // Import can be again and again imported with same prefix.
         testEvaluate(SAME_IMPORT_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateImportUsedFn() throws BallerinaShellException {
+    public void testEvaluateImportUsedFn() {
         // Functions using imports are correctly processed.
         testEvaluate(IMPORT_USED_FN_TESTCASE);
     }
 
     @Test
-    public void testEvaluateQualifiers() throws BallerinaShellException {
+    public void testEvaluateQualifiers() {
         // Test for qualifiers use.
         testEvaluate(QUALIFIERS_TESTCASE);
     }
 
     @Test
-    public void testEvaluatePanicSaveState() throws BallerinaShellException {
+    public void testEvaluatePanicSaveState() {
         // Check if panic correctly preserves state.
         testEvaluate(PANIC_SAVE_STATE_TESTCASE);
     }
 
     @Test
-    public void testEvaluateCyclicType() throws BallerinaShellException {
+    public void testEvaluateCyclicType() {
         // Cyclic types use.
         testEvaluate(IMPORT_CYCLIC_TYPE_TESTCASE);
     }

--- a/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/SimpleEvaluatorTest.java
+++ b/ballerina-shell/modules/shell-core/src/test/java/io/ballerina/shell/test/evaluator/SimpleEvaluatorTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.shell.test.evaluator;
 
-import io.ballerina.shell.exceptions.BallerinaShellException;
 import org.testng.annotations.Test;
 
 /**
@@ -31,12 +30,12 @@ public class SimpleEvaluatorTest extends AbstractEvaluatorTest {
     private static final String LITERALS_EVALUATOR_TESTCASE = "testcases/evaluator/values.literals.json";
 
     @Test
-    public void testEvaluateBasic() throws BallerinaShellException {
+    public void testEvaluateBasic() {
         testEvaluate(BASIC_EVALUATOR_TESTCASE);
     }
 
     @Test
-    public void testEvaluateLiterals() throws BallerinaShellException {
+    public void testEvaluateLiterals() {
         testEvaluate(LITERALS_EVALUATOR_TESTCASE);
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BallerinaXmlSerializer.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BallerinaXmlSerializer.java
@@ -27,7 +27,6 @@ import io.ballerina.runtime.internal.values.XmlSequence;
 import io.ballerina.runtime.internal.values.XmlText;
 
 import java.io.CharArrayWriter;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -98,7 +97,7 @@ public class BallerinaXmlSerializer extends OutputStream {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         try {
             xmlStreamWriter.close();
         } catch (XMLStreamException e) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableJsonDataSource.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableJsonDataSource.java
@@ -86,11 +86,7 @@ public class TableJsonDataSource implements JsonDataSource {
             TupleValueImpl tupleValue = (TupleValueImpl) itr.next();
             //Retrieve table value from key-value tuple
             BMap<?, ?> record = ((BMap<?, ?>) tupleValue.get(1));
-            try {
-                values.append(this.objGen.transform(record));
-            } catch (IOException e) {
-                throw ErrorCreator.createError(e);
-            }
+            values.append(this.objGen.transform(record));
         }
         return values;
     }
@@ -192,9 +188,8 @@ public class TableJsonDataSource implements JsonDataSource {
          *
          * @param record The record that should be used in the current position
          * @return The generated JSON object
-         * @throws IOException for JSON reading/serializing errors
          */
-        Object transform(BMap<?, ?> record) throws IOException;
+        Object transform(BMap<?, ?> record);
 
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/XmlFactory.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/XmlFactory.java
@@ -478,9 +478,8 @@ public final class XmlFactory {
      *
      * @param xmlFragment the well-formed XML fragment
      * @return The OMElement created out of the string XML fragment.
-     * @throws XMLStreamException when unexpected processing error occur while parsing.
      */
-    public static OMElement stringToOM(String xmlFragment) throws XMLStreamException {
+    public static OMElement stringToOM(String xmlFragment) {
         return stringToOM(OMAbstractFactory.getOMFactory(), xmlFragment);
     }
 
@@ -491,9 +490,8 @@ public final class XmlFactory {
      * @param omFactory the factory used to build the object model
      * @param xmlFragment the well-formed XML fragment
      * @return The OMElement created out of the string XML fragment.
-     * @throws XMLStreamException when unexpected processing error occur while parsing.
      */
-    private static OMElement stringToOM(OMFactory omFactory, String xmlFragment) throws XMLStreamException {
+    private static OMElement stringToOM(OMFactory omFactory, String xmlFragment) {
         return xmlFragment != null
                 ? OMXMLBuilderFactory
                     .createOMBuilder(omFactory, STAX_PARSER_CONFIGURATION, new StringReader(xmlFragment))

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
@@ -52,7 +52,6 @@ import java.util.Set;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
-import javax.xml.stream.XMLStreamException;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.STRING_NULL_VALUE;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.XML_LANG_LIB;
@@ -447,7 +446,7 @@ public final class XmlItem extends XmlValue implements BXmlItem {
             return omElement;
         } catch (BError e) {
             throw e;
-        } catch (OMException | XMLStreamException e) {
+        } catch (OMException e) {
             Throwable cause = e.getCause() == null ? e : e.getCause();
             throw ErrorCreator.createError(StringUtils.fromString((cause.getMessage())));
         } catch (Throwable e) {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -33,7 +33,6 @@ import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.SingleFileProject;
 import io.ballerina.projects.util.ProjectConstants;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
 
@@ -275,11 +274,7 @@ public class BuildCommand implements BLauncherCmd {
         }
 
         // Validate Settings.toml file
-        try {
-            RepoUtils.readSettings();
-        } catch (SettingsTomlException e) {
-            this.outStream.println("warning: " + e.getMessage());
-        }
+        RepoUtils.readSettings();
 
         if (!project.buildOptions().nativeImage() && !project.buildOptions().graalVMBuildOptions().isEmpty()) {
             this.outStream.println("WARNING: Additional GraalVM build options are ignored since graalvm " +

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
@@ -49,7 +49,6 @@ import org.ballerinalang.central.client.CentralAPIClient;
 import org.ballerinalang.central.client.CentralClientConstants;
 import org.ballerinalang.central.client.exceptions.CentralClientException;
 import org.ballerinalang.central.client.exceptions.PackageAlreadyExistsException;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.FileInputStream;
@@ -457,13 +456,9 @@ public final class CommandUtil {
                 .map(JvmTarget::code)
                 .collect(Collectors.joining(","));
             Settings settings;
-        try {
-            settings = readSettings();
-            // Ignore Settings.toml diagnostics in the pull command
-        } catch (SettingsTomlException e) {
-            // Ignore 'Settings.toml' parsing errors and return empty Settings object
-            settings = Settings.from();
-        }
+        settings = readSettings();
+        // Ignore Settings.toml diagnostics in the pull command
+
         CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                 initializeProxy(settings.getProxy()), settings.getProxy().username(),
                 settings.getProxy().password(),

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/DeprecateCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/DeprecateCommand.java
@@ -23,7 +23,6 @@ import io.ballerina.projects.JvmTarget;
 import io.ballerina.projects.Settings;
 import org.ballerinalang.central.client.CentralAPIClient;
 import org.ballerinalang.central.client.exceptions.CentralClientException;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
 
@@ -157,13 +156,9 @@ public class DeprecateCommand implements BLauncherCmd {
     private void deprecateInCentral(String packageInfo) {
         try {
             Settings settings;
-            try {
-                settings = RepoUtils.readSettings();
-                // Ignore Settings.toml diagnostics in the deprecate command
-            } catch (SettingsTomlException e) {
-                // Ignore 'Settings.toml' parsing errors and return empty Settings object
-                settings = Settings.from();
-            }
+            settings = RepoUtils.readSettings();
+            // Ignore Settings.toml diagnostics in the deprecate command
+
             String packageValue = packageInfo;
             if (packageInfo.split(":").length != 2) {
                 packageValue = packageInfo + ":*";

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/GraphCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/GraphCommand.java
@@ -31,7 +31,6 @@ import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.SingleFileProject;
 import io.ballerina.projects.util.ProjectConstants;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
 
@@ -134,11 +133,7 @@ public class GraphCommand implements BLauncherCmd {
     }
 
     private void validateSettingsToml() {
-        try {
-            RepoUtils.readSettings();
-        } catch (SettingsTomlException e) {
-            this.outStream.println("warning: " + e.getMessage());
-        }
+        RepoUtils.readSettings();
     }
 
     private void exitIfRequired() {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
@@ -17,7 +17,6 @@ import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.toml.semantic.TomlType;
 import io.ballerina.toml.semantic.ast.TomlTableNode;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
 
@@ -246,11 +245,7 @@ public class PackCommand implements BLauncherCmd {
         }
 
         // Validate Settings.toml file
-        try {
-            RepoUtils.readSettings();
-        } catch (SettingsTomlException e) {
-            this.outStream.println("warning: " + e.getMessage());
-        }
+        RepoUtils.readSettings();
 
         // Check package files are modified after last build
         boolean isPackageModified = isProjectUpdated(project);

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
@@ -37,7 +37,6 @@ import org.ballerinalang.central.client.exceptions.CentralClientException;
 import org.ballerinalang.central.client.exceptions.PackageAlreadyExistsException;
 import org.ballerinalang.maven.bala.client.MavenResolverClient;
 import org.ballerinalang.maven.bala.client.MavenResolverClientException;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
@@ -193,11 +192,7 @@ public class PullCommand implements BLauncherCmd {
         }
 
         Settings settings;
-        try {
-            settings = RepoUtils.readSettings();
-        } catch (SettingsTomlException e) {
-            settings = Settings.from();
-        }
+        settings = RepoUtils.readSettings();
 
         if (repositoryName == null) {
             repositoryName = ProjectConstants.CENTRAL_REPOSITORY_CACHE_NAME;

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
@@ -42,7 +42,6 @@ import org.ballerinalang.central.client.exceptions.CentralClientException;
 import org.ballerinalang.central.client.exceptions.NoPackageException;
 import org.ballerinalang.maven.bala.client.MavenResolverClient;
 import org.ballerinalang.maven.bala.client.MavenResolverClientException;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
 
@@ -249,7 +248,7 @@ public class PushCommand implements BLauncherCmd {
                     pushBalaToRemote(balaPath, client);
                 }
             }
-        } catch (ProjectException | CentralClientException | SettingsTomlException e) {
+        } catch (ProjectException | CentralClientException e) {
             CommandUtil.printError(this.errStream, e.getMessage(), null, false);
             CommandUtil.exitError(this.exitWhenFinish);
             return;
@@ -484,12 +483,7 @@ public class PushCommand implements BLauncherCmd {
             Path ballerinaHomePath = RepoUtils.createAndGetHomeReposPath();
             Path settingsTomlFilePath = ballerinaHomePath.resolve(SETTINGS_FILE_NAME);
 
-            try {
-                authenticate(errStream, getBallerinaCentralCliTokenUrl(), settingsTomlFilePath, client);
-            } catch (SettingsTomlException e) {
-                CommandUtil.printError(this.errStream, e.getMessage(), null, false);
-                return;
-            }
+            authenticate(errStream, getBallerinaCentralCliTokenUrl(), settingsTomlFilePath, client);
 
             try {
                 client.pushPackage(balaPath, org, name, version, JvmTarget.JAVA_17.code(),

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/SearchCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/SearchCommand.java
@@ -24,7 +24,6 @@ import io.ballerina.projects.Settings;
 import org.ballerinalang.central.client.CentralAPIClient;
 import org.ballerinalang.central.client.exceptions.CentralClientException;
 import org.ballerinalang.central.client.model.PackageSearchResult;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
 
@@ -133,13 +132,9 @@ public class SearchCommand implements BLauncherCmd {
     private void searchInCentral(String query) {
         try {
             Settings settings;
-            try {
-                settings = RepoUtils.readSettings();
-                // Ignore Settings.toml diagnostics in the search command
-            } catch (SettingsTomlException e) {
-                // Ignore 'Settings.toml' parsing errors and return empty Settings object
-                settings = Settings.from();
-            }
+            settings = RepoUtils.readSettings();
+            // Ignore Settings.toml diagnostics in the search command
+
             CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                                                            initializeProxy(settings.getProxy()),
                                                             settings.getProxy().username(),

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/ToolCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/ToolCommand.java
@@ -40,7 +40,6 @@ import org.ballerinalang.central.client.exceptions.CentralClientException;
 import org.ballerinalang.central.client.exceptions.PackageAlreadyExistsException;
 import org.ballerinalang.central.client.model.Tool;
 import org.ballerinalang.central.client.model.ToolSearchResult;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
@@ -514,13 +513,9 @@ public class ToolCommand implements BLauncherCmd {
 
     private void pullToolFromCentral(String supportedPlatform, Path balaCacheDirPath) throws CentralClientException {
         Settings settings;
-        try {
-            settings = RepoUtils.readSettings();
-            // Ignore Settings.toml diagnostics in the pull command
-        } catch (SettingsTomlException e) {
-            // Ignore 'Settings.toml' parsing errors and return empty Settings object
-            settings = Settings.from();
-        }
+        settings = RepoUtils.readSettings();
+        // Ignore Settings.toml diagnostics in the pull command
+
         System.setProperty(CentralClientConstants.ENABLE_OUTPUT_STREAM, "true");
         CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                 initializeProxy(settings.getProxy()), settings.getProxy().username(),
@@ -655,13 +650,9 @@ public class ToolCommand implements BLauncherCmd {
     private void searchToolsInCentral(String keyword) {
         try {
             Settings settings;
-            try {
-                settings = RepoUtils.readSettings();
-                // Ignore Settings.toml diagnostics in the search command
-            } catch (SettingsTomlException e) {
-                // Ignore 'Settings.toml' parsing errors and return empty Settings object
-                settings = Settings.from();
-            }
+            settings = RepoUtils.readSettings();
+            // Ignore Settings.toml diagnostics in the search command
+
             CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                     initializeProxy(settings.getProxy()), settings.getProxy().username(),
                     settings.getProxy().password(), getAccessTokenOfCLI(settings),
@@ -817,13 +808,9 @@ public class ToolCommand implements BLauncherCmd {
     private String getLatestVersionForUpdateCommand(String supportedPlatforms, BalToolsManifest.Tool tool)
             throws CentralClientException {
         Settings settings;
-        try {
-            settings = RepoUtils.readSettings();
-            // Ignore Settings.toml diagnostics in the pull command
-        } catch (SettingsTomlException e) {
-            // Ignore 'Settings.toml' parsing errors and return empty Settings object
-            settings = Settings.from();
-        }
+        settings = RepoUtils.readSettings();
+        // Ignore Settings.toml diagnostics in the pull command
+
         System.setProperty(CentralClientConstants.ENABLE_OUTPUT_STREAM, "true");
         CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                 initializeProxy(settings.getProxy()), settings.getProxy().username(),

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunBuildToolsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunBuildToolsTask.java
@@ -46,7 +46,6 @@ import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import org.ballerinalang.central.client.CentralAPIClient;
 import org.ballerinalang.central.client.CentralClientConstants;
 import org.ballerinalang.central.client.exceptions.CentralClientException;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.File;
@@ -306,13 +305,9 @@ public class RunBuildToolsTask implements Task {
                 .collect(Collectors.joining(","));
         Path balaCacheDirPath = BuildToolUtils.getCentralBalaDirPath();
         Settings settings;
-        try {
-            settings = RepoUtils.readSettings();
-            // Ignore Settings.toml diagnostics in the pull command
-        } catch (SettingsTomlException e) {
-            // Ignore 'Settings.toml' parsing errors and return empty Settings object
-            settings = Settings.from();
-        }
+        settings = RepoUtils.readSettings();
+        // Ignore Settings.toml diagnostics in the pull command
+
         System.setProperty(CentralClientConstants.ENABLE_OUTPUT_STREAM, Boolean.TRUE.toString());
         CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                 initializeProxy(settings.getProxy()), settings.getProxy().username(),

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/CentralUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/CentralUtils.java
@@ -20,7 +20,6 @@ package io.ballerina.cli.utils;
 import io.ballerina.cli.launcher.LauncherUtils;
 import io.ballerina.projects.Settings;
 import org.ballerinalang.central.client.CentralAPIClient;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.IOException;
@@ -51,7 +50,7 @@ public final class CentralUtils {
      * Checks if the access token is available in Settings.toml or not.
      */
     public static void authenticate(PrintStream errStream, String ballerinaCentralCliTokenUrl,
-                                    Path settingsTomlFilePath, CentralAPIClient client) throws SettingsTomlException {
+                                    Path settingsTomlFilePath, CentralAPIClient client) {
         String accessToken = client.accessToken();
 
         if (accessToken.isEmpty()) {

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PullCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PullCommandTest.java
@@ -21,7 +21,6 @@ package io.ballerina.cli.cmd;
 import io.ballerina.projects.Settings;
 import io.ballerina.projects.TomlDocument;
 import io.ballerina.projects.internal.SettingsBuilder;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -147,7 +146,7 @@ public class PullCommandTest extends BaseCommandTest {
     }
 
     @Test(description = "Pull a package from custom remote repository")
-    public void testPullCustom() throws SettingsTomlException, IOException {
+    public void testPullCustom() {
 
         Path customrRepoPath = Paths.get("src", "test", "resources", "test-resources", "custom-repo",
                 "repositories", "repo-push-pull");
@@ -169,7 +168,7 @@ public class PullCommandTest extends BaseCommandTest {
     }
 
     @Test(description = "Pull a package from custom remote repository(not exist in Settings.toml)")
-    public void testPullNonExistingCustom() throws SettingsTomlException, IOException {
+    public void testPullNonExistingCustom() throws IOException {
 
         Path customrRepoPath = Paths.get("src", "test", "resources", "test-resources", "custom-repo",
                 "repositories", "repo-push-pull");
@@ -191,7 +190,7 @@ public class PullCommandTest extends BaseCommandTest {
                 "Only repositories mentioned in the Settings.toml are supported.\n"));
     }
 
-    private static Settings readMockSettings(Path settingsFilePath, String repoPath) throws SettingsTomlException {
+    private static Settings readMockSettings(Path settingsFilePath, String repoPath) {
         try {
             String settingString = Files.readString(settingsFilePath);
             settingString = settingString.replaceAll("REPO_PATH", repoPath);

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/ShellCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/ShellCommandTest.java
@@ -110,7 +110,7 @@ public class ShellCommandTest extends BaseCommandTest {
                             shellPrompt, testCase[0], testCase[1], shellPrompt);
                     Assert.assertEquals(filteredString(exprResponse), filteredString(expectedExprResponse));
                 }
-            } catch (IOException | InterruptedException ignored) {
+            } catch (IOException ignored) {
             }
         });
         testIntegratorThread.start();
@@ -137,7 +137,7 @@ public class ShellCommandTest extends BaseCommandTest {
         return data.toString();
     }
 
-    private void sendRequest(PrintStream stream, String string) throws InterruptedException {
+    private void sendRequest(PrintStream stream, String string) {
         stream.append(string);
         stream.println(System.lineSeparator());
         stream.flush();

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/utils/TestCentralUtils.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/utils/TestCentralUtils.java
@@ -1,7 +1,6 @@
 package io.ballerina.cli.utils;
 
 import io.ballerina.projects.Settings;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -21,7 +20,7 @@ public class TestCentralUtils {
     private static final Path UTILS_TEST_RESOURCES = Paths.get("src/test/resources/test-resources/central-utils");
 
     @Test(description = "Test get access token from Settings.toml")
-    public void testGetAccessTokenOfCliFromSettings() throws SettingsTomlException {
+    public void testGetAccessTokenOfCliFromSettings() {
         try (MockedStatic<RepoUtils> repoUtils = Mockito.mockStatic(RepoUtils.class)) {
             repoUtils.when(RepoUtils::createAndGetHomeReposPath).thenReturn(UTILS_TEST_RESOURCES);
             Settings settings = RepoUtils.readSettings();
@@ -30,7 +29,7 @@ public class TestCentralUtils {
     }
 
     @Test(description = "Test read settings")
-    public void testReadSettings() throws SettingsTomlException {
+    public void testReadSettings() {
         try (MockedStatic<RepoUtils> repoUtils = Mockito.mockStatic(RepoUtils.class)) {
             repoUtils.when(RepoUtils::createAndGetHomeReposPath).thenReturn(UTILS_TEST_RESOURCES);
             Settings settings = RepoUtils.readSettings();

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -54,8 +54,6 @@ import org.ballerinalang.central.client.model.ToolSearchResult;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.Proxy;
-import java.net.SocketTimeoutException;
-import java.net.UnknownHostException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -287,9 +285,6 @@ public class CentralAPIClient {
             }
 
             throw new CentralClientException(ERR_CANNOT_FIND_PACKAGE + packageSignature);
-        } catch (SocketTimeoutException e) {
-            throw new ConnectionErrorException(ERR_CANNOT_FIND_PACKAGE + packageSignature + ". reason: " +
-                    e.getMessage());
         } catch (IOException e) {
             throw new CentralClientException(ERR_CANNOT_FIND_PACKAGE + packageSignature + ". reason: " +
                     e.getMessage());
@@ -373,9 +368,6 @@ public class CentralAPIClient {
             }
 
             throw new CentralClientException(ERR_CANNOT_FIND_VERSIONS + packageSignature + ".");
-        } catch (SocketTimeoutException | UnknownHostException e) {
-            throw new ConnectionErrorException(ERR_CANNOT_FIND_VERSIONS + packageSignature + ". reason: " +
-                    e.getMessage());
         } catch (IOException e) {
             throw new CentralClientException(ERR_CANNOT_FIND_VERSIONS + packageSignature + ". reason: " +
                     e.getMessage());
@@ -1825,11 +1817,10 @@ public class CentralAPIClient {
      * @param org          org name
      * @param body         response body
      * @param responseBody error message
-     * @throws IOException            when accessing response body
      * @throws CentralClientException with unauthorized error message
      */
     private void handleUnauthorizedResponse(String org, Optional<ResponseBody> body, String responseBody)
-            throws IOException, CentralClientException {
+            throws CentralClientException {
         if (body.isPresent()) {
             Optional<MediaType> contentType = Optional.ofNullable(body.get().contentType());
             if (contentType.isPresent() && isApplicationJsonContentType(contentType.get().toString())) {
@@ -1848,11 +1839,10 @@ public class CentralAPIClient {
      *
      * @param body         response body
      * @param responseBody error message
-     * @throws IOException            when accessing response body
      * @throws CentralClientException with unauthorized error message
      */
     private void handleUnauthorizedResponse(Optional<ResponseBody> body, String responseBody)
-            throws IOException, CentralClientException {
+            throws CentralClientException {
         if (body.isPresent()) {
             Optional<MediaType> contentType = Optional.ofNullable(body.get().contentType());
             if (contentType.isPresent() && isApplicationJsonContentType(contentType.get().toString())) {
@@ -1871,11 +1861,10 @@ public class CentralAPIClient {
      *
      * @param mediaType mediaType
      * @param responseBody response body
-     * @throws IOException            when accessing response body
      * @throws CentralClientException with unauthorized error message
      */
     private void handleUnauthorizedResponse(MediaType mediaType, String responseBody)
-            throws IOException, CentralClientException {
+            throws CentralClientException {
         Optional<MediaType> contentType = Optional.ofNullable(mediaType);
         StringBuilder message = new StringBuilder("unauthorized access token. " +
                     "check access token set in 'Settings.toml' file.");

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
@@ -594,7 +594,7 @@ public final class Utils {
      * A listener interface that allows tracking byte writing.
      */
     public interface ProgressListener {
-        void onRequestProgress(long bytesWritten, long contentLength) throws IOException;
+        void onRequestProgress(long bytesWritten, long contentLength);
     }
 
     /**

--- a/cli/central-client/src/test/java/org/ballerinalang/central/client/TestCustomRetryInterceptor.java
+++ b/cli/central-client/src/test/java/org/ballerinalang/central/client/TestCustomRetryInterceptor.java
@@ -92,10 +92,10 @@ public class TestCustomRetryInterceptor {
 
     @Test(description = "Return successful response before retry maximum is reached.", dependsOnMethods = "testRetries")
     public void testRetries2() throws IOException {
-        String expectedOutputPrefix =  "* Retrying request to http://localhost:57803/ " +
+        String expectedOutputPrefix =  "* Retrying request to http://localhost:57804/ " +
                 "due to 502 response code. Retry attempt: ";
         mockWebServer = new MockWebServer();
-        mockWebServer.start(PORT);
+        mockWebServer.start(PORT + 1);
         mockWebServer.enqueue(new MockResponse().setResponseCode(HttpURLConnection.HTTP_BAD_GATEWAY));
         mockWebServer.enqueue(new MockResponse().setResponseCode(HttpURLConnection.HTTP_BAD_GATEWAY));
         mockWebServer.enqueue(new MockResponse().setResponseCode(HttpURLConnection.HTTP_OK));

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildToolResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildToolResolution.java
@@ -31,7 +31,6 @@ import org.ballerinalang.central.client.CentralAPIClient;
 import org.ballerinalang.central.client.exceptions.CentralClientException;
 import org.ballerinalang.central.client.model.ToolResolutionCentralRequest;
 import org.ballerinalang.central.client.model.ToolResolutionCentralResponse;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.util.ArrayList;
@@ -227,11 +226,7 @@ public class BuildToolResolution {
     private List<BuildTool> getToolResolutionResponse(ToolResolutionCentralRequest toolResolutionRequest)
             throws CentralClientException {
         Settings settings;
-        try {
-            settings = RepoUtils.readSettings();
-        } catch (SettingsTomlException e) {
-            settings = Settings.from();
-        }
+        settings = RepoUtils.readSettings();
         CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                 initializeProxy(settings.getProxy()), settings.getProxy().username(),
                 settings.getProxy().password(), getAccessTokenOfCLI(settings),

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Target.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/Target.java
@@ -242,7 +242,7 @@ public class Target {
     /**
      * Clean any files that created from the build.
      */
-    public void clean(boolean isModified, boolean cacheEnabled) throws IOException {
+    public void clean(boolean isModified, boolean cacheEnabled) {
         if (isModified || !cacheEnabled) {
             // Remove from cache
             ProjectUtils.deleteDirectory(this.cache);
@@ -259,7 +259,7 @@ public class Target {
     /**
      * Clean cache files that created from the build.
      */
-    public void cleanCache() throws IOException {
+    public void cleanCache() {
         // Remove from cache
         ProjectUtils.deleteDirectory(this.cache);
     }
@@ -274,7 +274,7 @@ public class Target {
         return nativeConfigPath;
     }
 
-    public void cleanBinTests() throws IOException {
+    public void cleanBinTests() {
         ProjectUtils.deleteDirectory(this.binPath.resolve(ProjectConstants.TEST_DIR_NAME));
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/MavenPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/MavenPackageRepository.java
@@ -36,9 +36,7 @@ import io.ballerina.projects.util.ProjectUtils;
 import org.apache.commons.io.FileUtils;
 import org.ballerinalang.maven.bala.client.MavenResolverClient;
 import org.ballerinalang.maven.bala.client.MavenResolverClientException;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.wso2.ballerinalang.util.RepoUtils;
-
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -92,11 +90,7 @@ public class MavenPackageRepository extends AbstractPackageRepository {
         }
 
         Settings settings;
-        try {
-            settings = RepoUtils.readSettings();
-        } catch (SettingsTomlException e) {
-            settings = Settings.from();
-        }
+        settings = RepoUtils.readSettings();
         Proxy proxy = settings.getProxy();
         mvnClient.setProxy(proxy.host(), proxy.port(), proxy.username(), proxy.password());
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
@@ -418,8 +418,7 @@ public final class FileUtils {
         }
 
         @Override
-        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
-                throws IOException {
+        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
 
             int depth = dir.getNameCount() - startingPath.getNameCount();
             if (depth >= 10) {
@@ -429,8 +428,7 @@ public final class FileUtils {
         }
 
         @Override
-        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                throws IOException {
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
 
             if (FILE_MATCHER.matches(file)) {
                 setBallerinaTomlFound(true);

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/CompilerOutputEntry.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/CompilerOutputEntry.java
@@ -17,7 +17,6 @@
  */
 package org.ballerinalang.repository;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -67,7 +66,6 @@ public interface CompilerOutputEntry {
      * Returns the content as an input stream.
      *
      * @return the {@link InputStream} of the entry
-     * @throws IOException if input is not resolved
      */
-    InputStream getInputStream() throws IOException;
+    InputStream getInputStream();
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -1071,7 +1071,7 @@ public class BIRPackageSymbolEnter {
         return stringCPEntry.value;
     }
 
-    private String getStringCPEntryValue(int cpIndex) throws IOException {
+    private String getStringCPEntryValue(int cpIndex) {
         StringCPEntry stringCPEntry = (StringCPEntry) this.env.constantPool[cpIndex];
         return stringCPEntry.value;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FilterSearch.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FilterSearch.java
@@ -23,7 +23,7 @@ class FilterSearch<T> extends SimpleFileVisitor<T> {
     }
 
     @Override
-    public FileVisitResult preVisitDirectory(Object dir, BasicFileAttributes attrs) throws IOException {
+    public FileVisitResult preVisitDirectory(Object dir, BasicFileAttributes attrs) {
         if (!isExcluded((Path) dir)) {
             return FileVisitResult.CONTINUE;
         } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
@@ -22,7 +22,6 @@ import io.ballerina.projects.TomlDocument;
 import io.ballerina.projects.internal.SettingsBuilder;
 import io.ballerina.projects.util.ProjectConstants;
 import org.ballerinalang.compiler.BLangCompilerException;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.ballerinalang.toml.exceptions.TomlException;
 import org.ballerinalang.toml.model.Manifest;
 import org.ballerinalang.toml.parser.ManifestProcessor;
@@ -338,7 +337,7 @@ public final class RepoUtils {
      *
      * @return {@link Settings} settings object
      */
-    public static Settings readSettings() throws SettingsTomlException {
+    public static Settings readSettings() {
         Path settingsFilePath = RepoUtils.createAndGetHomeReposPath().resolve(ProjectConstants.SETTINGS_FILE_NAME);
         try {
             TomlDocument settingsTomlDocument = TomlDocument

--- a/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/BLangNodeTransformerTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/BLangNodeTransformerTest.java
@@ -54,7 +54,7 @@ public class BLangNodeTransformerTest {
 
     @Test(dataProvider = "testTransformationTestProvider", enabled = false)
     public void testTransformation(String configName, String sourcePackage)
-            throws IOException, IllegalAccessException {
+            throws IllegalAccessException {
         // Get expected result json
         JsonObject expJsonObj = fileContentAsObject(configName);
 

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/codelenses/spi/LSCodeLensesProvider.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/codelenses/spi/LSCodeLensesProvider.java
@@ -17,7 +17,6 @@ package org.ballerinalang.langserver.commons.codelenses.spi;
 
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
-import org.ballerinalang.langserver.commons.codelenses.LSCodeLensesProviderException;
 import org.eclipse.lsp4j.CodeLens;
 
 import java.util.List;
@@ -40,9 +39,8 @@ public interface LSCodeLensesProvider {
      *
      * @param context           Language Server Context
      * @return {@link List}     List of code lenses
-     * @throws LSCodeLensesProviderException exception while executing the code lenses provider
      */
-    List<CodeLens> getLenses(DocumentServiceContext context) throws LSCodeLensesProviderException;
+    List<CodeLens> getLenses(DocumentServiceContext context);
 
     /**
      * Mark code lenses provider is enabled or not.

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/workspace/LSDocumentIdentifier.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/workspace/LSDocumentIdentifier.java
@@ -15,9 +15,7 @@
  */
 package org.ballerinalang.langserver.commons.workspace;
 
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -43,10 +41,8 @@ public interface LSDocumentIdentifier {
      * Get the URI of the given string URI.
      *
      * @return {@link URI} get the URI
-     * @throws MalformedURLException can throw malformed url exception
-     * @throws URISyntaxException    can throw URI syntax exception
      */
-    URI getURI() throws MalformedURLException, URISyntaxException;
+    URI getURI();
 
     /**
      * Get the uri.

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/workspace/WorkspaceDocumentManager.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/workspace/WorkspaceDocumentManager.java
@@ -54,9 +54,8 @@ public interface WorkspaceDocumentManager {
      *
      * @param filePath Path of the file
      * @param content  Content of the file
-     * @throws WorkspaceDocumentException when file cannot be opened.
      */
-    void openFile(Path filePath, String content) throws WorkspaceDocumentException;
+    void openFile(Path filePath, String content);
 
     /**
      * Updates given file in document manager with new content.
@@ -73,10 +72,8 @@ public interface WorkspaceDocumentManager {
      *
      * @param filePath       Path of the file
      * @param updatedContent New content of the file
-     * @throws WorkspaceDocumentException when file cannot be updated.
      */
-    void updateFile(Path filePath, List<TextDocumentContentChangeEvent> updatedContent)
-            throws WorkspaceDocumentException;
+    void updateFile(Path filePath, List<TextDocumentContentChangeEvent> updatedContent);
 
     /**
      * Updates code lenses of a given file in document manager with new code lenses sent to client.
@@ -93,9 +90,8 @@ public interface WorkspaceDocumentManager {
      *
      * @param filePath Path of the file
      * @param codeLens New code lenses of the file
-     * @throws WorkspaceDocumentException when file cannot be updated.
      */
-    void setCodeLenses(Path filePath, List<CodeLens> codeLens) throws WorkspaceDocumentException;
+    void setCodeLenses(Path filePath, List<CodeLens> codeLens);
 
     /**
      * Returns the code lenses of the file.
@@ -110,28 +106,25 @@ public interface WorkspaceDocumentManager {
      *
      * @param filePath Path of the file
      * @return LSDocument of the file
-     * @throws WorkspaceDocumentException when the LSDocument is not available
      */
-    LSDocumentIdentifier getLSDocument(Path filePath) throws WorkspaceDocumentException;
+    LSDocumentIdentifier getLSDocument(Path filePath);
 
     /**
      * Close the given file in document manager.
      *
      * @param filePath Path of the file
-     * @throws WorkspaceDocumentException when file cannot be closed.
      */
-    void closeFile(Path filePath) throws WorkspaceDocumentException;
+    void closeFile(Path filePath);
 
     /**
      * Returns the content of the file.
      *
      * @param filePath Path of the file
      * @return Content of the file
-     * @throws WorkspaceDocumentException when file cannot be read.
      * @deprecated Use #getTree(Path filePath) instead
      */
     @Deprecated
-    String getFileContent(Path filePath) throws WorkspaceDocumentException;
+    String getFileContent(Path filePath);
 
     /**
      * Acquire a file lock.
@@ -168,16 +161,14 @@ public interface WorkspaceDocumentManager {
      *
      * @param filePath Path of the file
      * @return SyntaxTree
-     * @throws WorkspaceDocumentException when document read failed
      */
-    SyntaxTree getTree(Path filePath) throws WorkspaceDocumentException;
+    SyntaxTree getTree(Path filePath);
 
     /**
      * Set the new tree.
      *
      * @param filePath Path of the file
      * @param newTree  new tree
-     * @throws WorkspaceDocumentException when file is not open
      */
-    void setTree(Path filePath, SyntaxTree newTree) throws WorkspaceDocumentException;
+    void setTree(Path filePath, SyntaxTree newTree);
 }

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/workspace/WorkspaceManager.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/workspace/WorkspaceManager.java
@@ -208,9 +208,8 @@ public interface WorkspaceManager {
      *
      * @param filePath {@link Path} of the document
      * @param params   {@link DidCloseTextDocumentParams}
-     * @throws WorkspaceDocumentException project not found
      */
-    void didClose(Path filePath, DidCloseTextDocumentParams params) throws WorkspaceDocumentException;
+    void didClose(Path filePath, DidCloseTextDocumentParams params);
 
     /**
      * The file change notification is sent from the client to the server to signal changes to watched files.

--- a/language-server/modules/langserver-commons/src/test/java/org/ballerina/langserver/commons/toml/completion/SchemaVisitorTest.java
+++ b/language-server/modules/langserver-commons/src/test/java/org/ballerina/langserver/commons/toml/completion/SchemaVisitorTest.java
@@ -43,7 +43,7 @@ import java.util.Map;
 public class SchemaVisitorTest {
 
     @Test(dataProvider = "testDataProvider")
-    public void test(String configFileName) throws IOException {
+    public void test(String configFileName) {
         String configPath = FileUtils.RES_DIR.resolve("toml").resolve("completion")
                 .resolve("schema_visitor").resolve("config").resolve(configFileName).toString();
         JsonObject configJson =

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/CodeLensUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/CodeLensUtil.java
@@ -15,13 +15,9 @@
  */
 package org.ballerinalang.langserver.codelenses;
 
-import org.ballerinalang.langserver.LSClientLogger;
-import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
-import org.ballerinalang.langserver.commons.codelenses.LSCodeLensesProviderException;
 import org.ballerinalang.langserver.commons.codelenses.spi.LSCodeLensesProvider;
 import org.eclipse.lsp4j.CodeLens;
-import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 
 import java.util.ArrayList;
@@ -47,16 +43,9 @@ public final class CodeLensUtil {
         List<CodeLens> lenses = new ArrayList<>();
         List<LSCodeLensesProvider> providers = LSCodeLensesProviderHolder
                 .getInstance(codeLensContext.languageServercontext()).getProviders();
-        LSClientLogger clientLogger = LSClientLogger.getInstance(codeLensContext.languageServercontext());
         for (LSCodeLensesProvider provider : providers) {
-            try {
-                codeLensContext.checkCancelled();
-                lenses.addAll(provider.getLenses(codeLensContext));
-            } catch (LSCodeLensesProviderException e) {
-                clientLogger.logError(LSContextOperation.TXT_CODE_LENS,
-                        "Error while retrieving lenses from: " + provider.getName(), e, txtDoc,
-                        (Position) null);
-            }
+            codeLensContext.checkCancelled();
+            lenses.addAll(provider.getLenses(codeLensContext));
         }
         return lenses;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/AbstractDocumentationExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/AbstractDocumentationExecutor.java
@@ -30,7 +30,6 @@ import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.PathUtil;
 import org.ballerinalang.langserver.commons.ExecuteCommandContext;
 import org.ballerinalang.langserver.commons.command.CommandArgument;
-import org.ballerinalang.langserver.commons.command.LSCommandExecutorException;
 import org.ballerinalang.langserver.commons.command.spi.LSCommandExecutor;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
@@ -58,7 +57,7 @@ public abstract class AbstractDocumentationExecutor implements LSCommandExecutor
      * @param ctx
      */
     @Override
-    public Object execute(ExecuteCommandContext ctx) throws LSCommandExecutorException {
+    public Object execute(ExecuteCommandContext ctx) {
         String documentUri = "";
         Range nodeRange = null;
         VersionedTextDocumentIdentifier textDocumentIdentifier = new VersionedTextDocumentIdentifier();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -28,7 +28,6 @@ import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.ExecuteCommandContext;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
 import org.ballerinalang.langserver.commons.command.CommandArgument;
-import org.ballerinalang.langserver.commons.command.LSCommandExecutorException;
 import org.ballerinalang.langserver.commons.command.spi.LSCommandExecutor;
 import org.ballerinalang.langserver.commons.eventsync.EventKind;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
@@ -70,7 +69,7 @@ public class PullModuleExecutor implements LSCommandExecutor {
      * @param context
      */
     @Override
-    public Object execute(ExecuteCommandContext context) throws LSCommandExecutorException {
+    public Object execute(ExecuteCommandContext context) {
         String fileUri = null;
         String moduleName = null;
         for (CommandArgument arg : context.getArguments()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/ReportFeatureUsageExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/ReportFeatureUsageExecutor.java
@@ -18,7 +18,6 @@ package org.ballerinalang.langserver.command.executors;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.ExecuteCommandContext;
 import org.ballerinalang.langserver.commons.command.CommandArgument;
-import org.ballerinalang.langserver.commons.command.LSCommandExecutorException;
 import org.ballerinalang.langserver.commons.command.spi.LSCommandExecutor;
 import org.ballerinalang.langserver.telemetry.LSFeatureUsageTelemetryEvent;
 import org.ballerinalang.langserver.telemetry.TelemetryUtil;
@@ -37,7 +36,7 @@ public class ReportFeatureUsageExecutor implements LSCommandExecutor {
     public static final String COMMAND = "REPORT_FEATURE_USAGE";
 
     @Override
-    public Object execute(ExecuteCommandContext context) throws LSCommandExecutorException {
+    public Object execute(ExecuteCommandContext context) {
         List<CommandArgument> arguments = context.getArguments();
 
         if (arguments == null || arguments.isEmpty()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/StopExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/StopExecutor.java
@@ -18,7 +18,6 @@ package org.ballerinalang.langserver.command.executors;
 import com.google.gson.JsonPrimitive;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.ExecuteCommandContext;
-import org.ballerinalang.langserver.commons.command.LSCommandExecutorException;
 import org.ballerinalang.langserver.commons.command.spi.LSCommandExecutor;
 
 import java.nio.file.Path;
@@ -33,7 +32,7 @@ import java.nio.file.Path;
 public class StopExecutor implements LSCommandExecutor {
 
     @Override
-    public Boolean execute(ExecuteCommandContext context) throws LSCommandExecutorException {
+    public Boolean execute(ExecuteCommandContext context) {
         return context.workspace().stop(extractPath(context));
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompilerPluginCompletionExtension.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompilerPluginCompletionExtension.java
@@ -65,7 +65,7 @@ public class CompilerPluginCompletionExtension implements CompletionExtension {
 
     @Override
     public List<CompletionItem> execute(CompletionParams inputParams, CompletionContext context,
-                                        LanguageServerContext serverContext) throws Throwable {
+                                        LanguageServerContext serverContext) {
 
         return Collections.emptyList();
     }
@@ -74,7 +74,7 @@ public class CompilerPluginCompletionExtension implements CompletionExtension {
     public List<CompletionItem> execute(CompletionParams inputParams,
                                         CompletionContext context,
                                         LanguageServerContext serverContext,
-                                        CancelChecker cancelChecker) throws Throwable {
+                                        CancelChecker cancelChecker) {
         Optional<PackageCompilation> packageCompilation =
                 context.workspace().waitAndGetPackageCompilation(context.filePath());
         if (packageCompilation.isEmpty() || context.currentDocument().isEmpty() ||

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AsyncSendActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AsyncSendActionNodeContext.java
@@ -18,7 +18,6 @@ package org.ballerinalang.langserver.completions.providers.context;
 import io.ballerina.compiler.syntax.tree.AsyncSendActionNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.util.SortingUtil;
 
@@ -37,8 +36,7 @@ public class AsyncSendActionNodeContext extends RightArrowActionNodeContext<Asyn
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, AsyncSendActionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, AsyncSendActionNode node) {
         List<LSCompletionItem> completionItems = this.getFilteredItems(context, node, node.expression());
         this.sort(context, node, completionItems);
         

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ClientResourceAccessActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ClientResourceAccessActionNodeContext.java
@@ -45,7 +45,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SymbolCompletionItem;
 import org.ballerinalang.langserver.completions.builder.ResourcePathCompletionItemBuilder;
@@ -76,7 +75,7 @@ public class ClientResourceAccessActionNodeContext
 
     @Override
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context,
-                                                 ClientResourceAccessActionNode node) throws LSCompletionException {
+                                                 ClientResourceAccessActionNode node) {
 
         List<LSCompletionItem> completionItems = new ArrayList<>();
         if (onSuggestClients(node, context)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ComputedResourceAccessSegmentNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ComputedResourceAccessSegmentNodeContext.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -47,7 +46,7 @@ public class ComputedResourceAccessSegmentNodeContext extends
 
     @Override
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context,
-                                                 ComputedResourceAccessSegmentNode node) throws LSCompletionException {
+                                                 ComputedResourceAccessSegmentNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         if (QNameRefCompletionUtil.onQualifiedNameIdentifier(context, node.expression())) {
             /*

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ConditionalExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ConditionalExpressionNodeContext.java
@@ -25,7 +25,6 @@ import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -48,8 +47,7 @@ public class ConditionalExpressionNodeContext extends AbstractCompletionProvider
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ConditionalExpressionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ConditionalExpressionNode node) {
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
         List<LSCompletionItem> completionItems = new ArrayList<>();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/DefaultableParameterNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/DefaultableParameterNodeContext.java
@@ -22,7 +22,6 @@ import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -45,8 +44,7 @@ public class DefaultableParameterNodeContext extends AbstractCompletionProvider<
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, DefaultableParameterNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, DefaultableParameterNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = ctx.getNodeAtCursor();
         if (this.onQualifiedNameIdentifier(ctx, nodeAtCursor)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/EnumDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/EnumDeclarationNodeContext.java
@@ -19,7 +19,6 @@ import io.ballerina.compiler.syntax.tree.EnumDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 
@@ -38,8 +37,7 @@ public class EnumDeclarationNodeContext extends AbstractCompletionProvider<EnumD
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, EnumDeclarationNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, EnumDeclarationNode node) {
         return Collections.emptyList();
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/EnumMemberNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/EnumMemberNodeContext.java
@@ -25,7 +25,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -48,8 +47,7 @@ public class EnumMemberNodeContext extends AbstractCompletionProvider<EnumMember
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, EnumMemberNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, EnumMemberNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = ctx.getNodeAtCursor();
         List<Symbol> visibleSymbols = new ArrayList<>();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ExpressionFunctionBodyNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ExpressionFunctionBodyNodeContext.java
@@ -22,7 +22,6 @@ import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -45,8 +44,7 @@ public class ExpressionFunctionBodyNodeContext extends AbstractCompletionProvide
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, ExpressionFunctionBodyNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, ExpressionFunctionBodyNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = ctx.getNodeAtCursor();
         if (QNameRefCompletionUtil.onQualifiedNameIdentifier(ctx, nodeAtCursor)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ExternalFunctionBodyNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ExternalFunctionBodyNodeContext.java
@@ -18,7 +18,6 @@ package org.ballerinalang.langserver.completions.providers.context;
 import io.ballerina.compiler.syntax.tree.ExternalFunctionBodyNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -39,8 +38,7 @@ public class ExternalFunctionBodyNodeContext extends AbstractCompletionProvider<
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ExternalFunctionBodyNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ExternalFunctionBodyNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
 
         if (node.externalKeyword().isMissing()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FailStatementNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FailStatementNodeContext.java
@@ -29,7 +29,6 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SymbolCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -53,8 +52,7 @@ public class FailStatementNodeContext extends AbstractCompletionProvider<FailSta
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, FailStatementNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, FailStatementNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode symbolAtCursor = context.getNodeAtCursor();
         if (symbolAtCursor.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessExpressionNodeContext.java
@@ -20,7 +20,6 @@ import io.ballerina.compiler.syntax.tree.FieldAccessExpressionNode;
 import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 
 import java.util.List;
@@ -38,8 +37,7 @@ public class FieldAccessExpressionNodeContext
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, FieldAccessExpressionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, FieldAccessExpressionNode node) {
         ExpressionNode expression = node.expression();
         List<LSCompletionItem> completionItems = getEntries(context, expression);
         this.sort(context, node, completionItems);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FlushActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FlushActionNodeContext.java
@@ -20,7 +20,6 @@ import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.FlushActionNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -41,8 +40,7 @@ public class FlushActionNodeContext extends AbstractCompletionProvider<FlushActi
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, FlushActionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, FlushActionNode node) {
         // TODO: Following logic can be generalized
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         List<Symbol> filteredWorkers = visibleSymbols.stream()

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ForEachStatementNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ForEachStatementNodeContext.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
 import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -45,8 +44,7 @@ public class ForEachStatementNodeContext extends AbstractCompletionProvider<ForE
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ForEachStatementNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ForEachStatementNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
 
         if (withinTypeDescContext(context, node)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ForkStatementNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ForkStatementNodeContext.java
@@ -18,7 +18,6 @@ package org.ballerinalang.langserver.completions.providers.context;
 import io.ballerina.compiler.syntax.tree.ForkStatementNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -39,8 +38,7 @@ public class ForkStatementNodeContext extends AbstractCompletionProvider<ForkSta
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ForkStatementNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ForkStatementNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_WORKER.get()));
         return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FunctionCallExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FunctionCallExpressionNodeContext.java
@@ -24,7 +24,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
 
@@ -45,8 +44,7 @@ public class FunctionCallExpressionNodeContext extends InvocationNodeContextProv
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, FunctionCallExpressionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, FunctionCallExpressionNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         if (QNameRefCompletionUtil.onQualifiedNameIdentifier(ctx, ctx.getNodeAtCursor())) {
             QualifiedNameReferenceNode qNameRef = (QualifiedNameReferenceNode) ctx.getNodeAtCursor();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/IfElseStatementNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/IfElseStatementNodeContext.java
@@ -24,7 +24,6 @@ import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -46,8 +45,7 @@ public class IfElseStatementNodeContext extends AbstractCompletionProvider<IfEls
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, IfElseStatementNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, IfElseStatementNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
         if (this.onQualifiedNameIdentifier(context, nodeAtCursor)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImplicitAnonymousFunctionExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImplicitAnonymousFunctionExpressionNodeContext.java
@@ -19,7 +19,6 @@ import io.ballerina.compiler.syntax.tree.ImplicitAnonymousFunctionExpressionNode
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 
 import java.util.Collections;
@@ -40,8 +39,7 @@ public class ImplicitAnonymousFunctionExpressionNodeContext
 
     @Override
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context,
-                                                 ImplicitAnonymousFunctionExpressionNode node)
-            throws LSCompletionException {
+                                                 ImplicitAnonymousFunctionExpressionNode node) {
         if (withinExpression(node, context)) {
             List<LSCompletionItem> completionItems = this.initializerContextCompletions(context, node.expression());
             this.sort(context, node, completionItems);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/IncludedRecordParameterNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/IncludedRecordParameterNodeContext.java
@@ -25,7 +25,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -49,8 +48,7 @@ public class IncludedRecordParameterNodeContext extends AbstractCompletionProvid
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, IncludedRecordParameterNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, IncludedRecordParameterNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = ctx.getNodeAtCursor();
         Predicate<Symbol> predicate = symbol -> symbol.kind() == SymbolKind.TYPE_DEFINITION

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/IndexedExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/IndexedExpressionNodeContext.java
@@ -21,7 +21,6 @@ import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -42,8 +41,7 @@ public class IndexedExpressionNodeContext extends AbstractCompletionProvider<Ind
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, IndexedExpressionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, IndexedExpressionNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/IntersectionTypeDescriptorNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/IntersectionTypeDescriptorNodeContext.java
@@ -21,7 +21,6 @@ import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -44,7 +43,7 @@ public class IntersectionTypeDescriptorNodeContext extends AbstractCompletionPro
 
     @Override
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context,
-                                                 IntersectionTypeDescriptorNode node) throws LSCompletionException {
+                                                 IntersectionTypeDescriptorNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/InvocationNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/InvocationNodeContextProvider.java
@@ -37,7 +37,6 @@ import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.NameUtil;
 import org.ballerinalang.langserver.common.utils.TypeResolverUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.NamedArgCompletionItem;
 import org.ballerinalang.langserver.completions.builder.NamedArgCompletionItemBuilder;
@@ -65,8 +64,7 @@ public class InvocationNodeContextProvider<T extends Node> extends AbstractCompl
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, T node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, T node) {
         return Collections.emptyList();
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/KeySpecifierNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/KeySpecifierNodeContext.java
@@ -31,7 +31,6 @@ import org.ballerinalang.langserver.common.utils.RawTypeSymbolWrapper;
 import org.ballerinalang.langserver.common.utils.RecordUtil;
 import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.RecordFieldCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -57,8 +56,7 @@ public class KeySpecifierNodeContext extends AbstractCompletionProvider<KeySpeci
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, KeySpecifierNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, KeySpecifierNode node) {
         List<LSCompletionItem> completionItems = getKeyCompletionItems(context, node);
         this.sort(context, node, completionItems);
         return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListConstructorExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListConstructorExpressionNodeContext.java
@@ -32,7 +32,6 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.NameUtil;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SpreadCompletionItem;
 import org.ballerinalang.langserver.completions.builder.SpreadCompletionItemBuilder;
@@ -58,8 +57,8 @@ public class ListConstructorExpressionNodeContext extends AbstractCompletionProv
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ListConstructorExpressionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context,
+                                                 ListConstructorExpressionNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
         if (QNameRefCompletionUtil.onQualifiedNameIdentifier(context, nodeAtCursor)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListenerDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListenerDeclarationNodeContext.java
@@ -36,7 +36,6 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.ModuleUtil;
 import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.SymbolCompletionItem;
@@ -74,8 +73,7 @@ public class ListenerDeclarationNodeContext extends AbstractCompletionProvider<L
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ListenerDeclarationNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ListenerDeclarationNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
 
         Optional<ListenerDeclarationNode> listenerNode = listenerNode(context);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
@@ -33,7 +33,6 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SpreadCompletionItem;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -58,7 +57,7 @@ public class MappingConstructorExpressionNodeContext extends
 
     @Override
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context,
-                                                 MappingConstructorExpressionNode node) throws LSCompletionException {
+                                                 MappingConstructorExpressionNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
         Optional<Node> evalNode = CommonUtil.getMappingContextEvalNode(nodeAtCursor);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingMatchPatternNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingMatchPatternNodeContext.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 
 import java.util.ArrayList;
@@ -43,8 +42,7 @@ public class MappingMatchPatternNodeContext extends MappingContextProvider<Mappi
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, MappingMatchPatternNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, MappingMatchPatternNode node) {
 
         List<LSCompletionItem> completionItems = new ArrayList<>();
         Optional<Node> evalNode = CommonUtil.getMappingContextEvalNode(context.getNodeAtCursor());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MarkdownDocumentationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MarkdownDocumentationNodeContext.java
@@ -18,7 +18,6 @@ package org.ballerinalang.langserver.completions.providers.context;
 import io.ballerina.compiler.syntax.tree.MarkdownDocumentationNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 
@@ -39,7 +38,7 @@ public class MarkdownDocumentationNodeContext extends AbstractCompletionProvider
 
     @Override
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context,
-                                                 MarkdownDocumentationNode node) throws LSCompletionException {
+                                                 MarkdownDocumentationNode node) {
         // As of now, we are not showing any completions within documentation node
         return Collections.emptyList();
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MatchGuardNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MatchGuardNodeContext.java
@@ -21,7 +21,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -43,7 +42,7 @@ public class MatchGuardNodeContext extends AbstractCompletionProvider<MatchGuard
 
     @Override
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context,
-                                                 MatchGuardNode node) throws LSCompletionException {
+                                                 MatchGuardNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         if (QNameRefCompletionUtil.onQualifiedNameIdentifier(context, context.getNodeAtCursor())) {
             QualifiedNameReferenceNode qNameRef = (QualifiedNameReferenceNode) context.getNodeAtCursor();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MethodCallExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MethodCallExpressionNodeContext.java
@@ -24,7 +24,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SymbolCompletionItem;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -47,8 +46,7 @@ public class MethodCallExpressionNodeContext extends FieldAccessContext<MethodCa
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, MethodCallExpressionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, MethodCallExpressionNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         if (this.withinParameterContext(context, node)) {
             if (QNameRefCompletionUtil.onQualifiedNameIdentifier(context, context.getNodeAtCursor())) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MethodDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MethodDeclarationNodeContext.java
@@ -18,7 +18,6 @@ package org.ballerinalang.langserver.completions.providers.context;
 import io.ballerina.compiler.syntax.tree.MethodDeclarationNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -39,8 +38,7 @@ public class MethodDeclarationNodeContext extends AbstractCompletionProvider<Met
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, MethodDeclarationNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, MethodDeclarationNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
 
         if (node.functionKeyword().isMissing()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/NamedArgumentNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/NamedArgumentNodeContext.java
@@ -27,7 +27,6 @@ import io.ballerina.tools.text.TextRange;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -51,8 +50,7 @@ public class NamedArgumentNodeContext extends AbstractCompletionProvider<NamedAr
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, NamedArgumentNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, NamedArgumentNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         if (QNameRefCompletionUtil.onQualifiedNameIdentifier(context, node.expression())) {
             /*

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/OptionalFieldAccessExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/OptionalFieldAccessExpressionNodeContext.java
@@ -18,7 +18,6 @@ package org.ballerinalang.langserver.completions.providers.context;
 import io.ballerina.compiler.syntax.tree.OptionalFieldAccessExpressionNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 
 import java.util.List;
@@ -36,8 +35,8 @@ public class OptionalFieldAccessExpressionNodeContext
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, OptionalFieldAccessExpressionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx,
+                                                 OptionalFieldAccessExpressionNode node) {
         List<LSCompletionItem> completionItems = getEntries(ctx, node.expression());
         this.sort(ctx, node, completionItems);
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/PanicStatementNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/PanicStatementNodeContext.java
@@ -22,7 +22,6 @@ import io.ballerina.compiler.syntax.tree.PanicStatementNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.SortingUtil;
@@ -44,8 +43,7 @@ public class PanicStatementNodeContext extends AbstractCompletionProvider<PanicS
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, PanicStatementNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, PanicStatementNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         List<Symbol> filteredList = visibleSymbols.stream()

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/QueryExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/QueryExpressionNodeContext.java
@@ -22,7 +22,6 @@ import io.ballerina.compiler.syntax.tree.QueryExpressionNode;
 import io.ballerina.compiler.syntax.tree.QueryPipelineNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -47,8 +46,7 @@ public class QueryExpressionNodeContext extends AbstractCompletionProvider<Query
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, QueryExpressionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, QueryExpressionNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
 
         if (node.queryConstructType().isPresent() && 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ReceiveActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ReceiveActionNodeContext.java
@@ -20,7 +20,6 @@ import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.ReceiveActionNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -41,8 +40,7 @@ public class ReceiveActionNodeContext extends AbstractCompletionProvider<Receive
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ReceiveActionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ReceiveActionNode node) {
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         List<Symbol> filteredWorkers = visibleSymbols.stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.WORKER)

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RecordFieldWithDefaultValueNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RecordFieldWithDefaultValueNodeContext.java
@@ -19,7 +19,6 @@ import io.ballerina.compiler.syntax.tree.RecordFieldWithDefaultValueNode;
 import io.ballerina.tools.text.TextRange;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 
 import java.util.List;
@@ -43,8 +42,7 @@ public class RecordFieldWithDefaultValueNodeContext extends
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, RecordFieldWithDefaultValueNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, RecordFieldWithDefaultValueNode node) {
         List<LSCompletionItem> completionItems = this.initializerContextCompletions(ctx, node.expression());
         this.sort(ctx, node, completionItems);
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RemoteMethodCallActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RemoteMethodCallActionNodeContext.java
@@ -28,7 +28,6 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.common.utils.TypeResolverUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
 import org.ballerinalang.langserver.completions.util.SortingUtil;
@@ -51,8 +50,7 @@ public class RemoteMethodCallActionNodeContext extends RightArrowActionNodeConte
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, RemoteMethodCallActionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, RemoteMethodCallActionNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         if (onSuggestClients(node, context)) {
             // Covers following:

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RequiredParameterNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RequiredParameterNodeContext.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
 import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -48,8 +47,7 @@ public class RequiredParameterNodeContext extends AbstractCompletionProvider<Req
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, RequiredParameterNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, RequiredParameterNode node) {
 
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ResourcePathParameterNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ResourcePathParameterNodeContext.java
@@ -25,7 +25,6 @@ import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -46,8 +45,7 @@ public class ResourcePathParameterNodeContext extends AbstractCompletionProvider
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ResourcePathParameterNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ResourcePathParameterNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         if (!this.onTypeDescContext(context, node)) {
             return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ReturnStatementNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ReturnStatementNodeContext.java
@@ -21,7 +21,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.ReturnStatementNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -44,8 +43,7 @@ public class ReturnStatementNodeContext extends AbstractCompletionProvider<Retur
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ReturnStatementNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ReturnStatementNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
 
         if (node.expression().isPresent()

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ReturnTypeDescriptorNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ReturnTypeDescriptorNodeContext.java
@@ -20,7 +20,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.ReturnTypeDescriptorNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -42,8 +41,7 @@ public class ReturnTypeDescriptorNodeContext extends AbstractCompletionProvider<
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ReturnTypeDescriptorNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ReturnTypeDescriptorNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
 
         if (QNameRefCompletionUtil.onQualifiedNameIdentifier(context, context.getNodeAtCursor())) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ServiceDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ServiceDeclarationNodeContext.java
@@ -30,7 +30,6 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.SymbolCompletionItem;
@@ -61,8 +60,7 @@ public class ServiceDeclarationNodeContext extends ObjectBodiedNodeContextProvid
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ServiceDeclarationNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ServiceDeclarationNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         ServiceContext cursorContext;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SpreadFieldNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SpreadFieldNodeContext.java
@@ -25,7 +25,6 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SymbolCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -50,7 +49,7 @@ public class SpreadFieldNodeContext extends AbstractCompletionProvider<SpreadFie
 
     @Override
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context,
-                                                 SpreadFieldNode node) throws LSCompletionException {
+                                                 SpreadFieldNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         if (QNameRefCompletionUtil.onQualifiedNameIdentifier(context, context.getNodeAtCursor())) {
             QualifiedNameReferenceNode qNameRef = (QualifiedNameReferenceNode) context.getNodeAtCursor();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/StartActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/StartActionNodeContext.java
@@ -27,7 +27,6 @@ import io.ballerina.compiler.syntax.tree.StartActionNode;
 import io.ballerina.tools.text.TextRange;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SymbolCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -53,8 +52,7 @@ public class StartActionNodeContext extends AbstractCompletionProvider<StartActi
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, StartActionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, StartActionNode node) {
 
         List<LSCompletionItem> completionItems = new ArrayList<>();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SyncSendActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/SyncSendActionNodeContext.java
@@ -20,7 +20,6 @@ import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.SyncSendActionNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -41,8 +40,7 @@ public class SyncSendActionNodeContext extends AbstractCompletionProvider<SyncSe
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, SyncSendActionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, SyncSendActionNode node) {
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         List<Symbol> filteredWorkers = visibleSymbols.stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.WORKER)

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TemplateExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TemplateExpressionNodeContext.java
@@ -30,7 +30,6 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SymbolCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -57,8 +56,7 @@ public class TemplateExpressionNodeContext extends AbstractCompletionProvider<Te
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, TemplateExpressionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, TemplateExpressionNode node) {
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
         List<LSCompletionItem> completionItems = new ArrayList<>();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TrapExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TrapExpressionNodeContext.java
@@ -21,7 +21,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.TrapExpressionNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -41,8 +40,7 @@ public class TrapExpressionNodeContext extends AbstractCompletionProvider<TrapEx
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, TrapExpressionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, TrapExpressionNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = ctx.getNodeAtCursor();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TupleTypeDescriptorNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TupleTypeDescriptorNodeContext.java
@@ -21,7 +21,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.TupleTypeDescriptorNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -42,8 +41,7 @@ public class TupleTypeDescriptorNodeContext extends AbstractCompletionProvider<T
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, TupleTypeDescriptorNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, TupleTypeDescriptorNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
         if (QNameRefCompletionUtil.onQualifiedNameIdentifier(context, nodeAtCursor)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeCastExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeCastExpressionNodeContext.java
@@ -21,7 +21,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.TypeCastExpressionNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -42,8 +41,7 @@ public class TypeCastExpressionNodeContext extends AbstractCompletionProvider<Ty
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, TypeCastExpressionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, TypeCastExpressionNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
         if (QNameRefCompletionUtil.onQualifiedNameIdentifier(context, nodeAtCursor)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeDefinitionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeDefinitionNodeContext.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
@@ -48,8 +47,7 @@ public class TypeDefinitionNodeContext extends AbstractCompletionProvider<TypeDe
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, TypeDefinitionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, TypeDefinitionNode node) {
         if (this.onTypeNameContext(context, node)) {
             return new ArrayList<>();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeofExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeofExpressionNodeContext.java
@@ -21,7 +21,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.TypeofExpressionNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -41,8 +40,7 @@ public class TypeofExpressionNodeContext extends AbstractCompletionProvider<Type
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, TypeofExpressionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, TypeofExpressionNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
         if (this.onQualifiedNameIdentifier(context, nodeAtCursor)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/UnionTypeDescriptorNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/UnionTypeDescriptorNodeContext.java
@@ -24,7 +24,6 @@ import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.UnionTypeDescriptorNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -46,8 +45,7 @@ public class UnionTypeDescriptorNodeContext extends AbstractCompletionProvider<U
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, UnionTypeDescriptorNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, UnionTypeDescriptorNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitActionNodeContext.java
@@ -26,7 +26,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.WaitActionNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.SymbolCompletionItem;
@@ -60,8 +59,7 @@ public class WaitActionNodeContext extends AbstractCompletionProvider<WaitAction
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, WaitActionNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, WaitActionNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
 
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitFieldsListNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitFieldsListNodeContext.java
@@ -26,7 +26,6 @@ import io.ballerina.compiler.syntax.tree.WaitFieldsListNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -52,8 +51,7 @@ public class WaitFieldsListNodeContext extends AbstractCompletionProvider<WaitFi
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, WaitFieldsListNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, WaitFieldsListNode node) {
 
         List<LSCompletionItem> completionItems = new ArrayList<>();
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WhileStatementNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WhileStatementNodeContext.java
@@ -24,7 +24,6 @@ import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.WhileStatementNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.QNameRefCompletionUtil;
@@ -47,8 +46,7 @@ public class WhileStatementNodeContext extends AbstractCompletionProvider<WhileS
     }
 
     @Override
-    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, WhileStatementNode node)
-            throws LSCompletionException {
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, WhileStatementNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         if (QNameRefCompletionUtil.onQualifiedNameIdentifier(context, context.getNodeAtCursor())) {
             QualifiedNameReferenceNode qNameRef = (QualifiedNameReferenceNode) context.getNodeAtCursor();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionExtension.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionExtension.java
@@ -52,7 +52,7 @@ public class BallerinaTomlCompletionExtension implements TomlCompletionExtension
     @Override
     public List<CompletionItem> execute(CompletionParams completionParams,
                                         CompletionContext completionContext,
-                                        LanguageServerContext languageServerContext) throws Throwable {
+                                        LanguageServerContext languageServerContext) {
         BallerinaTomlCompletionContext ballerinaTomlCompletionContext =
                 new BallerinaTomlCompletionContext(completionContext, languageServerContext);
         return BallerinaTomlCompletionUtil.getCompletionItems(ballerinaTomlCompletionContext, languageServerContext);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/TestUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/TestUtil.java
@@ -533,9 +533,8 @@ public final class TestUtil {
      * @param serviceEndpoint Language Server Service Endpoint
      * @param fileUri         uri of the document to open
      * @param content         File content
-     * @throws IOException Exception while reading the file content
      */
-    public static void openDocument(Endpoint serviceEndpoint, String fileUri, String content) throws IOException {
+    public static void openDocument(Endpoint serviceEndpoint, String fileUri, String content) {
         DidOpenTextDocumentParams documentParams = new DidOpenTextDocumentParams();
         TextDocumentItem textDocumentItem = new TextDocumentItem();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManagerProxy.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManagerProxy.java
@@ -47,7 +47,6 @@ public interface BallerinaWorkspaceManagerProxy extends WorkspaceManagerProxy {
      * Handle the document close event.
      *
      * @param params {@link DidCloseTextDocumentParams}
-     * @throws WorkspaceDocumentException on failure
      */
-    void didClose(DidCloseTextDocumentParams params) throws WorkspaceDocumentException;
+    void didClose(DidCloseTextDocumentParams params);
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManagerProxyImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManagerProxyImpl.java
@@ -86,7 +86,7 @@ public class BallerinaWorkspaceManagerProxyImpl implements BallerinaWorkspaceMan
     }
 
     @Override
-    public void didClose(DidCloseTextDocumentParams params) throws WorkspaceDocumentException {
+    public void didClose(DidCloseTextDocumentParams params) {
         String uri = params.getTextDocument().getUri();
         Optional<Path> path = PathUtil.getPathFromURI(uri);
         if (path.isEmpty()) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/AbstractLSTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/AbstractLSTest.java
@@ -112,7 +112,7 @@ public abstract class AbstractLSTest {
     }
 
     @BeforeClass
-    public void init() throws Exception {
+    public void init() {
         this.languageServer = new BallerinaLanguageServer();
         if (this.loadMockedPackages()) {
             setUp();

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AbstractCommandExecutionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AbstractCommandExecutionTest.java
@@ -53,7 +53,7 @@ public abstract class AbstractCommandExecutionTest {
     private static final Logger log = LoggerFactory.getLogger(AbstractCommandExecutionTest.class);
 
     @BeforeClass
-    public void init() throws Exception {
+    public void init() {
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/DefinitionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/DefinitionTest.java
@@ -56,7 +56,7 @@ public class DefinitionTest {
     private static final Logger log = LoggerFactory.getLogger(DefinitionTest.class);
 
     @BeforeClass
-    public void init() throws Exception {
+    public void init() {
         configRoot = FileUtils.RES_DIR.resolve("definition").resolve("expected");
         sourceRoot = FileUtils.RES_DIR.resolve("definition").resolve("sources");
         this.serviceEndpoint = getServiceEndpoint();
@@ -132,7 +132,7 @@ public class DefinitionTest {
     }
 
     @DataProvider
-    protected Object[][] testDataProvider() throws IOException {
+    protected Object[][] testDataProvider() {
         log.info("Test textDocument/definition for Basic Cases");
         return new Object[][]{
                 {"defProject1.json", "project"},
@@ -163,7 +163,7 @@ public class DefinitionTest {
     }
 
     @DataProvider
-    protected Object[][] testStdLibDataProvider() throws IOException {
+    protected Object[][] testStdLibDataProvider() {
         log.info("Test textDocument/definition for Std Lib Cases");
         return new Object[][]{
                 {"defProject8.json", "project"},
@@ -175,7 +175,7 @@ public class DefinitionTest {
     }
 
     @DataProvider
-    protected Object[][] testInterStdLibDataProvider() throws IOException {
+    protected Object[][] testInterStdLibDataProvider() {
         log.info("Test textDocument/definition for Inter Std Lib Cases");
         return new Object[][]{
                 {"inter_stdlib_config1.json", "stdlib"},
@@ -184,7 +184,7 @@ public class DefinitionTest {
     }
 
     @AfterClass
-    public void shutDownLanguageServer() throws IOException {
+    public void shutDownLanguageServer() {
         TestUtil.shutdownLanguageServer(this.serviceEndpoint);
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/docsymbol/DocumentSymbolTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/docsymbol/DocumentSymbolTest.java
@@ -50,7 +50,7 @@ public class DocumentSymbolTest {
     private static final Logger log = LoggerFactory.getLogger(DocumentSymbolTest.class);
 
     @BeforeClass
-    public void init() throws Exception {
+    public void init() {
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
     }
     

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolTest.java
@@ -27,7 +27,7 @@ public class DocumentSymbolTest {
     protected Endpoint serviceEndpoint;
 
     @BeforeClass
-    public void init() throws Exception {
+    public void init() {
         this.configRoot = FileUtils.RES_DIR.resolve("documentsymbol").resolve("config");
         this.sourceRoot = FileUtils.RES_DIR.resolve("documentsymbol").resolve("source");
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
@@ -53,7 +53,7 @@ public class DocumentSymbolTest {
     }
 
     @AfterClass
-    public void shutDownLanguageServer() throws IOException {
+    public void shutDownLanguageServer() {
         TestUtil.shutdownLanguageServer(this.serviceEndpoint);
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/ConfigurablesTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/ConfigurablesTest.java
@@ -41,7 +41,7 @@ public class ConfigurablesTest {
             .resolve("configurables.bal");
 
     @BeforeClass
-    public void startLangServer() throws IOException {
+    public void startLangServer() {
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxApiCallsGenTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxApiCallsGenTest.java
@@ -43,7 +43,7 @@ public class SyntaxApiCallsGenTest {
     private Endpoint serviceEndpoint;
 
     @BeforeClass
-    public void startLanguageServer() throws Exception {
+    public void startLanguageServer() {
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeByNameTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeByNameTest.java
@@ -59,7 +59,7 @@ public class SyntaxTreeByNameTest {
             .resolve("non-exist.bal");
 
     @BeforeClass
-    public void startLanguageServer() throws Exception {
+    public void startLanguageServer() {
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeByRangeTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeByRangeTest.java
@@ -39,7 +39,7 @@ public class SyntaxTreeByRangeTest {
             .resolve("empty.bal");
 
     @BeforeClass
-    public void startLanguageServer() throws Exception {
+    public void startLanguageServer() {
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeLocateTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeLocateTest.java
@@ -45,7 +45,7 @@ public class SyntaxTreeLocateTest {
             .resolve("source.bal");
 
     @BeforeClass
-    public void startLanguageServer() throws Exception {
+    public void startLanguageServer() {
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeModifyTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeModifyTest.java
@@ -124,7 +124,7 @@ public class SyntaxTreeModifyTest {
     }
 
     @BeforeClass
-    public void startLangServer() throws IOException {
+    public void startLangServer() {
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeNodeByPositionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeNodeByPositionTest.java
@@ -46,7 +46,7 @@ public class SyntaxTreeNodeByPositionTest {
             .resolve("main.bal");
 
     @BeforeClass
-    public void startLanguageServer() throws Exception {
+    public void startLanguageServer() {
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
@@ -40,7 +40,7 @@ public class SymbolDocumentationTest {
             .resolve("symbolDocumentation.bal");
 
     @BeforeClass
-    public void startLangServer() throws IOException {
+    public void startLangServer() {
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/foldingrange/LineFoldingOnlyTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/foldingrange/LineFoldingOnlyTest.java
@@ -40,7 +40,7 @@ public class LineFoldingOnlyTest {
     private Endpoint serviceEndpoint;
 
     @BeforeClass
-    public void init() throws Exception {
+    public void init() {
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
@@ -108,7 +108,7 @@ public class FormattingTest {
     }
 
     @AfterClass
-    public void shutdownLanguageServer() throws IOException {
+    public void shutdownLanguageServer() {
         TestUtil.shutdownLanguageServer(this.serviceEndpoint);
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/hover/HoverProviderTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/hover/HoverProviderTest.java
@@ -46,7 +46,7 @@ public class HoverProviderTest {
     protected Path sourceRoot;
 
     @BeforeClass
-    public void loadLangServer() throws IOException {
+    public void loadLangServer() {
         serviceEndpoint = TestUtil.initializeLanguageSever();
         configRoot = FileUtils.RES_DIR.resolve("hover").resolve("configs");
         sourceRoot = FileUtils.RES_DIR.resolve("hover").resolve("source");

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/inlayhint/InlayHintTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/inlayhint/InlayHintTest.java
@@ -22,7 +22,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
 import org.ballerinalang.langserver.AbstractLSTest;
-import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.util.FileUtils;
 import org.ballerinalang.langserver.util.TestUtil;
 import org.eclipse.lsp4j.InlayHint;
@@ -60,7 +59,7 @@ public class InlayHintTest extends AbstractLSTest {
     private final Path testRoot = FileUtils.RES_DIR.resolve("inlayhint");
 
     @Test(dataProvider = "data-provider")
-    public void test(String config, String source) throws WorkspaceDocumentException, IOException {
+    public void test(String config, String source) throws IOException {
         Path configPath = getConfigJsonPath(config);
         TestConfig testConfig = gson.fromJson(Files.newBufferedReader(configPath), TestConfig.class);
         Path sourcePath = sourcesPath.resolve(testConfig.source);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
@@ -23,7 +23,6 @@ import org.ballerinalang.langserver.LSPackageLoader;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.eventsync.EventKind;
 import org.ballerinalang.langserver.commons.eventsync.exceptions.EventSyncException;
-import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.contexts.ContextBuilder;
 import org.ballerinalang.langserver.eventsync.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.util.FileUtils;
@@ -54,7 +53,7 @@ public class LSPackageLoaderTest extends AbstractLSTest {
     private List<LSPackageLoader.ModuleInfo> remoteRepoPackages = new ArrayList<>(getRemotePackages());
 
     @Test(dataProvider = "data-provider")
-    public void test(String source) throws IOException, EventSyncException, WorkspaceDocumentException {
+    public void test(String source) throws IOException, EventSyncException {
         //Open the source text document and load project
         Path sourcePath = testRoot.resolve("source").resolve(source);
         Endpoint endpoint = getServiceEndpoint();

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/memoryusagemonitor/MemoryUsageMonitorTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/memoryusagemonitor/MemoryUsageMonitorTest.java
@@ -20,7 +20,6 @@ import org.ballerinalang.langserver.BallerinaLanguageServer;
 import org.ballerinalang.langserver.MemoryUsageMonitor;
 import org.ballerinalang.langserver.commons.capability.InitializationOptions;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
-import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.util.TestUtil;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
@@ -30,7 +29,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryUsage;
 
@@ -47,7 +45,7 @@ public class MemoryUsageMonitorTest extends AbstractLSTest {
 
     @BeforeClass
     @Override
-    public void init() throws Exception {
+    public void init() {
         MemoryUsageMonitor memoryUsageMonitor = new MemoryUsageMonitor(createMockMemoryMXBean());
         this.languageServer = new BallerinaLanguageServer();
         languageServer.getServerContext().put(MemoryUsageMonitor.MEMORY_USAGE_MONITOR_KEY, memoryUsageMonitor);
@@ -55,7 +53,7 @@ public class MemoryUsageMonitorTest extends AbstractLSTest {
     }
 
     @Test
-    public void test() throws WorkspaceDocumentException, IOException, InterruptedException {
+    public void test() throws InterruptedException {
         TestUtil.LanguageServerBuilder builder = TestUtil.newLanguageServer()
                 .withLanguageServer(languageServer)
                 .withClient(mockClient)

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/packages/ComponentsTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/packages/ComponentsTest.java
@@ -30,7 +30,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,7 +54,7 @@ public class ComponentsTest {
     }
 
     @Test(description = "Test package components API", dataProvider = "components-data-provider")
-    public void packageComponentsTestCase(String[] projects, String expected) throws IOException {
+    public void packageComponentsTestCase(String[] projects, String expected) {
         Path configsPath = this.resourceRoot.resolve("configs");
         List<String> filePaths = new ArrayList<>();
         for (String project : projects) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rangeformat/RangeFormattingTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rangeformat/RangeFormattingTest.java
@@ -84,7 +84,7 @@ public class RangeFormattingTest {
     }
 
     @AfterClass
-    public void shutdownLanguageServer() throws IOException {
+    public void shutdownLanguageServer() {
         TestUtil.shutdownLanguageServer(this.serviceEndpoint);
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/references/ReferenceTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/references/ReferenceTest.java
@@ -49,7 +49,7 @@ public class ReferenceTest {
     protected Endpoint serviceEndpoint;
 
     @BeforeClass
-    public void init() throws Exception {
+    public void init() {
         this.configRoot = FileUtils.RES_DIR.resolve("reference").resolve("expected");
         this.sourceRoot = FileUtils.RES_DIR.resolve("reference").resolve("sources");
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
@@ -76,14 +76,14 @@ public class ReferenceTest {
 
 
     @DataProvider
-    public Object[][] testDataProvider() throws IOException {
+    public Object[][] testDataProvider() {
         return new Object[][]{
                 {"refFunction1.json", "function"}
         };
     }
 
     @AfterClass
-    public void shutDownLanguageServer() throws IOException {
+    public void shutDownLanguageServer() {
         TestUtil.shutdownLanguageServer(this.serviceEndpoint);
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/references/ReferencesTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/references/ReferencesTest.java
@@ -56,7 +56,7 @@ public class ReferencesTest {
     private static final Logger log = LoggerFactory.getLogger(ReferencesTest.class);
 
     @BeforeClass
-    public void init() throws Exception {
+    public void init() {
         configRoot = FileUtils.RES_DIR.resolve("references").resolve("expected");
         sourceRoot = FileUtils.RES_DIR.resolve("references").resolve("sources");
         this.serviceEndpoint = getLanguageServerEndpoint();
@@ -136,7 +136,7 @@ public class ReferencesTest {
     }
 
     @AfterClass
-    public void shutDownLanguageServer() throws IOException {
+    public void shutDownLanguageServer() {
         TestUtil.shutdownLanguageServer(this.serviceEndpoint);
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/AbstractRenameTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/AbstractRenameTest.java
@@ -40,7 +40,7 @@ public abstract class AbstractRenameTest {
     protected Endpoint serviceEndpoint;
 
     @BeforeClass
-    public void init() throws Exception {
+    public void init() {
         this.configRoot = FileUtils.RES_DIR.resolve("rename").resolve("expected").resolve(configRoot());
         this.sourceRoot = FileUtils.RES_DIR.resolve("rename").resolve("sources").resolve(sourceRoot());
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
@@ -77,7 +77,7 @@ public abstract class AbstractRenameTest {
     }
 
     @AfterClass
-    public void shutDownLanguageServer() throws IOException {
+    public void shutDownLanguageServer() {
         TestUtil.shutdownLanguageServer(this.serviceEndpoint);
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/ProjectRenameTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/ProjectRenameTest.java
@@ -60,7 +60,7 @@ public class ProjectRenameTest extends AbstractRenameTest {
 
     @Override
     @AfterClass
-    public void shutDownLanguageServer() throws IOException {
+    public void shutDownLanguageServer() {
         TestUtil.shutdownLanguageServer(this.serviceEndpoint);
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/AbstractSignatureHelpTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/AbstractSignatureHelpTest.java
@@ -54,7 +54,7 @@ public abstract class AbstractSignatureHelpTest {
     private static final Logger log = LoggerFactory.getLogger(AbstractSignatureHelpTest.class);
 
     @BeforeClass
-    public void init() throws Exception {
+    public void init() {
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/TestWorkspaceManager.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/TestWorkspaceManager.java
@@ -96,7 +96,7 @@ public class TestWorkspaceManager {
     }
 
     @Test(dataProvider = "fileOpenUpdateTestDataProvider")
-    public void testOpenDocument(Path filePath) throws IOException, WorkspaceDocumentException {
+    public void testOpenDocument(Path filePath) throws WorkspaceDocumentException {
         // Inputs from lang server
         openFile(filePath);
 
@@ -107,8 +107,7 @@ public class TestWorkspaceManager {
     }
 
     @Test(dataProvider = "fileOpenWithDuplicateFilesDataProvider")
-    public void testOpenDocumentWithDuplicateFiles(Path filePath) throws IOException,
-            WorkspaceDocumentException {
+    public void testOpenDocumentWithDuplicateFiles(Path filePath) {
         try {
             // Inputs from lang server
             openFile(filePath);
@@ -557,7 +556,7 @@ public class TestWorkspaceManager {
 
     @Test
     public void testWSRunStopProject()
-            throws WorkspaceDocumentException, EventSyncException, LSCommandExecutorException, IOException {
+            throws WorkspaceDocumentException, EventSyncException, LSCommandExecutorException {
         Path projectPath = RESOURCE_DIRECTORY.resolve("long_running");
         Path filePath = projectPath.resolve("main.bal");
         ExecuteCommandContext execContext = runViaLs(filePath);
@@ -639,8 +638,7 @@ public class TestWorkspaceManager {
         return execContext;
     }
 
-    private static void stopViaLs(ExecuteCommandContext execContext, Path projectPath)
-            throws LSCommandExecutorException {
+    private static void stopViaLs(ExecuteCommandContext execContext, Path projectPath) {
         StopExecutor stopExecutor = new StopExecutor();
         Boolean didStop = stopExecutor.execute(execContext);
         Assert.assertTrue(didStop);

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenMvnResolver.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenMvnResolver.java
@@ -119,7 +119,8 @@ public class BindgenMvnResolver {
     private void populateBallerinaToml(String groupId, String artifactId, String version,
                                        File tomlFile, Path projectRoot, String parent,
                                        JvmTarget parentJvmTarget) throws BindgenException {
-        try (FileWriterWithEncoding fileWriter = new FileWriterWithEncoding(tomlFile, StandardCharsets.UTF_8, true)) {
+        try (FileWriterWithEncoding fileWriter = FileWriterWithEncoding.builder()
+                .setFile(tomlFile).setCharset(StandardCharsets.UTF_8).setAppend(true).get()) {
             TomlDocument tomlDocument = env.getTomlDocument();
             if (tomlDocument == null) {
                 return;

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/ConstructorsTestResource.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/ConstructorsTestResource.java
@@ -25,6 +25,7 @@ import java.io.IOException;
  *
  * @since 2.0.0
  */
+@SuppressWarnings("all")
 public class ConstructorsTestResource {
 
     // The tool should not generate constructors with private access modifier.

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/MethodsTestResource.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/MethodsTestResource.java
@@ -31,6 +31,7 @@ import java.util.Set;
  *
  * @since 2.0.0
  */
+@SuppressWarnings("all")
 public class MethodsTestResource extends AbstractTestResource implements InterfaceTestResource {
 
     // Different instance method combinations

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/config/ClientLaunchConfigHolder.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/config/ClientLaunchConfigHolder.java
@@ -114,7 +114,7 @@ public class ClientLaunchConfigHolder extends ClientConfigHolder {
         return networkLogsEnabled;
     }
 
-    public Optional<Integer> getNetworkLogsPort() throws ClientConfigurationException {
+    public Optional<Integer> getNetworkLogsPort() {
         if (networkLogsPort == null) {
             if (clientRequestArgs.containsKey(ARG_NETWORK_LOGS_PORT)) {
                 return Optional.empty();

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/EvaluationImportResolver.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/EvaluationImportResolver.java
@@ -61,7 +61,7 @@ public class EvaluationImportResolver extends NodeVisitor {
      *
      * @return a map of all the imports declared in the current debug source.
      */
-    public Map<String, BImport> getAllImports() throws EvaluationException {
+    public Map<String, BImport> getAllImports() {
         resolveVisibleImports();
         return Map.copyOf(visibleImports);
     }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/Modifier.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/Modifier.java
@@ -16,11 +16,8 @@
 
 package org.ballerinalang.debugadapter.evaluation.engine;
 
-import com.sun.jdi.ClassNotLoadedException;
-import com.sun.jdi.InvalidTypeException;
 import com.sun.jdi.Type;
 import com.sun.jdi.Value;
-import org.ballerinalang.debugadapter.evaluation.EvaluationException;
 
 /**
  * Value modifier implementation.
@@ -34,11 +31,11 @@ public interface Modifier {
     /**
      * sets the value to the expression.
      */
-    void setValue(Value value) throws ClassNotLoadedException, InvalidTypeException, EvaluationException;
+    void setValue(Value value);
 
     /**
      * @return the expected type of the expression or null is class was not loaded.
      */
-    Type getExpectedType() throws ClassNotLoadedException, EvaluationException;
+    Type getExpectedType();
 
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/QualifiedNameReferenceEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/QualifiedNameReferenceEvaluator.java
@@ -129,8 +129,7 @@ public class QualifiedNameReferenceEvaluator extends Evaluator {
         return Optional.empty();
     }
 
-    private Optional<BExpressionValue> searchForModuleVariable(ModuleSymbol moduleSymbol, String modulePrefix)
-            throws EvaluationException {
+    private Optional<BExpressionValue> searchForModuleVariable(ModuleSymbol moduleSymbol, String modulePrefix) {
         Optional<VariableSymbol> variableSymbol = moduleSymbol.allSymbols().stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.VARIABLE
                         && symbol.getName().isPresent()

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/EvaluationUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/EvaluationUtils.java
@@ -524,7 +524,7 @@ public final class EvaluationUtils {
      * @param val     string value
      * @return {@link StringReference} instance
      */
-    public static Value getAsJString(SuspendedContext context, String val) throws EvaluationException {
+    public static Value getAsJString(SuspendedContext context, String val) {
         return context.getAttachedVm().mirrorOf(val);
     }
 
@@ -603,8 +603,7 @@ public final class EvaluationUtils {
      * @param name    name of the variable to be retrieved
      * @return the JDI value instance of the Ballerina variable
      */
-    public static Optional<BExpressionValue> fetchVariableReferenceValue(EvaluationContext context, String name)
-            throws EvaluationException {
+    public static Optional<BExpressionValue> fetchVariableReferenceValue(EvaluationContext context, String name) {
         Optional<BExpressionValue> bExpressionValue = searchLocalVariables(context.getSuspendedContext(), name);
         if (bExpressionValue.isPresent()) {
             return bExpressionValue;

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/jdi/VirtualMachineProxyImpl.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/jdi/VirtualMachineProxyImpl.java
@@ -227,7 +227,7 @@ public class VirtualMachineProxyImpl implements JdiTimer, VirtualMachineProxy {
      * @deprecated use {@link #mirrorOfVoid()} instead
      */
     @Deprecated
-    public VoidValue mirrorOf() throws JdiProxyException {
+    public VoidValue mirrorOf() {
         return mirrorOfVoid();
     }
 

--- a/misc/diagram-util/src/test/java/org/ballerinalang/diagramutil/FileVisitor.java
+++ b/misc/diagram-util/src/test/java/org/ballerinalang/diagramutil/FileVisitor.java
@@ -53,7 +53,7 @@ public class FileVisitor extends SimpleFileVisitor<Path> {
     }
 
     @Override
-    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
         Path newFile = target.resolve(source.relativize(file));
         try {
             Files.copy(file, newFile, StandardCopyOption.REPLACE_EXISTING);
@@ -65,7 +65,7 @@ public class FileVisitor extends SimpleFileVisitor<Path> {
     }
 
     @Override
-    public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+    public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
         return FileVisitResult.CONTINUE;
     }
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ModuleDoc.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ModuleDoc.java
@@ -21,7 +21,6 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import org.ballerinalang.docgen.docs.utils.BallerinaDocUtils;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -45,10 +44,9 @@ public class ModuleDoc {
      * @param syntaxTreeMap a hash map of bal file names and syntax trees.
      * @param semanticModel the semantic model
      * @param isDefault whether this is the default module (not a sub-module)
-     * @throws IOException on error.
      */
     public ModuleDoc(String moduleMd, List<Path> resources, Map<String, SyntaxTree> syntaxTreeMap,
-                     SemanticModel semanticModel, boolean isDefault) throws IOException {
+                     SemanticModel semanticModel, boolean isDefault) {
         this.description = moduleMd;
         this.summary = BallerinaDocUtils.getSummary(moduleMd);
         this.resources = resources;

--- a/misc/ls-extensions/modules/bal-shell-service/src/main/java/io/ballerina/shell/service/ConsoleOutCollector.java
+++ b/misc/ls-extensions/modules/bal-shell-service/src/main/java/io/ballerina/shell/service/ConsoleOutCollector.java
@@ -15,7 +15,6 @@
  */
 package io.ballerina.shell.service;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -36,7 +35,7 @@ public class ConsoleOutCollector extends OutputStream {
     }
 
     @Override
-    public void write(int characterInt) throws IOException {
+    public void write(int characterInt) {
         if (characterInt == '\n') {
             String buffered = collectFromBuffer();
             lines.add(buffered);

--- a/misc/ls-extensions/modules/trigger-service/src/main/java/io/ballerina/trigger/BallerinaTriggerService.java
+++ b/misc/ls-extensions/modules/trigger-service/src/main/java/io/ballerina/trigger/BallerinaTriggerService.java
@@ -34,7 +34,6 @@ import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
 import org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
@@ -85,7 +84,7 @@ public class BallerinaTriggerService implements ExtendedLanguageServerService {
                         triggerSearchResult.getAsString(), CentralTriggerListResult.class);
                 triggersList.setCentralTriggers(centralTriggerListResult.getTriggers());
                 return triggersList;
-            } catch (CentralClientException | SettingsTomlException e) {
+            } catch (CentralClientException e) {
                 String msg = "Operation 'ballerinaTrigger/triggers' failed!";
                 this.languageClient.logMessage(new MessageParams(MessageType.Error, msg));
                 return triggersList;
@@ -116,7 +115,7 @@ public class BallerinaTriggerService implements ExtendedLanguageServerService {
                 trigger = client.getTrigger(request.getTriggerId(), "any", RepoUtils.getBallerinaVersion());
                 return Optional.of(trigger);
             }
-        } catch (CentralClientException | SettingsTomlException e) {
+        } catch (CentralClientException e) {
             String msg = "Operation 'ballerinaTrigger/trigger' failed!";
             this.languageClient.logMessage(new MessageParams(MessageType.Error, msg));
         }

--- a/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/BallerinaPackageResolver.java
+++ b/misc/semver-checker/modules/semver-checker-core/src/main/java/io/ballerina/semver/checker/BallerinaPackageResolver.java
@@ -38,7 +38,6 @@ import io.ballerina.semver.checker.exception.SemverToolException;
 import org.ballerinalang.central.client.CentralAPIClient;
 import org.ballerinalang.central.client.CentralClientConstants;
 import org.ballerinalang.central.client.exceptions.CentralClientException;
-import org.ballerinalang.toml.exceptions.SettingsTomlException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerinalang.util.RepoUtils;
@@ -175,13 +174,9 @@ class BallerinaPackageResolver {
 
     private void initializeCentralClient() {
         Settings settings;
-        try {
-            settings = RepoUtils.readSettings();
-            // Ignore Settings.toml diagnostics in the search command
-        } catch (SettingsTomlException e) {
-            // Ignore 'Settings.toml' parsing errors and return empty Settings object
-            settings = Settings.from();
-        }
+        settings = RepoUtils.readSettings();
+        // Ignore Settings.toml diagnostics in the search command
+
         this.centralClient = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
                 initializeProxy(settings.getProxy()), settings.getProxy().username(),
                 settings.getProxy().password(), getAccessTokenOfCLI(settings),

--- a/misc/syntax-api-calls-gen/src/test/java/io/ballerina/syntaxapicallsgen/test/e2e/AbstractSegmentTest.java
+++ b/misc/syntax-api-calls-gen/src/test/java/io/ballerina/syntaxapicallsgen/test/e2e/AbstractSegmentTest.java
@@ -65,8 +65,7 @@ public abstract class AbstractSegmentTest {
      * @param templateFile Template to use for dynamic class loading.
      */
     protected void testForGeneratedCode(String sourceCode, SyntaxApiCallsGenConfig.Formatter formatter,
-                                        File templateFile)
-            throws URISyntaxException {
+                                        File templateFile) {
         sourceCode = sourceCode.trim();
         SyntaxApiCallsGenConfig config = new SyntaxApiCallsGenConfig.Builder()
                 .templateFile(templateFile)

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/agent/server/WebServer.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/agent/server/WebServer.java
@@ -148,7 +148,7 @@ public class WebServer {
          * @param ch The Channel which was registered.
          */
         @Override
-        public void initChannel(SocketChannel ch) throws Exception {
+        public void initChannel(SocketChannel ch) {
             final ChannelPipeline p = ch.pipeline();
             p.addLast("decoder", new HttpRequestDecoder(4096, 8192, 8192, false));
             p.addLast("aggregator", new HttpObjectAggregator(100 * 1024 * 1024));
@@ -190,7 +190,7 @@ public class WebServer {
          * @param o The HTTP request message.
          */
         @Override
-        protected void channelRead0(ChannelHandlerContext channelHandlerContext, Object o) throws Exception {
+        protected void channelRead0(ChannelHandlerContext channelHandlerContext, Object o) {
             if (!(o instanceof FullHttpRequest request)) {
                 return;
             }

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BMainInstance.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BMainInstance.java
@@ -79,7 +79,7 @@ public class BMainInstance implements BMain {
     }
 
 
-    public BMainInstance(BalServer balServer) throws BallerinaTestException {
+    public BMainInstance(BalServer balServer) {
         this.balServer = balServer;
         initialize();
     }

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/client/HttpClient.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/client/HttpClient.java
@@ -72,7 +72,7 @@ public class HttpClient {
                            .remoteAddress(new InetSocketAddress(host, port))
                            .handler(new ChannelInitializer<SocketChannel>() {
                                @Override
-                               public void initChannel(SocketChannel ch) throws Exception {
+                               public void initChannel(SocketChannel ch) {
                                    ch.pipeline().addLast(new HttpClientCodec());
                                    ch.pipeline().addLast(new HttpObjectAggregator(1024 * 512));
                                    ch.pipeline().addLast(responseHandler);

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/DependencyEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/DependencyEvaluationTest.java
@@ -37,7 +37,7 @@ public class DependencyEvaluationTest extends BaseTestCase {
 
     @Override
     @BeforeClass(alwaysRun = true)
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         String testProjectName = "evaluation-tests-2";
         String testModuleFileName = "main.bal";
         debugTestRunner = new DebugTestRunner(testProjectName, testModuleFileName, true);

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationBaseTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationBaseTest.java
@@ -120,9 +120,9 @@ public abstract class ExpressionEvaluationBaseTest extends BaseTestCase {
 
     public abstract void literalEvaluationTest() throws BallerinaTestException;
 
-    public abstract void listConstructorEvaluationTest() throws BallerinaTestException;
+    public abstract void listConstructorEvaluationTest();
 
-    public abstract void mappingConstructorEvaluationTest() throws BallerinaTestException;
+    public abstract void mappingConstructorEvaluationTest();
 
     public abstract void stringTemplateEvaluationTest() throws BallerinaTestException;
 
@@ -178,7 +178,7 @@ public abstract class ExpressionEvaluationBaseTest extends BaseTestCase {
 
     public abstract void conditionalExpressionEvaluationTest() throws BallerinaTestException;
 
-    public abstract void checkingExpressionEvaluationTest() throws BallerinaTestException;
+    public abstract void checkingExpressionEvaluationTest();
 
     public abstract void trapExpressionEvaluationTest() throws BallerinaTestException;
 

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationNegativeTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationNegativeTest.java
@@ -43,19 +43,19 @@ public abstract class ExpressionEvaluationNegativeTest extends ExpressionEvaluat
 
     @Override
     @Test(enabled = false)
-    public void literalEvaluationTest() throws BallerinaTestException {
+    public void literalEvaluationTest() {
         // Todo
     }
 
     @Override
     @Test(enabled = false)
-    public void listConstructorEvaluationTest() throws BallerinaTestException {
+    public void listConstructorEvaluationTest() {
         // Todo
     }
 
     @Override
     @Test(enabled = false)
-    public void mappingConstructorEvaluationTest() throws BallerinaTestException {
+    public void mappingConstructorEvaluationTest() {
         // Todo
     }
 
@@ -70,7 +70,7 @@ public abstract class ExpressionEvaluationNegativeTest extends ExpressionEvaluat
 
     @Override
     @Test(enabled = false)
-    public void xmlTemplateEvaluationTest() throws BallerinaTestException {
+    public void xmlTemplateEvaluationTest() {
         // Todo
     }
 
@@ -112,13 +112,13 @@ public abstract class ExpressionEvaluationNegativeTest extends ExpressionEvaluat
 
     @Override
     @Test(enabled = false)
-    public void builtInNameReferenceEvaluationTest() throws BallerinaTestException {
+    public void builtInNameReferenceEvaluationTest() {
         // Todo
     }
 
     @Override
     @Test(enabled = false)
-    public void fieldAccessEvaluationTest() throws BallerinaTestException {
+    public void fieldAccessEvaluationTest() {
         // Todo
     }
 
@@ -275,7 +275,7 @@ public abstract class ExpressionEvaluationNegativeTest extends ExpressionEvaluat
 
     @Override
     @Test(enabled = false)
-    public void typeOfExpressionEvaluationTest() throws BallerinaTestException {
+    public void typeOfExpressionEvaluationTest() {
         // Todo
     }
 
@@ -360,7 +360,7 @@ public abstract class ExpressionEvaluationNegativeTest extends ExpressionEvaluat
 
     @Override
     @Test(enabled = false)
-    public void equalityEvaluationTest() throws BallerinaTestException {
+    public void equalityEvaluationTest() {
         // Todo
     }
 
@@ -391,19 +391,19 @@ public abstract class ExpressionEvaluationNegativeTest extends ExpressionEvaluat
 
     @Override
     @Test(enabled = false)
-    public void conditionalExpressionEvaluationTest() throws BallerinaTestException {
+    public void conditionalExpressionEvaluationTest() {
         // Todo
     }
 
     @Override
     @Test(enabled = false)
-    public void checkingExpressionEvaluationTest() throws BallerinaTestException {
+    public void checkingExpressionEvaluationTest() {
         // Todo
     }
 
     @Override
     @Test(enabled = false)
-    public void trapExpressionEvaluationTest() throws BallerinaTestException {
+    public void trapExpressionEvaluationTest() {
         // Todo
     }
 

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
@@ -63,13 +63,13 @@ public abstract class ExpressionEvaluationTest extends ExpressionEvaluationBaseT
 
     @Override
     @Test(enabled = false)
-    public void listConstructorEvaluationTest() throws BallerinaTestException {
+    public void listConstructorEvaluationTest() {
         // Todo
     }
 
     @Override
     @Test(enabled = false)
-    public void mappingConstructorEvaluationTest() throws BallerinaTestException {
+    public void mappingConstructorEvaluationTest() {
         // Todo
     }
 
@@ -800,7 +800,7 @@ public abstract class ExpressionEvaluationTest extends ExpressionEvaluationBaseT
 
     @Override
     @Test(enabled = false)
-    public void checkingExpressionEvaluationTest() throws BallerinaTestException {
+    public void checkingExpressionEvaluationTest() {
         // Todo
     }
 

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/runinterminal/ProjectBasedRunInTerminalTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/runinterminal/ProjectBasedRunInTerminalTest.java
@@ -33,7 +33,7 @@ public class ProjectBasedRunInTerminalTest {
     boolean didRunInIntegratedTerminal;
 
     @BeforeMethod(alwaysRun = true)
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         String testFolderName = "basic-project";
         String testSingleFileName = "hello_world.bal";
         debugTestRunner = new DebugTestRunner(testFolderName, testSingleFileName, true);

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/runinterminal/SingleFileRunInTerminalTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/runinterminal/SingleFileRunInTerminalTest.java
@@ -35,7 +35,7 @@ public class SingleFileRunInTerminalTest extends BaseTestCase {
 
     @Override
     @BeforeMethod(alwaysRun = true)
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         String testFolderName = "basic-project";
         String testSingleFileName = "hello_world.bal";
         debugTestRunner = new DebugTestRunner(testFolderName, testSingleFileName, false);

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaRunRemoteDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaRunRemoteDebugTest.java
@@ -45,7 +45,7 @@ public class BallerinaRunRemoteDebugTest extends BaseTestCase {
 
     @Override
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         testProjectName = "basic-project";
         String testSingleFileName = "hello_world.bal";
         debugTestRunner = new DebugTestRunner(testProjectName, testSingleFileName, false);

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaTestRemoteDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaTestRemoteDebugTest.java
@@ -38,7 +38,7 @@ public class BallerinaTestRemoteDebugTest extends BaseTestCase {
 
     @Override
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         String testProjectName = "basic-project";
         String testSingleFileName = "hello_world.bal";
         debugTestRunner = new DebugTestRunner(testProjectName, testSingleFileName, false);

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/BaseTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/BaseTest.java
@@ -37,7 +37,7 @@ public class BaseTest {
     }
 
     @AfterSuite(alwaysRun = true)
-    public void destroy() throws BallerinaTestException {
+    public void destroy() {
         balServer.cleanup();
     }
 }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/bindgen/BindgenTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/bindgen/BindgenTestCase.java
@@ -46,7 +46,7 @@ public class BindgenTestCase extends BaseTest {
     private BMainInstance balClient;
 
     @BeforeClass()
-    public void setUp() throws IOException, BallerinaTestException {
+    public void setUp() throws IOException {
         tempProjectsDir = Files.createTempDirectory("bal-test-integration-bindgen-");
         // copy TestProject to a temp
         Path testProject = Paths.get("src", "test", "resources", "bindgen")

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/isolated/IsolatedInferenceWithTestsTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/isolated/IsolatedInferenceWithTestsTest.java
@@ -41,7 +41,7 @@ public class IsolatedInferenceWithTestsTest extends BaseTest {
     private BMainInstance bMainInstance;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         bMainInstance = new BMainInstance(balServer);
     }
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/MavenTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/MavenTestCase.java
@@ -46,7 +46,7 @@ public class MavenTestCase extends BaseTest {
     private BMainInstance balClient;
 
     @BeforeClass
-    public void setUp() throws IOException, BallerinaTestException {
+    public void setUp() throws IOException {
         this.tempHomeDirectory = Files.createTempDirectory("bal-test-integration-maven-home-");
         this.projectPath = Files.createTempDirectory("bal-test-integration-maven-");
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/profiler/ProfilerTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/profiler/ProfilerTest.java
@@ -48,7 +48,7 @@ public class ProfilerTest extends BaseTest {
     public static final String BALLERINA_HOME = "ballerina.home";
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         bMainInstance = new BMainInstance(balServer);
     }
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/semver/SemverValidatorNegativeTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/semver/SemverValidatorNegativeTest.java
@@ -39,7 +39,7 @@ import java.util.List;
 public class SemverValidatorNegativeTest extends SemverValidatorBaseTest {
 
     @BeforeClass()
-    private void setup() throws IOException, BallerinaTestException {
+    private void setup() throws IOException {
         tempProjectsDir = Files.createTempDirectory("bal-test-integration-semver-");
         customRepoDir = tempProjectsDir.resolve("ballerina-home");
         Path testProject = Paths.get("src", "test", "resources", "semver").toAbsolutePath();

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/semver/SemverValidatorTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/semver/SemverValidatorTest.java
@@ -38,7 +38,7 @@ import java.util.List;
 public class SemverValidatorTest extends SemverValidatorBaseTest {
 
     @BeforeClass()
-    private void setup() throws IOException, BallerinaTestException {
+    private void setup() throws IOException {
         tempProjectsDir = Files.createTempDirectory("bal-test-integration-semver-");
         customRepoDir = tempProjectsDir.resolve("ballerina-home");
         Path testProject = Paths.get("src", "test", "resources", "semver").toAbsolutePath();

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/file/sample/OrderProcessingServiceSampleTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/file/sample/OrderProcessingServiceSampleTestCase.java
@@ -22,7 +22,6 @@ import org.ballerinalang.test.context.Constant;
 import org.testng.Assert;
 
 import java.io.File;
-import java.io.IOException;
 
 /**
  * Testing the Echo service sample located in
@@ -31,7 +30,7 @@ import java.io.IOException;
 public class OrderProcessingServiceSampleTestCase {
 
 //    @Test(description = "Test whether files have been deleted after reading the content")
-    public void testFileDeletion() throws IOException, InterruptedException {
+    public void testFileDeletion() throws InterruptedException {
         // Wait till relevant contents are read and files are deleted.
         Thread.sleep(5000);
         ClassLoader classLoader = getClass().getClassLoader();

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/testarina/TestarinaTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/testarina/TestarinaTestCase.java
@@ -19,7 +19,6 @@ package org.ballerinalang.test.testarina;
 
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.context.BMainInstance;
-import org.ballerinalang.test.context.BallerinaTestException;
 import org.ballerinalang.test.context.LogLeecher;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -45,7 +44,7 @@ public class TestarinaTestCase extends BaseTest {
     private BMainInstance balClient;
 
     @BeforeClass(enabled = false)
-    public void setUp() throws IOException, BallerinaTestException {
+    public void setUp() throws IOException {
         tempProjectDirectory = Files.createTempDirectory("bal-test-integration-testarina-project-");
 
         // copy TestProject1 to a temp

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/troubleshoot/StrandDumpTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/troubleshoot/StrandDumpTest.java
@@ -53,7 +53,7 @@ public class StrandDumpTest extends BaseTest {
     private BMainInstance bMainInstance;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         bMainInstance = new BMainInstance(balServer);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods.java
@@ -35,6 +35,7 @@ import io.ballerina.runtime.internal.values.ObjectValue;
  *
  * @since 1.0.0
  */
+@SuppressWarnings({"all"})
 public class InstanceMethods {
 
     private Integer counter = 0;
@@ -62,7 +63,7 @@ public class InstanceMethods {
     }
 
     public Integer setAndGetCounterValueWhichThrowsCheckedException(Integer newValue)
-    throws JavaInteropTestCheckedException {
+            throws JavaInteropTestCheckedException {
         this.counter = newValue;
         return this.counter;
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
@@ -79,6 +79,7 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * @since 1.0.0
  */
+@SuppressWarnings({"all"})
 public final class StaticMethods {
 
     private static final BArrayType intArrayType = new BArrayType(PredefinedTypes.TYPE_INT);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeWithBValueAPITests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeWithBValueAPITests.java
@@ -59,6 +59,7 @@ import static io.ballerina.runtime.api.utils.TypeUtils.getType;
  *
  * @since 1.0.0
  */
+@SuppressWarnings({"unused", "RedundantThrows"})
 public class RefTypeWithBValueAPITests {
 
     private CompileResult result;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/JSONLibraryTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/JSONLibraryTest.java
@@ -106,7 +106,7 @@ public class JSONLibraryTest {
     }
 
     @Test
-    public void testJsonEscapeChars() throws IOException {
+    public void testJsonEscapeChars() {
         String json = "[{\"a\":\"abc\\\"\", \"x\":\"1\\b\\f\", \"c\":3.14, \"d\":true, \"e\":false, \"f\":null, \"g\":"
                 + "{\"1\\n2\":\"a\\r\", \"2\":\"b\"}, \"h\":[\"A\\tB\", 20, 30, \"D\\\\\"]}]";
         String expected =

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BasicCasesTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BasicCasesTest.java
@@ -38,7 +38,7 @@ public class BasicCasesTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass()
-    public void setup() throws BallerinaTestException, IOException {
+    public void setup() throws IOException {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.toString();
         FileUtils.copyFolder(Paths.get("build/libs"),

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/CodeCoverageReportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/CodeCoverageReportTest.java
@@ -56,7 +56,7 @@ public class CodeCoverageReportTest extends BaseTestCase {
     private String singleModuleTestRoot;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         singleModuleTestRoot = "single-module-codecov";
         multiModuleTestRoot = "test-report-tests";

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/CodegenCodeCoverageTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/CodegenCodeCoverageTest.java
@@ -57,7 +57,7 @@ public class CodegenCodeCoverageTest extends BaseTestCase {
     private JsonObject resultObj;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException, IOException {
+    public void setup() throws IOException {
         balClient = new BMainInstance(balServer);
         FileUtils.copyFolder(Paths.get("build").resolve("compiler-plugin-jars"),
                 projectBasedTestsPath.resolve("compiler-plugin-jars"));

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ConfigurableCliArgsTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ConfigurableCliArgsTest.java
@@ -37,7 +37,7 @@ public class ConfigurableCliArgsTest extends BaseTestCase {
     private String singleFileTestLocation;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         bMainInstance = new BMainInstance(balServer);
         testFileLocation = projectBasedTestsPath.resolve("configurable-cli-args-test").toString();
         singleFileTestLocation = singleFileTestsPath.resolve("configurable-cli-arguments").toString();

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/DataProviderTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/DataProviderTest.java
@@ -39,7 +39,7 @@ public class DataProviderTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass()
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/DisableTestsTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/DisableTestsTestCase.java
@@ -35,7 +35,7 @@ public class DisableTestsTestCase extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = singleFileTestsPath.resolve("disabled-tests").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/EscapedIdentifiersValidationTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/EscapedIdentifiersValidationTest.java
@@ -34,7 +34,7 @@ public class EscapedIdentifiersValidationTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ExcludeFromCodeCoverageTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ExcludeFromCodeCoverageTest.java
@@ -44,7 +44,7 @@ public class ExcludeFromCodeCoverageTest extends BaseTestCase {
     private JsonObject resultObj;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.resolve("code-cov-exclusion");
         resultsJsonPath = projectBasedTestsPath.resolve("code-cov-exclusion").resolve("target").resolve("report")
@@ -52,7 +52,7 @@ public class ExcludeFromCodeCoverageTest extends BaseTestCase {
     }
 
     @Test(description = "Exclude coverage with relative source paths and wildcards")
-    public void testExcludingBalFileCoverage() throws BallerinaTestException, IOException {
+    public void testExcludingBalFileCoverage() throws BallerinaTestException {
         String [][] exclusionListOfList = {{"./main.bal", "./modules/util/util.bal", "./generated/util/util_gen.bal",
                 "./generated/util2/util2_gen.bal", "./generated/main_gen.bal"},
                 {"./*", "./modules/util/ut*.bal", "./generated**"},
@@ -85,7 +85,7 @@ public class ExcludeFromCodeCoverageTest extends BaseTestCase {
     }
 
     @Test(description = "Exclude a source file from coverage exclusion list", enabled = false)
-    public void testExcludesSrcFileFromExclusionList() throws BallerinaTestException, IOException {
+    public void testExcludesSrcFileFromExclusionList() throws BallerinaTestException {
         String [] exclusionList =  {"./*", "!./main.bal"};
         String[] args = mergeCoverageArgs(new String[]{"--test-report", "--coverage-format=xml",
                 "--excludes=" + String.join(",", exclusionList)});
@@ -103,7 +103,7 @@ public class ExcludeFromCodeCoverageTest extends BaseTestCase {
     }
 
     @Test(description = "Exclude a folder from coverage exclusion list", enabled = false)
-    public void testExcludesSrcFolderFromExclusionList() throws BallerinaTestException, IOException {
+    public void testExcludesSrcFolderFromExclusionList() throws BallerinaTestException {
         String [] exclusionList = {"./generated", "!./generated/util"};
         String[] args = mergeCoverageArgs(new String[]{"--test-report", "--coverage-format=xml",
                 "--excludes=" + String.join(",", exclusionList)});

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/FunctionNameValidationTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/FunctionNameValidationTest.java
@@ -35,7 +35,7 @@ public class FunctionNameValidationTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/GroupingTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/GroupingTest.java
@@ -35,7 +35,7 @@ public class GroupingTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = singleFileTestsPath.resolve("grouping").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ImportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ImportTest.java
@@ -36,7 +36,7 @@ public class ImportTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass()
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ModuleExecutionFlowTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ModuleExecutionFlowTest.java
@@ -41,7 +41,7 @@ public class ModuleExecutionFlowTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.resolve("module-execution-flow-tests").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ModuleExecutionTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ModuleExecutionTest.java
@@ -40,7 +40,7 @@ public class ModuleExecutionTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.resolve("module-execution-tests").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ModuleExecutionWithInitStartFailuresTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ModuleExecutionWithInitStartFailuresTest.java
@@ -44,7 +44,7 @@ public class ModuleExecutionWithInitStartFailuresTest {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.resolve("module-execution-tests-with-init-start-failures").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ModuleGracefulStopTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ModuleGracefulStopTest.java
@@ -41,7 +41,7 @@ public class ModuleGracefulStopTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.resolve("module-graceful-stop-tests").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/PathVerificationTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/PathVerificationTest.java
@@ -35,7 +35,7 @@ public class PathVerificationTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/RerunFailedTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/RerunFailedTest.java
@@ -41,7 +41,7 @@ public class RerunFailedTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/SelectedFunctionTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/SelectedFunctionTest.java
@@ -35,7 +35,7 @@ public class SelectedFunctionTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = singleFileTestsPath.resolve("single-test-execution").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/SingleTestExecutionWithInitFailuresTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/SingleTestExecutionWithInitFailuresTest.java
@@ -33,7 +33,7 @@ public class SingleTestExecutionWithInitFailuresTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = singleFileTestsPath.resolve("single-test-execution").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/SourcelessTestExecutionTests.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/SourcelessTestExecutionTests.java
@@ -18,7 +18,7 @@ public class SourcelessTestExecutionTests extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.resolve("sourceless-test-execution-tests").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestExecutionWithInitFailuresTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestExecutionWithInitFailuresTest.java
@@ -40,7 +40,7 @@ public class TestExecutionWithInitFailuresTest {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.resolve("test-execution-with-init-failure").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
@@ -54,7 +54,7 @@ public class TestReportTest extends BaseTestCase {
     private static final int FAILED = 3;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.resolve("test-report-tests").toString();
         resultsJsonPath = projectBasedTestsPath.resolve("test-report-tests").resolve("target").resolve("report")

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestparallelizationTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestparallelizationTest.java
@@ -22,7 +22,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
 import java.util.HashMap;
 
 /**
@@ -36,13 +35,13 @@ public class TestparallelizationTest extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.resolve("parallelisation-test").toString();
     }
 
     @Test
-    public void testParallelization() throws BallerinaTestException, IOException {
+    public void testParallelization() throws BallerinaTestException {
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "parallelisation-simple-test"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -57,7 +56,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testNonParallelizable() throws BallerinaTestException, IOException {
+    public void testNonParallelizable() throws BallerinaTestException {
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "parallelisation-serialExecution"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -74,7 +73,7 @@ public class TestparallelizationTest extends BaseTestCase {
 
 
     @Test
-    public void testParalallelizableTupleDataProvider() throws BallerinaTestException, IOException {
+    public void testParalallelizableTupleDataProvider() throws BallerinaTestException {
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "parallelisation-tuple-data-provider"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -89,7 +88,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testParalallelizableMapDataProvider() throws BallerinaTestException, IOException {
+    public void testParalallelizableMapDataProvider() throws BallerinaTestException {
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "parallelisation-map-data-provider"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -105,7 +104,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testNonParalallelizableTupleDataProvider() throws BallerinaTestException, IOException {
+    public void testNonParalallelizableTupleDataProvider() throws BallerinaTestException {
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "non-parallelisation-tuple-data-provider"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -121,7 +120,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testNonIsolatedTestFunction() throws BallerinaTestException, IOException {
+    public void testNonIsolatedTestFunction() throws BallerinaTestException {
         String warningDiagnostics = "WARNING: Test function 'testAssertEquals*' cannot be parallelized, reason: " +
                 "non-isolated test function";
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "non-isolated-tests"});
@@ -141,7 +140,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testNonIsolatedTestParameter() throws BallerinaTestException, IOException {
+    public void testNonIsolatedTestParameter() throws BallerinaTestException {
         String warningDiagnostics = "WARNING: Test function 'mapDataProviderTest' cannot be parallelized, reason: " +
                 "unsafe test parameters";
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "non-isolated-test-params"});
@@ -160,7 +159,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testNonIsolatedDataProvider() throws BallerinaTestException, IOException {
+    public void testNonIsolatedDataProvider() throws BallerinaTestException {
         String warningDiagnostics = "WARNING: Test function 'mapDataProviderTest' cannot be parallelized, reason: " +
                 "non-isolated data-provider function";
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "non-isolated-data-provider"});
@@ -179,7 +178,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testNonIsolatedAfterEach() throws BallerinaTestException, IOException {
+    public void testNonIsolatedAfterEach() throws BallerinaTestException {
         String warningDiagnostics = "WARNING: Test function 'mapDataProviderTest' cannot be parallelized, reason: " +
                 "non-isolated after-each function";
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "non-isolated-after-each"});
@@ -198,7 +197,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testNonIsolatedBeforeEach() throws BallerinaTestException, IOException {
+    public void testNonIsolatedBeforeEach() throws BallerinaTestException {
         String warningDiagnostics = "WARNING: Test function 'mapDataProviderTest' cannot be parallelized, reason: " +
                 "non-isolated before-each function";
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "non-isolated-before-each"});
@@ -217,7 +216,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testNonIsolatedAfterFunc() throws BallerinaTestException, IOException {
+    public void testNonIsolatedAfterFunc() throws BallerinaTestException {
         String warningDiagnostics = "WARNING: Test function 'mapDataProviderTest' cannot be parallelized, reason: " +
                 "non-isolated after function";
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "non-isolated-after-func"});
@@ -236,7 +235,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testNonIsolatedBeforeFunc() throws BallerinaTestException, IOException {
+    public void testNonIsolatedBeforeFunc() throws BallerinaTestException {
         String warningDiagnostics = "WARNING: Test function 'mapDataProviderTest' cannot be parallelized, reason: " +
                 "non-isolated before function";
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "non-isolated-before-func"});
@@ -255,7 +254,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testNonIsolatedAfterGroup() throws BallerinaTestException, IOException {
+    public void testNonIsolatedAfterGroup() throws BallerinaTestException {
         String warningDiagnostics = "WARNING: Test function 'mapDataProviderTest' cannot be parallelized, reason: " +
                 "non-isolated after-groups function";
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "non-isolated-after-grp"});
@@ -274,7 +273,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testNonIsolatedBeforeGroup() throws BallerinaTestException, IOException {
+    public void testNonIsolatedBeforeGroup() throws BallerinaTestException {
         String warningDiagnostics = "WARNING: Test function 'mapDataProviderTest' cannot be parallelized, reason: " +
                 "non-isolated before-groups function";
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "non-isolated-before-grp"});
@@ -293,7 +292,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testIsolatedSetUpTearDown() throws BallerinaTestException, IOException {
+    public void testIsolatedSetUpTearDown() throws BallerinaTestException {
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "isolated-set-up-tear-down"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -309,7 +308,7 @@ public class TestparallelizationTest extends BaseTestCase {
     }
 
     @Test
-    public void testNonParalallelizableMapDataProvider() throws BallerinaTestException, IOException {
+    public void testNonParalallelizableMapDataProvider() throws BallerinaTestException {
         String[] args = mergeCoverageArgs(new String[]{PARALLEL_FLAG, "non-parallelisation-map-data-provider"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/InvalidConfigurableCliArgsTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/InvalidConfigurableCliArgsTestCase.java
@@ -38,7 +38,7 @@ public class InvalidConfigurableCliArgsTestCase extends BaseTestCase {
     private String testFileLocation;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         bMainInstance = new BMainInstance(balServer);
         testFileLocation = projectBasedTestsPath.resolve("configurable-cli-args-test").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/InvalidDataProviderTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/InvalidDataProviderTestCase.java
@@ -41,7 +41,7 @@ public class InvalidDataProviderTestCase extends BaseTestCase {
     private Path errorlogFile;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = singleFileTestsPath.resolve("invalid-data-providers").toString();
         errorlogFile = Paths.get(projectPath).resolve("ballerina-internal.log");

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/InvalidFunctionMockingTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/InvalidFunctionMockingTestCase.java
@@ -36,7 +36,7 @@ public class InvalidFunctionMockingTestCase extends BaseTestCase {
     private BMainInstance balClient;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
     }
 

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/InvalidTestDefinitionsTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/InvalidTestDefinitionsTestCase.java
@@ -37,7 +37,7 @@ public class InvalidTestDefinitionsTestCase extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = singleFileTestsPath.resolve("invalid-test-definitions").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/MissingFunctionsTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/MissingFunctionsTestCase.java
@@ -36,7 +36,7 @@ public class MissingFunctionsTestCase extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = singleFileTestsPath.resolve("missing-functions").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/SkipTestsTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/SkipTestsTestCase.java
@@ -36,7 +36,7 @@ public class SkipTestsTestCase extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = singleFileTestsPath.resolve("skip-tests").toString();
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/UnusedVarWithErrorTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/UnusedVarWithErrorTestCase.java
@@ -38,7 +38,7 @@ public class UnusedVarWithErrorTestCase extends BaseTestCase {
     private String projectPath;
 
     @BeforeClass
-    public void setup() throws BallerinaTestException {
+    public void setup() {
         balClient = new BMainInstance(balServer);
         projectPath = projectBasedTestsPath.resolve("unused-var-with-error-test").toString();
     }


### PR DESCRIPTION
## Purpose
Superfluous exceptions within throws clauses have negative effects on the readability and maintainability of the code. An exception in a throws clause is superfluous if it is:

listed multiple times
a subclass of another listed exception
not actually thrown by any execution path of the method
https://sonarcloud.io/organizations/ballerina-platform/rules?open=java%3AS1130&rule_key=java%3AS1130

Reopens: #42946

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
