### PR TITLE
[Refactoring] Names and Name cleanup (use static access & getter)

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -684,7 +684,7 @@ public class BallerinaSemanticModel implements SemanticModel {
     }
 
     private boolean isIgnorableSelfSymbol(Name name, BSymbol symbol, BSymbol symbolEnvScopeOwner) {
-        return name.value.equals("self") && !symbol.owner.owner.equals(symbolEnvScopeOwner.owner);
+        return name.getValue().equals("self") && !symbol.owner.owner.equals(symbolEnvScopeOwner.owner);
     }
 
     private boolean isFilteredVarSymbol(BSymbol symbol, Set<DiagnosticState> states) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ExpectedTypeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ExpectedTypeFinder.java
@@ -1099,7 +1099,7 @@ public class ExpectedTypeFinder extends NodeTransformer<Optional<TypeSymbol>> {
             //Skip the first n arguments where n is the number of positional arguments specified by the user.
             int numOfPositionalArgs = argumentIndex - namedArgs.size();
             return invokableSymbol.params.subList(numOfPositionalArgs, paramsSize)
-                    .stream().filter(param -> !namedArgs.contains(param.name.value))
+                    .stream().filter(param -> !namedArgs.contains(param.name.getValue()))
                     .findFirst().flatMap(this::getSymbolType);
         }
         if (invokableSymbol.restParam != null) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibrary.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibrary.java
@@ -75,8 +75,8 @@ public class LangLibrary {
             PackageID moduleID = module.pkgID;
 
             if (isLangLibModule(moduleID)) {
-                if (!LANG_VALUE.equals(moduleID.nameComps.get(1).value)) {
-                    addLangLibMethods(moduleID.nameComps.get(1).value, module, this.langLibMethods, types);
+                if (!LANG_VALUE.equals(moduleID.nameComps.get(1).getValue())) {
+                    addLangLibMethods(moduleID.nameComps.get(1).getValue(), module, this.langLibMethods, types);
                 } else {
                     populateLangValueLibrary(module, this.langLibMethods);
                 }
@@ -186,7 +186,7 @@ public class LangLibrary {
                     (!invSymbol.params.isEmpty() && equalsToBasicType(invSymbol.params.get(0).type, basicType) ||
                             invSymbol.restParam != null &&
                                     equalsToBasicType(((BArrayType) invSymbol.restParam.type).eType, basicType))) {
-                methods.put(invSymbol.name.value, invSymbol);
+                methods.put(invSymbol.name.getValue(), invSymbol);
             }
         }
 
@@ -204,7 +204,7 @@ public class LangLibrary {
                 continue;
             }
 
-            methods.put(symbol.name.value, (BInvokableSymbol) symbol);
+            methods.put(symbol.name.getValue(), (BInvokableSymbol) symbol);
         }
 
         langLibMethods.put(LANG_VALUE, methods);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -1479,7 +1479,7 @@ public class ReferenceFinder extends BaseVisitor {
             }
             
             BLangLiteral literal = (BLangLiteral) expr;
-            if (literal.value.equals(pathSymbol.name.value) && addIfSameSymbol(pathSymbol, expr.pos)) {
+            if (literal.value.equals(pathSymbol.name.getValue()) && addIfSameSymbol(pathSymbol, expr.pos)) {
                 return;
             }
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -524,7 +524,7 @@ public class SymbolFactory {
 
         List<ConstantSymbol> members = new ArrayList<>();
         for (BConstantSymbol member : enumSymbol.members) {
-            members.add(this.createConstantSymbol(member, member.name.value));
+            members.add(this.createConstantSymbol(member, member.name.getValue()));
         }
 
         for (AnnotationAttachmentSymbol annot : enumSymbol.getAnnotations()) {
@@ -766,7 +766,7 @@ public class SymbolFactory {
         for (BAttachedFunction mthd : methods) {
             if (method == mthd.symbol) {
                 if (mthd instanceof BResourceFunction bResourceFunction) {
-                    return bResourceFunction.accessor.value;
+                    return bResourceFunction.accessor.getValue();
                 }
                 return mthd.symbol.getOriginalName().getValue();
             }
@@ -788,7 +788,7 @@ public class SymbolFactory {
     }
 
     private BField getBField(BVarSymbol symbol) {
-        String fieldName = symbol.name.value;
+        String fieldName = symbol.name.getValue();
         BStructureType type = (BStructureType) symbol.owner.type;
         return type.fields.get(fieldName);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractIntSubTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractIntSubTypeSymbol.java
@@ -48,8 +48,8 @@ public abstract class AbstractIntSubTypeSymbol extends AbstractTypeSymbol {
         SymbolTable symTable = SymbolTable.getInstance(this.context);
         SymbolFactory symFactory = SymbolFactory.getInstance(this.context);
         this.module = (ModuleSymbol) symFactory.getBCompiledSymbol(symTable.langIntModuleSymbol,
-                                                                   symTable.langIntModuleSymbol
-                                                                           .getOriginalName().value);
+                symTable.langIntModuleSymbol
+                        .getOriginalName().getValue());
         return Optional.of(this.module);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractXMLSubTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractXMLSubTypeSymbol.java
@@ -48,8 +48,8 @@ public abstract class AbstractXMLSubTypeSymbol extends AbstractTypeSymbol {
         SymbolTable symTable = SymbolTable.getInstance(this.context);
         SymbolFactory symFactory = SymbolFactory.getInstance(this.context);
         this.module = (ModuleSymbol) symFactory.getBCompiledSymbol(symTable.langXmlModuleSymbol,
-                                                                   symTable.langXmlModuleSymbol
-                                                                           .getOriginalName().value);
+                symTable.langXmlModuleSymbol
+                        .getOriginalName().getValue());
         return Optional.of(this.module);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -91,7 +91,7 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
         BObjectType type = (BObjectType) this.getBType();
 
         for (BField field : type.fields.values()) {
-            fields.put(field.symbol.getOriginalName().value, new BallerinaClassFieldSymbol(this.context, field));
+            fields.put(field.symbol.getOriginalName().getValue(), new BallerinaClassFieldSymbol(this.context, field));
         }
 
         this.classFields = Collections.unmodifiableMap(fields);
@@ -108,8 +108,8 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
         if (this.initMethod == null && this.internalSymbol.initializerFunc != null) {
             SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
             this.initMethod = symbolFactory.createMethodSymbol(internalSymbol.initializerFunc.symbol,
-                                                               internalSymbol.initializerFunc.symbol
-                                                                       .getOriginalName().value);
+                    internalSymbol.initializerFunc.symbol
+                            .getOriginalName().getValue());
         }
 
         return Optional.ofNullable(this.initMethod);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
@@ -91,7 +91,7 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
 
     @Override
     public String signature() {
-        return this.getInternalSymbol().name.value;
+        return this.getInternalSymbol().name.getValue();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
@@ -83,7 +83,7 @@ public class BallerinaErrorTypeSymbol extends AbstractTypeSymbol implements Erro
         }
 
         SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
-        this.module = symbolFactory.createModuleSymbol((BPackageSymbol) symbol, symbol.name.value);
+        this.module = symbolFactory.createModuleSymbol((BPackageSymbol) symbol, symbol.name.getValue());
         return Optional.of(this.module);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
@@ -59,7 +59,7 @@ public class BallerinaObjectFieldSymbol extends BallerinaSymbol implements Objec
     private List<io.ballerina.compiler.api.symbols.AnnotationAttachmentSymbol> annotAttachments;
 
     public BallerinaObjectFieldSymbol(CompilerContext context, BField bField, SymbolKind kind) {
-        super(bField.symbol.getOriginalName().value, kind, bField.symbol, context);
+        super(bField.symbol.getOriginalName().getValue(), kind, bField.symbol, context);
         this.bField = bField;
         this.docAttachment = new BallerinaDocumentation(bField.symbol.markdownDocumentation);
         this.deprecated = Symbols.isFlagOn(bField.symbol.flags, Flags.DEPRECATED);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -94,7 +94,7 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
         BObjectType type = (BObjectType) this.getBType();
 
         for (BField field : type.fields.values()) {
-            fields.put(field.symbol.getOriginalName().value, new BallerinaObjectFieldSymbol(this.context, field));
+            fields.put(field.symbol.getOriginalName().getValue(), new BallerinaObjectFieldSymbol(this.context, field));
         }
 
         this.objectFields = Collections.unmodifiableMap(fields);
@@ -113,11 +113,11 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
         for (BAttachedFunction attachedFunc : ((BObjectTypeSymbol) this.getBType().tsymbol).attachedFuncs) {
             if (attachedFunc instanceof BResourceFunction resFn) {
                 String resPath = resFn.pathSegmentSymbols.stream()
-                        .map(p -> p.name.value).collect(Collectors.joining("/"));
-                methods.put(resFn.accessor.value + " " + resPath,
+                        .map(p -> p.name.getValue()).collect(Collectors.joining("/"));
+                methods.put(resFn.accessor.getValue() + " " + resPath,
                             symbolFactory.createResourceMethodSymbol(attachedFunc.symbol));
             } else {
-                methods.put(attachedFunc.funcName.value,
+                methods.put(attachedFunc.funcName.getValue(),
                             symbolFactory.createMethodSymbol(attachedFunc.symbol,
                                                              attachedFunc.symbol.getOriginalName().getValue()));
             }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
@@ -58,7 +58,7 @@ public class BallerinaRecordFieldSymbol extends BallerinaSymbol implements Recor
     private boolean deprecated;
 
     public BallerinaRecordFieldSymbol(CompilerContext context, BField bField) {
-        super(bField.symbol.getOriginalName().value, SymbolKind.RECORD_FIELD, bField.symbol, context);
+        super(bField.symbol.getOriginalName().getValue(), SymbolKind.RECORD_FIELD, bField.symbol, context);
         this.bField = bField;
         this.docAttachment = new BallerinaDocumentation(bField.symbol.markdownDocumentation);
         this.deprecated = Symbols.isFlagOn(bField.symbol.flags, Flags.DEPRECATED);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
@@ -61,7 +61,7 @@ public class BallerinaRecordTypeSymbol extends AbstractStructuredTypeSymbol impl
         BRecordType type = (BRecordType) this.getBType();
 
         for (BField field : type.fields.values()) {
-            fields.put(field.symbol.getOriginalName().value, new BallerinaRecordFieldSymbol(this.context, field));
+            fields.put(field.symbol.getOriginalName().getValue(), new BallerinaRecordFieldSymbol(this.context, field));
         }
 
         this.fieldSymbols = Collections.unmodifiableMap(fields);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRegexpTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRegexpTypeSymbol.java
@@ -56,7 +56,7 @@ public class BallerinaRegexpTypeSymbol extends AbstractTypeSymbol implements Reg
             SymbolTable symTable = SymbolTable.getInstance(this.context);
             SymbolFactory symFactory = SymbolFactory.getInstance(this.context);
             this.module = (ModuleSymbol) symFactory.getBCompiledSymbol(symTable.langRegexpModuleSymbol,
-                    symTable.langRegexpModuleSymbol.getOriginalName().value);
+                    symTable.langRegexpModuleSymbol.getOriginalName().getValue());
         }
         return Optional.ofNullable(this.module);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaResourceMethodSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaResourceMethodSymbol.java
@@ -150,6 +150,6 @@ public class BallerinaResourceMethodSymbol extends BallerinaMethodSymbol impleme
         }
 
         throw new IllegalStateException(
-                "Matching BResourceFunction not found for internal symbol: " + internalSymbol.name.value);
+                "Matching BResourceFunction not found for internal symbol: " + internalSymbol.name.getValue());
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
@@ -123,7 +123,7 @@ public class BallerinaServiceDeclarationSymbol extends BallerinaSymbol implement
         Map<String, ClassFieldSymbol> fields = new LinkedHashMap<>();
 
         for (BField field : classType.fields.values()) {
-            fields.put(field.name.value, new BallerinaClassFieldSymbol(this.context, field));
+            fields.put(field.name.getValue(), new BallerinaClassFieldSymbol(this.context, field));
         }
 
         this.fields = Collections.unmodifiableMap(fields);
@@ -146,14 +146,15 @@ public class BallerinaServiceDeclarationSymbol extends BallerinaSymbol implement
                 StringJoiner stringJoiner = new StringJoiner("/");
 
                 for (BResourcePathSegmentSymbol pathSegmentSym : resFn.pathSegmentSymbols) {
-                    stringJoiner.add(pathSegmentSym.name.value);
+                    stringJoiner.add(pathSegmentSym.name.getValue());
                 }
 
-                methods.put(resFn.accessor.value + " " + stringJoiner.toString(),
+                methods.put(resFn.accessor.getValue() + " " + stringJoiner.toString(),
                             symbolFactory.createResourceMethodSymbol(method.symbol));
             } else {
-                methods.put(method.funcName.value,
-                            symbolFactory.createMethodSymbol(method.symbol, method.symbol.getOriginalName().value));
+                methods.put(
+                        method.funcName.getValue(),
+                        symbolFactory.createMethodSymbol(method.symbol, method.symbol.getOriginalName().getValue()));
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
@@ -62,8 +62,8 @@ public class BallerinaStringCharTypeSymbol extends AbstractTypeSymbol implements
         SymbolTable symTable = SymbolTable.getInstance(this.context);
         SymbolFactory symFactory = SymbolFactory.getInstance(this.context);
         this.module = (ModuleSymbol) symFactory.getBCompiledSymbol(symTable.langStringModuleSymbol,
-                                                                   symTable.langStringModuleSymbol
-                                                                           .getOriginalName().value);
+                symTable.langStringModuleSymbol
+                        .getOriginalName().getValue());
         return Optional.of(this.module);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -98,7 +98,7 @@ public class BallerinaSymbol implements Symbol {
         }
 
         SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
-        this.module = symbolFactory.createModuleSymbol((BPackageSymbol) symbol, symbol.name.value);
+        this.module = symbolFactory.createModuleSymbol((BPackageSymbol) symbol, symbol.name.getValue());
         return Optional.of(this.module);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -209,7 +209,7 @@ public class TypesFactory {
             case OBJECT:
                 ObjectTypeSymbol objType = new BallerinaObjectTypeSymbol(this.context, (BObjectType) bType);
                 if (Symbols.isFlagOn(tSymbol.flags, Flags.CLASS)) {
-                    return symbolFactory.createClassSymbol((BClassSymbol) tSymbol, tSymbol.name.value, objType);
+                    return symbolFactory.createClassSymbol((BClassSymbol) tSymbol, tSymbol.name.getValue(), objType);
                 }
                 return objType;
             case RECORD:
@@ -302,7 +302,7 @@ public class TypesFactory {
             return false;
         }
 
-        if (!isBuiltinNamedType(bType.tag) && !(tSymbol.name.value.isEmpty()
+        if (!isBuiltinNamedType(bType.tag) && !(tSymbol.name.getValue().isEmpty()
                 || anonymousModelHelper.isAnonymousType(tSymbol))) {
             return true;
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/resourcepath/BallerinaPathSegmentList.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/resourcepath/BallerinaPathSegmentList.java
@@ -72,7 +72,7 @@ public class BallerinaPathSegmentList implements PathSegmentList {
         for (int i = 0; i < segments.size(); i++) {
             Name internalSegment = segments.get(i);
             BResourcePathSegmentSymbol pathSegSymbol = this.internalPathSegmentSymbols.get(i);
-            switch (internalSegment.value) {
+            switch (internalSegment.getValue()) {
                 case "^":
                     BVarSymbol paramVarSymbol = this.internalPathParams.get(internalPathParamCount++);
                     pathParams.add(symbolFactory.createPathParamSymbol(paramVarSymbol.getOriginalName().getValue(),

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ConfigReader.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ConfigReader.java
@@ -203,7 +203,7 @@ public final class ConfigReader {
                         // Get description
                         String description = getDescriptionValue(varSymbol, module);
                         configVariables.add(new ConfigVariable(
-                                varSymbol.name.value.replace("\\", ""), varSymbol.type,
+                                varSymbol.name.getValue().replace("\\", ""), varSymbol.type,
                                 Symbols.isFlagOn(varSymbol.flags, Flags.REQUIRED), description));
                     }
                 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DocumentContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DocumentContext.java
@@ -144,10 +144,10 @@ class DocumentContext {
         TransactionImportValidator trxImportValidator = new TransactionImportValidator();
 
         if (trxImportValidator.shouldImportTransactionPackage(modulePartNode) &&
-                !currentModuleDesc.name().toString().equals(Names.TRANSACTION.value)) {
-            String moduleName = Names.TRANSACTION.value;
+                !currentModuleDesc.name().toString().equals(Names.TRANSACTION.getValue())) {
+            String moduleName = Names.TRANSACTION.getValue();
             ModuleLoadRequest ballerinaiLoadReq = new ModuleLoadRequest(
-                    PackageOrg.from(Names.BALLERINA_INTERNAL_ORG.value),
+                    PackageOrg.from(Names.BALLERINA_INTERNAL_ORG.getValue()),
                     moduleName, scope, DependencyResolutionType.PLATFORM_PROVIDED);
             moduleLoadRequestSet.add(ballerinaiLoadReq);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBalaWriter.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBalaWriter.java
@@ -247,8 +247,8 @@ public class JBallerinaBalaWriter extends BalaWriter {
 
         // 1) Check direct dependencies of imports in the package have any `ballerina/java` dependency
         for (ResolvedPackageDependency dependency : resolvedPackageDependencies) {
-            if (dependency.packageInstance().packageOrg().value().equals(Names.BALLERINA_ORG.value) &&
-                    dependency.packageInstance().packageName().value().equals(Names.JAVA.value) &&
+            if (dependency.packageInstance().packageOrg().value().equals(Names.BALLERINA_ORG.getValue()) &&
+                    dependency.packageInstance().packageName().value().equals(Names.JAVA.getValue()) &&
                     !dependency.scope().equals(PackageDependencyScope.TEST_ONLY)) {
                 return this.backend.targetPlatform();
             }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -327,7 +327,7 @@ public class PackageResolution {
             {
                 String moduleName = Names.OBSERVE.getValue();
                 ModuleLoadRequest observeModuleLoadReq = new ModuleLoadRequest(
-                        PackageOrg.from(Names.BALLERINA_INTERNAL_ORG.value), moduleName,
+                        PackageOrg.from(Names.BALLERINA_INTERNAL_ORG.getValue()), moduleName,
                         PackageDependencyScope.DEFAULT, DependencyResolutionType.PLATFORM_PROVIDED);
                 allModuleLoadRequests.add(observeModuleLoadReq);
             }
@@ -338,7 +338,7 @@ public class PackageResolution {
                 "choreo".equals(compilationOptions.getCloud())) {
             String moduleName = Names.CLOUD.getValue();
             ModuleLoadRequest c2cModuleLoadReq = new ModuleLoadRequest(
-                    PackageOrg.from(Names.BALLERINA_ORG.value), moduleName,
+                    PackageOrg.from(Names.BALLERINA_ORG.getValue()), moduleName,
                     PackageDependencyScope.DEFAULT, DependencyResolutionType.COMPILER_PLUGIN);
             allModuleLoadRequests.add(c2cModuleLoadReq);
         }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/PackageID.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/PackageID.java
@@ -166,7 +166,7 @@ public class PackageID {
         if (name == Names.DEFAULT_PACKAGE) {
             return Lists.of(Names.DEFAULT_PACKAGE);
         }
-        return Arrays.stream(name.value.split("\\.")).map(Name::new).toList();
+        return Arrays.stream(name.getValue().split("\\.")).map(Name::new).toList();
     }
 
     /**
@@ -256,19 +256,19 @@ public class PackageID {
     @Override
     public String toString() {
         if (Names.DOT.equals(this.name)) {
-            return this.name.value;
+            return this.name.getValue();
         }
 
         String org = "";
         if (this.orgName != null && !this.orgName.equals(Names.ANON_ORG)) {
-            org = this.orgName + Names.ORG_NAME_SEPARATOR.value;
+            org = this.orgName + Names.ORG_NAME_SEPARATOR.getValue();
         }
 
         if (version.equals(Names.EMPTY)) {
-            return org + this.name.value;
+            return org + this.name.getValue();
         }
 
-        return org + this.name + Names.VERSION_SEPARATOR.value + this.version;
+        return org + this.name + Names.VERSION_SEPARATOR.getValue() + this.version;
     }
 
     public Name getOrgName() {

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/GeneralFSPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/GeneralFSPackageRepository.java
@@ -167,7 +167,7 @@ public class GeneralFSPackageRepository implements PackageRepository {
 
         Path pkgDirPath = this.basePath;
         for (Name comp : pkgID.getNameComps()) {
-            pkgDirPath = pkgDirPath.resolve(comp.value);
+            pkgDirPath = pkgDirPath.resolve(comp.getValue());
         }
         return pkgDirPath;
     }
@@ -183,7 +183,7 @@ public class GeneralFSPackageRepository implements PackageRepository {
     }
 
     private Path generatePathNew(PackageID pkgID) {
-        Path pkgDirPath = this.basePath.resolve(pkgID.getOrgName().value);
+        Path pkgDirPath = this.basePath.resolve(pkgID.getOrgName().getValue());
         return pkgDirPath.resolve(createPackageNameWithDots(pkgID));
     }
 
@@ -194,7 +194,7 @@ public class GeneralFSPackageRepository implements PackageRepository {
             if (i != 0) {
                 builder.append(".");
             }
-            builder.append(nameComps.get(i).value);
+            builder.append(nameComps.get(i).getValue());
         }
         return builder.toString();
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -135,7 +135,6 @@ public class BIRPackageSymbolEnter {
     private final PackageCache packageCache;
     private final SymbolResolver symbolResolver;
     private final SymbolTable symTable;
-    private final Names names;
     private final TypeParamAnalyzer typeParamAnalyzer;
     private final Types types;
     private BIRTypeReader typeReader;
@@ -167,7 +166,6 @@ public class BIRPackageSymbolEnter {
         this.packageCache = PackageCache.getInstance(context);
         this.symbolResolver = SymbolResolver.getInstance(context);
         this.symTable = SymbolTable.getInstance(context);
-        this.names = Names.getInstance(context);
         this.typeParamAnalyzer = TypeParamAnalyzer.getInstance(context);
         this.types = Types.getInstance(context);
     }
@@ -1945,11 +1943,11 @@ public class BIRPackageSymbolEnter {
     private BType getEffectiveImmutableType(BType type) {
         return ImmutableTypeCloner.getEffectiveImmutableType(null, types, type,
                 type.tsymbol.pkgID, type.tsymbol.owner,
-                symTable, null, names);
+                symTable, null);
     }
 
     private BType getEffectiveImmutableType(BType type, PackageID pkgID, BSymbol owner) {
         return ImmutableTypeCloner.getEffectiveImmutableType(null, types, type, pkgID, owner, symTable,
-                null, names);
+                null);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -281,9 +281,10 @@ public class BIRPackageSymbolEnter {
                             // we should not copy private functions.
                             continue;
                         }
-                        String referencedFuncName = function.funcName.value;
+                        String referencedFuncName = function.funcName.getValue();
                         Name funcName = Names.fromString(
-                                Symbols.getAttachedFuncSymbolName(structureTypeSymbol.name.value, referencedFuncName));
+                                Symbols.getAttachedFuncSymbolName(structureTypeSymbol.name.getValue(),
+                                        referencedFuncName));
                         Scope.ScopeEntry matchingObjFuncSym = objectType.tsymbol.scope.lookup(funcName);
                         if (matchingObjFuncSym == NOT_FOUND_ENTRY) {
                             structureTypeSymbol.attachedFuncs.add(function);
@@ -416,7 +417,7 @@ public class BIRPackageSymbolEnter {
             // Update the symbol
             invokableSymbol.owner = attachedType.tsymbol;
             invokableSymbol.name =
-                    Names.fromString(Symbols.getAttachedFuncSymbolName(attachedType.tsymbol.name.value, funcName));
+                    Names.fromString(Symbols.getAttachedFuncSymbolName(attachedType.tsymbol.name.getValue(), funcName));
             if (attachedType.tag == TypeTags.OBJECT || attachedType.tag == TypeTags.RECORD) {
                 scopeToDefine = attachedType.tsymbol.scope;
                 if (isResourceFunction) {
@@ -478,10 +479,10 @@ public class BIRPackageSymbolEnter {
                             new BAttachedFunction(Names.fromString(funcName), invokableSymbol, funcType,
                                     symTable.builtinPos);
                     BStructureTypeSymbol structureTypeSymbol = (BStructureTypeSymbol) attachedType.tsymbol;
-                    if (Names.USER_DEFINED_INIT_SUFFIX.value.equals(funcName) ||
-                            funcName.equals(Names.INIT_FUNCTION_SUFFIX.value)) {
+                    if (Names.USER_DEFINED_INIT_SUFFIX.getValue().equals(funcName) ||
+                            funcName.equals(Names.INIT_FUNCTION_SUFFIX.getValue())) {
                         ((BObjectTypeSymbol) structureTypeSymbol).initializerFunc = attachedFunc;
-                    } else if (funcName.equals(Names.GENERATED_INIT_SUFFIX.value)) {
+                    } else if (funcName.equals(Names.GENERATED_INIT_SUFFIX.getValue())) {
                         ((BObjectTypeSymbol) structureTypeSymbol).generatedInitializerFunc = attachedFunc;
                     } else {
                         structureTypeSymbol.attachedFuncs.add(attachedFunc);
@@ -541,7 +542,7 @@ public class BIRPackageSymbolEnter {
         BTypeReferenceType referenceType = null;
         boolean hasReferenceType = dataInStream.readBoolean();
         if (hasReferenceType) {
-            if (type.tag == TypeTags.TYPEREFDESC && Objects.equals(type.tsymbol.name.value, typeDefName)
+            if (type.tag == TypeTags.TYPEREFDESC && Objects.equals(type.tsymbol.name.getValue(), typeDefName)
                     && type.tsymbol.owner == this.env.pkgSymbol) {
                 referenceType = (BTypeReferenceType) type;
                 referenceType.tsymbol.pos = pos;
@@ -1298,7 +1299,7 @@ public class BIRPackageSymbolEnter {
                         defineMarkDownDocAttachment(varSymbol, docBytes);
 
                         BField structField = new BField(varSymbol.name, varSymbol.pos, varSymbol);
-                        recordType.fields.put(structField.name.value, structField);
+                        recordType.fields.put(structField.name.getValue(), structField);
                         recordSymbol.scope.define(varSymbol.name, varSymbol);
                     }
 
@@ -1654,7 +1655,7 @@ public class BIRPackageSymbolEnter {
                         defineMarkDownDocAttachment(objectVarSymbol, docBytes);
 
                         BField structField = new BField(objectVarSymbol.name, null, objectVarSymbol);
-                        objectType.fields.put(structField.name.value, structField);
+                        objectType.fields.put(structField.name.getValue(), structField);
                         objectSymbol.scope.define(objectVarSymbol.name, objectVarSymbol);
                     }
                     boolean generatedConstructorPresent = inputStream.readBoolean();
@@ -1804,7 +1805,7 @@ public class BIRPackageSymbolEnter {
             long attachedFuncFlags = inputStream.readLong();
             BInvokableType attachedFuncType = (BInvokableType) readTypeFromCp();
             Name funcName = Names.fromString(Symbols.getAttachedFuncSymbolName(
-                    objectSymbol.name.value, attachedFuncName));
+                    objectSymbol.name.getValue(), attachedFuncName));
             Name funcOrigName = Names.fromString(attachedFuncOrigName);
             BInvokableSymbol attachedFuncSymbol =
                     Symbols.createFunctionSymbol(attachedFuncFlags, funcName, funcOrigName,
@@ -1832,7 +1833,8 @@ public class BIRPackageSymbolEnter {
     private BType getType(BType readShape, SymbolEnv pkgEnv, Name name) {
         BType type = symbolResolver.lookupSymbolInMainSpace(pkgEnv, name).type;
 
-        if (type != symTable.noType && (!name.value.contains(ANON_PREFIX) || types.isSameBIRShape(readShape, type))) {
+        if (type != symTable.noType && (!name.getValue().contains(ANON_PREFIX) ||
+                types.isSameBIRShape(readShape, type))) {
             return type;
         }
 
@@ -1847,7 +1849,7 @@ public class BIRPackageSymbolEnter {
                     if (types.isSameBIRShape(readShape, anonType)) {
                         return anonType;
                     }
-                } else if (typeDefName.equals(name.value)) {
+                } else if (typeDefName.equals(name.getValue())) {
                     return symbol.type;
                 }
             }
@@ -1855,7 +1857,7 @@ public class BIRPackageSymbolEnter {
             for (Map.Entry<Name, Scope.ScopeEntry> value : pkgEnv.scope.entries.entrySet()) {
                 BSymbol symbol = value.getValue().symbol;
 
-                if (value.getKey().value.contains(ANON_PREFIX)) {
+                if (value.getKey().getValue().contains(ANON_PREFIX)) {
                     BType anonType = symbol.type;
 
                     if (types.isSameBIRShape(readShape, anonType)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageCache.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageCache.java
@@ -78,7 +78,7 @@ public class PackageCache {
 
     public void remove(PackageID packageID) {
         packageMap.remove(getCacheID(packageID));
-        String[] packageElements = packageID.toString().split(Names.VERSION_SEPARATOR.value);
+        String[] packageElements = packageID.toString().split(Names.VERSION_SEPARATOR.getValue());
         packageSymbolMap.remove(packageElements[0]);
     }
 
@@ -106,7 +106,7 @@ public class PackageCache {
     }
 
     public BPackageSymbol getSymbol(String bvmAlias) {
-        String[] packageElements = bvmAlias.split(Names.VERSION_SEPARATOR.value);
+        String[] packageElements = bvmAlias.split(Names.VERSION_SEPARATOR.getValue());
         Map<String, BPackageSymbol> versionMap = packageSymbolMap.get(packageElements[0]);
         if (versionMap != null) {
             if (packageElements.length > 1) {
@@ -122,13 +122,13 @@ public class PackageCache {
     }
 
     public void putSymbol(PackageID packageID, BPackageSymbol packageSymbol) {
-        String[] packageElements = packageID.toString().split(Names.VERSION_SEPARATOR.value);
+        String[] packageElements = packageID.toString().split(Names.VERSION_SEPARATOR.getValue());
         Map<String, BPackageSymbol> versionMap =
                 packageSymbolMap.computeIfAbsent(packageElements[0], k -> new LinkedHashMap<>());
         if (packageElements.length > 1) {
             versionMap.put(getMajorVersion(packageElements[1]), packageSymbol);
         } else {
-            versionMap.put(Names.DEFAULT_VERSION.value, packageSymbol);
+            versionMap.put(Names.DEFAULT_VERSION.getValue(), packageSymbol);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectoryManager.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectoryManager.java
@@ -53,7 +53,6 @@ public class SourceDirectoryManager implements Project {
             new CompilerContext.Key<>();
 
     private final CompilerOptions options;
-    private final Names names;
     private final SourceDirectory sourceDirectory;
     private Manifest manifest;
 
@@ -71,7 +70,6 @@ public class SourceDirectoryManager implements Project {
         // This has to be further refactored with ProjectAPI Implementation
         context.put(PROJECT_KEY, this);
 
-        this.names = Names.getInstance(context);
         this.options = CompilerOptions.getInstance(context);
 
         // Check whether the compilation is initiated by the project API.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectoryManager.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectoryManager.java
@@ -236,9 +236,9 @@ public class SourceDirectoryManager implements Project {
 
     @Override
     public boolean isModuleExists(PackageID moduleId) {
-        if (this.sourceDirectory.getSourcePackageNames().contains(moduleId.name.value) &&
-            this.manifest.getProject().getOrgName().equals(moduleId.orgName.value) &&
-            this.manifest.getProject().getVersion().equals(moduleId.version.value)) {
+        if (this.sourceDirectory.getSourcePackageNames().contains(moduleId.name.getValue()) &&
+            this.manifest.getProject().getOrgName().equals(moduleId.orgName.getValue()) &&
+            this.manifest.getProject().getVersion().equals(moduleId.version.getValue())) {
             return true;
         } else {
             return false;
@@ -253,11 +253,11 @@ public class SourceDirectoryManager implements Project {
         // Get the version of the project.
         String versionNo = manifest.getProject().getVersion();
         // Identify the platform version
-        String platform = manifest.getTargetPlatform(moduleId.name.value);
+        String platform = manifest.getTargetPlatform(moduleId.name.getValue());
         // {module}-{lang spec version}-{platform}-{version}.bala
         //+ "2019R2" + ProjectDirConstants.FILE_NAME_DELIMITER
-        String balaFileName = moduleId.name.value + "-"
-                + moduleId.orgName.value + "-"
+        String balaFileName = moduleId.name.getValue() + "-"
+                + moduleId.orgName.getValue() + "-"
                 + platform + "-"
                 + versionNo
                 + BLANG_COMPILED_PKG_BINARY_EXT;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -237,7 +237,6 @@ public class BIRGen extends BLangNodeVisitor {
 
     public static final String DEFAULT_WORKER_NAME = "function";
     private BIRGenEnv env;
-    private final Names names;
     private final SymbolTable symTable;
     private final BIROptimizer birOptimizer;
     private final Types types;
@@ -271,7 +270,6 @@ public class BIRGen extends BLangNodeVisitor {
     private BIRGen(CompilerContext context) {
         context.put(BIR_GEN, this);
 
-        this.names = Names.getInstance(context);
         this.symTable = SymbolTable.getInstance(context);
         this.birOptimizer = BIROptimizer.getInstance(context);
         this.unifier = new Unifier();
@@ -451,7 +449,7 @@ public class BIRGen extends BLangNodeVisitor {
             }
 
             birFunc.returnVariable = new BIRVariableDcl(astTypeDefinition.pos, funcSymbol.retType,
-                    this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.RETURN, null);
+                    this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.RETURN, null);
             birFunc.localVars.add(0, birFunc.returnVariable);
 
             typeDef.attachedFuncs.add(birFunc);
@@ -512,7 +510,7 @@ public class BIRGen extends BLangNodeVisitor {
             }
 
             birFunc.returnVariable = new BIRVariableDcl(classDefinition.pos, funcSymbol.retType,
-                                                        this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                                                        this.env.nextLocalVarId(), VarScope.FUNCTION,
                                                         VarKind.RETURN, null);
             birFunc.localVars.add(0, birFunc.returnVariable);
 
@@ -576,7 +574,7 @@ public class BIRGen extends BLangNodeVisitor {
         boolean isTypeAttachedFunction = astFunc.flagSet.contains(Flag.ATTACHED) &&
                 !typeDefs.containsKey(astFunc.receiver.getBType().tsymbol);
 
-        Name workerName = names.fromIdNode(astFunc.defaultWorkerName);
+        Name workerName = Names.fromIdNode(astFunc.defaultWorkerName);
 
         this.env.unlockVars.push(new BIRLockDetailsHolder());
         Name funcName;
@@ -591,7 +589,7 @@ public class BIRGen extends BLangNodeVisitor {
         this.currentScope = new BirScope(0, null);
         if (astFunc.receiver != null) {
             BIRFunctionParameter birVarDcl = new BIRFunctionParameter(astFunc.pos, astFunc.receiver.getBType(),
-                    this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG, astFunc.receiver.name.value,
+                    this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.ARG, astFunc.receiver.name.value,
                     false, false);
             this.env.symbolVarMap.put(astFunc.receiver.symbol, birVarDcl);
             birFunc.receiver = getSelf(astFunc.receiver.symbol);
@@ -635,7 +633,7 @@ public class BIRGen extends BLangNodeVisitor {
         // TODO: Return variable with NIL type should be written to BIR
         // Special %0 location for storing return values
         BType retType = unifier.build(astFunc.symbol.type.getReturnType());
-        birFunc.returnVariable = new BIRVariableDcl(astFunc.pos, retType, this.env.nextLocalVarId(names),
+        birFunc.returnVariable = new BIRVariableDcl(astFunc.pos, retType, this.env.nextLocalVarId(),
                                                     VarScope.FUNCTION, VarKind.RETURN, null);
         birFunc.localVars.add(0, birFunc.returnVariable);
 
@@ -716,7 +714,7 @@ public class BIRGen extends BLangNodeVisitor {
     }
     
     private BIRVariableDcl createBIRVarDeclForPathParam(BVarSymbol pathParamSym) {
-        return new BIRVariableDcl(pathParamSym.pos, pathParamSym.type, this.env.nextLocalVarId(names), 
+        return new BIRVariableDcl(pathParamSym.pos, pathParamSym.type, this.env.nextLocalVarId(),
                 VarScope.FUNCTION, VarKind.ARG, pathParamSym.name.value);
     }
 
@@ -811,7 +809,7 @@ public class BIRGen extends BLangNodeVisitor {
     public void visit(BLangLambdaFunction lambdaExpr) {
         //fpload instruction
         BIRVariableDcl tempVarLambda = new BIRVariableDcl(lambdaExpr.pos, lambdaExpr.getBType(),
-                                                          this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                                                          this.env.nextLocalVarId(), VarScope.FUNCTION,
                                                           VarKind.TEMP, null);
         this.env.enclFunc.localVars.add(tempVarLambda);
         BIROperand lhsOp = new BIROperand(tempVarLambda);
@@ -822,14 +820,14 @@ public class BIRGen extends BLangNodeVisitor {
         lambdaExpr.function.requiredParams.forEach(param -> {
 
             BIRVariableDcl birVarDcl = new BIRVariableDcl(param.pos, param.symbol.type,
-                    this.env.nextLambdaVarId(names), VarScope.FUNCTION, VarKind.ARG, param.name.value);
+                    this.env.nextLambdaVarId(), VarScope.FUNCTION, VarKind.ARG, param.name.value);
             params.add(birVarDcl);
         });
 
         BLangSimpleVariable restParam = lambdaExpr.function.restParam;
         if (restParam != null) {
             BIRVariableDcl birVarDcl = new BIRVariableDcl(restParam.pos, restParam.symbol.type,
-                    this.env.nextLambdaVarId(names), VarScope.FUNCTION, VarKind.ARG, null);
+                    this.env.nextLambdaVarId(), VarScope.FUNCTION, VarKind.ARG, null);
             params.add(birVarDcl);
         }
 
@@ -913,7 +911,7 @@ public class BIRGen extends BLangNodeVisitor {
         boolean isPathParam = paramSymbol.kind == SymbolKind.PATH_PARAMETER ||
                 paramSymbol.kind == SymbolKind.PATH_REST_PARAMETER;
         BIRFunctionParameter birVarDcl = new BIRFunctionParameter(pos, paramSymbol.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG,
+                this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.ARG,
                 paramSymbol.name.value, defaultValExpr != null, isPathParam);
 
         birFunc.localVars.add(birVarDcl);
@@ -930,7 +928,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     private void addRestParam(BIRFunction birFunc, BVarSymbol paramSymbol, Location pos) {
         BIRFunctionParameter birVarDcl = new BIRFunctionParameter(pos, paramSymbol.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.value, false,
+                this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.value, false,
                 paramSymbol.kind == SymbolKind.PATH_REST_PARAMETER);
         birFunc.parameters.add(birVarDcl);
         birFunc.localVars.add(birVarDcl);
@@ -948,7 +946,7 @@ public class BIRGen extends BLangNodeVisitor {
         boolean isPathParam = paramSymbol.kind == SymbolKind.PATH_PARAMETER ||
                 paramSymbol.kind == SymbolKind.PATH_REST_PARAMETER;
         BIRFunctionParameter birVarDcl = new BIRFunctionParameter(pos, paramSymbol.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.value,
+                this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.value,
                 false, isPathParam);
         birFunc.parameters.add(birVarDcl);
         birFunc.localVars.add(birVarDcl);
@@ -1076,7 +1074,7 @@ public class BIRGen extends BLangNodeVisitor {
             kind = VarKind.LOCAL;
         }
         BIRVariableDcl birVarDcl = new BIRVariableDcl(astVarDefStmt.pos, astVarDefStmt.var.symbol.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, kind, astVarDefStmt.var.name.value);
+                this.env.nextLocalVarId(), VarScope.FUNCTION, kind, astVarDefStmt.var.name.value);
         birVarDcl.startBB = this.env.enclBB;
         this.env.varDclsByBlock.get(this.currentBlock).add(birVarDcl);
         this.env.enclFunc.localVars.add(birVarDcl);
@@ -1179,7 +1177,7 @@ public class BIRGen extends BLangNodeVisitor {
     public void visit(BLangAlternateWorkerReceive altWorkerReceive) {
         BIRBasicBlock thenBB = new BIRBasicBlock(this.env.nextBBId());
         addToTrapStack(thenBB);
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(altWorkerReceive.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(altWorkerReceive.getBType(), this.env.nextLocalVarId(),
                 VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
@@ -1215,7 +1213,7 @@ public class BIRGen extends BLangNodeVisitor {
     public void visit(BLangMultipleWorkerReceive multipleWorkerReceive) {
         BIRBasicBlock thenBB = new BIRBasicBlock(this.env.nextBBId());
         addToTrapStack(thenBB);
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(multipleWorkerReceive.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(multipleWorkerReceive.getBType(), this.env.nextLocalVarId(),
                 VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
@@ -1233,7 +1231,7 @@ public class BIRGen extends BLangNodeVisitor {
         BIRBasicBlock thenBB = new BIRBasicBlock(this.env.nextBBId());
         addToTrapStack(thenBB);
 
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(workerReceive.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(workerReceive.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
@@ -1257,7 +1255,7 @@ public class BIRGen extends BLangNodeVisitor {
         asyncSendExpr.expr.accept(this);
         BIROperand dataOp = this.env.targetOperand;
         BIRVariableDcl tempVarDcl = new BIRVariableDcl(asyncSendExpr.receive.matchingSendsError,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
         this.env.targetOperand = lhsOp;
@@ -1279,7 +1277,7 @@ public class BIRGen extends BLangNodeVisitor {
         BIROperand dataOp = this.env.targetOperand;
 
         BIRVariableDcl tempVarDcl = new BIRVariableDcl(syncSend.receive.matchingSendsError,
-                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                                                       this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
         this.env.targetOperand = lhsOp;
@@ -1307,7 +1305,7 @@ public class BIRGen extends BLangNodeVisitor {
             channels[i] = new BIRNode.ChannelDetails(sendStmt.getChannel().channelId(), isOnSameStrand, true);
             i++;
         }
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(flushExpr.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(flushExpr.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
@@ -1331,7 +1329,7 @@ public class BIRGen extends BLangNodeVisitor {
             exprList.add(this.env.targetOperand);
         });
 
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(waitExpr.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(waitExpr.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
@@ -1346,7 +1344,7 @@ public class BIRGen extends BLangNodeVisitor {
     @Override
     public void visit(BLangErrorConstructorExpr errorConstructorExpr) {
         BIRVariableDcl tempVarError = new BIRVariableDcl(errorConstructorExpr.getBType(),
-                                                         this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                                                         this.env.nextLocalVarId(), VarScope.FUNCTION,
                                                          VarKind.TEMP);
 
         this.env.enclFunc.localVars.add(tempVarError);
@@ -1400,7 +1398,7 @@ public class BIRGen extends BLangNodeVisitor {
         }
 
         // Create a temporary variable to store the return operation result.
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(invocationExpr.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(invocationExpr.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
@@ -1603,14 +1601,14 @@ public class BIRGen extends BLangNodeVisitor {
     @Override
     public void visit(BLangIgnoreExpr ignoreExpr) {
         BIRVariableDcl tempVarDcl = new BIRVariableDcl(ignoreExpr.getBType(),
-                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                                                       this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
     }
 
     @Override
     public void visit(BLangLiteral astLiteralExpr) {
         BIRVariableDcl tempVarDcl = new BIRVariableDcl(astLiteralExpr.getBType(),
-                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                                                       this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
         setScopeAndEmit(new BIRNonTerminator.ConstantLoad(astLiteralExpr.pos,
@@ -1627,7 +1625,7 @@ public class BIRGen extends BLangNodeVisitor {
         visitTypedesc(astMapLiteralExpr.pos, type, Collections.emptyList(), getAnnotations(type.tsymbol, this.env));
 
         BIRVariableDcl tempVarDcl =
-                new BIRVariableDcl(astMapLiteralExpr.getBType(), this.env.nextLocalVarId(names),
+                new BIRVariableDcl(astMapLiteralExpr.getBType(), this.env.nextLocalVarId(),
                                    VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
@@ -1641,7 +1639,7 @@ public class BIRGen extends BLangNodeVisitor {
     @Override
     public void visit(BLangTypeConversionExpr astTypeConversionExpr) {
         BIRVariableDcl tempVarDcl = new BIRVariableDcl(astTypeConversionExpr.getBType(),
-                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                                                       this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
@@ -1661,7 +1659,7 @@ public class BIRGen extends BLangNodeVisitor {
         visitTypedesc(astStructLiteralExpr.pos, type, Collections.emptyList(), getAnnotations(type.tsymbol, this.env));
 
         BIRVariableDcl tempVarDcl = new BIRVariableDcl(astStructLiteralExpr.getBType(),
-                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                                                       this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
@@ -1678,7 +1676,7 @@ public class BIRGen extends BLangNodeVisitor {
     @Override
     public void visit(BLangTypeInit connectorInitExpr) {
         BType exprType = connectorInitExpr.getBType();
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(exprType, this.env.nextLocalVarId(names), VarScope.FUNCTION,
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(exprType, this.env.nextLocalVarId(), VarScope.FUNCTION,
                 VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
@@ -1752,7 +1750,7 @@ public class BIRGen extends BLangNodeVisitor {
                             keyRegIndex, rhsOp, astMapAccessExpr.isStoreOnCreation));
             return;
         }
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astMapAccessExpr.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astMapAccessExpr.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand tempVarRef = new BIROperand(tempVarDcl);
@@ -1780,7 +1778,7 @@ public class BIRGen extends BLangNodeVisitor {
                     varRefRegIndex, keyRegIndex, rhsOp));
             return;
         }
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astTableAccessExpr.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astTableAccessExpr.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand tempVarRef = new BIROperand(tempVarDcl);
@@ -1814,7 +1812,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangStringAccessExpr stringAccessExpr) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(stringAccessExpr.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(stringAccessExpr.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand tempVarRef = new BIROperand(tempVarDcl);
@@ -1843,7 +1841,7 @@ public class BIRGen extends BLangNodeVisitor {
     @Override
     public void visit(BLangIsLikeExpr isLikeExpr) {
         BIRVariableDcl tempVarDcl = new BIRVariableDcl(symTable.booleanType,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
@@ -1859,7 +1857,7 @@ public class BIRGen extends BLangNodeVisitor {
     @Override
     public void visit(BLangTypeTestExpr typeTestExpr) {
         BIRVariableDcl tempVarDcl = new BIRVariableDcl(symTable.booleanType,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
@@ -1885,7 +1883,7 @@ public class BIRGen extends BLangNodeVisitor {
             }
         } else {
             BIRVariableDcl tempVarDcl = new BIRVariableDcl(varSymbol.type,
-                    this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                    this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
             this.env.enclFunc.localVars.add(tempVarDcl);
             BIROperand tempVarRef = new BIROperand(tempVarDcl);
 
@@ -1912,7 +1910,7 @@ public class BIRGen extends BLangNodeVisitor {
         } else {
             if (this.env.isInArrayOrStructure > 0) {
                 BIRVariableDcl tempVarDcl = new BIRVariableDcl(astPackageVarRefExpr.getBType(),
-                        this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                        this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
                 this.env.enclFunc.localVars.add(tempVarDcl);
                 BIROperand tempVarRef = new BIROperand(tempVarDcl);
                 BIROperand fromVarRef = new BIROperand(getVarRef(astPackageVarRefExpr));
@@ -1952,7 +1950,7 @@ public class BIRGen extends BLangNodeVisitor {
 
         // Create a temporary variable to store the binary operation result.
         BIRVariableDcl tempVarDcl = new BIRVariableDcl(astBinaryExpr.getBType(),
-                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                                                       this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
         this.env.targetOperand = lhsOp;
@@ -1970,7 +1968,7 @@ public class BIRGen extends BLangNodeVisitor {
 
         // Create a temporary variable to store the unary operation result.
         BIRVariableDcl tempVarDcl = new BIRVariableDcl(unaryExpr.getBType(),
-                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                                                       this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
 
@@ -2024,7 +2022,7 @@ public class BIRGen extends BLangNodeVisitor {
         addToTrapStack(thenBB);
 
         BIRVariableDcl tempVarDcl = new BIRVariableDcl(waitLiteral.getBType(),
-                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                                                       this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
         setScopeAndEmit(new BIRNonTerminator.NewStructure(waitLiteral.pos, toVarRef, this.env.targetOperand));
@@ -2049,7 +2047,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangIsAssignableExpr assignableExpr) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(symTable.booleanType, this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(symTable.booleanType, this.env.nextLocalVarId(),
                 VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
@@ -2065,7 +2063,7 @@ public class BIRGen extends BLangNodeVisitor {
     @Override
     public void visit(BLangXMLQName xmlQName) {
         BIRVariableDcl tempVarDcl =
-                new BIRVariableDcl(symTable.anyType, this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                new BIRVariableDcl(symTable.anyType, this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
@@ -2089,7 +2087,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangXMLElementLiteral xmlElementLiteral) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlElementLiteral.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlElementLiteral.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
@@ -2134,7 +2132,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangXMLSequenceLiteral xmlSequenceLiteral) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlSequenceLiteral.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlSequenceLiteral.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
 
         this.env.enclFunc.localVars.add(tempVarDcl);
@@ -2150,7 +2148,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangXMLTextLiteral xmlTextLiteral) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlTextLiteral.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlTextLiteral.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
@@ -2166,7 +2164,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangXMLCommentLiteral xmlCommentLiteral) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlCommentLiteral.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlCommentLiteral.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
@@ -2184,7 +2182,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangXMLProcInsLiteral xmlProcInsLiteral) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlProcInsLiteral.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlProcInsLiteral.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
@@ -2236,7 +2234,7 @@ public class BIRGen extends BLangNodeVisitor {
     @Override
     public void visit(BLangTypedescExpr accessExpr) {
         BIRVariableDcl tempVarDcl =
-                new BIRVariableDcl(accessExpr.getBType(), this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                new BIRVariableDcl(accessExpr.getBType(), this.env.nextLocalVarId(), VarScope.FUNCTION,
                                    VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
@@ -2247,7 +2245,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangTableConstructorExpr tableConstructorExpr) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(tableConstructorExpr.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(tableConstructorExpr.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
 
         this.env.enclFunc.localVars.add(tempVarDcl);
@@ -2303,7 +2301,7 @@ public class BIRGen extends BLangNodeVisitor {
     }
 
     private void visitTypedesc(Location pos, BType type, List<BIROperand> varDcls, BIROperand annotations) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(symTable.typeDesc, this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(symTable.typeDesc, this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         BIRGenEnv env = this.env;
         env.enclFunc.localVars.add(tempVarDcl);
@@ -2648,7 +2646,7 @@ public class BIRGen extends BLangNodeVisitor {
     }
 
     private BIROperand createVarRefOperand(BType type) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(type, this.env.nextLocalVarId(names), VarScope.FUNCTION,
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(type, this.env.nextLocalVarId(), VarScope.FUNCTION,
                 VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         return new BIROperand(tempVarDcl);
@@ -2702,7 +2700,7 @@ public class BIRGen extends BLangNodeVisitor {
     private void generateListConstructorExpr(BLangListConstructorExpr listConstructorExpr) {
         this.env.isInArrayOrStructure++;
         // Emit create array instruction
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(listConstructorExpr.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(listConstructorExpr.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
@@ -2770,7 +2768,7 @@ public class BIRGen extends BLangNodeVisitor {
                     varRefRegIndex, keyRegIndex, rhsOp));
             return;
         }
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astArrayAccessExpr.getBType(), this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astArrayAccessExpr.getBType(), this.env.nextLocalVarId(),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand tempVarRef = new BIROperand(tempVarDcl);
@@ -2813,7 +2811,7 @@ public class BIRGen extends BLangNodeVisitor {
                             rhsOp, astIndexBasedAccessExpr.isStoreOnCreation));
         } else {
             BIRVariableDcl tempVarDcl = new BIRVariableDcl(astIndexBasedAccessExpr.getBType(),
-                                                           this.env.nextLocalVarId(names),
+                                                           this.env.nextLocalVarId(),
                                                            VarScope.FUNCTION, VarKind.TEMP);
             this.env.enclFunc.localVars.add(tempVarDcl);
             BIROperand tempVarRef = new BIROperand(tempVarDcl);
@@ -2876,7 +2874,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     private void generateXMLNamespace(BLangXMLNS xmlnsNode) {
         BIRVariableDcl birVarDcl = new BIRVariableDcl(xmlnsNode.pos, symTable.stringType,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.LOCAL, null);
+                this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.LOCAL, null);
         this.env.enclFunc.localVars.add(birVarDcl);
         this.env.symbolVarMap.put(xmlnsNode.symbol, birVarDcl);
 
@@ -2902,7 +2900,7 @@ public class BIRGen extends BLangNodeVisitor {
             return generateStringLiteral(nsSymbol.namespaceURI);
         }
 
-        BIRVariableDcl nsURIVarDcl = new BIRVariableDcl(symTable.stringType, this.env.nextLocalVarId(names),
+        BIRVariableDcl nsURIVarDcl = new BIRVariableDcl(symTable.stringType, this.env.nextLocalVarId(),
                 VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(nsURIVarDcl);
         BIROperand nsURIVarRef = new BIROperand(nsURIVarDcl);
@@ -2955,7 +2953,7 @@ public class BIRGen extends BLangNodeVisitor {
         }
 
         BIRVariableDcl tempQNameVarDcl = new BIRVariableDcl(symTable.anyType,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempQNameVarDcl);
         BIROperand qnameVarRef = new BIROperand(tempQNameVarDcl);
         setScopeAndEmit(new BIRNonTerminator.NewStringXMLQName(qnameExpr.pos, qnameVarRef, keyRegIndex));
@@ -2984,7 +2982,7 @@ public class BIRGen extends BLangNodeVisitor {
     private void generateFPVarRef(BLangExpression fpVarRef, BInvokableSymbol funcSymbol) {
         // fpload instruction
         BIRVariableDcl tempVarLambda =
-                new BIRVariableDcl(fpVarRef.getBType(), this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                new BIRVariableDcl(fpVarRef.getBType(), this.env.nextLocalVarId(), VarScope.FUNCTION,
                                    VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarLambda);
         BIROperand lhsOp = new BIROperand(tempVarLambda);
@@ -2993,14 +2991,14 @@ public class BIRGen extends BLangNodeVisitor {
         List<BIRVariableDcl> params = new ArrayList<>();
 
         funcSymbol.params.forEach(param -> {
-            BIRVariableDcl birVarDcl = new BIRVariableDcl(fpVarRef.pos, param.type, this.env.nextLambdaVarId(names),
+            BIRVariableDcl birVarDcl = new BIRVariableDcl(fpVarRef.pos, param.type, this.env.nextLambdaVarId(),
                     VarScope.FUNCTION, VarKind.ARG, null);
             params.add(birVarDcl);
         });
 
         BVarSymbol restParam = funcSymbol.restParam;
         if (restParam != null) {
-            BIRVariableDcl birVarDcl = new BIRVariableDcl(fpVarRef.pos, restParam.type, this.env.nextLambdaVarId(names),
+            BIRVariableDcl birVarDcl = new BIRVariableDcl(fpVarRef.pos, restParam.type, this.env.nextLambdaVarId(),
                     VarScope.FUNCTION, VarKind.ARG, null);
             params.add(birVarDcl);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -364,7 +364,7 @@ public class BIRGen extends BLangNodeVisitor {
         BType type = getDefinedType(astTypeDefinition);
         BType referredType = Types.getImpliedType(type);
         BSymbol symbol = astTypeDefinition.symbol;
-        String displayName = symbol.name.value;
+        String displayName = symbol.name.getValue();
         if (referredType.tag == TypeTags.RECORD) {
             BRecordType recordType = (BRecordType) referredType;
             if (recordType.shouldPrintShape()) {
@@ -579,12 +579,12 @@ public class BIRGen extends BLangNodeVisitor {
         this.env.unlockVars.push(new BIRLockDetailsHolder());
         Name funcName;
         if (isTypeAttachedFunction) {
-            funcName = Names.fromString(astFunc.symbol.name.value);
+            funcName = Names.fromString(astFunc.symbol.name.getValue());
         } else {
             funcName = getFuncName(astFunc.symbol);
         }
         BIRFunction birFunc = new BIRFunction(astFunc.pos, funcName,
-                Names.fromString(astFunc.symbol.getOriginalName().value), astFunc.symbol.flags, type, workerName,
+                Names.fromString(astFunc.symbol.getOriginalName().getValue()), astFunc.symbol.flags, type, workerName,
                 astFunc.sendsToThis.size(), astFunc.symbol.origin.toBIROrigin());
         this.currentScope = new BirScope(0, null);
         if (astFunc.receiver != null) {
@@ -651,7 +651,7 @@ public class BIRGen extends BLangNodeVisitor {
             // Parent symbol will always be BObjectTypeSymbol for resource functions
             BObjectTypeSymbol objectTypeSymbol = (BObjectTypeSymbol) parentTSymbol;
             for (BAttachedFunction func : objectTypeSymbol.attachedFuncs) {
-                if (func.funcName.value.equals(funcName.value)) {
+                if (func.funcName.getValue().equals(funcName.getValue())) {
                     BResourceFunction resourceFunction = (BResourceFunction) func;
                     
                     List<BVarSymbol> pathParamSymbols = resourceFunction.pathParams;
@@ -715,7 +715,7 @@ public class BIRGen extends BLangNodeVisitor {
     
     private BIRVariableDcl createBIRVarDeclForPathParam(BVarSymbol pathParamSym) {
         return new BIRVariableDcl(pathParamSym.pos, pathParamSym.type, this.env.nextLocalVarId(),
-                VarScope.FUNCTION, VarKind.ARG, pathParamSym.name.value);
+                VarScope.FUNCTION, VarKind.ARG, pathParamSym.name.getValue());
     }
 
     private BIRVariableDcl getSelf(BSymbol receiver) {
@@ -832,7 +832,7 @@ public class BIRGen extends BLangNodeVisitor {
         }
 
         PackageID pkgID = lambdaExpr.function.symbol.pkgID;
-        PackageID boundMethodPkgId = getPackageIdForBoundMethod(lambdaExpr, funcName.value);
+        PackageID boundMethodPkgId = getPackageIdForBoundMethod(lambdaExpr, funcName.getValue());
         boolean isWorker = lambdaExpr.function.flagSet.contains(Flag.WORKER);
 
         List<BIROperand> closureMapOperands = getClosureMapOperands(lambdaExpr);
@@ -841,14 +841,14 @@ public class BIRGen extends BLangNodeVisitor {
                 lambdaExpr.getBType(), lambdaExpr.function.symbol.strandName,
                 lambdaExpr.function.symbol.schedulerPolicy, isWorker);
         setScopeAndEmit(fpLoad);
-        BType targetType = getRecordTargetType(funcName.value);
+        BType targetType = getRecordTargetType(funcName.getValue());
         if (lambdaExpr.function.flagSet.contains(Flag.RECORD) && targetType != null &&
                 targetType.tag == TypeTags.RECORD) {
             // If the function is for record type and has captured variables, then we need to create a
             // temp value in the type and keep it
             setScopeAndEmit(
                     new BIRNonTerminator.RecordDefaultFPLoad(lhsOp.pos, lhsOp, targetType,
-                            getFieldName(funcName.value, targetType.tsymbol.name.value)));
+                            getFieldName(funcName.getValue(), targetType.tsymbol.name.getValue())));
         }
         this.env.targetOperand = lhsOp;
     }
@@ -865,7 +865,7 @@ public class BIRGen extends BLangNodeVisitor {
         String[] split = funcName.split(Pattern.quote(RECORD_DELIMITER));
         String typeName = split[split.length - 2];
         for (BIRTypeDefinition type : this.env.enclPkg.typeDefs) {
-            if (typeName.equals(type.originalName.value)) {
+            if (typeName.equals(type.originalName.getValue())) {
                 return type.type;
             }
         }
@@ -889,11 +889,11 @@ public class BIRGen extends BLangNodeVisitor {
 
     private Name getFuncName(BInvokableSymbol symbol) {
         if (symbol.receiverSymbol == null) {
-            return Names.fromString(symbol.name.value);
+            return Names.fromString(symbol.name.getValue());
         }
 
-        int offset = symbol.receiverSymbol.type.tsymbol.name.value.length() + 1;
-        String attachedFuncName = symbol.name.value;
+        int offset = symbol.receiverSymbol.type.tsymbol.name.getValue().length() + 1;
+        String attachedFuncName = symbol.name.getValue();
         return Names.fromString(attachedFuncName.substring(offset));
     }
 
@@ -912,7 +912,7 @@ public class BIRGen extends BLangNodeVisitor {
                 paramSymbol.kind == SymbolKind.PATH_REST_PARAMETER;
         BIRFunctionParameter birVarDcl = new BIRFunctionParameter(pos, paramSymbol.type,
                 this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.ARG,
-                paramSymbol.name.value, defaultValExpr != null, isPathParam);
+                paramSymbol.name.getValue(), defaultValExpr != null, isPathParam);
 
         birFunc.localVars.add(birVarDcl);
 
@@ -928,7 +928,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     private void addRestParam(BIRFunction birFunc, BVarSymbol paramSymbol, Location pos) {
         BIRFunctionParameter birVarDcl = new BIRFunctionParameter(pos, paramSymbol.type,
-                this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.value, false,
+                this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.getValue(), false,
                 paramSymbol.kind == SymbolKind.PATH_REST_PARAMETER);
         birFunc.parameters.add(birVarDcl);
         birFunc.localVars.add(birVarDcl);
@@ -946,7 +946,7 @@ public class BIRGen extends BLangNodeVisitor {
         boolean isPathParam = paramSymbol.kind == SymbolKind.PATH_PARAMETER ||
                 paramSymbol.kind == SymbolKind.PATH_REST_PARAMETER;
         BIRFunctionParameter birVarDcl = new BIRFunctionParameter(pos, paramSymbol.type,
-                this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.value,
+                this.env.nextLocalVarId(), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.getValue(),
                 false, isPathParam);
         birFunc.parameters.add(birVarDcl);
         birFunc.localVars.add(birVarDcl);
@@ -1101,8 +1101,8 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangSimpleVariable varNode) {
-        String name = ANNOTATION_DATA.equals(varNode.symbol.name.value) ? ANNOTATION_DATA : varNode.name.value;
-        String originalName = ANNOTATION_DATA.equals(varNode.symbol.getOriginalName().value) ?
+        String name = ANNOTATION_DATA.equals(varNode.symbol.name.getValue()) ? ANNOTATION_DATA : varNode.name.value;
+        String originalName = ANNOTATION_DATA.equals(varNode.symbol.getOriginalName().getValue()) ?
                                                                     ANNOTATION_DATA : varNode.name.originalValue;
         BIRGlobalVariableDcl birVarDcl = new BIRGlobalVariableDcl(varNode.pos, varNode.symbol.flags,
                                                                   varNode.symbol.type, varNode.symbol.pkgID,
@@ -1183,7 +1183,7 @@ public class BIRGen extends BLangNodeVisitor {
         BIROperand lhsOp = new BIROperand(tempVarDcl);
         this.env.targetOperand = lhsOp;
 
-        boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.value);
+        boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.getValue());
 
         this.env.enclBB.terminator = new BIRTerminator.WorkerAlternateReceive(altWorkerReceive.pos,
                 getChannelList(altWorkerReceive), lhsOp, isOnSameStrand, thenBB, this.currentScope);
@@ -1218,7 +1218,7 @@ public class BIRGen extends BLangNodeVisitor {
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
         this.env.targetOperand = lhsOp;
-        boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.value);
+        boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.getValue());
 
         this.env.enclBB.terminator = new BIRTerminator.WorkerMultipleReceive(multipleWorkerReceive.pos,
                 getChannelList(multipleWorkerReceive), lhsOp, isOnSameStrand, thenBB, this.currentScope);
@@ -1237,7 +1237,7 @@ public class BIRGen extends BLangNodeVisitor {
         BIROperand lhsOp = new BIROperand(tempVarDcl);
         this.env.targetOperand = lhsOp;
 
-        boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.value);
+        boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.getValue());
 
         this.env.enclBB.terminator = new BIRTerminator.WorkerReceive(workerReceive.pos,
                 Names.fromString(workerReceive.getChannel().channelId()), lhsOp, isOnSameStrand, thenBB,
@@ -1259,7 +1259,7 @@ public class BIRGen extends BLangNodeVisitor {
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
         this.env.targetOperand = lhsOp;
-        boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.value);
+        boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.getValue());
 
         this.env.enclBB.terminator = new BIRTerminator.WorkerSend(
                 asyncSendExpr.pos, Names.fromString(asyncSendExpr.getChannel().channelId()), dataOp, isOnSameStrand,
@@ -1282,7 +1282,7 @@ public class BIRGen extends BLangNodeVisitor {
         BIROperand lhsOp = new BIROperand(tempVarDcl);
         this.env.targetOperand = lhsOp;
 
-        boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.value);
+        boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.getValue());
 
         this.env.enclBB.terminator = new BIRTerminator.WorkerSend(
                 syncSend.pos, Names.fromString(syncSend.getChannel().channelId()), dataOp, isOnSameStrand, true, lhsOp,
@@ -1300,7 +1300,7 @@ public class BIRGen extends BLangNodeVisitor {
         //create channelDetails array
         BIRNode.ChannelDetails[] channels = new BIRNode.ChannelDetails[flushExpr.cachedWorkerSendStmts.size()];
         int i = 0;
-        boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.value);
+        boolean isOnSameStrand = DEFAULT_WORKER_NAME.equals(this.env.enclFunc.workerName.getValue());
         for (BLangWorkerAsyncSendExpr sendStmt : flushExpr.cachedWorkerSendStmts) {
             channels[i] = new BIRNode.ChannelDetails(sendStmt.getChannel().channelId(), isOnSameStrand, true);
             i++;
@@ -1687,7 +1687,7 @@ public class BIRGen extends BLangNodeVisitor {
             BIRTypeDefinition def = typeDefs.get(objectTypeSymbol);
             instruction = new BIRNonTerminator.NewInstance(connectorInitExpr.pos, def, toVarRef, objectType);
         } else {
-            String objectName = objectTypeSymbol.name.value;
+            String objectName = objectTypeSymbol.name.getValue();
             instruction = new BIRNonTerminator.NewInstance(connectorInitExpr.pos, objectTypeSymbol.pkgID, objectName,
                     toVarRef, objectType);
         }
@@ -2394,7 +2394,7 @@ public class BIRGen extends BLangNodeVisitor {
                 birGlobalVar = dummyGlobalVarMapForLocks.computeIfAbsent(globalVar, k ->
                         new BIRGlobalVariableDcl(null, globalVar.flags, globalVar.type, globalVar.pkgID,
                                                  globalVar.name, globalVar.getOriginalName(), VarScope.GLOBAL,
-                                                 VarKind.GLOBAL, globalVar.name.value,
+                                                 VarKind.GLOBAL, globalVar.name.getValue(),
                                                  globalVar.origin.toBIROrigin()));
             }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGenEnv.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGenEnv.java
@@ -85,14 +85,14 @@ class BIRGenEnv {
         return ++currentBBId;
     }
 
-    Name nextLocalVarId(Names names) {
+    Name nextLocalVarId() {
         currentLocalVarId++;
-        return names.merge(Names.BIR_LOCAL_VAR_PREFIX, Names.fromString(Integer.toString(currentLocalVarId)));
+        return Names.merge(Names.BIR_LOCAL_VAR_PREFIX, Names.fromString(Integer.toString(currentLocalVarId)));
     }
 
-    Name nextLambdaVarId(Names names) {
+    Name nextLambdaVarId() {
         currentLambdaVarId++;
-        return names.merge(Names.BIR_LOCAL_VAR_PREFIX, Names.fromString(Integer.toString(currentLambdaVarId)));
+        return Names.merge(Names.BIR_LOCAL_VAR_PREFIX, Names.fromString(Integer.toString(currentLambdaVarId)));
     }
 
     void clear() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
@@ -203,8 +203,8 @@ public final class JvmCodeGenUtil {
         objectType = getImpliedType(objectType);
         // The call name will be in the format of`objectTypeName.funcName` for attached functions of imported modules.
         // Therefore, We need to remove the type name.
-        if (!objectType.tsymbol.name.value.isEmpty() && value.startsWith(objectType.tsymbol.name.value)) {
-            value = value.replace(objectType.tsymbol.name.value + ".", "").trim();
+        if (!objectType.tsymbol.name.getValue().isEmpty() && value.startsWith(objectType.tsymbol.name.getValue())) {
+            value = value.replace(objectType.tsymbol.name.getValue() + ".", "").trim();
         }
         return Utils.encodeFunctionIdentifier(value);
     }
@@ -281,16 +281,16 @@ public final class JvmCodeGenUtil {
 
     private static String getPackageNameWithSeparator(PackageID packageID, String separator) {
         String packageName = "";
-        String orgName = Utils.encodeNonFunctionIdentifier(packageID.orgName.value);
+        String orgName = Utils.encodeNonFunctionIdentifier(packageID.orgName.getValue());
         String moduleName;
         if (!packageID.isTestPkg) {
-            moduleName = Utils.encodeNonFunctionIdentifier(packageID.name.value);
+            moduleName = Utils.encodeNonFunctionIdentifier(packageID.name.getValue());
         } else {
-            moduleName = Utils.encodeNonFunctionIdentifier(packageID.name.value) + Names.TEST_PACKAGE.value;
+            moduleName = Utils.encodeNonFunctionIdentifier(packageID.name.getValue()) + Names.TEST_PACKAGE.getValue();
         }
         if (!moduleName.equals(ENCODED_DOT_CHARACTER)) {
-            if (!packageID.version.value.isEmpty()) {
-                packageName = getMajorVersion(packageID.version.value) + separator;
+            if (!packageID.version.getValue().isEmpty()) {
+                packageName = getMajorVersion(packageID.version.getValue()) + separator;
             }
             packageName = moduleName + separator + packageName;
         }
@@ -471,9 +471,9 @@ public final class JvmCodeGenUtil {
         if ((typeSymbol.kind == SymbolKind.RECORD || typeSymbol.kind == SymbolKind.OBJECT) &&
                 ((BStructureTypeSymbol) typeSymbol).typeDefinitionSymbol != null) {
             return Utils.encodeNonFunctionIdentifier(((BStructureTypeSymbol) typeSymbol)
-                    .typeDefinitionSymbol.name.value);
+                    .typeDefinitionSymbol.name.getValue());
         }
-        return Utils.encodeNonFunctionIdentifier(typeSymbol.name.value);
+        return Utils.encodeNonFunctionIdentifier(typeSymbol.name.getValue());
     }
 
     public static boolean isBallerinaBuiltinModule(String orgName, String moduleName) {
@@ -487,7 +487,7 @@ public final class JvmCodeGenUtil {
 
         int insCount = bb.instructions.size();
         for (int i = 0; i < insCount; i++) {
-            Label insLabel = labelGen.getLabel(funcName + bb.id.value + "ins" + i);
+            Label insLabel = labelGen.getLabel(funcName + bb.id.getValue() + "ins" + i);
             mv.visitLabel(insLabel);
             BIRAbstractInstruction inst = bb.instructions.get(i);
             if (inst != null) {
@@ -556,7 +556,7 @@ public final class JvmCodeGenUtil {
         mv.visitMethodInsn(INVOKEVIRTUAL, STRAND_CLASS, "isYielded", "()Z", false);
         generateSetYieldedStatus(mv, labelGen, funcName, yieldLocationVarIndex, terminatorPos,
                 fullyQualifiedFuncName, yieldStatus, yieldStatusVarIndex);
-        Label gotoLabel = labelGen.getLabel(funcName + thenBB.id.value);
+        Label gotoLabel = labelGen.getLabel(funcName + thenBB.id.getValue());
         mv.visitJumpInsn(GOTO, gotoLabel);
     }
 
@@ -583,24 +583,25 @@ public final class JvmCodeGenUtil {
     }
 
     public static PackageID cleanupPackageID(PackageID pkgID) {
-        Name org = new Name(Utils.encodeNonFunctionIdentifier(pkgID.orgName.value));
-        Name module = new Name(Utils.encodeNonFunctionIdentifier(pkgID.name.value));
+        Name org = new Name(Utils.encodeNonFunctionIdentifier(pkgID.orgName.getValue()));
+        Name module = new Name(Utils.encodeNonFunctionIdentifier(pkgID.name.getValue()));
         return new PackageID(org, module, pkgID.version);
     }
 
     public static boolean isBuiltInPackage(PackageID packageID) {
         packageID = cleanupPackageID(packageID);
-        return BALLERINA.equals(packageID.orgName.value) && BUILT_IN_PACKAGE_NAME.equals(packageID.name.value);
+        return BALLERINA.equals(packageID.orgName.getValue()) &&
+                BUILT_IN_PACKAGE_NAME.equals(packageID.name.getValue());
     }
 
     public static boolean isSameModule(PackageID moduleId, PackageID importModule) {
         PackageID cleanedPkg = cleanupPackageID(importModule);
-        if (!moduleId.orgName.value.equals(cleanedPkg.orgName.value)) {
+        if (!moduleId.orgName.getValue().equals(cleanedPkg.orgName.getValue())) {
             return false;
-        } else if (!moduleId.name.value.equals(cleanedPkg.name.value)) {
+        } else if (!moduleId.name.getValue().equals(cleanedPkg.name.getValue())) {
             return false;
         } else {
-            return getMajorVersion(moduleId.version.value).equals(getMajorVersion(cleanedPkg.version.value));
+            return getMajorVersion(moduleId.version.getValue()).equals(getMajorVersion(cleanedPkg.version.getValue()));
         }
     }
 
@@ -745,7 +746,7 @@ public final class JvmCodeGenUtil {
     }
 
     public static String getRefTypeConstantName(BTypeReferenceType type) {
-        return JvmConstants.TYPEREF_TYPE_VAR_PREFIX + Utils.encodeNonFunctionIdentifier(type.tsymbol.name.value);
+        return JvmConstants.TYPEREF_TYPE_VAR_PREFIX + Utils.encodeNonFunctionIdentifier(type.tsymbol.name.getValue());
     }
 
     public static void visitMaxStackForMethod(MethodVisitor mv, String funcName, String className) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -113,14 +113,14 @@ public final class JvmDesugarPhase {
 
         // Rename the function name by appending the record name to it.
         // This done to avoid frame class name overlapping.
-        func.name = new Name(toNameString(recordType) + func.name.value);
+        func.name = new Name(toNameString(recordType) + func.name.getValue());
 
         // change the kind of receiver to 'ARG'
         receiver.kind = VarKind.ARG;
 
         // Update the name of the reciever. Then any instruction that was refering to the receiver will
         // now refer to the injected parameter.
-        String paramName = "$_" + receiver.name.value;
+        String paramName = "$_" + receiver.name.getValue();
         receiver.name = new Name(paramName);
 
         // Inject an additional parameter to accept the self-record value into the init function
@@ -154,22 +154,22 @@ public final class JvmDesugarPhase {
     }
 
     private static void encodePackageIdentifiers(PackageID packageID, HashMap<String, String> encodedVsInitialIds) {
-        packageID.orgName = Names.fromString(encodeNonFunctionIdentifier(packageID.orgName.value,
+        packageID.orgName = Names.fromString(encodeNonFunctionIdentifier(packageID.orgName.getValue(),
                                                                          encodedVsInitialIds));
-        packageID.name = Names.fromString(encodeNonFunctionIdentifier(packageID.name.value, encodedVsInitialIds));
+        packageID.name = Names.fromString(encodeNonFunctionIdentifier(packageID.name.getValue(), encodedVsInitialIds));
     }
 
     private static void encodeTypeDefIdentifiers(List<BIRTypeDefinition> typeDefs,
                                                  HashMap<String, String> encodedVsInitialIds) {
         for (BIRTypeDefinition typeDefinition : typeDefs) {
             typeDefinition.type.tsymbol.name = Names.fromString(encodeNonFunctionIdentifier(
-                    typeDefinition.type.tsymbol.name.value, encodedVsInitialIds));
+                    typeDefinition.type.tsymbol.name.getValue(), encodedVsInitialIds));
             typeDefinition.internalName =
-                    Names.fromString(encodeNonFunctionIdentifier(typeDefinition.internalName.value,
+                    Names.fromString(encodeNonFunctionIdentifier(typeDefinition.internalName.getValue(),
                             encodedVsInitialIds));
             if (typeDefinition.referenceType != null) {
                 typeDefinition.referenceType.tsymbol.name = Names.fromString(encodeNonFunctionIdentifier(
-                        typeDefinition.referenceType.tsymbol.name.value, encodedVsInitialIds));
+                        typeDefinition.referenceType.tsymbol.name.getValue(), encodedVsInitialIds));
             }
 
             encodeFunctionIdentifiers(typeDefinition.attachedFuncs, encodedVsInitialIds);
@@ -181,13 +181,15 @@ public final class JvmDesugarPhase {
                     encodeAttachedFunctionIdentifiers(objectTypeSymbol.attachedFuncs, encodedVsInitialIds);
                 }
                 for (BField field : objectType.fields.values()) {
-                    field.name = Names.fromString(encodeNonFunctionIdentifier(field.name.value, encodedVsInitialIds));
+                    field.name = Names.fromString(
+                            encodeNonFunctionIdentifier(field.name.getValue(), encodedVsInitialIds));
                 }
             }
             if (bType.tag == TypeTags.RECORD) {
                 BRecordType recordType = (BRecordType) bType;
                 for (BField field : recordType.fields.values()) {
-                    field.name = Names.fromString(encodeNonFunctionIdentifier(field.name.value, encodedVsInitialIds));
+                    field.name = Names.fromString(
+                            encodeNonFunctionIdentifier(field.name.getValue(), encodedVsInitialIds));
                 }
             }
         }
@@ -196,7 +198,7 @@ public final class JvmDesugarPhase {
     private static void encodeFunctionIdentifiers(List<BIRFunction> functions,
                                                   HashMap<String, String> encodedVsInitialIds) {
         for (BIRFunction function : functions) {
-            function.name = Names.fromString(encodeFunctionIdentifier(function.name.value, encodedVsInitialIds));
+            function.name = Names.fromString(encodeFunctionIdentifier(function.name.getValue(), encodedVsInitialIds));
             for (BIRNode.BIRVariableDcl localVar : function.localVars) {
                 if (localVar.metaVarName == null) {
                     continue;
@@ -204,12 +206,12 @@ public final class JvmDesugarPhase {
                 localVar.metaVarName = encodeNonFunctionIdentifier(localVar.metaVarName, encodedVsInitialIds);
             }
             for (BIRNode.BIRParameter parameter : function.requiredParams) {
-                parameter.name = Names.fromString(encodeNonFunctionIdentifier(parameter.name.value,
+                parameter.name = Names.fromString(encodeNonFunctionIdentifier(parameter.name.getValue(),
                                                                               encodedVsInitialIds));
             }
             if (function.type.tsymbol != null) {
                 for (BVarSymbol parameter : ((BInvokableTypeSymbol) function.type.tsymbol).params) {
-                    parameter.name = Names.fromString(encodeNonFunctionIdentifier(parameter.name.value,
+                    parameter.name = Names.fromString(encodeNonFunctionIdentifier(parameter.name.getValue(),
                             encodedVsInitialIds));
                 }
             }
@@ -224,7 +226,7 @@ public final class JvmDesugarPhase {
             return;
         }
         for (BInvokableSymbol defaultFunc : typeSymbol.defaultValues.values()) {
-            defaultFunc.name = Names.fromString(encodeFunctionIdentifier(defaultFunc.name.value,
+            defaultFunc.name = Names.fromString(encodeFunctionIdentifier(defaultFunc.name.getValue(),
                     encodedVsInitialIds));
         }
     }
@@ -232,7 +234,7 @@ public final class JvmDesugarPhase {
     private static void encodeWorkerName(BIRFunction function,
                                          HashMap<String, String> encodedVsInitialIds) {
         if (function.workerName != null) {
-            function.workerName = Names.fromString(encodeNonFunctionIdentifier(function.workerName.value,
+            function.workerName = Names.fromString(encodeNonFunctionIdentifier(function.workerName.getValue(),
                                                                                encodedVsInitialIds));
         }
     }
@@ -240,7 +242,7 @@ public final class JvmDesugarPhase {
     private static void encodeAttachedFunctionIdentifiers(List<BAttachedFunction> functions,
                                                           HashMap<String, String> encodedVsInitialIds) {
         for (BAttachedFunction function : functions) {
-            function.funcName = Names.fromString(encodeFunctionIdentifier(function.funcName.value,
+            function.funcName = Names.fromString(encodeFunctionIdentifier(function.funcName.getValue(),
                                                                           encodedVsInitialIds));
         }
     }
@@ -248,14 +250,16 @@ public final class JvmDesugarPhase {
     private static void encodeGlobalVariableIdentifiers(List<BIRNode.BIRGlobalVariableDcl> globalVars,
                                                         HashMap<String, String> encodedVsInitialIds) {
         for (BIRNode.BIRGlobalVariableDcl globalVar : globalVars) {
-            globalVar.name = Names.fromString(encodeNonFunctionIdentifier(globalVar.name.value, encodedVsInitialIds));
+            globalVar.name = Names.fromString(
+                    encodeNonFunctionIdentifier(globalVar.name.getValue(), encodedVsInitialIds));
         }
     }
 
     private static void encodeImportedGlobalVariableIdentifiers(Set<BIRNode.BIRGlobalVariableDcl> globalVars,
                                                                 HashMap<String, String> encodedVsInitialIds) {
         for (BIRNode.BIRGlobalVariableDcl globalVar : globalVars) {
-            globalVar.name = Names.fromString(encodeNonFunctionIdentifier(globalVar.name.value, encodedVsInitialIds));
+            globalVar.name = Names.fromString(
+                    encodeNonFunctionIdentifier(globalVar.name.getValue(), encodedVsInitialIds));
         }
     }
 
@@ -369,7 +373,7 @@ public final class JvmDesugarPhase {
     }
 
     private static Name getInitialIdString(Name encodedIdString, HashMap<String, String> encodedVsInitialIds) {
-        String initialString = encodedVsInitialIds.get(encodedIdString.value);
+        String initialString = encodedVsInitialIds.get(encodedIdString.getValue());
         if (initialString != null) {
             return Names.fromString(initialString);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmErrorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmErrorGen.java
@@ -64,7 +64,7 @@ public class JvmErrorGen {
     private BIRNode.BIRErrorEntry findErrorEntry(List<BIRNode.BIRErrorEntry> errors, BIRNode.BIRBasicBlock currentBB) {
 
         for (BIRNode.BIRErrorEntry err : errors) {
-            if (err != null && err.endBB.id.value.equals(currentBB.id.value)) {
+            if (err != null && err.endBB.id.getValue().equals(currentBB.id.getValue())) {
                 return err;
             }
         }
@@ -88,7 +88,7 @@ public class JvmErrorGen {
             return;
         }
 
-        Label startLabel = labelGen.getLabel(funcName + currentEE.trapBB.id.value);
+        Label startLabel = labelGen.getLabel(funcName + currentEE.trapBB.id.getValue());
         Label endLabel = new Label();
         Label jumpLabel = new Label();
 
@@ -96,7 +96,7 @@ public class JvmErrorGen {
         this.mv.visitJumpInsn(GOTO, jumpLabel);
         if (currentEE instanceof JErrorEntry jCurrentEE) {
             BIRNode.BIRVariableDcl retVarDcl = currentEE.errorOp.variableDcl;
-            int retIndex = this.indexMap.addIfNotExists(retVarDcl.name.value, retVarDcl.type);
+            int retIndex = this.indexMap.addIfNotExists(retVarDcl.name.getValue(), retVarDcl.type);
             boolean exeptionExist = false;
             for (CatchIns catchIns : jCurrentEE.catchIns) {
                 if (ERROR_VALUE.equals(catchIns.errorClass)) {
@@ -138,7 +138,7 @@ public class JvmErrorGen {
         this.mv.visitLabel(errorValueLabel);
 
         BIRNode.BIRVariableDcl varDcl = currentEE.errorOp.variableDcl;
-        int lhsIndex = this.indexMap.addIfNotExists(varDcl.name.value, varDcl.type);
+        int lhsIndex = this.indexMap.addIfNotExists(varDcl.name.getValue(), varDcl.type);
         jvmInstructionGen.generateVarStore(this.mv, varDcl, lhsIndex);
         this.mv.visitJumpInsn(GOTO, jumpLabel);
         this.mv.visitLabel(otherErrorLabel);
@@ -149,6 +149,6 @@ public class JvmErrorGen {
     }
 
     private int getJVMIndexOfVarRef(BIRNode.BIRVariableDcl varDcl) {
-        return this.indexMap.addIfNotExists(varDcl.name.value, varDcl.type);
+        return this.indexMap.addIfNotExists(varDcl.name.getValue(), varDcl.type);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -395,7 +395,7 @@ public class JvmInstructionGen {
                 return;
             }
             case CONSTANT, GLOBAL -> {
-                String varName = varDcl.name.value;
+                String varName = varDcl.name.getValue();
                 PackageID moduleId = ((BIRNode.BIRGlobalVariableDcl) varDcl).pkgId;
                 String pkgName = JvmCodeGenUtil.getPackageName(moduleId);
                 String className = jvmPackageGen.lookupGlobalVarClassName(pkgName, varName);
@@ -443,7 +443,7 @@ public class JvmInstructionGen {
 
         BType bType = JvmCodeGenUtil.getImpliedType(varDcl.type);
         if (varDcl.kind == VarKind.GLOBAL || varDcl.kind == VarKind.CONSTANT) {
-            String varName = varDcl.name.value;
+            String varName = varDcl.name.getValue();
             PackageID moduleId = ((BIRNode.BIRGlobalVariableDcl) varDcl).pkgId;
             String pkgName = JvmCodeGenUtil.getPackageName(moduleId);
             String className = jvmPackageGen.lookupGlobalVarClassName(pkgName, varName);
@@ -1224,7 +1224,7 @@ public class JvmInstructionGen {
     }
 
     private int getJVMIndexOfVarRef(BIRNode.BIRVariableDcl varDcl) {
-        return this.indexMap.addIfNotExists(varDcl.name.value, varDcl.type);
+        return this.indexMap.addIfNotExists(varDcl.name.getValue(), varDcl.type);
     }
 
     void generateMapNewIns(BIRNonTerminator.NewStructure mapNewIns, int localVarOffset) {
@@ -1636,7 +1636,7 @@ public class JvmInstructionGen {
                                               objectNewIns.objectName);
         } else {
             className = getTypeValueClassName(JvmCodeGenUtil.getPackageName(type.tsymbol.pkgID),
-                                              objectNewIns.def.internalName.value);
+                    objectNewIns.def.internalName.getValue());
         }
 
         this.mv.visitTypeInsn(NEW, className);
@@ -1668,7 +1668,7 @@ public class JvmInstructionGen {
     void generateFPLoadIns(BIRNonTerminator.FPLoad inst) {
         this.mv.visitTypeInsn(NEW, FUNCTION_POINTER);
         this.mv.visitInsn(DUP);
-        String name = inst.funcName.value;
+        String name = inst.funcName.getValue();
 
         String funcKey = inst.pkgId.toString() + ":" + name;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -115,11 +115,11 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_GE
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_INIT_CLASS_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_STARTED;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_START_ATTEMPTED;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PARENT_MODULE_START_ATTEMPTED;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_STOP_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_TYPES_CLASS_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.NO_OF_DEPENDANT_MODULES;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PARENT_MODULE_START_ATTEMPTED;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SERVICE_EP_AVAILABLE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TEST_EXECUTE_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.VALUE_CREATOR;
@@ -169,7 +169,7 @@ public class JvmPackageGen {
     }
 
     private static String getBvmAlias(String orgName, String moduleName) {
-        if (Names.ANON_ORG.value.equals(orgName)) {
+        if (Names.ANON_ORG.getValue().equals(orgName)) {
             return moduleName;
         }
         return orgName + "/" + moduleName;
@@ -219,15 +219,15 @@ public class JvmPackageGen {
     }
 
     public static boolean isLangModule(PackageID moduleId) {
-        if (!BALLERINA.equals(moduleId.orgName.value)) {
+        if (!BALLERINA.equals(moduleId.orgName.getValue())) {
             return false;
         }
-        return moduleId.name.value.startsWith("lang" + ENCODED_DOT_CHARACTER) ||
-                moduleId.name.value.equals(ENCODED_JAVA_MODULE);
+        return moduleId.name.getValue().startsWith("lang" + ENCODED_DOT_CHARACTER) ||
+                moduleId.name.getValue().equals(ENCODED_JAVA_MODULE);
     }
 
     private static void generatePackageVariable(BIRGlobalVariableDcl globalVar, ClassWriter cw) {
-        String varName = globalVar.name.value;
+        String varName = globalVar.name.getValue();
         BType bType = globalVar.type;
         String descriptor = JvmCodeGenUtil.getFieldTypeSignature(bType);
         FieldVisitor fv = cw.visitField(ACC_PUBLIC + ACC_STATIC, varName, descriptor, null, null);
@@ -363,7 +363,7 @@ public class JvmPackageGen {
     private static BIRFunction findFunction(List<BIRFunction> functions, String funcName) {
 
         for (BIRFunction func : functions) {
-            if (func.name.value.equals(funcName)) {
+            if (func.name.getValue().equals(funcName)) {
                 return func;
             }
         }
@@ -474,7 +474,7 @@ public class JvmPackageGen {
         String pkgName = JvmCodeGenUtil.getPackageName(module.packageID);
         for (BIRGlobalVariableDcl globalVar : module.globalVars) {
             if (globalVar != null) {
-                globalVarClassMap.put(pkgName + globalVar.name.value, initClass);
+                globalVarClassMap.put(pkgName + globalVar.name.getValue(), initClass);
             }
         }
 
@@ -497,7 +497,7 @@ public class JvmPackageGen {
             for (BIRFunction func : attachedFuncs) {
 
                 // link the bir function for lookup
-                String functionName = func.name.value;
+                String functionName = func.name.getValue();
                 String lookupKey = typeName + "." + functionName;
                 String pkgName = JvmCodeGenUtil.getPackageName(module.packageID);
                 String className = JvmValueGen.getTypeValueClassName(pkgName, typeName);
@@ -533,7 +533,7 @@ public class JvmPackageGen {
         // Generate init class. Init function should be the first function of the package, hence check first
         // function.
         BIRFunction initFunc = functions.get(0);
-        String functionName = Utils.encodeFunctionIdentifier(initFunc.name.value);
+        String functionName = Utils.encodeFunctionIdentifier(initFunc.name.getValue());
         String fileName = initFunc.pos.lineRange().fileName();
         JavaClass klass = new JavaClass(fileName, fileName);
         klass.functions.add(0, initFunc);
@@ -545,14 +545,14 @@ public class JvmPackageGen {
 
         // Add start function
         BIRFunction startFunc = functions.get(1);
-        functionName = Utils.encodeFunctionIdentifier(startFunc.name.value);
+        functionName = Utils.encodeFunctionIdentifier(startFunc.name.getValue());
         birFunctionMap.put(pkgName + functionName, getFunctionWrapper(startFunc, packageID, initClass));
         klass.functions.add(1, startFunc);
         count += 1;
 
         // Add stop function
         BIRFunction stopFunc = functions.get(2);
-        functionName = Utils.encodeFunctionIdentifier(stopFunc.name.value);
+        functionName = Utils.encodeFunctionIdentifier(stopFunc.name.getValue());
         birFunctionMap.put(pkgName + functionName, getFunctionWrapper(stopFunc, packageID, initClass));
         klass.functions.add(2, stopFunc);
         count += 1;
@@ -564,7 +564,7 @@ public class JvmPackageGen {
             BIRFunction birFunc = functions.get(count);
             count = count + 1;
             // link the bir function for lookup
-            String birFuncName = birFunc.name.value;
+            String birFuncName = birFunc.name.getValue();
             String balFileName;
             if (birFunc.pos == symbolTable.builtinPos) {
                 balFileName = MODULE_INIT_CLASS_NAME;
@@ -581,14 +581,14 @@ public class JvmPackageGen {
             }
 
             String cleanedBalFileName = balFileName;
-            if (!birFunc.name.value.startsWith(MethodGenUtils.encodeModuleSpecialFuncName(".<test"))) {
+            if (!birFunc.name.getValue().startsWith(MethodGenUtils.encodeModuleSpecialFuncName(".<test"))) {
                 // skip removing `.bal` from generated file names. otherwise `.<testinit>` brakes because,
                 // it's "file name" may end in `.bal` due to module. see #27201
                 cleanedBalFileName = JvmCodeGenUtil.cleanupPathSeparators(balFileName);
             }
             String birModuleClassName = getModuleLevelClassName(packageID, cleanedBalFileName);
 
-            if (!JvmCodeGenUtil.isBallerinaBuiltinModule(packageID.orgName.value, packageID.name.value)) {
+            if (!JvmCodeGenUtil.isBallerinaBuiltinModule(packageID.orgName.getValue(), packageID.name.getValue())) {
                 JavaClass javaClass = jvmClassMap.get(birModuleClassName);
                 if (javaClass != null) {
                     javaClass.functions.add(birFunc);
@@ -632,7 +632,7 @@ public class JvmPackageGen {
             BIRFunction func = findFunction(node, funcName);
             if (func != null && func.pos != null) {
                 dlog.error(func.pos, DiagnosticErrorCode.METHOD_TOO_LARGE,
-                        Utils.decodeIdentifier(func.name.value));
+                        Utils.decodeIdentifier(func.name.getValue()));
             } else {
                 dlog.error(node.pos, DiagnosticErrorCode.METHOD_TOO_LARGE,
                         Utils.decodeIdentifier(funcName));
@@ -699,7 +699,7 @@ public class JvmPackageGen {
         boolean serviceEPAvailable = module.isListenerAvailable;
         for (BIRNode.BIRImportModule importModule : module.importModules) {
             BPackageSymbol pkgSymbol = packageCache.getSymbol(
-                    getBvmAlias(importModule.packageID.orgName.value, importModule.packageID.name.value));
+                    getBvmAlias(importModule.packageID.orgName.getValue(), importModule.packageID.name.getValue()));
             if (pkgSymbol.bir != null) {
                 String moduleInitClass =
                         JvmCodeGenUtil.getModuleLevelClassName(pkgSymbol.bir.packageID, MODULE_INIT_CLASS_NAME);
@@ -727,7 +727,8 @@ public class JvmPackageGen {
         addBuiltinImports(module.packageID, immediateImports);
         for (BIRNode.BIRImportModule immediateImport : module.importModules) {
             BPackageSymbol pkgSymbol = packageCache.getSymbol(
-                    getBvmAlias(immediateImport.packageID.orgName.value, immediateImport.packageID.name.value));
+                    getBvmAlias(immediateImport.packageID.orgName.getValue(),
+                            immediateImport.packageID.name.getValue()));
             immediateImports.add(pkgSymbol.pkgID);
         }
 
@@ -799,7 +800,7 @@ public class JvmPackageGen {
     private BIRFunction getFunction(BIRPackage module, String funcName) {
         BIRFunction function = null;
         for (BIRFunction birFunc : module.functions) {
-            if (birFunc.name.value.equals(funcName)) {
+            if (birFunc.name.getValue().equals(funcName)) {
                 function = birFunc;
                 break;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -231,7 +231,7 @@ public class JvmTypeGen {
                 // do not generate anything for other types (e.g.: finite type, type reference types etc.)
                 continue;
             }
-            String name = typeDef.internalName.value;
+            String name = typeDef.internalName.getValue();
             generateTypeField(cw, name);
             generateTypedescField(cw, name);
         }
@@ -730,7 +730,7 @@ public class JvmTypeGen {
         mv.visitTypeInsn(NEW, INTERSECTION_TYPE_IMPL);
         mv.visitInsn(DUP);
 
-        mv.visitLdcInsn(Utils.decodeIdentifier(bType.tsymbol.name.value));
+        mv.visitLdcInsn(Utils.decodeIdentifier(bType.tsymbol.name.getValue()));
         String varName = jvmConstantsGen.getModuleConstantVar(bType.tsymbol.pkgID);
         mv.visitFieldInsn(GETSTATIC, jvmConstantsGen.getModuleConstantClass(), varName, GET_MODULE);
         // Create the constituent types array.
@@ -785,9 +785,9 @@ public class JvmTypeGen {
         String typeOwner = JvmCodeGenUtil.getPackageName(pkgID) + MODULE_INIT_CLASS_NAME;
         String defName = "";
         if ((typeSymbol.kind == SymbolKind.RECORD || typeSymbol.kind == SymbolKind.OBJECT)
-                && typeSymbol.name.value.isEmpty()) {
-            defName = Utils
-                    .encodeNonFunctionIdentifier(((BStructureTypeSymbol) typeSymbol).typeDefinitionSymbol.name.value);
+                && typeSymbol.name.getValue().isEmpty()) {
+            defName = Utils.encodeNonFunctionIdentifier(
+                    ((BStructureTypeSymbol) typeSymbol).typeDefinitionSymbol.name.getValue());
         }
         //class symbols
         String fieldName = defName.isEmpty() ? getTypeFieldName(toNameString(typeToLoad)) : defName;
@@ -906,18 +906,18 @@ public class JvmTypeGen {
             mv.visitInsn(L2I);
             mv.visitTypeInsn(NEW, FUNCTION_PARAMETER);
             mv.visitInsn(DUP);
-            mv.visitLdcInsn(paramSymbol.name.value);
+            mv.visitLdcInsn(paramSymbol.name.getValue());
             if (paramSymbol.isDefaultable) {
                 mv.visitInsn(ICONST_1);
             } else {
                 mv.visitInsn(ICONST_0);
             }
             BInvokableSymbol bInvokableSymbol = invokableSymbol.defaultValues.get(
-                    Utils.decodeIdentifier(paramSymbol.name.value));
+                    Utils.decodeIdentifier(paramSymbol.name.getValue()));
             if (bInvokableSymbol == null) {
                 mv.visitInsn(ACONST_NULL);
             } else {
-                mv.visitLdcInsn(bInvokableSymbol.name.value);
+                mv.visitLdcInsn(bInvokableSymbol.name.getValue());
             }
             loadType(mv, paramSymbol.type);
             mv.visitMethodInsn(INVOKESPECIAL, FUNCTION_PARAMETER, JVM_INIT_METHOD, INIT_FUNCTION_PARAM, false);
@@ -1013,7 +1013,7 @@ public class JvmTypeGen {
         String name = Utils.decodeIdentifier(toNameString(finiteType));
         mv.visitLdcInsn(name);
         // load original type name
-        mv.visitLdcInsn(finiteType.tsymbol.originalName.value);
+        mv.visitLdcInsn(finiteType.tsymbol.originalName.getValue());
 
         mv.visitTypeInsn(NEW, LINKED_HASH_SET);
         mv.visitInsn(DUP);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeTestGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeTestGen.java
@@ -68,7 +68,7 @@ public class JvmTypeTestGen {
         // instanceof operator.
         if (canOptimizeNilCheck(sourceType, targetType) ||
                 canOptimizeNilUnionCheck(sourceType, targetType) ||
-                sourceValue.name.value.startsWith(MAIN_ARG_VAR_PREFIX)) {
+                sourceValue.name.getValue().startsWith(MAIN_ARG_VAR_PREFIX)) {
             handleNilUnionType(typeTestIns);
             return;
         }
@@ -146,7 +146,7 @@ public class JvmTypeTestGen {
             }
         }
         return (foundError == 1 && types.isAssignable(errorType, targetType)) || (foundError > 0 && "error".equals(
-                targetType.tsymbol.name.value));
+                targetType.tsymbol.name.getValue()));
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -190,8 +190,8 @@ public class JvmValueGen {
                 return;
             }
             BType bType = optionalTypeDef.type;
-            String className = getTypeValueClassName(packageName, optionalTypeDef.internalName.value);
-            String valueClass = VALUE_CLASS_PREFIX + optionalTypeDef.internalName.value;
+            String className = getTypeValueClassName(packageName, optionalTypeDef.internalName.getValue());
+            String valueClass = VALUE_CLASS_PREFIX + optionalTypeDef.internalName.getValue();
             asyncDataCollector.setCurrentSourceFileName(valueClass);
             asyncDataCollector.setCurrentSourceFileWithoutExt(valueClass);
             if (optionalTypeDef.type.tag == TypeTags.OBJECT &&
@@ -204,7 +204,7 @@ public class JvmValueGen {
                 byte[] bytes = this.createRecordValueClass(recordType, className, optionalTypeDef,
                         asyncDataCollector, jvmTypeGen);
                 jarEntries.put(className + CLASS_FILE_SUFFIX, bytes);
-                String typedescClass = getTypeDescClassName(packageName, optionalTypeDef.internalName.value);
+                String typedescClass = getTypeDescClassName(packageName, optionalTypeDef.internalName.getValue());
                 bytes = this.createRecordTypeDescClass(recordType, typedescClass, optionalTypeDef, jvmTypeGen);
                 jarEntries.put(typedescClass + CLASS_FILE_SUFFIX, bytes);
             }
@@ -316,7 +316,7 @@ public class JvmValueGen {
         jvmRecordGen.createAndSplitContainsKeyMethod(cw, fields, className);
         jvmRecordGen.createAndSplitGetValuesMethod(cw, fields, className, jvmCastGen);
         this.createGetSizeMethod(cw, fields, className);
-        this.createRecordClearMethod(cw, typeDef.name.value);
+        this.createRecordClearMethod(cw, typeDef.name.getValue());
         jvmRecordGen.createAndSplitRemoveMethod(cw, fields, className, jvmCastGen);
         jvmRecordGen.createAndSplitGetKeysMethod(cw, fields, className);
         this.createRecordPopulateInitialValuesMethod(cw, className);
@@ -393,7 +393,7 @@ public class JvmValueGen {
             if (field == null) {
                 continue;
             }
-            String fieldName = field.name.value;
+            String fieldName = field.name.getValue();
             FieldVisitor fv = cw.visitField(0, fieldName, getTypeDesc(field.type), null, null);
             fv.visitEnd();
 
@@ -418,7 +418,7 @@ public class JvmValueGen {
 
         int requiredFieldsCount = 0;
         for (BField optionalField : fields.values()) {
-            String fieldName = optionalField.name.value;
+            String fieldName = optionalField.name.getValue();
             if (isOptionalRecordField(optionalField)) {
                 mv.visitVarInsn(ALOAD, 0);
                 mv.visitFieldInsn(GETFIELD, className, getFieldIsPresentFlagName(fieldName),
@@ -490,10 +490,10 @@ public class JvmValueGen {
             if (field == null) {
                 continue;
             }
-            FieldVisitor fvb = cw.visitField(0, field.name.value, getTypeDesc(field.type), null, null);
+            FieldVisitor fvb = cw.visitField(0, field.name.getValue(), getTypeDesc(field.type), null, null);
             fvb.visitEnd();
             String lockClass = "L" + LOCK_VALUE + ";";
-            FieldVisitor fv = cw.visitField(ACC_PUBLIC, computeLockNameFromString(field.name.value),
+            FieldVisitor fv = cw.visitField(ACC_PUBLIC, computeLockNameFromString(field.name.getValue()),
                     lockClass, null, null);
             fv.visitEnd();
         }
@@ -524,7 +524,7 @@ public class JvmValueGen {
         int methodCountPerSplitClass = 0;
 
         for (BIRNode.BIRFunction func : attachedFuncs) {
-            if (func.name.value.contains("$init$")) {
+            if (func.name.getValue().contains("$init$")) {
                 methodGen.generateMethod(func, cw, module, currentObjectType, moduleClassName,
                         jvmTypeGen, jvmCastGen, jvmConstantsGen, asyncDataCollector);
                 continue;
@@ -579,7 +579,7 @@ public class JvmValueGen {
             mv.visitTypeInsn(NEW, LOCK_VALUE);
             mv.visitInsn(DUP);
             mv.visitMethodInsn(INVOKESPECIAL, LOCK_VALUE, JVM_INIT_METHOD, VOID_METHOD_DESC, false);
-            mv.visitFieldInsn(PUTFIELD, className, computeLockNameFromString(field.name.value), lockClass);
+            mv.visitFieldInsn(PUTFIELD, className, computeLockNameFromString(field.name.getValue()), lockClass);
         }
 
         mv.visitInsn(RETURN);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/internal/FieldNameHashComparator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/internal/FieldNameHashComparator.java
@@ -32,8 +32,8 @@ public class FieldNameHashComparator implements Comparator<NamedNode> {
 
     @Override
     public int compare(NamedNode o1, NamedNode o2) {
-        String name1 = Utils.decodeIdentifier(o1.getName().value);
-        String name2 = Utils.decodeIdentifier(o2.getName().value);
+        String name1 = Utils.decodeIdentifier(o1.getName().getValue());
+        String name2 = Utils.decodeIdentifier(o2.getName().getValue());
         return Integer.compare(name1.hashCode(), name2.hashCode());
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/internal/FunctionParamComparator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/internal/FunctionParamComparator.java
@@ -35,7 +35,7 @@ public class FunctionParamComparator implements Comparator<BIRNode.BIRVariableDc
             return Integer.compare(getWeight(o1), getWeight(o2));
         }
         if (o1.kind == VarKind.TEMP) {
-            return Integer.compare(o1.name.value.hashCode(), o2.name.value.hashCode());
+            return Integer.compare(o1.name.getValue().hashCode(), o2.name.getValue().hashCode());
         }
         return 0;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/internal/NameHashComparator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/internal/NameHashComparator.java
@@ -30,8 +30,8 @@ public class NameHashComparator implements Comparator<NamedNode> {
 
     @Override
     public int compare(NamedNode o1, NamedNode o2) {
-        String name1 = o1.getName().value;
-        String name2 = o2.getName().value;
+        String name1 = o1.getName().getValue();
+        String name2 = o2.getName().getValue();
         return Integer.compare(name1.hashCode(), name2.hashCode());
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/AnnotationProc.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/AnnotationProc.java
@@ -60,7 +60,7 @@ public final class AnnotationProc {
             return null;
         }
 
-        String annotTagRef = annotAttach.annotTagRef.value;
+        String annotTagRef = annotAttach.annotTagRef.getValue();
         return createJInteropValidationRequest(annotTagRef, annotAttach, birFunc);
     }
 
@@ -76,9 +76,9 @@ public final class AnnotationProc {
 
     private static boolean isInteropAnnotAttachment(BIRAnnotationAttachment annotAttach) {
 
-        return INTEROP_ANNOT_ORG.equals(annotAttach.annotPkgId.orgName.value) &&
-                INTEROP_ANNOT_MODULE.equals(annotAttach.annotPkgId.name.value) &&
-                isInteropAnnotationTag(annotAttach.annotTagRef.value);
+        return INTEROP_ANNOT_ORG.equals(annotAttach.annotPkgId.orgName.getValue()) &&
+                INTEROP_ANNOT_MODULE.equals(annotAttach.annotPkgId.name.getValue()) &&
+                isInteropAnnotationTag(annotAttach.annotTagRef.getValue());
     }
 
     private static InteropValidationRequest createJInteropValidationRequest(String annotTagRef,
@@ -177,7 +177,7 @@ public final class AnnotationProc {
             return JVM_INIT_METHOD;
         } else {
             String methodName = (String) getLiteralValueFromAnnotValue(jNameValueEntry);
-            return methodName != null ? methodName : birFunc.name.value;
+            return methodName != null ? methodName : birFunc.name.getValue();
         }
     }
 
@@ -185,6 +185,6 @@ public final class AnnotationProc {
                                                  BIRFunction birFunc) {
 
         String fieldName = (String) getLiteralValueFromAnnotValue(jNameValueEntry);
-        return fieldName != null ? fieldName : birFunc.name.value;
+        return fieldName != null ? fieldName : birFunc.name.getValue();
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -147,7 +147,7 @@ public final class InteropMethodGen {
 
         String desc = JvmCodeGenUtil.getMethodDesc(birFunc.type.paramTypes, retType);
         int access = birFunc.receiver != null ? ACC_PUBLIC : ACC_PUBLIC + ACC_STATIC;
-        MethodVisitor mv = classWriter.visitMethod(access, birFunc.name.value, desc, null, null);
+        MethodVisitor mv = classWriter.visitMethod(access, birFunc.name.getValue(), desc, null, null);
         JvmInstructionGen instGen = new JvmInstructionGen(mv, indexMap, birModule, jvmPackageGen, jvmTypeGen,
                                                           jvmCastGen, jvmConstantsGen, asyncDataCollector, types);
         JvmErrorGen errorGen = new JvmErrorGen(mv, indexMap, instGen);
@@ -166,7 +166,7 @@ public final class InteropMethodGen {
         for (BIRVariableDcl birLocalVarOptional : birFunc.localVars) {
             if (birLocalVarOptional instanceof BIRNode.BIRFunctionParameter functionParameter) {
                 birFuncParams.add(functionParameter);
-                indexMap.addIfNotExists(functionParameter.name.value, functionParameter.type);
+                indexMap.addIfNotExists(functionParameter.name.getValue(), functionParameter.type);
             }
         }
 
@@ -176,7 +176,7 @@ public final class InteropMethodGen {
         // Load receiver which is the 0th parameter in the birFunc
         if (!jField.isStatic()) {
             BIRNode.BIRVariableDcl var = birFuncParams.get(0);
-            int receiverLocalVarIndex = indexMap.addIfNotExists(var.name.value, var.type);
+            int receiverLocalVarIndex = indexMap.addIfNotExists(var.name.getValue(), var.type);
             mv.visitVarInsn(ALOAD, receiverLocalVarIndex);
             mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, GET_VALUE_METHOD, "()Ljava/lang/Object;", false);
             mv.visitTypeInsn(CHECKCAST, jField.getDeclaringClassName());
@@ -203,7 +203,7 @@ public final class InteropMethodGen {
         int birFuncParamIndex = jField.isStatic() ? 0 : 1;
         if (birFuncParamIndex < birFuncParams.size()) {
             BIRNode.BIRFunctionParameter birFuncParam = birFuncParams.get(birFuncParamIndex);
-            int paramLocalVarIndex = indexMap.addIfNotExists(birFuncParam.name.value, birFuncParam.type);
+            int paramLocalVarIndex = indexMap.addIfNotExists(birFuncParam.name.getValue(), birFuncParam.type);
             loadMethodParamToStackInInteropFunction(mv, birFuncParam, jFieldType,
                                                     paramLocalVarIndex, instGen, jvmCastGen);
         }
@@ -224,7 +224,7 @@ public final class InteropMethodGen {
 
         // Handle return type
         BIRVariableDcl retVarDcl = new BIRVariableDcl(retType, new Name("$_ret_var_$"), null, VarKind.LOCAL);
-        int returnVarRefIndex = indexMap.addIfNotExists(retVarDcl.name.value, retType);
+        int returnVarRefIndex = indexMap.addIfNotExists(retVarDcl.name.getValue(), retType);
 
         int retTypeTag = JvmCodeGenUtil.getImpliedType(retType).tag;
         if (retTypeTag == TypeTags.NIL) {
@@ -253,7 +253,7 @@ public final class InteropMethodGen {
         mv.visitLabel(retLabel);
         mv.visitLineNumber(birFunc.pos.lineRange().endLine().line() + 1, retLabel);
         termGen.genReturnTerm(returnVarRefIndex, birFunc, -1, 0);
-        JvmCodeGenUtil.visitMaxStackForMethod(mv, birFunc.name.value, birFunc.javaField.getDeclaringClassName());
+        JvmCodeGenUtil.visitMaxStackForMethod(mv, birFunc.name.getValue(), birFunc.javaField.getDeclaringClassName());
         mv.visitEnd();
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodResolver.java
@@ -551,7 +551,8 @@ class JMethodResolver {
                                                 jMethodRequest.declaringClass.getName() + "': Java type '" +
                                                 jReturnType.getName() +
                                                 "' will not be matched to ballerina type '" +
-                                                (bReturnType.tag == TypeTags.FINITE ? bReturnType.tsymbol.name.value :
+                                                (bReturnType.tag == TypeTags.FINITE ?
+                                                        bReturnType.tsymbol.name.getValue() :
                                                         bReturnType) + "'");
         }
     }
@@ -1095,7 +1096,7 @@ class JMethodResolver {
         throw new JInteropException(DiagnosticErrorCode.METHOD_SIGNATURE_DOES_NOT_MATCH,
                 "Incompatible param type for method '" + methodName + "' in class '" + declaringClass.getName() +
                         "': Java type '" + jType.getName() + "' will not be matched to ballerina type '" +
-                        (bType.tag == TypeTags.FINITE ? bType.tsymbol.name.value : bType) + "'");
+                        (bType.tag == TypeTags.FINITE ? bType.tsymbol.name.getValue() : bType) + "'");
     }
 
     private void throwParamCountMismatchError(JMethodRequest jMethodRequest) throws JInteropException {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/ConfigMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/ConfigMethodGen.java
@@ -196,7 +196,7 @@ public class ConfigMethodGen {
                 mv.visitInsn(DUP);
                 mv.visitFieldInsn(GETSTATIC, moduleClass, CURRENT_MODULE_VAR_NAME,
                         "L" + MODULE + ";");
-                mv.visitLdcInsn(globalVar.name.value);
+                mv.visitLdcInsn(globalVar.name.getValue());
                 jvmTypeGen.loadType(mv, globalVar.type);
                 mv.visitLdcInsn(getOneBasedLocationString(module, globalVar.pos));
                 if (Symbols.isFlagOn(globalVarFlags, Flags.REQUIRED)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/FrameClassGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/FrameClassGen.java
@@ -73,7 +73,7 @@ public class FrameClassGen {
                                                JarEntries pkgEntries,
                                                BType attachedType) {
         String frameClassName = MethodGenUtils.getFrameClassName(JvmCodeGenUtil.getPackageName(packageID),
-                                                                 func.name.value, attachedType);
+                func.name.getValue(), attachedType);
         ClassWriter cw = new BallerinaClassWriter(COMPUTE_FRAMES);
         if (func.pos != null && func.pos.lineRange().fileName() != null) {
             cw.visitSource(func.pos.lineRange().fileName(), null);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/InitMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/InitMethodGen.java
@@ -521,7 +521,7 @@ public class InitMethodGen {
                                                                    List<BIRNode.BIRGlobalVariableDcl> globalVars) {
 
         for (BIRNode.BIRGlobalVariableDcl globalVar : globalVars) {
-            if (globalVar.name.value.equals(name.value)) {
+            if (globalVar.name.getValue().equals(name.getValue())) {
                 return globalVar;
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/LambdaGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/LambdaGen.java
@@ -228,7 +228,7 @@ public class LambdaGen {
         mv.visitInsn(AALOAD);
         mv.visitTypeInsn(CHECKCAST, STRAND_CLASS);
 
-        mv.visitLdcInsn(JvmCodeGenUtil.rewriteVirtualCallTypeName(ins.name.value, ref.variableDcl.type));
+        mv.visitLdcInsn(JvmCodeGenUtil.rewriteVirtualCallTypeName(ins.name.getValue(), ref.variableDcl.type));
         int objectArrayLength = paramTypes.size() - 1;
         mv.visitIntInsn(BIPUSH, objectArrayLength);
         mv.visitTypeInsn(ANEWARRAY, OBJECT);
@@ -461,17 +461,17 @@ public class LambdaGen {
                 if (call.isVirtual) {
                     return false;
                 }
-                methodName = call.name.value;
+                methodName = call.name.getValue();
                 packageID = call.calleePkg;
             }
             case ASYNC_CALL -> {
                 BIRTerminator.AsyncCall asyncCall = (BIRTerminator.AsyncCall) callIns;
-                methodName = asyncCall.name.value;
+                methodName = asyncCall.name.getValue();
                 packageID = asyncCall.calleePkg;
             }
             case FP_LOAD -> {
                 BIRNonTerminator.FPLoad fpLoad = (BIRNonTerminator.FPLoad) callIns;
-                methodName = fpLoad.funcName.value;
+                methodName = fpLoad.funcName.getValue();
                 packageID = fpLoad.pkgId;
             }
             default -> throw new BLangCompilerException("JVM static function call generation is not supported for " +

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
@@ -438,7 +438,8 @@ public class MainMethodGen {
         List<String> defaultableNames = new ArrayList<>();
         int defaultableIndex = 0;
         for (BIRNode.BIRAnnotationAttachment attachment : annotAttachments) {
-            if (attachment != null && attachment.annotTagRef.value.equals(JvmConstants.DEFAULTABLE_ARGS_ANOT_NAME)) {
+            if (attachment != null &&
+                    attachment.annotTagRef.getValue().equals(JvmConstants.DEFAULTABLE_ARGS_ANOT_NAME)) {
                 Map<String, BIRNode.ConstValue> annotFieldMap =
                         (Map<String, BIRNode.ConstValue>)
                                 ((BIRNode.BIRConstAnnotationAttachment) attachment).annotValue.value;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
@@ -118,9 +118,9 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_AN
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_INIT_CLASS_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_STARTED;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_START_ATTEMPTED;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PARENT_MODULE_START_ATTEMPTED;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.NO_OF_DEPENDANT_MODULES;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT_SELF_INSTANCE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PARENT_MODULE_START_ATTEMPTED;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STACK;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_CLASS;
@@ -196,7 +196,7 @@ public class MethodGen {
         BIRVarToJVMIndexMap indexMap = new BIRVarToJVMIndexMap();
         indexMap.addIfNotExists(OBJECT_SELF_INSTANCE, symbolTable.anyType);
         indexMap.addIfNotExists(STRAND, symbolTable.stringType);
-        String funcName = func.name.value;
+        String funcName = func.name.getValue();
         BType retType = getReturnType(func);
         String desc = JvmCodeGenUtil.getMethodDesc(func.type.paramTypes, retType);
         MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, funcName, desc, null, null);
@@ -209,7 +209,7 @@ public class MethodGen {
         mv.visitVarInsn(ALOAD, 0); // load self
         String encodedMethodName = Utils.encodeFunctionIdentifier(funcName);
         for (BIRNode.BIRFunctionParameter parameter : func.parameters) {
-            instGen.generateVarLoad(mv, parameter, indexMap.addIfNotExists(parameter.name.value, parameter.type));
+            instGen.generateVarLoad(mv, parameter, indexMap.addIfNotExists(parameter.name.getValue(), parameter.type));
         }
         String methodDesc = JvmCodeGenUtil.getMethodDesc(func.type.paramTypes, retType, moduleClassName);
         mv.visitMethodInsn(INVOKESTATIC, splitClassName, encodedMethodName, methodDesc, false);
@@ -222,7 +222,7 @@ public class MethodGen {
             String metaVarName = parameter.metaVarName;
             if (isValidArg(parameter) && isCompilerAddedVars(metaVarName)) {
                 mv.visitLocalVariable(metaVarName, getJVMTypeSign(parameter.type), null, methodStartLabel,
-                        methodEndLabel, indexMap.addIfNotExists(parameter.name.value, parameter.type));
+                        methodEndLabel, indexMap.addIfNotExists(parameter.name.getValue(), parameter.type));
             }
         }
         JvmCodeGenUtil.visitMaxStackForMethod(mv, funcName, moduleClassName);
@@ -269,7 +269,7 @@ public class MethodGen {
             indexMap.addIfNotExists(OBJECT_SELF_INSTANCE, symbolTable.anyType);
         }
 
-        String funcName = func.name.value;
+        String funcName = func.name.getValue();
         BType retType = getReturnType(func);
         String desc;
         int invocationCountArgVarIndex = -1;
@@ -489,7 +489,7 @@ public class MethodGen {
         localVars.sort(new FunctionParamComparator());
         for (int i = 1; i < localVars.size(); i++) {
             BIRVariableDcl localVar = localVars.get(i);
-            int index = indexMap.addIfNotExists(localVar.name.value, localVar.type);
+            int index = indexMap.addIfNotExists(localVar.name.getValue(), localVar.type);
             if (localVar.kind != VarKind.ARG) {
                 BType bType = localVar.type;
                 genDefaultValue(mv, bType, index);
@@ -499,7 +499,7 @@ public class MethodGen {
 
     private int getReturnVarRefIndex(BIRFunction func, BIRVarToJVMIndexMap indexMap, BType retType, MethodVisitor mv) {
         BIRVariableDcl varDcl = func.localVars.get(0);
-        int returnVarRefIndex = indexMap.addIfNotExists(varDcl.name.value, varDcl.type);
+        int returnVarRefIndex = indexMap.addIfNotExists(varDcl.name.getValue(), varDcl.type);
         genDefaultValue(mv, retType, returnVarRefIndex);
         return returnVarRefIndex;
     }
@@ -585,11 +585,11 @@ public class MethodGen {
         for (int i = 0; i < func.basicBlocks.size(); i++) {
             BIRBasicBlock bb = func.basicBlocks.get(i);
             if (i == 0) {
-                labels.add(caseIndex, labelGen.getLabel(funcName + bb.id.value));
+                labels.add(caseIndex, labelGen.getLabel(funcName + bb.id.getValue()));
                 states.add(caseIndex, caseIndex);
                 caseIndex += 1;
             }
-            labels.add(caseIndex, labelGen.getLabel(funcName + bb.id.value + "beforeTerm"));
+            labels.add(caseIndex, labelGen.getLabel(funcName + bb.id.getValue() + "beforeTerm"));
             states.add(caseIndex, caseIndex);
             caseIndex += 1;
         }
@@ -609,7 +609,7 @@ public class MethodGen {
                              int invocationVarIndex, int localVarOffset, BIRPackage module, BType attachedType,
                              String moduleClassName, Label loopLabel) {
 
-        String funcName = func.name.value;
+        String funcName = func.name.getValue();
         BirScope lastScope = null;
         Set<BirScope> visitedScopesSet = new HashSet<>();
 
@@ -617,7 +617,7 @@ public class MethodGen {
         for (int i = 0; i < func.basicBlocks.size(); i++) {
             BIRBasicBlock bb = func.basicBlocks.get(i);
             // create jvm label
-            Label bbLabel = labelGen.getLabel(funcName + bb.id.value);
+            Label bbLabel = labelGen.getLabel(funcName + bb.id.getValue());
             mv.visitLabel(bbLabel);
             if (i == 0) {
                 pushShort(mv, stateVarIndex, caseIndex);
@@ -629,7 +629,7 @@ public class MethodGen {
                     .getLastScopeFromBBInsGen(mv, labelGen, instGen, localVarOffset, funcName, bb,
                             visitedScopesSet, lastScope);
 
-            Label bbEndLabel = labelGen.getLabel(funcName + bb.id.value + "beforeTerm");
+            Label bbEndLabel = labelGen.getLabel(funcName + bb.id.getValue() + "beforeTerm");
             mv.visitLabel(bbEndLabel);
 
             String fullyQualifiedFuncName = getFullyQualifiedFuncName(func.type.tsymbol, funcName);
@@ -714,7 +714,7 @@ public class MethodGen {
     }
 
     private boolean isModuleTestInitFunction(BIRFunction func) {
-        return func.name.value.equals(
+        return func.name.getValue().equals(
                 MethodGenUtils
                         .encodeModuleSpecialFuncName(".<testinit>"));
     }
@@ -754,7 +754,7 @@ public class MethodGen {
                 continue;
             }
             BType bType = JvmCodeGenUtil.getImpliedType(localVar.type);
-            int index = indexMap.addIfNotExists(localVar.name.value, bType);
+            int index = indexMap.addIfNotExists(localVar.name.getValue(), bType);
             mv.visitInsn(DUP);
 
             if (TypeTags.isIntegerTypeTag(bType.tag)) {
@@ -893,7 +893,7 @@ public class MethodGen {
                 continue;
             }
             BType bType = JvmCodeGenUtil.getImpliedType(localVar.type);
-            int index = indexMap.addIfNotExists(localVar.name.value, bType);
+            int index = indexMap.addIfNotExists(localVar.name.getValue(), bType);
             mv.visitInsn(DUP);
 
             if (TypeTags.isIntegerTypeTag(bType.tag)) {
@@ -1053,7 +1053,7 @@ public class MethodGen {
     private void createLocalVariableTable(BIRFunction func, BIRVarToJVMIndexMap indexMap, int localVarOffset,
                                           MethodVisitor mv, Label methodStartLabel, LabelGenerator labelGen,
                                           Label methodEndLabel, boolean isObjectMethodSplit) {
-        String funcName = func.name.value;
+        String funcName = func.name.getValue();
         // Add strand variable to LVT
         mv.visitLocalVariable(STRAND_LOCAL_VARIABLE_NAME, GET_STRAND, null, methodStartLabel, methodEndLabel,
                 localVarOffset);
@@ -1075,14 +1075,14 @@ public class MethodGen {
                     startLabel = labelGen.getLabel(funcName + SCOPE_PREFIX + localVar.insScope.id());
                 }
                 if (localVar.endBB != null) {
-                    endLabel = labelGen.getLabel(funcName + localVar.endBB.id.value + "beforeTerm");
+                    endLabel = labelGen.getLabel(funcName + localVar.endBB.id.getValue() + "beforeTerm");
                 }
             }
             String metaVarName = localVar.metaVarName;
             if (isCompilerAddedVars(metaVarName)) {
                 mv.visitLocalVariable(metaVarName, getJVMTypeSign(localVar.type), null,
                         startLabel, endLabel,
-                        indexMap.addIfNotExists(localVar.name.value, localVar.type));
+                        indexMap.addIfNotExists(localVar.name.getValue(), localVar.type));
             }
         }
     }
@@ -1090,7 +1090,7 @@ public class MethodGen {
     private boolean isValidArg(BIRVariableDcl localVar) {
         boolean localArg = localVar.kind == VarKind.LOCAL || localVar.kind == VarKind.ARG;
         boolean synArg = JvmCodeGenUtil.getImpliedType(localVar.type).tag == TypeTags.BOOLEAN &&
-                localVar.name.value.startsWith("%syn");
+                localVar.name.getValue().startsWith("%syn");
         boolean lambdaMapArg = localVar.metaVarName != null && localVar.metaVarName.startsWith("$map$block$") &&
                 localVar.kind == VarKind.SYNTHETIC;
         return (localArg && !synArg) || lambdaMapArg;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGenUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGenUtils.java
@@ -70,7 +70,7 @@ public final class MethodGenUtils {
     }
 
     static boolean isModuleInitFunction(BIRNode.BIRFunction func) {
-        return func.name.value.equals(encodeModuleSpecialFuncName(INIT_FUNCTION_SUFFIX));
+        return func.name.getValue().equals(encodeModuleSpecialFuncName(INIT_FUNCTION_SUFFIX));
     }
 
     public static void submitToScheduler(MethodVisitor mv, String strandMetadataClass, String workerName,
@@ -92,14 +92,14 @@ public final class MethodGenUtils {
     }
 
     static String calculateLambdaStopFuncName(PackageID id) {
-        String orgName = id.orgName.value;
+        String orgName = id.orgName.getValue();
         String moduleName;
         if (id.isTestPkg) {
-            moduleName = id.name.value + Names.TEST_PACKAGE;
+            moduleName = id.name.getValue() + Names.TEST_PACKAGE;
         } else {
-            moduleName = id.name.value;
+            moduleName = id.name.getValue();
         }
-        String version = getMajorVersion(id.version.value);
+        String version = getMajorVersion(id.version.getValue());
         String funcSuffix = MethodGenUtils.STOP_FUNCTION_SUFFIX;
 
         String funcName;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/optimizer/LargeMethodOptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/optimizer/LargeMethodOptimizer.java
@@ -490,7 +490,7 @@ public class LargeMethodOptimizer {
                 // hence split function should be created after such function call
                 // only in this case we have to consider RHS operands (only function arguments)
                 BIRTerminator.Call callIns = (BIRTerminator.Call) bbTerminator;
-                if (callIns.name.value.contains(OBJECT_INITIALIZATION_FUNCTION_NAME)) {
+                if (callIns.name.getValue().contains(OBJECT_INITIALIZATION_FUNCTION_NAME)) {
                     for (BIROperand arg : callIns.args) {
                         addOperandToInsSplitPoints(arrayOrMapValueOperands, insSplitPoints, callIns, arg,
                                 operandsInSameBB, remainingArrayValueOperands);
@@ -1374,8 +1374,8 @@ public class LargeMethodOptimizer {
                 }
                 currentBB.terminator = basicBlocks.get(bbNum).terminator;
                 newBBList.add(currentBB);
-                changedLocalVarStartBB.put(basicBlocks.get(bbNum).id.value, currentBB.id.value);
-                changedLocalVarEndBB.put(basicBlocks.get(bbNum).id.value, currentBB.id.value);
+                changedLocalVarStartBB.put(basicBlocks.get(bbNum).id.getValue(), currentBB.id.getValue());
+                changedLocalVarEndBB.put(basicBlocks.get(bbNum).id.getValue(), currentBB.id.getValue());
                 startInsNum = 0;
                 bbNum += 1;
                 continue;
@@ -1398,7 +1398,7 @@ public class LargeMethodOptimizer {
             if (currentBB == null) {
                 throw new IllegalStateException("currentBB cannot be null");
             }
-            changedLocalVarStartBB.put(basicBlocks.get(bbNum).id.value, currentBB.id.value);
+            changedLocalVarStartBB.put(basicBlocks.get(bbNum).id.getValue(), currentBB.id.getValue());
             if (!splitsInSameBBList.isEmpty()) {
                 // current unfinished BB is passed to the function and a new one is returned from it
                 currentBB = generateSplitsInSameBB(function, bbNum, splitsInSameBBList, newlyAddedFunctions,
@@ -1415,7 +1415,7 @@ public class LargeMethodOptimizer {
                 }
                 currentBB.terminator = basicBlocks.get(bbNum).terminator;
                 newBBList.add(currentBB);
-                changedLocalVarEndBB.put(basicBlocks.get(bbNum).id.value, currentBB.id.value);
+                changedLocalVarEndBB.put(basicBlocks.get(bbNum).id.getValue(), currentBB.id.getValue());
                 startInsNum = 0;
                 bbNum += 1;
                 if (splitNum < possibleSplits.size() && (possibleSplits.get(splitNum).startBBNum == bbNum)) {
@@ -1468,7 +1468,7 @@ public class LargeMethodOptimizer {
                     currentPackageId, newFuncName, args, splitFuncCallResultOp, parentFuncNewBB,
                     Collections.emptyList(), Collections.emptySet(), lastInstruction.scope);
             newBBList.add(currentBB);
-            changedLocalVarEndBB.put(basicBlocks.get(bbNum).id.value, currentBB.id.value);
+            changedLocalVarEndBB.put(basicBlocks.get(bbNum).id.getValue(), currentBB.id.getValue());
             currentBB = parentFuncNewBB;
             if (currSplit.returnValAssigned) {
                 currentBB = handleNewFuncReturnVal(function, splitFuncCallResultOp, lastInstruction.scope, currentBB,
@@ -1622,22 +1622,22 @@ public class LargeMethodOptimizer {
 
         Map<String, BIRBasicBlock> newBBs = new HashMap<>();
         for (BIRBasicBlock newBB : newBBList) {
-            newBBs.put(newBB.id.value, newBB);
+            newBBs.put(newBB.id.getValue(), newBB);
         }
         for (BIRVariableDcl localVar : birFunction.localVars) {
             if (localVar.kind == VarKind.LOCAL) {
                 if (localVar.startBB != null) {
-                    if (changedLocalVarStartBB.containsKey(localVar.startBB.id.value)) {
-                        localVar.startBB = newBBs.get(changedLocalVarStartBB.get(localVar.startBB.id.value));
+                    if (changedLocalVarStartBB.containsKey(localVar.startBB.id.getValue())) {
+                        localVar.startBB = newBBs.get(changedLocalVarStartBB.get(localVar.startBB.id.getValue()));
                     } else {
-                        localVar.startBB = newBBs.get(localVar.startBB.id.value);
+                        localVar.startBB = newBBs.get(localVar.startBB.id.getValue());
                     }
                 }
                 if (localVar.endBB != null) {
-                    if (changedLocalVarEndBB.containsKey(localVar.endBB.id.value)) {
-                        localVar.endBB = newBBs.get(changedLocalVarEndBB.get(localVar.endBB.id.value));
+                    if (changedLocalVarEndBB.containsKey(localVar.endBB.id.getValue())) {
+                        localVar.endBB = newBBs.get(changedLocalVarEndBB.get(localVar.endBB.id.getValue()));
                     } else {
-                        localVar.endBB = newBBs.get(localVar.endBB.id.value);
+                        localVar.endBB = newBBs.get(localVar.endBB.id.getValue());
                     }
                 }
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmCreateTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmCreateTypeGen.java
@@ -266,7 +266,7 @@ public class JvmCreateTypeGen {
 
         // Create the type
         for (BIRTypeDefinition optionalTypeDef : typeDefs) {
-            String name = optionalTypeDef.internalName.value;
+            String name = optionalTypeDef.internalName.getValue();
             BType bType = optionalTypeDef.type;
             int bTypeTag = bType.tag;
             if (JvmCodeGenUtil.needNoTypeGeneration(bTypeTag)) {
@@ -284,7 +284,7 @@ public class JvmCreateTypeGen {
                         jvmRecordTypeGen.createRecordType(mv, (BRecordType) bType, typeOwnerClass, name);
                 case TypeTags.OBJECT -> jvmObjectTypeGen.createObjectType(mv, (BObjectType) bType);
                 case TypeTags.ERROR ->
-                        jvmErrorTypeGen.createErrorType(mv, (BErrorType) bType, bType.tsymbol.name.value);
+                        jvmErrorTypeGen.createErrorType(mv, (BErrorType) bType, bType.tsymbol.name.getValue());
                 case TypeTags.TUPLE -> jvmTupleTypeGen.createTupleType(mv, (BTupleType) bType);
                 default -> jvmUnionTypeGen.createUnionType(mv, (BUnionType) bType);
             }
@@ -318,7 +318,7 @@ public class JvmCreateTypeGen {
                 continue;
             }
 
-            fieldName = getTypeFieldName(optionalTypeDef.internalName.value);
+            fieldName = getTypeFieldName(optionalTypeDef.internalName.getValue());
             String methodName = POPULATE_METHOD_PREFIX + fieldName;
             MethodVisitor mv;
             switch (bTypeTag) {
@@ -435,9 +435,9 @@ public class JvmCreateTypeGen {
                 labels.add(i, new Label());
                 String name;
                 if (decodeCase) {
-                    name = decodeIdentifier(node.getName().value);
+                    name = decodeIdentifier(node.getName().getValue());
                 } else {
-                    name = node.getName().value;
+                    name = node.getName().getValue();
                 }
                 hashCodes[i] = name.hashCode();
                 i += 1;
@@ -466,9 +466,9 @@ public class JvmCreateTypeGen {
             mv.visitLabel(labels.get(i));
             mv.visitVarInsn(ALOAD, nameRegIndex);
             if (decodeCase) {
-                mv.visitLdcInsn(decodeIdentifier(node.getName().value));
+                mv.visitLdcInsn(decodeIdentifier(node.getName().getValue()));
             } else {
-                mv.visitLdcInsn(node.getName().value);
+                mv.visitLdcInsn(node.getName().getValue());
             }
             mv.visitMethodInsn(INVOKEVIRTUAL, STRING_VALUE, "equals",
                     ANY_TO_JBOOLEAN, false);
@@ -590,7 +590,7 @@ public class JvmCreateTypeGen {
         for (BIRTypeDefinition node : nodes) {
             if (node != null) {
                 BType type = node.type;
-                String fieldName = getTypeFieldName(node.internalName.value);
+                String fieldName = getTypeFieldName(node.internalName.getValue());
                 Integer typeHash = typeHashVisitor.visit(type);
                 boolean fieldExists = labelFieldMapping.containsKey(fieldName);
                 boolean hashExists = labelHashMapping.containsKey(typeHash);
@@ -654,7 +654,7 @@ public class JvmCreateTypeGen {
             mv.visitVarInsn(ALOAD, fieldMapIndex);
 
             // Load field name
-            mv.visitLdcInsn(decodeIdentifier(optionalField.name.value));
+            mv.visitLdcInsn(decodeIdentifier(optionalField.name.getValue()));
 
             // create and load field type
             createField(mv, optionalField);
@@ -698,7 +698,7 @@ public class JvmCreateTypeGen {
         jvmTypeGen.loadType(mv, field.symbol.type);
 
         // Load field name
-        mv.visitLdcInsn(decodeIdentifier(field.name.value));
+        mv.visitLdcInsn(decodeIdentifier(field.name.getValue()));
 
         // Load flags
         mv.visitLdcInsn(field.symbol.flags);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmBallerinaConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmBallerinaConstantsGen.java
@@ -114,7 +114,7 @@ public class JvmBallerinaConstantsGen {
         if (JvmCodeGenUtil.isSimpleBasicType(constValue.type)) {
             String descriptor = JvmCodeGenUtil.getFieldTypeSignature(constValue.type);
             JvmCodeGenUtil.loadConstantValue(constValue.type, constValue.value, mv, jvmConstantsGen);
-            mv.visitFieldInsn(PUTSTATIC, className, constant.name.value, descriptor);
+            mv.visitFieldInsn(PUTSTATIC, className, constant.name.getValue(), descriptor);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmErrorTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmErrorTypeConstantsGen.java
@@ -137,7 +137,7 @@ public class JvmErrorTypeConstantsGen {
     }
 
     private void createBErrorType(BErrorType errorType, String varName) {
-        jvmErrorTypeGen.createErrorType(mv, errorType, errorType.tsymbol.name.value);
+        jvmErrorTypeGen.createErrorType(mv, errorType, errorType.tsymbol.name.getValue());
         mv.visitFieldInsn(Opcodes.PUTSTATIC, errorVarConstantsClass, varName,
                 GET_ERROR_TYPE_IMPL);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmModuleConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmModuleConstantsGen.java
@@ -117,9 +117,9 @@ public class JvmModuleConstantsGen {
             String varName = entry.getValue();
             mv.visitTypeInsn(NEW, MODULE);
             mv.visitInsn(DUP);
-            mv.visitLdcInsn(Utils.decodeIdentifier(packageID.orgName.value));
-            mv.visitLdcInsn(Utils.decodeIdentifier(packageID.name.value));
-            mv.visitLdcInsn(getMajorVersion(packageID.version.value));
+            mv.visitLdcInsn(Utils.decodeIdentifier(packageID.orgName.getValue()));
+            mv.visitLdcInsn(Utils.decodeIdentifier(packageID.name.getValue()));
+            mv.visitLdcInsn(getMajorVersion(packageID.version.getValue()));
             if (packageID.isTestPkg) {
                 mv.visitInsn(ICONST_1);
             } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmStrandMetadataConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmStrandMetadataConstantsGen.java
@@ -81,9 +81,9 @@ public class JvmStrandMetadataConstantsGen {
     private void genStrandMetadataField(MethodVisitor mv, String varName, ScheduleFunctionInfo metaData) {
         mv.visitTypeInsn(Opcodes.NEW, STRAND_METADATA);
         mv.visitInsn(Opcodes.DUP);
-        mv.visitLdcInsn(Utils.decodeIdentifier(this.packageID.orgName.value));
-        mv.visitLdcInsn(Utils.decodeIdentifier(this.packageID.name.value));
-        mv.visitLdcInsn(getMajorVersion(this.packageID.version.value));
+        mv.visitLdcInsn(Utils.decodeIdentifier(this.packageID.orgName.getValue()));
+        mv.visitLdcInsn(Utils.decodeIdentifier(this.packageID.name.getValue()));
+        mv.visitLdcInsn(getMajorVersion(this.packageID.version.getValue()));
         if (metaData.typeName == null) {
             mv.visitInsn(Opcodes.ACONST_NULL);
         } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/creators/JvmFunctionCallsCreatorsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/creators/JvmFunctionCallsCreatorsGen.java
@@ -96,7 +96,7 @@ public class JvmFunctionCallsCreatorsGen {
         List<Label> targetLabels = new ArrayList<>();
         String callMethod = CALL_FUNCTION;
         for (BIRNode.BIRFunction func : functions) {
-            String encodedMethodName = Utils.encodeFunctionIdentifier(func.name.value);
+            String encodedMethodName = Utils.encodeFunctionIdentifier(func.name.getValue());
             String packageName = JvmCodeGenUtil.getPackageName(packageID);
             BIRFunctionWrapper functionWrapper =
                     jvmPackageGen.lookupBIRFunctionWrapper(packageName + encodedMethodName);
@@ -135,7 +135,7 @@ public class JvmFunctionCallsCreatorsGen {
                 jvmCastGen.addUnboxInsn(mv, paramType);
                 j += 1;
             }
-            mv.visitMethodInsn(INVOKESTATIC, functionWrapper.fullQualifiedClassName(), func.name.value,
+            mv.visitMethodInsn(INVOKESTATIC, functionWrapper.fullQualifiedClassName(), func.name.getValue(),
                     functionWrapper.jvmMethodDescription(), false);
             int retTypeTag = JvmCodeGenUtil.getImpliedType(retType).tag;
             if (retType == null || retTypeTag == TypeTags.NIL || retTypeTag == TypeTags.NEVER) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/creators/JvmObjectCreatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/creators/JvmObjectCreatorGen.java
@@ -168,11 +168,11 @@ public class JvmObjectCreatorGen {
                         bTypesCount, remainingCases, labels, defaultCaseLabel);
                 i = 0;
             }
-            String fieldName = getTypeFieldName(optionalTypeDef.internalName.value);
+            String fieldName = getTypeFieldName(optionalTypeDef.internalName.getValue());
             Label targetLabel = targetLabels.get(i);
             mv.visitLabel(targetLabel);
             mv.visitVarInsn(ALOAD, 0);
-            String className = getTypeValueClassName(moduleId, optionalTypeDef.internalName.value);
+            String className = getTypeValueClassName(moduleId, optionalTypeDef.internalName.getValue());
             mv.visitTypeInsn(NEW, className);
             mv.visitInsn(DUP);
             mv.visitFieldInsn(GETSTATIC, moduleInitClass, fieldName, GET_TYPE);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmObjectTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmObjectTypeGen.java
@@ -238,8 +238,8 @@ public class JvmObjectTypeGen {
             }
             // create and load attached function
             createObjectMemberFunction(mv, attachedFunc, objType);
-            int attachedFunctionVarIndex = indexMap.addIfNotExists(toNameString(objType) + attachedFunc.funcName.value,
-                    symbolTable.anyType);
+            int attachedFunctionVarIndex = indexMap.addIfNotExists(
+                    toNameString(objType) + attachedFunc.funcName.getValue(), symbolTable.anyType);
             mv.visitVarInsn(ASTORE, attachedFunctionVarIndex);
 
             mv.visitInsn(DUP);
@@ -273,13 +273,13 @@ public class JvmObjectTypeGen {
                                        BIRVarToJVMIndexMap indexMap, String funcName,
                                        SymbolTable symbolTable, boolean isGeneratedInit) {
 
-        if (initFunction == null || !initFunction.funcName.value.contains(funcName)) {
+        if (initFunction == null || !initFunction.funcName.getValue().contains(funcName)) {
             return;
         }
 
         mv.visitInsn(DUP);
         createObjectMemberFunction(mv, initFunction, objType);
-        int attachedFunctionVarIndex = indexMap.addIfNotExists(objType.name + initFunction.funcName.value,
+        int attachedFunctionVarIndex = indexMap.addIfNotExists(objType.name + initFunction.funcName.getValue(),
                 symbolTable.anyType);
         mv.visitVarInsn(ASTORE, attachedFunctionVarIndex);
         mv.visitVarInsn(ALOAD, attachedFunctionVarIndex);
@@ -345,7 +345,7 @@ public class JvmObjectTypeGen {
             BResourceFunction resourceFunction = (BResourceFunction) attachedFunc;
             createResourceFunction(mv, resourceFunction, objType);
 
-            String varRefName = toNameString(objType) + resourceFunction.funcName.value + "$r$func";
+            String varRefName = toNameString(objType) + resourceFunction.funcName.getValue() + "$r$func";
             int rFuncVarIndex = indexMap.addIfNotExists(varRefName, symbolTable.anyType);
             mv.visitVarInsn(ASTORE, rFuncVarIndex);
 
@@ -405,7 +405,7 @@ public class JvmObjectTypeGen {
 
         mv.visitInsn(DUP);
         // Load function name
-        mv.visitLdcInsn(decodeIdentifier(attachedFunc.funcName.value));
+        mv.visitLdcInsn(decodeIdentifier(attachedFunc.funcName.getValue()));
 
         // Load module
         String moduleName = jvmConstantsGen.getModuleConstantVar(objType.tsymbol.pkgID);
@@ -430,7 +430,7 @@ public class JvmObjectTypeGen {
         mv.visitInsn(DUP);
 
         // Load function name
-        mv.visitLdcInsn(decodeIdentifier(attachedFunc.funcName.value));
+        mv.visitLdcInsn(decodeIdentifier(attachedFunc.funcName.getValue()));
 
         // Load module
         String moduleName = jvmConstantsGen.getModuleConstantVar(objType.tsymbol.pkgID);
@@ -456,7 +456,7 @@ public class JvmObjectTypeGen {
         mv.visitInsn(DUP);
 
         // Load function name
-        mv.visitLdcInsn(resourceFunction.funcName.value);
+        mv.visitLdcInsn(resourceFunction.funcName.getValue());
 
         // Load module
         String moduleName = jvmConstantsGen.getModuleConstantVar(objType.tsymbol.pkgID);
@@ -490,7 +490,7 @@ public class JvmObjectTypeGen {
         mv.visitLdcInsn(resourceFunction.symbol.flags);
 
         // Load accessor
-        mv.visitLdcInsn(decodeIdentifier(resourceFunction.accessor.value));
+        mv.visitLdcInsn(decodeIdentifier(resourceFunction.accessor.getValue()));
 
         // Load resource path
         mv.visitLdcInsn((long) pathSegmentSize);
@@ -503,7 +503,7 @@ public class JvmObjectTypeGen {
             mv.visitInsn(L2I);
 
             // load resource path name
-            mv.visitLdcInsn(path.value);
+            mv.visitLdcInsn(path.getValue());
 
             mv.visitInsn(AASTORE);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmRecordTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmRecordTypeGen.java
@@ -195,7 +195,7 @@ public class JvmRecordTypeGen {
             fullName = recordType.toString();
         } else {
             // for non-shape values toString gives the org name + name, we only need the name
-            fullName = recordType.tsymbol.name.value;
+            fullName = recordType.tsymbol.name.getValue();
         }
         return fullName;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmRefTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmRefTypeGen.java
@@ -60,7 +60,7 @@ public class JvmRefTypeGen {
     public void createTypeRefType(MethodVisitor mv, BTypeReferenceType typeRefType) {
         mv.visitTypeInsn(NEW, TYPE_REF_TYPE_IMPL);
         mv.visitInsn(DUP);
-        mv.visitLdcInsn(Utils.decodeIdentifier(typeRefType.tsymbol.name.value));
+        mv.visitLdcInsn(Utils.decodeIdentifier(typeRefType.tsymbol.name.getValue()));
         String varName = jvmConstantsGen.getModuleConstantVar(typeRefType.tsymbol.pkgID);
         mv.visitFieldInsn(GETSTATIC, jvmConstantsGen.getModuleConstantClass(), varName, GET_MODULE);
         mv.visitLdcInsn(jvmTypeGen.typeFlag(typeRefType.referredType));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
@@ -146,7 +146,7 @@ public class JvmObjectGen {
                 j += 1;
             }
 
-            mv.visitMethodInsn(INVOKEVIRTUAL, objClassName, func.name.value,
+            mv.visitMethodInsn(INVOKEVIRTUAL, objClassName, func.name.getValue(),
                     methodSig, false);
             int retTypeTag = JvmCodeGenUtil.getImpliedType(retType).tag;
             if (retType == null || retTypeTag == TypeTags.NIL || retTypeTag == TypeTags.NEVER) {
@@ -197,7 +197,8 @@ public class JvmObjectGen {
     }
 
     private boolean isListenerAttach(BIRNode.BIRFunction func) {
-        return func.name.value.equals("attach") && Symbols.isFlagOn(func.parameters.get(0).type.flags, Flags.SERVICE);
+        return func.name.getValue().equals("attach") &&
+                Symbols.isFlagOn(func.parameters.get(0).type.flags, Flags.SERVICE);
     }
 
     public void createAndSplitGetMethod(ClassWriter cw, Map<String, BField> fields, String className,
@@ -266,7 +267,7 @@ public class JvmObjectGen {
             Label targetLabel = targetLabels.get(i);
             mv.visitLabel(targetLabel);
             mv.visitVarInsn(ALOAD, 0);
-            mv.visitFieldInsn(GETFIELD, className, optionalField.name.value, getTypeDesc(optionalField.type));
+            mv.visitFieldInsn(GETFIELD, className, optionalField.name.getValue(), getTypeDesc(optionalField.type));
             jvmCastGen.addBoxInsn(mv, optionalField.type);
             mv.visitInsn(ARETURN);
             i += 1;
@@ -398,7 +399,7 @@ public class JvmObjectGen {
             mv.visitVarInsn(ALOAD, 0);
             mv.visitVarInsn(ALOAD, valueRegIndex);
             jvmCastGen.addUnboxInsn(mv, optionalField.type);
-            String filedName = optionalField.name.value;
+            String filedName = optionalField.name.getValue();
             mv.visitFieldInsn(PUTFIELD, className, filedName, getTypeDesc(optionalField.type));
             mv.visitInsn(RETURN);
             i += 1;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmRecordGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmRecordGen.java
@@ -215,7 +215,7 @@ public class JvmRecordGen {
 
             // if the field is an optional-field, first check the 'isPresent' flag of that field.
             Label ifPresentLabel = new Label();
-            String fieldName = optionalField.name.value;
+            String fieldName = optionalField.name.getValue();
             if (isOptionalRecordField(optionalField)) {
                 mv.visitVarInsn(ALOAD, selfRegIndex);
                 mv.visitFieldInsn(GETFIELD, className, getFieldIsPresentFlagName(fieldName),
@@ -332,7 +332,7 @@ public class JvmRecordGen {
             mv.visitLabel(targetLabel);
 
             // load the existing value to return
-            String fieldName = optionalField.name.value;
+            String fieldName = optionalField.name.getValue();
             mv.visitVarInsn(ALOAD, selfRegIndex);
             mv.visitFieldInsn(GETFIELD, className, fieldName, getTypeDesc(optionalField.type));
             jvmCastGen.addBoxInsn(mv, optionalField.type);
@@ -436,7 +436,7 @@ public class JvmRecordGen {
             Label ifNotPresent = new Label();
 
             // If its an optional field, generate if-condition to check the presence of the field.
-            String fieldName = optionalField.name.value;
+            String fieldName = optionalField.name.getValue();
             if (isOptionalRecordField(optionalField)) {
                 mv.visitVarInsn(ALOAD, 0);
                 mv.visitFieldInsn(GETFIELD, className, getFieldIsPresentFlagName(fieldName),
@@ -545,7 +545,7 @@ public class JvmRecordGen {
             Label targetLabel = targetLabels.get(i);
             mv.visitLabel(targetLabel);
 
-            String fieldName = optionalField.name.value;
+            String fieldName = optionalField.name.getValue();
             if (isOptionalRecordField(optionalField)) {
                 // if the field is optional, then return the value is the 'isPresent' flag.
                 mv.visitVarInsn(ALOAD, selfRegIndex);
@@ -637,7 +637,7 @@ public class JvmRecordGen {
             Label ifNotPresent = new Label();
 
             // If its an optional field, generate if-condition to check the presence of the field.
-            String fieldName = optionalField.name.value;
+            String fieldName = optionalField.name.getValue();
             if (isOptionalRecordField(optionalField)) {
                 mv.visitVarInsn(ALOAD, 0); // this
                 mv.visitFieldInsn(GETFIELD, className, getFieldIsPresentFlagName(fieldName),
@@ -742,7 +742,7 @@ public class JvmRecordGen {
 
             //Setting isPresent as zero
             if (isOptionalRecordField(optionalField)) {
-                String fieldName = optionalField.name.value;
+                String fieldName = optionalField.name.getValue();
                 mv.visitVarInsn(ALOAD, 0);
                 mv.visitInsn(ICONST_0);
                 mv.visitFieldInsn(PUTFIELD, className, getFieldIsPresentFlagName(fieldName),
@@ -853,7 +853,7 @@ public class JvmRecordGen {
             Label ifNotPresent = new Label();
 
             // If its an optional field, generate if-condition to check the presense of the field.
-            String fieldName = optionalField.name.value;
+            String fieldName = optionalField.name.getValue();
             if (isOptionalRecordField(optionalField)) {
                 mv.visitVarInsn(ALOAD, 0); // this
                 mv.visitFieldInsn(GETFIELD, className, getFieldIsPresentFlagName(fieldName),
@@ -928,7 +928,7 @@ public class JvmRecordGen {
             BField field = sortedFields.get(i);
             Label targetLabel = targetLabels.get(i);
             mv.visitLabel(targetLabel);
-            String fieldName = field.name.value;
+            String fieldName = field.name.getValue();
 
             mv.visitVarInsn(ALOAD, selfRegister);
             BType fieldType = field.type;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/BIREmitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/BIREmitter.java
@@ -138,7 +138,7 @@ public class BIREmitter {
 
     private static String emitTypeDef(BIRNode.BIRTypeDefinition tDef) {
         // Adding the type to global type map
-        TypeEmitter.B_TYPES.put(tDef.internalName.value, tDef.type);
+        TypeEmitter.B_TYPES.put(tDef.internalName.getValue(), tDef.type);
 
         StringBuilder tDefStr = new StringBuilder();
         tDefStr.append(emitFlags(tDef.flags));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/EmitterUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/EmitterUtils.java
@@ -40,7 +40,7 @@ final class EmitterUtils {
     private EmitterUtils() {}
 
     static String emitName(Name name) {
-        return name.value;
+        return name.getValue();
     }
 
     static String emitVarRef(BIROperand ref) {
@@ -62,9 +62,9 @@ final class EmitterUtils {
         String str = "";
         str += modId.orgName + "/";
         str += modId.name;
-        if (!modId.version.value.isEmpty()) {
+        if (!modId.version.getValue().isEmpty()) {
             str += ":";
-            str += modId.version.value;
+            str += modId.version.getValue();
         }
         return str;
     }
@@ -148,7 +148,7 @@ final class EmitterUtils {
     }
 
     static boolean isEmpty(Name nameVal) {
-        return nameVal.value.isEmpty();
+        return nameVal.getValue().isEmpty();
     }
 
     static String emitValue(Object value, BType type) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -140,7 +140,7 @@ public abstract class BIRNode {
             this.scope = scope;
             this.kind = kind;
             this.metaVarName = metaVarName;
-            this.jvmVarName = name.value.replace("%", "_");
+            this.jvmVarName = name.getValue().replace("%", "_");
         }
 
         public BIRVariableDcl(Location pos, BType type, Name name, VarScope scope,
@@ -173,7 +173,7 @@ public abstract class BIRNode {
 
         @Override
         public int hashCode() {
-            return this.name.value.hashCode();
+            return this.name.getValue().hashCode();
         }
 
         @Override
@@ -485,7 +485,7 @@ public abstract class BIRNode {
 
         @Override
         public String toString() {
-            return id.value;
+            return id.getValue();
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRRecordValueOptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRRecordValueOptimizer.java
@@ -120,12 +120,12 @@ public class BIRRecordValueOptimizer extends BIRVisitor {
             return;
         }
 
-        if (!fpCall.fp.variableDcl.name.value.contains(recordType.tsymbol.name.value)) {
+        if (!fpCall.fp.variableDcl.name.getValue().contains(recordType.tsymbol.name.getValue())) {
             resetBasicBlock(basicBlock);
             return;
         }
 
-        BIRNode.BIRFunction defaultFunction = getDefaultBIRFunction(fpCall.fp.variableDcl.name.value);
+        BIRNode.BIRFunction defaultFunction = getDefaultBIRFunction(fpCall.fp.variableDcl.name.getValue());
         if (defaultFunction == null) {
             resetBasicBlock(basicBlock);
             return;
@@ -160,7 +160,7 @@ public class BIRRecordValueOptimizer extends BIRVisitor {
         BIRNonTerminator.ConstantLoad constantLoad = (BIRNonTerminator.ConstantLoad) firstBB.instructions.get(0);
         if (firstBB.instructions.size() == 2) {
             BIRNonTerminator.TypeCast typeCast = (BIRNonTerminator.TypeCast) firstBB.instructions.get(1);
-            String tempVarName = "%temp_" + typeCast.rhsOp.variableDcl.name.value;
+            String tempVarName = "%temp_" + typeCast.rhsOp.variableDcl.name.getValue();
             BIRNode.BIRVariableDcl tempVar;
             if (typecastVars.containsKey(tempVarName)) {
                 tempVar = typecastVars.get(tempVarName);
@@ -212,7 +212,7 @@ public class BIRRecordValueOptimizer extends BIRVisitor {
 
     private BIRNode.BIRFunction getDefaultBIRFunction(String funcName) {
         for (BIRNode.BIRFunction func : moduleFunctions) {
-            if (func.name.value.equals(funcName)) {
+            if (func.name.getValue().equals(funcName)) {
                 return func;
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -150,7 +150,7 @@ public class BIRBinaryWriter {
             writePosition(buf, birGlobalVar.pos);
             buf.writeByte(birGlobalVar.kind.getValue());
             // Name
-            buf.writeInt(addStringCPEntry(birGlobalVar.name.value));
+            buf.writeInt(addStringCPEntry(birGlobalVar.name.getValue()));
             // Flags
             buf.writeLong(birGlobalVar.flags);
             // Origin
@@ -169,9 +169,9 @@ public class BIRBinaryWriter {
                            BIRTypeDefinition typeDef) {
         writePosition(buf, typeDef.pos);
         // Type name CP Index
-        buf.writeInt(addStringCPEntry(typeDef.internalName.value));
+        buf.writeInt(addStringCPEntry(typeDef.internalName.getValue()));
         // Type original-name CP Index
-        buf.writeInt(addStringCPEntry(typeDef.originalName.value));
+        buf.writeInt(addStringCPEntry(typeDef.originalName.getValue()));
         // Flags
         buf.writeLong(typeDef.flags);
         // Origin
@@ -195,11 +195,11 @@ public class BIRBinaryWriter {
         // Write Position
         writePosition(buf, birFunction.pos);
         // Function name CP Index
-        buf.writeInt(addStringCPEntry(birFunction.name.value));
+        buf.writeInt(addStringCPEntry(birFunction.name.getValue()));
         // Function original name CP Index
-        buf.writeInt(addStringCPEntry(birFunction.originalName.value));
+        buf.writeInt(addStringCPEntry(birFunction.originalName.getValue()));
         // Function worker name CP Index
-        buf.writeInt(addStringCPEntry(birFunction.workerName.value));
+        buf.writeInt(addStringCPEntry(birFunction.workerName.getValue()));
         // Flags
         buf.writeLong(birFunction.flags);
         // Origin
@@ -218,7 +218,7 @@ public class BIRBinaryWriter {
 
         buf.writeInt(birFunction.requiredParams.size());
         for (BIRParameter parameter : birFunction.requiredParams) {
-            buf.writeInt(addStringCPEntry(parameter.name.value));
+            buf.writeInt(addStringCPEntry(parameter.name.getValue()));
             buf.writeLong(parameter.flags);
             BIRWriterUtils.writeAnnotAttachments(cp, buf, parameter.annotAttachments);
         }
@@ -228,7 +228,7 @@ public class BIRBinaryWriter {
         boolean restParamExist = restParam != null;
         buf.writeBoolean(restParamExist);
         if (restParamExist) {
-            buf.writeInt(addStringCPEntry(restParam.name.value));
+            buf.writeInt(addStringCPEntry(restParam.name.getValue()));
             BIRWriterUtils.writeAnnotAttachments(cp, buf, restParam.annotAttachments);
         }
 
@@ -237,7 +237,7 @@ public class BIRBinaryWriter {
         if (hasReceiverType) {
             buf.writeByte(birFunction.receiver.kind.getValue());
             BIRWriterUtils.writeType(cp, buf, birFunction.receiver.type);
-            buf.writeInt(addStringCPEntry(birFunction.receiver.name.value));
+            buf.writeInt(addStringCPEntry(birFunction.receiver.name.getValue()));
         }
 
         typeWriter.writeMarkdownDocAttachment(buf, birFunction.markdownDocAttachment);
@@ -256,14 +256,14 @@ public class BIRBinaryWriter {
         if (birFunction.returnVariable != null) {
             birbuf.writeByte(birFunction.returnVariable.kind.getValue());
             BIRWriterUtils.writeType(cp, birbuf, birFunction.returnVariable.type);
-            birbuf.writeInt(addStringCPEntry(birFunction.returnVariable.name.value));
+            birbuf.writeInt(addStringCPEntry(birFunction.returnVariable.name.getValue()));
         }
 
         birbuf.writeInt(birFunction.parameters.size());
         for (BIRNode.BIRFunctionParameter param : birFunction.parameters) {
             birbuf.writeByte(param.kind.getValue());
             BIRWriterUtils.writeType(cp, birbuf, param.type);
-            birbuf.writeInt(addStringCPEntry(param.name.value));
+            birbuf.writeInt(addStringCPEntry(param.name.getValue()));
             if (param.kind.equals(VarKind.ARG)) {
                 birbuf.writeInt(addStringCPEntry(param.metaVarName != null ? param.metaVarName : ""));
             }
@@ -274,7 +274,7 @@ public class BIRBinaryWriter {
         for (BIRNode.BIRVariableDcl localVar : birFunction.localVars) {
             birbuf.writeByte(localVar.kind.getValue());
             BIRWriterUtils.writeType(cp, birbuf, localVar.type);
-            birbuf.writeInt(addStringCPEntry(localVar.name.value));
+            birbuf.writeInt(addStringCPEntry(localVar.name.getValue()));
             // skip compiler added vars and only write metaVarName for user added vars
             if (localVar.kind.equals(VarKind.ARG)) {
                 birbuf.writeInt(addStringCPEntry(localVar.metaVarName != null ? localVar.metaVarName : ""));
@@ -282,8 +282,8 @@ public class BIRBinaryWriter {
             // add enclosing basic block id
             if (localVar.kind.equals(VarKind.LOCAL)) {
                 birbuf.writeInt(addStringCPEntry(localVar.metaVarName != null ? localVar.metaVarName : ""));
-                birbuf.writeInt(addStringCPEntry(localVar.endBB != null ? localVar.endBB.id.value : ""));
-                birbuf.writeInt(addStringCPEntry(localVar.startBB != null ? localVar.startBB.id.value : ""));
+                birbuf.writeInt(addStringCPEntry(localVar.endBB != null ? localVar.endBB.id.getValue() : ""));
+                birbuf.writeInt(addStringCPEntry(localVar.startBB != null ? localVar.startBB.id.getValue() : ""));
                 birbuf.writeInt(localVar.insOffset);
             }
         }
@@ -335,12 +335,12 @@ public class BIRBinaryWriter {
             int pathSegmentCount = resourcePath.size();
             buf.writeInt(pathSegmentCount);
             for (int i = 0; i < pathSegmentCount; i++) {
-                buf.writeInt(addStringCPEntry(resourcePath.get(i).value));
+                buf.writeInt(addStringCPEntry(resourcePath.get(i).getValue()));
                 writePosition(buf, pathSegmentPosList.get(i));
                 BIRWriterUtils.writeType(cp, buf, pathSegmentTypeList.get(i));
             }
 
-            buf.writeInt(addStringCPEntry(birFunction.accessor.value));
+            buf.writeInt(addStringCPEntry(birFunction.accessor.getValue()));
         }
     }
 
@@ -348,7 +348,7 @@ public class BIRBinaryWriter {
         buf.writeInt(birFunction.dependentGlobalVars.size());
 
         for (BIRNode.BIRVariableDcl var : birFunction.dependentGlobalVars) {
-            buf.writeInt(addStringCPEntry(var.name.value));
+            buf.writeInt(addStringCPEntry(var.name.getValue()));
         }
     }
 
@@ -370,9 +370,9 @@ public class BIRBinaryWriter {
         buf.writeInt(BIRWriterUtils.addPkgCPEntry(birAnnotation.packageID, this.cp));
 
         // Annotation name CP Index
-        buf.writeInt(addStringCPEntry(birAnnotation.name.value));
+        buf.writeInt(addStringCPEntry(birAnnotation.name.getValue()));
         // Annotation original name CP Index
-        buf.writeInt(addStringCPEntry(birAnnotation.originalName.value));
+        buf.writeInt(addStringCPEntry(birAnnotation.originalName.getValue()));
 
         buf.writeLong(birAnnotation.flags);
         buf.writeByte(birAnnotation.origin.value());
@@ -397,7 +397,7 @@ public class BIRBinaryWriter {
 
     private void writeConstant(ByteBuf buf, BIRTypeWriter typeWriter, BIRNode.BIRConstant birConstant) {
         // Annotation name CP Index
-        buf.writeInt(addStringCPEntry(birConstant.name.value));
+        buf.writeInt(addStringCPEntry(birConstant.name.getValue()));
         buf.writeLong(birConstant.flags);
         buf.writeByte(birConstant.origin.value());
         writePosition(buf, birConstant.pos);
@@ -423,8 +423,8 @@ public class BIRBinaryWriter {
     }
 
     private void writeServiceDeclaration(ByteBuf buf, BIRNode.BIRServiceDeclaration birServiceDecl) {
-        buf.writeInt(addStringCPEntry(birServiceDecl.generatedName.value));
-        buf.writeInt(addStringCPEntry(birServiceDecl.associatedClassName.value));
+        buf.writeInt(addStringCPEntry(birServiceDecl.generatedName.getValue()));
+        buf.writeInt(addStringCPEntry(birServiceDecl.associatedClassName.getValue()));
         buf.writeLong(birServiceDecl.flags);
         buf.writeByte(birServiceDecl.origin.value());
         writePosition(buf, birServiceDecl.pos);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRInstructionWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRInstructionWriter.java
@@ -130,7 +130,7 @@ public class BIRInstructionWriter extends BIRVisitor {
     @Override
     public void visit(BIRBasicBlock birBasicBlock) {
         //Name of the basic block
-        addCpAndWriteString(birBasicBlock.id.value);
+        addCpAndWriteString(birBasicBlock.id.getValue());
         // Number of instructions
         // Adding the terminator instruction as well.
         buf.writeInt(birBasicBlock.instructions.size() + 1);
@@ -164,35 +164,35 @@ public class BIRInstructionWriter extends BIRVisitor {
 
     @Override
     public void visit(BIRNode.BIRErrorEntry errorEntry) {
-        addCpAndWriteString(errorEntry.trapBB.id.value);
-        addCpAndWriteString(errorEntry.endBB.id.value);
+        addCpAndWriteString(errorEntry.trapBB.id.getValue());
+        addCpAndWriteString(errorEntry.endBB.id.getValue());
         errorEntry.errorOp.accept(this);
-        addCpAndWriteString(errorEntry.targetBB.id.value);
+        addCpAndWriteString(errorEntry.targetBB.id.getValue());
     }
 
     // Terminating instructions
 
     @Override
     public void visit(BIRTerminator.GOTO birGoto) {
-        addCpAndWriteString(birGoto.targetBB.id.value);
+        addCpAndWriteString(birGoto.targetBB.id.getValue());
     }
 
     @Override
     public void visit(BIRTerminator.Lock lock) {
-        addCpAndWriteString(lock.lockedBB.id.value);
+        addCpAndWriteString(lock.lockedBB.id.getValue());
     }
 
     @Override
     public void visit(BIRTerminator.FieldLock lock) {
         // TODO properly use operand instead of variablDcl.name here
-        addCpAndWriteString(lock.localVar.variableDcl.name.value);
+        addCpAndWriteString(lock.localVar.variableDcl.name.getValue());
         addCpAndWriteString(lock.field);
-        addCpAndWriteString(lock.lockedBB.id.value);
+        addCpAndWriteString(lock.lockedBB.id.getValue());
     }
 
     @Override
     public void visit(BIRTerminator.Unlock unlock) {
-        addCpAndWriteString(unlock.unlockBB.id.value);
+        addCpAndWriteString(unlock.unlockBB.id.getValue());
     }
 
     @Override
@@ -204,9 +204,9 @@ public class BIRInstructionWriter extends BIRVisitor {
     public void visit(BIRTerminator.Branch birBranch) {
         birBranch.op.accept(this);
         // true:BB
-        addCpAndWriteString(birBranch.trueBB.id.value);
+        addCpAndWriteString(birBranch.trueBB.id.getValue());
         // false:BB
-        addCpAndWriteString(birBranch.falseBB.id.value);
+        addCpAndWriteString(birBranch.falseBB.id.getValue());
     }
 
     @Override
@@ -216,7 +216,7 @@ public class BIRInstructionWriter extends BIRVisitor {
             expr.accept(this);
         }
         waitEntry.lhsOp.accept(this);
-        addCpAndWriteString(waitEntry.thenBB.id.value);
+        addCpAndWriteString(waitEntry.thenBB.id.getValue());
     }
 
     @Override
@@ -228,7 +228,7 @@ public class BIRInstructionWriter extends BIRVisitor {
             buf.writeBoolean(detail.send);
         }
         entry.lhsOp.accept(this);
-        addCpAndWriteString(entry.thenBB.id.value);
+        addCpAndWriteString(entry.thenBB.id.getValue());
     }
 
     @Override
@@ -236,7 +236,7 @@ public class BIRInstructionWriter extends BIRVisitor {
         buf.writeInt(addStringCPEntry(entry.workerName.getValue()));
         entry.lhsOp.accept(this);
         buf.writeBoolean(entry.isSameStrand);
-        addCpAndWriteString(entry.thenBB.id.value);
+        addCpAndWriteString(entry.thenBB.id.getValue());
     }
 
     @Override
@@ -248,7 +248,7 @@ public class BIRInstructionWriter extends BIRVisitor {
         if (entry.isSync) {
             entry.lhsOp.accept(this);
         }
-        addCpAndWriteString(entry.thenBB.id.value);
+        addCpAndWriteString(entry.thenBB.id.getValue());
     }
 
     @Override
@@ -256,7 +256,7 @@ public class BIRInstructionWriter extends BIRVisitor {
         entry.channels.forEach(key -> buf.writeInt(addStringCPEntry(key)));
         entry.lhsOp.accept(this);
         buf.writeBoolean(entry.isSameStrand);
-        addCpAndWriteString(entry.thenBB.id.value);
+        addCpAndWriteString(entry.thenBB.id.getValue());
     }
 
     @Override
@@ -268,7 +268,7 @@ public class BIRInstructionWriter extends BIRVisitor {
         writeType(entry.targetType);
         entry.lhsOp.accept(this);
         buf.writeBoolean(entry.isSameStrand);
-        addCpAndWriteString(entry.thenBB.id.value);
+        addCpAndWriteString(entry.thenBB.id.getValue());
     }
 
     @Override
@@ -278,7 +278,7 @@ public class BIRInstructionWriter extends BIRVisitor {
         waitAll.keys.forEach(key -> buf.writeInt(addStringCPEntry(key)));
         buf.writeInt(waitAll.valueExprs.size());
         waitAll.valueExprs.forEach(val -> val.accept(this));
-        addCpAndWriteString(waitAll.thenBB.id.value);
+        addCpAndWriteString(waitAll.thenBB.id.getValue());
     }
 
     // Non-terminating instructions
@@ -300,14 +300,14 @@ public class BIRInstructionWriter extends BIRVisitor {
     @Override
     public void visit(BIRTerminator.Call birCall) {
         writeCallInstruction(birCall);
-        addCpAndWriteString(birCall.thenBB.id.value);
+        addCpAndWriteString(birCall.thenBB.id.getValue());
     }
 
     @Override
     public void visit(BIRTerminator.AsyncCall birAsyncCall) {
         writeCallInstruction(birAsyncCall);
         BIRWriterUtils.writeAnnotAttachments(this.cp, buf, birAsyncCall.annotAttachments);
-        addCpAndWriteString(birAsyncCall.thenBB.id.value);
+        addCpAndWriteString(birAsyncCall.thenBB.id.getValue());
     }
 
     private void writeCallInstruction(BIRTerminator.Call birCall) {
@@ -342,7 +342,7 @@ public class BIRInstructionWriter extends BIRVisitor {
             buf.writeByte(0);
         }
         buf.writeBoolean(fpCall.isAsync);
-        addCpAndWriteString(fpCall.thenBB.id.value);
+        addCpAndWriteString(fpCall.thenBB.id.getValue());
     }
 
     @Override
@@ -497,7 +497,7 @@ public class BIRInstructionWriter extends BIRVisitor {
         buf.writeByte(birOperand.variableDcl.scope.getValue());
 
         // TODO use the integer index of the variable.
-        addCpAndWriteString(birOperand.variableDcl.name.value);
+        addCpAndWriteString(birOperand.variableDcl.name.getValue());
 
         if (birOperand.variableDcl.kind == VarKind.GLOBAL || birOperand.variableDcl.kind == VarKind.CONSTANT) {
             int pkgIndex = addPkgCPEntry(((BIRGlobalVariableDcl) birOperand.variableDcl).pkgId);
@@ -535,7 +535,7 @@ public class BIRInstructionWriter extends BIRVisitor {
         fpLoad.params.forEach(param -> {
             buf.writeByte(param.kind.getValue());
             writeType(param.type);
-            buf.writeInt(addStringCPEntry(param.name.value));
+            buf.writeInt(addStringCPEntry(param.name.getValue()));
         });
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -145,7 +145,7 @@ public class BIRTypeWriter implements TypeVisitor {
         // Write the error package and type name
         int pkgIndex = BIRWriterUtils.addPkgCPEntry(bErrorType.tsymbol.pkgID, cp);
         buff.writeInt(pkgIndex);
-        buff.writeInt(addStringCPEntry(bErrorType.tsymbol.name.value));
+        buff.writeInt(addStringCPEntry(bErrorType.tsymbol.name.getValue()));
         // Write detail types.
         writeTypeCpIndex(bErrorType.detailType);
         writeTypeIds(bErrorType.typeIdSet);
@@ -172,7 +172,7 @@ public class BIRTypeWriter implements TypeVisitor {
     @Override
     public void visit(BFiniteType bFiniteType) {
         BTypeSymbol tsymbol = bFiniteType.tsymbol;
-        buff.writeInt(addStringCPEntry(tsymbol.name.value));
+        buff.writeInt(addStringCPEntry(tsymbol.name.getValue()));
         buff.writeLong(tsymbol.flags);
         buff.writeInt(bFiniteType.getValueSpace().size());
         for (BLangExpression valueLiteral : bFiniteType.getValueSpace()) {
@@ -214,7 +214,7 @@ public class BIRTypeWriter implements TypeVisitor {
         BInvokableTypeSymbol invokableTypeSymbol = (BInvokableTypeSymbol) bInvokableType.tsymbol;
         buff.writeInt(invokableTypeSymbol.params.size());
         for (BVarSymbol symbol : invokableTypeSymbol.params) {
-            buff.writeInt(addStringCPEntry(symbol.name.value));
+            buff.writeInt(addStringCPEntry(symbol.name.getValue()));
             buff.writeLong(symbol.flags);
             writeMarkdownDocAttachment(buff, symbol.markdownDocumentation);
             writeTypeCpIndex(symbol.type);
@@ -224,7 +224,7 @@ public class BIRTypeWriter implements TypeVisitor {
         boolean restParamExists = restParam != null;
         buff.writeBoolean(restParamExists);
         if (restParamExists) {
-            buff.writeInt(addStringCPEntry(restParam.name.value));
+            buff.writeInt(addStringCPEntry(restParam.name.getValue()));
             buff.writeLong(restParam.flags);
             writeMarkdownDocAttachment(buff, restParam.markdownDocumentation);
             writeTypeCpIndex(restParam.type);
@@ -238,14 +238,14 @@ public class BIRTypeWriter implements TypeVisitor {
     }
 
     private void writeSymbolOfClosure(BInvokableSymbol invokableSymbol) {
-        buff.writeInt(addStringCPEntry(invokableSymbol.name.value));
+        buff.writeInt(addStringCPEntry(invokableSymbol.name.getValue()));
         buff.writeLong(invokableSymbol.flags);
         writeTypeCpIndex(invokableSymbol.type);
         writePackageIndex(invokableSymbol.type.tsymbol);
 
         buff.writeInt(invokableSymbol.params.size());
         for (BVarSymbol symbol : invokableSymbol.params) {
-            buff.writeInt(addStringCPEntry(symbol.name.value));
+            buff.writeInt(addStringCPEntry(symbol.name.getValue()));
             buff.writeLong(symbol.flags);
             writeMarkdownDocAttachment(buff, symbol.markdownDocumentation);
             writeTypeCpIndex(symbol.type);
@@ -356,7 +356,7 @@ public class BIRTypeWriter implements TypeVisitor {
         if (bUnionType.isCyclic && (tsymbol != null && !tsymbol.name.getValue().isEmpty())) {
             buff.writeBoolean(true);
             writePackageIndex(tsymbol);
-            buff.writeInt(addStringCPEntry(bUnionType.tsymbol.name.value));
+            buff.writeInt(addStringCPEntry(bUnionType.tsymbol.name.getValue()));
         } else {
             buff.writeBoolean(false);
         }
@@ -381,11 +381,11 @@ public class BIRTypeWriter implements TypeVisitor {
     private void writeEnumSymbolInfo(BEnumSymbol symbol) {
         writePackageIndex(symbol);
 
-        buff.writeInt(addStringCPEntry(symbol.name.value));
+        buff.writeInt(addStringCPEntry(symbol.name.getValue()));
 
         buff.writeInt(symbol.members.size());
         for (BConstantSymbol member : symbol.members) {
-            buff.writeInt(addStringCPEntry(member.name.value));
+            buff.writeInt(addStringCPEntry(member.name.getValue()));
         }
     }
 
@@ -408,7 +408,7 @@ public class BIRTypeWriter implements TypeVisitor {
         writePackageIndex(tsymbol);
 
         BTypeDefinitionSymbol typDefSymbol = tsymbol.typeDefinitionSymbol;
-        buff.writeInt(addStringCPEntry(Objects.requireNonNullElse(typDefSymbol, tsymbol).name.value));
+        buff.writeInt(addStringCPEntry(Objects.requireNonNullElse(typDefSymbol, tsymbol).name.getValue()));
 
         buff.writeBoolean(bRecordType.sealed);
         writeTypeCpIndex(bRecordType.restFieldType);
@@ -416,7 +416,7 @@ public class BIRTypeWriter implements TypeVisitor {
         buff.writeInt(bRecordType.fields.size());
         for (BField field : bRecordType.fields.values()) {
             BSymbol symbol = field.symbol;
-            buff.writeInt(addStringCPEntry(symbol.name.value));
+            buff.writeInt(addStringCPEntry(symbol.name.getValue()));
             buff.writeLong(symbol.flags);
             writeMarkdownDocAttachment(buff, field.symbol.markdownDocumentation);
             writeTypeCpIndex(field.type);
@@ -446,12 +446,12 @@ public class BIRTypeWriter implements TypeVisitor {
         writePackageIndex(tSymbol);
 
         BTypeDefinitionSymbol typDefSymbol = ((BObjectTypeSymbol) tSymbol).typeDefinitionSymbol;
-        buff.writeInt(addStringCPEntry(Objects.requireNonNullElse(typDefSymbol, tSymbol).name.value));
+        buff.writeInt(addStringCPEntry(Objects.requireNonNullElse(typDefSymbol, tSymbol).name.getValue()));
 
         buff.writeLong(tSymbol.flags);
         buff.writeInt(bObjectType.fields.size());
         for (BField field : bObjectType.fields.values()) {
-            buff.writeInt(addStringCPEntry(field.name.value));
+            buff.writeInt(addStringCPEntry(field.name.getValue()));
             // TODO add position
             buff.writeLong(field.symbol.flags);
             buff.writeBoolean(field.symbol.isDefaultable);
@@ -488,7 +488,7 @@ public class BIRTypeWriter implements TypeVisitor {
     }
 
     private void writeAttachFunction(BAttachedFunction attachedFunc) {
-        buff.writeInt(addStringCPEntry(attachedFunc.funcName.value));
+        buff.writeInt(addStringCPEntry(attachedFunc.funcName.getValue()));
         buff.writeInt(addStringCPEntry(attachedFunc.symbol.getOriginalName().getValue()));
         buff.writeLong(attachedFunc.symbol.flags);
         writeTypeCpIndex(attachedFunc.type);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRWriterUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRWriterUtils.java
@@ -181,7 +181,7 @@ public final class BIRWriterUtils {
         annotBuf.writeInt(BIRWriterUtils.addPkgCPEntry(annotAttachment.annotPkgId, cp));
         // Write position
         writePosition(annotAttachment.pos, annotBuf, cp);
-        annotBuf.writeInt(addStringCPEntry(annotAttachment.annotTagRef.value, cp));
+        annotBuf.writeInt(addStringCPEntry(annotAttachment.annotTagRef.getValue(), cp));
 
         if (!(annotAttachment instanceof BIRNode.BIRConstAnnotationAttachment)) {
             annotBuf.writeBoolean(false);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
@@ -167,9 +167,9 @@ public final class ASTBuilderUtil {
         target.stmts.add(index, stmt);
     }
 
-    static void defineVariable(BLangSimpleVariable variable, BSymbol targetSymbol, Names names) {
-        variable.symbol = new BVarSymbol(0, names.fromIdNode(variable.name),
-                                         names.originalNameFromIdNode(variable.name),
+    static void defineVariable(BLangSimpleVariable variable, BSymbol targetSymbol) {
+        variable.symbol = new BVarSymbol(0, Names.fromIdNode(variable.name),
+                                         Names.originalNameFromIdNode(variable.name),
                                          targetSymbol.pkgID, variable.getBType(), targetSymbol, variable.pos, VIRTUAL);
         targetSymbol.scope.define(variable.symbol.name, variable.symbol);
     }
@@ -628,7 +628,6 @@ public final class ASTBuilderUtil {
                                                         BLangExpression lhsExpr,
                                                         BType targetType,
                                                         BType type,
-                                                        Names names,
                                                         Location opSymPos) {
         final BLangIsAssignableExpr assignableExpr = new BLangIsAssignableExpr();
         assignableExpr.pos = pos;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
@@ -499,7 +499,7 @@ public final class ASTBuilderUtil {
                                                       List<BLangSimpleVariable> restArgs, SymbolResolver symResolver) {
         final BLangInvocation invokeLambda = (BLangInvocation) TreeBuilder.createInvocationNode();
         invokeLambda.pos = pos;
-        invokeLambda.name = createIdentifier(pos, invokableSymbol.name.value);
+        invokeLambda.name = createIdentifier(pos, invokableSymbol.name.getValue());
         invokeLambda.requiredArgs.addAll(requiredArgs);
         invokeLambda.restArgs
                 .addAll(generateArgExprs(pos, restArgs, Lists.of(invokableSymbol.restParam), symResolver));
@@ -518,7 +518,7 @@ public final class ASTBuilderUtil {
     static BLangSimpleVarRef createVariableRef(Location pos, BSymbol varSymbol) {
         final BLangSimpleVarRef varRef = (BLangSimpleVarRef) TreeBuilder.createSimpleVariableReferenceNode();
         varRef.pos = pos;
-        varRef.variableName = createIdentifier(pos, varSymbol.name.value);
+        varRef.variableName = createIdentifier(pos, varSymbol.name.getValue());
         varRef.symbol = varSymbol;
         varRef.setBType(varSymbol.type);
         return varRef;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
@@ -499,7 +499,7 @@ public class AnnotationDesugar {
                 // Add the lambda/invocation in a temporary block.
                 BLangBlockStmt target = (BLangBlockStmt) TreeBuilder.createBlockNode();
                 target.pos = initFnBody.pos;
-                String identifier = function.attachedFunction ? function.symbol.name.value : function.name.value;
+                String identifier = function.attachedFunction ? function.symbol.name.getValue() : function.name.value;
 
                 int index;
                 if (function.attachedFunction
@@ -765,7 +765,7 @@ public class AnnotationDesugar {
 
         for (BVarSymbol varSymbol : mainFunc.symbol.getParameters()) {
             BLangLiteral str = (BLangLiteral) TreeBuilder.createLiteralExpression();
-            str.value = varSymbol.name.value;
+            str.value = varSymbol.name.getValue();
             str.setBType(symTable.stringType);
             str.typeChecked = true;
             valueLiteral.exprs.add(str);
@@ -773,7 +773,7 @@ public class AnnotationDesugar {
 
         if (mainFunc.symbol.restParam != null) {
             BLangLiteral str = (BLangLiteral) TreeBuilder.createLiteralExpression();
-            str.value = mainFunc.symbol.restParam.name.value;
+            str.value = mainFunc.symbol.restParam.name.getValue();
             str.setBType(symTable.stringType);
             str.typeChecked = true;
             valueLiteral.exprs.add(str);
@@ -999,7 +999,7 @@ public class AnnotationDesugar {
         BLangInvocation funcInvocation = (BLangInvocation) TreeBuilder.createInvocationNode();
         funcInvocation.setBType(symbol.retType);
         funcInvocation.symbol = symbol;
-        funcInvocation.name = ASTBuilderUtil.createIdentifier(symbol.pos, symbol.name.value);
+        funcInvocation.name = ASTBuilderUtil.createIdentifier(symbol.pos, symbol.name.getValue());
         funcInvocation.functionPointerInvocation = true;
         return funcInvocation;
     }
@@ -1041,7 +1041,7 @@ public class AnnotationDesugar {
         funcInvocation.expr = null;
         BInvokableSymbol lambdaSymbol = lambdaFunction.function.symbol;
         funcInvocation.symbol = lambdaSymbol;
-        funcInvocation.name = ASTBuilderUtil.createIdentifier(lambdaFunction.pos, lambdaSymbol.name.value);
+        funcInvocation.name = ASTBuilderUtil.createIdentifier(lambdaFunction.pos, lambdaSymbol.name.getValue());
         return funcInvocation;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
@@ -135,7 +135,6 @@ public class AnnotationDesugar {
     private final Desugar desugar;
     private final SymbolTable symTable;
     private final Types types;
-    private final Names names;
     private SymbolResolver symResolver;
     private ConstantValueResolver constantValueResolver;
     private ClosureGenerator closureGenerator;
@@ -153,7 +152,6 @@ public class AnnotationDesugar {
         this.desugar = Desugar.getInstance(context);
         this.symTable = SymbolTable.getInstance(context);
         this.types = Types.getInstance(context);
-        this.names = Names.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
         this.constantValueResolver = ConstantValueResolver.getInstance(context);
         this.closureGenerator = ClosureGenerator.getInstance(context);
@@ -921,7 +919,7 @@ public class AnnotationDesugar {
                                                                           symTable.mapType,
                                                                           ASTBuilderUtil.createEmptyRecordLiteral(
                                                                                   pkgNode.pos, symTable.mapType), null);
-        ASTBuilderUtil.defineVariable(annotationMap, pkgNode.symbol, names);
+        ASTBuilderUtil.defineVariable(annotationMap, pkgNode.symbol);
         pkgNode.globalVars.add(0, annotationMap); // TODO fix this
         pkgNode.topLevelNodes.add(0, annotationMap);
         return annotationMap;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClassClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClassClosureDesugar.java
@@ -226,7 +226,7 @@ public class ClassClosureDesugar extends BLangNodeVisitor {
         BLangSimpleVarRef refToBlockClosureMap = ASTBuilderUtil.createVariableRef(function.pos, blockMap);
 
         // self.$map$objectCtor
-        BLangIdentifier identifierNode = ASTBuilderUtil.createIdentifier(function.pos, classMapSymbol.name.value);
+        BLangIdentifier identifierNode = ASTBuilderUtil.createIdentifier(function.pos, classMapSymbol.name.getValue());
         BLangFieldBasedAccess fieldAccess = ASTBuilderUtil.createFieldAccessExpr(selfVarRef, identifierNode);
         fieldAccess.symbol = oceMap;
         fieldAccess.setBType(classMapSymbol.type);
@@ -254,11 +254,11 @@ public class ClassClosureDesugar extends BLangNodeVisitor {
     }
 
     private void addMapSymbolAsAField(BLangClassDefinition classDef, BVarSymbol mapSymbol) {
-        BLangSimpleVariable mapVar = ASTBuilderUtil.createVariable(symTable.builtinPos, mapSymbol.name.value,
+        BLangSimpleVariable mapVar = ASTBuilderUtil.createVariable(symTable.builtinPos, mapSymbol.name.getValue(),
                 mapSymbol.type, null, mapSymbol);
 
         BObjectType object = (BObjectType) classDef.getBType();
-        object.fields.put(mapSymbol.name.value, new BField(mapSymbol.name, classDef.pos, mapSymbol));
+        object.fields.put(mapSymbol.name.getValue(), new BField(mapSymbol.name, classDef.pos, mapSymbol));
         classDef.fields.add(0, mapVar);
     }
 
@@ -313,7 +313,7 @@ public class ClassClosureDesugar extends BLangNodeVisitor {
 
     private BLangSimpleVariableDef getClosureMap(BVarSymbol mapSymbol, SymbolEnv blockEnv) {
         BLangRecordLiteral emptyRecord = ASTBuilderUtil.createEmptyRecordLiteral(symTable.builtinPos, mapSymbol.type);
-        BLangSimpleVariable mapVar = ASTBuilderUtil.createVariable(symTable.builtinPos, mapSymbol.name.value,
+        BLangSimpleVariable mapVar = ASTBuilderUtil.createVariable(symTable.builtinPos, mapSymbol.name.getValue(),
                                                                    mapSymbol.type, emptyRecord, mapSymbol);
         mapVar.typeNode = ASTBuilderUtil.createTypeNode(mapSymbol.type);
         BLangSimpleVariableDef mapVarDef = ASTBuilderUtil.createVariableDef(symTable.builtinPos, mapVar);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClassClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClassClosureDesugar.java
@@ -178,7 +178,6 @@ public class ClassClosureDesugar extends BLangNodeVisitor {
 
     private final SymbolTable symTable;
     private final Desugar desugar;
-    private final Names names;
     private final BLangDiagnosticLog dlog;
 
     static {
@@ -197,7 +196,6 @@ public class ClassClosureDesugar extends BLangNodeVisitor {
         context.put(CLASS_CLOSURE_DESUGAR_KEY, this);
         this.symTable = SymbolTable.getInstance(context);
         this.desugar = Desugar.getInstance(context);
-        this.names = Names.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
         CLOSURE_MAP_NOT_FOUND.pos = this.symTable.builtinPos;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -210,7 +210,6 @@ public class ClosureDesugar extends BLangNodeVisitor {
     private BLangNode result;
     private Types types;
     private Desugar desugar;
-    private Names names;
     private ClassClosureDesugar classClosureDesugar;
     private int funClosureMapCount = 1;
     private int blockClosureMapCount = 1;
@@ -233,7 +232,6 @@ public class ClosureDesugar extends BLangNodeVisitor {
         this.symTable = SymbolTable.getInstance(context);
         this.types = Types.getInstance(context);
         this.desugar = Desugar.getInstance(context);
-        this.names = Names.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
         this.classClosureDesugar = ClassClosureDesugar.getInstance(context);
         CLOSURE_MAP_NOT_FOUND.pos = this.symTable.builtinPos;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -298,7 +298,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
         BLangSimpleVarRef refToBlockClosureMap = ASTBuilderUtil.createVariableRef(function.pos, blockMap);
 
         // self.$map$objectCtor
-        BLangIdentifier identifierNode = ASTBuilderUtil.createIdentifier(function.pos, blockMap.name.value);
+        BLangIdentifier identifierNode = ASTBuilderUtil.createIdentifier(function.pos, blockMap.name.getValue());
         BLangFieldBasedAccess fieldAccess = ASTBuilderUtil.createFieldAccessExpr(selfVarRef, identifierNode);
         fieldAccess.symbol = oceMap;
         fieldAccess.setBType(classMapSymbol.type);
@@ -344,8 +344,8 @@ public class ClosureDesugar extends BLangNodeVisitor {
         initInvocation.argExprs.add(refToBlockClosureMap);
 
         // add closure map as a argument to init method of the object
-        BLangSimpleVariable blockClosureMap = ASTBuilderUtil.createVariable(symTable.builtinPos, mapSymbol.name.value,
-                mapSymbol.getType(), null, mapSymbol);
+        BLangSimpleVariable blockClosureMap = ASTBuilderUtil.createVariable(
+                symTable.builtinPos, mapSymbol.name.getValue(), mapSymbol.getType(), null, mapSymbol);
         blockClosureMap.flagSet.add(Flag.REQUIRED_PARAM);
         BObjectTypeSymbol typeSymbol = ((BObjectTypeSymbol) classDef.getBType().tsymbol);
         if (typeSymbol.generatedInitializerFunc != null) {
@@ -386,11 +386,11 @@ public class ClosureDesugar extends BLangNodeVisitor {
     }
 
     private void addMapSymbolAsAField(BLangClassDefinition classDef, BVarSymbol mapSymbol) {
-        BLangSimpleVariable mapVar = ASTBuilderUtil.createVariable(symTable.builtinPos, mapSymbol.name.value,
+        BLangSimpleVariable mapVar = ASTBuilderUtil.createVariable(symTable.builtinPos, mapSymbol.name.getValue(),
                 mapSymbol.type, null, mapSymbol);
 
         BObjectType object = (BObjectType) classDef.getBType();
-        object.fields.put(mapSymbol.name.value, new BField(mapSymbol.name, classDef.pos, mapSymbol));
+        object.fields.put(mapSymbol.name.getValue(), new BField(mapSymbol.name, classDef.pos, mapSymbol));
         classDef.fields.add(0, mapVar);
     }
 
@@ -402,7 +402,8 @@ public class ClosureDesugar extends BLangNodeVisitor {
 
         BVarSymbol functionMap = functionMapSymbol;
 
-        BVarSymbol classFunctionMapSymbol = createFunctionMapSymbolIfAbsent(classDef, functionMapSymbol.name.value);
+        BVarSymbol classFunctionMapSymbol = createFunctionMapSymbolIfAbsent(
+                classDef, functionMapSymbol.name.getValue());
         classDef.oceEnvData.classEnclosedFunctionMap = classFunctionMapSymbol;
 
         addMapSymbolAsAField(classDef, classFunctionMapSymbol);
@@ -622,7 +623,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
             return;
         }
         BLangRecordLiteral emptyRecord = ASTBuilderUtil.createEmptyRecordLiteral(funcNode.pos, symTable.mapAllType);
-        BLangSimpleVariable mapVar = ASTBuilderUtil.createVariable(funcNode.pos, funcNode.mapSymbol.name.value,
+        BLangSimpleVariable mapVar = ASTBuilderUtil.createVariable(funcNode.pos, funcNode.mapSymbol.name.getValue(),
                                                                    funcNode.mapSymbol.type, emptyRecord,
                                                                    funcNode.mapSymbol);
         mapVar.typeNode = ASTBuilderUtil.createTypeNode(funcNode.mapSymbol.type);
@@ -677,7 +678,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
         // $map$func$_num[localVarRef]
         BLangIndexBasedAccess accessExpr = ASTBuilderUtil.createIndexBasesAccessExpr(funcNode.pos, type,
                 funcNode.mapSymbol, ASTBuilderUtil.createLiteral(funcNode.pos, symTable.stringType,
-                        paramSymbol.name.value));
+                        paramSymbol.name.getValue()));
         accessExpr.setBType(((BMapType) funcNode.mapSymbol.type).constraint);
         accessExpr.isLValue = true;
         // $map$func$_num[localVarRef] = <tyoe> localVarRef;
@@ -705,7 +706,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
 
     private BLangSimpleVariableDef getClosureMap(BVarSymbol mapSymbol, SymbolEnv blockEnv) {
         BLangRecordLiteral emptyRecord = ASTBuilderUtil.createEmptyRecordLiteral(symTable.builtinPos, mapSymbol.type);
-        BLangSimpleVariable mapVar = ASTBuilderUtil.createVariable(symTable.builtinPos, mapSymbol.name.value,
+        BLangSimpleVariable mapVar = ASTBuilderUtil.createVariable(symTable.builtinPos, mapSymbol.name.getValue(),
                                                                    mapSymbol.type, emptyRecord, mapSymbol);
         mapVar.typeNode = ASTBuilderUtil.createTypeNode(mapSymbol.type);
         BLangSimpleVariableDef mapVarDef = ASTBuilderUtil.createVariableDef(symTable.builtinPos, mapVar);
@@ -1675,7 +1676,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
         // Create the index based access expression.
         // [varRefExpr]
         BLangLiteral indexExpr = ASTBuilderUtil.createLiteral(varRefExpr.pos, symTable.stringType,
-                varRefExpr.varSymbol.name.value);
+                varRefExpr.varSymbol.name.getValue());
         // mapSymbol[varRefExpr]
         BLangIndexBasedAccess accessExpr = ASTBuilderUtil.createIndexBasesAccessExpr(varRefExpr.pos,
                 varRefExpr.getBType(),
@@ -1748,7 +1749,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
             }
         }
         BVarSymbol blockMap = createMapSymbolIfAbsent(nodeKeepingClosureMap, blockClosureMapCount);
-        BVarSymbol classMapSymbol = createMapSymbolIfAbsent(classDef, blockMap.name.value, true);
+        BVarSymbol classMapSymbol = createMapSymbolIfAbsent(classDef, blockMap.name.getValue(), true);
         BVarSymbol parentBlockMap = null;
         if (!oceEnvData.parents.isEmpty()) {
             BLangClassDefinition parentClass = oceEnvData.parents.get(0);
@@ -1779,7 +1780,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
                         BLangSimpleVarRef selfVarRef = ASTBuilderUtil.createVariableRef(function.pos, selfSymbol);
 
                         BLangIdentifier identifierNode = ASTBuilderUtil.createIdentifier(function.pos,
-                                parentBlockMap.name.value);
+                                parentBlockMap.name.getValue());
                         BLangFieldBasedAccess fieldAccess = ASTBuilderUtil.createFieldAccessExpr(selfVarRef,
                                 identifierNode);
                         fieldAccess.symbol = parentBlockMap;
@@ -1797,7 +1798,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
                                 env.scope.owner.pkgID, parentBlockMap.getType(), env.scope.owner, body.pos, VIRTUAL);
 
                         BLangSimpleVariable blockMapVar = ASTBuilderUtil.createVariable(body.pos,
-                                parentBlockMap.name.value,
+                                parentBlockMap.name.getValue(),
                                 parentBlockMap.getType(), fieldAccess, parentBlockSymbol);
 
                         body.scope.define(blockMapVar.symbol.name, parentBlockSymbol);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
@@ -431,7 +431,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
         }
         List<String> fieldNames = getFieldNames(recordTypeNode.fields);
         BTypeSymbol typeSymbol = recordTypeNode.getBType().tsymbol;
-        String typeName = recordTypeNode.symbol.name.value;
+        String typeName = recordTypeNode.symbol.name.getValue();
         for (BLangType type : recordTypeNode.typeRefs) {
             BType bType = type.getBType();
             BRecordType recordType = (BRecordType) Types.getReferredType(bType);
@@ -580,7 +580,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
             varNode.typeNode = rewrite(varNode.typeNode, env);
         }
         if (Symbols.isFlagOn(varNode.symbol.flags, Flags.FIELD) && varNode.symbol.isDefaultable) {
-            String closureName = generateName(varNode.symbol.name.value, env.node);
+            String closureName = generateName(varNode.symbol.name.getValue(), env.node);
             varNode.pos = null;
             varNode.expr.pos = null;
             generateClosureForDefaultValues(closureName, varNode.name.value, varNode);
@@ -589,7 +589,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
         }
 
         if (Symbols.isFlagOn(varNode.symbol.flags, Flags.DEFAULTABLE_PARAM)) {
-            String closureName = generateName(varNode.symbol.name.value, env.node);
+            String closureName = generateName(varNode.symbol.name.getValue(), env.node);
             generateClosureForDefaultValues(closureName, varNode.name.value, varNode);
         } else {
             rewriteExpr(varNode.expr);
@@ -642,7 +642,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
         Location pos = funcSymbol.pos;
         for (BVarSymbol symbol : params) {
             Name symbolName = symbol.name;
-            if (paramName.equals(symbolName.value)) {
+            if (paramName.equals(symbolName.getValue())) {
                 break;
             }
             BType type = symbol.type;
@@ -651,7 +651,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
             funcSymbol.scope.define(symbolName, varSymbol);
             funcSymbol.params.add(varSymbol);
             ((BInvokableType) funcSymbol.type).paramTypes.add(type);
-            funcNode.requiredParams.add(ASTBuilderUtil.createVariable(pos, symbolName.value, type, null,
+            funcNode.requiredParams.add(ASTBuilderUtil.createVariable(pos, symbolName.getValue(), type, null,
                                                                       varSymbol));
         }
     }
@@ -675,7 +675,8 @@ public class ClosureGenerator extends BLangNodeVisitor {
         varSymbol.params = invokableSymbol.params;
         varSymbol.restParam = invokableSymbol.restParam;
         varSymbol.retType = invokableSymbol.retType;
-        BLangSimpleVariableDef variableDef = createSimpleVariableDef(pos, name.value, type, lambdaFunction, varSymbol);
+        BLangSimpleVariableDef variableDef = createSimpleVariableDef(
+                pos, name.getValue(), type, lambdaFunction, varSymbol);
         addToQueue(variableDef, isAnnotationClosure);
         return varSymbol;
     }
@@ -686,7 +687,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
         Name name = invokableSymbol.name;
         BVarSymbol varSymbol = new BVarSymbol(0, name, invokableSymbol.originalName, invokableSymbol.pkgID, type,
                                               invokableSymbol.owner, pos, VIRTUAL);
-        BLangSimpleVariableDef variableDef = createSimpleVariableDef(pos, name.value, type,
+        BLangSimpleVariableDef variableDef = createSimpleVariableDef(pos, name.getValue(), type,
                                                                      getInvocation(invokableSymbol), varSymbol);
         addToQueue(variableDef, isAnnotationClosure);
         return varSymbol;
@@ -713,7 +714,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
         BLangInvocation funcInvocation = (BLangInvocation) TreeBuilder.createInvocationNode();
         funcInvocation.setBType(symbol.retType);
         funcInvocation.symbol = symbol;
-        funcInvocation.name = ASTBuilderUtil.createIdentifier(symbol.pos, symbol.name.value);
+        funcInvocation.name = ASTBuilderUtil.createIdentifier(symbol.pos, symbol.name.getValue());
         funcInvocation.functionPointerInvocation = true;
         return funcInvocation;
     }
@@ -749,7 +750,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
         return switch (parent.getKind()) {
             case CLASS_DEFN ->
                     generateName(((BLangClassDefinition) parent).name.getValue() + UNDERSCORE + name, parent.parent);
-            case FUNCTION -> generateName(((BLangFunction) parent).symbol.name.value.replace(".", UNDERSCORE)
+            case FUNCTION -> generateName(((BLangFunction) parent).symbol.name.getValue().replace(".", UNDERSCORE)
                     + UNDERSCORE + name, parent.parent);
             case RESOURCE_FUNC ->
                     generateName(((BLangResourceFunction) parent).name.value + UNDERSCORE + name, parent.parent);
@@ -1045,7 +1046,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
     private void updateFunctionParams(BLangFunction funcNode, BLangSimpleVarRef varRefExpr) {
         BInvokableSymbol funcSymbol = funcNode.symbol;
         for (BVarSymbol varSymbol : funcSymbol.params) {
-            if (varSymbol.name.value.equals(varRefExpr.symbol.name.value)) {
+            if (varSymbol.name.getValue().equals(varRefExpr.symbol.name.getValue())) {
                 varRefExpr.symbol = varSymbol;
                 return;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Code2CloudDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Code2CloudDesugar.java
@@ -48,8 +48,8 @@ public class Code2CloudDesugar {
         String cloudOption = CompilerOptions.getInstance(context).get(CompilerOptionName.CLOUD);
         c2cEnabled = "k8s".equals(cloudOption) || "docker".equals(cloudOption) || "choreo".equals(cloudOption);
         packageCache = PackageCache.getInstance(context);
-        final BPackageSymbol symbol = PackageCache.getInstance(context).getSymbol(Names.BALLERINA_ORG.value
-                + Names.ORG_NAME_SEPARATOR.value + Names.CLOUD.value);
+        final BPackageSymbol symbol = PackageCache.getInstance(context).getSymbol(Names.BALLERINA_ORG.getValue()
+                + Names.ORG_NAME_SEPARATOR.getValue() + Names.CLOUD.getValue());
         if (symbol != null) {
             c2cPkgID = symbol.pkgID;
         }
@@ -69,10 +69,10 @@ public class Code2CloudDesugar {
                 && c2cPkgID != null) {
             BLangImportPackage importDcl = (BLangImportPackage) TreeBuilder.createImportPackageNode();
             List<BLangIdentifier> pkgNameComps = new ArrayList<>();
-            pkgNameComps.add(ASTBuilderUtil.createIdentifier(pkgNode.pos, Names.CLOUD.value));
+            pkgNameComps.add(ASTBuilderUtil.createIdentifier(pkgNode.pos, Names.CLOUD.getValue()));
             importDcl.pkgNameComps = pkgNameComps;
             importDcl.pos = pkgNode.symbol.pos;
-            importDcl.orgName = ASTBuilderUtil.createIdentifier(pkgNode.pos, Names.BALLERINA_ORG.value);
+            importDcl.orgName = ASTBuilderUtil.createIdentifier(pkgNode.pos, Names.BALLERINA_ORG.getValue());
             importDcl.alias = ASTBuilderUtil.createIdentifier(pkgNode.pos, "_");
             importDcl.version = ASTBuilderUtil.createIdentifier(pkgNode.pos, "");
             importDcl.symbol = packageCache.getSymbol(c2cPkgID);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/DeclarativeAuthDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/DeclarativeAuthDesugar.java
@@ -70,7 +70,6 @@ public class DeclarativeAuthDesugar {
 
     private final SymbolTable symTable;
     private final SymbolResolver symResolver;
-    private final Names names;
 
     private static final String ORG_NAME = "ballerina";
     private static final String HTTP_PACKAGE_NAME = "http";
@@ -94,7 +93,6 @@ public class DeclarativeAuthDesugar {
         context.put(DECLARATIVE_AUTH_DESUGAR_KEY, this);
         this.symTable = SymbolTable.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
-        this.names = Names.getInstance(context);
     }
 
     void desugarFunction(BLangFunction functionNode, SymbolEnv env, List<BType> expressionTypes) {
@@ -181,7 +179,7 @@ public class DeclarativeAuthDesugar {
         List<BLangStatement> statements = getFunctionBodyStatementList(functionNode);
         statements.add(0, result);
 
-        BVarSymbol resultSymbol = new BVarSymbol(0, names.fromIdNode(result.var.name), env.enclPkg.packageID,
+        BVarSymbol resultSymbol = new BVarSymbol(0, Names.fromIdNode(result.var.name), env.enclPkg.packageID,
                                                  result.var.getBType(), functionNode.symbol, pos, VIRTUAL);
         functionNode.symbol.scope.define(resultSymbol.name, resultSymbol);
         result.var.symbol = resultSymbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/DeclarativeAuthDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/DeclarativeAuthDesugar.java
@@ -125,7 +125,8 @@ public class DeclarativeAuthDesugar {
     }
 
     private boolean isDefinedInStdLibPackage(BObjectType type, String packageName) {
-        return type.tsymbol.pkgID.orgName.value.equals(ORG_NAME) && type.tsymbol.pkgID.name.value.equals(packageName);
+        return type.tsymbol.pkgID.orgName.getValue().equals(ORG_NAME) &&
+                type.tsymbol.pkgID.name.getValue().equals(packageName);
     }
 
     void addAuthDesugarFunctionInvocation(BLangFunction functionNode, SymbolEnv env, String packageName) {
@@ -188,15 +189,16 @@ public class DeclarativeAuthDesugar {
     private BPackageSymbol getPackageSymbol(SymbolEnv env, String packageName) {
         // This resolves the package symbol when the code have an import relevant to the particular service
         for (BLangImportPackage pkg : env.enclPkg.imports) {
-            if (pkg.symbol.pkgID.orgName.value.equals(ORG_NAME) && pkg.symbol.pkgID.name.value.equals(packageName)) {
+            if (pkg.symbol.pkgID.orgName.getValue().equals(ORG_NAME) &&
+                    pkg.symbol.pkgID.name.getValue().equals(packageName)) {
                 return pkg.symbol;
             }
         }
         // This resolves the package symbol when the code is at a submodule of the module which have the listener
         // definition. In that case, there is no any import relevant to the particular service.
         while (env.enclEnv != null) {
-            if (env.enclEnv.scope.owner.pkgID.orgName.value.equals(ORG_NAME) &&
-                    env.enclEnv.scope.owner.pkgID.name.value.equals(packageName)) {
+            if (env.enclEnv.scope.owner.pkgID.orgName.getValue().equals(ORG_NAME) &&
+                    env.enclEnv.scope.owner.pkgID.name.getValue().equals(packageName)) {
                 return env.enclEnv.enclPkg.symbol;
             }
             env = env.enclEnv;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -387,7 +387,6 @@ public class Desugar extends BLangNodeVisitor {
     private Code2CloudDesugar code2CloudDesugar;
     private AnnotationDesugar annotationDesugar;
     private Types types;
-    private Names names;
     private ServiceDesugar serviceDesugar;
     private BLangNode result;
     private NodeCloner nodeCloner;
@@ -465,8 +464,6 @@ public class Desugar extends BLangNodeVisitor {
         this.annotationDesugar = AnnotationDesugar.getInstance(context);
         this.largeMethodSplitter = LargeMethodSplitter.getInstance(context);
         this.types = Types.getInstance(context);
-        this.names = Names.getInstance(context);
-        this.names = Names.getInstance(context);
         this.serviceDesugar = ServiceDesugar.getInstance(context);
         this.nodeCloner = NodeCloner.getInstance(context);
         this.semanticAnalyzer = SemanticAnalyzer.getInstance(context);
@@ -1640,7 +1637,7 @@ public class Desugar extends BLangNodeVisitor {
 
             final BLangSimpleVariable foreachVariable = ASTBuilderUtil.createVariable(pos,
                     "$foreach$i", foreach.varType);
-            foreachVariable.symbol = new BVarSymbol(0, names.fromIdNode(foreachVariable.name),
+            foreachVariable.symbol = new BVarSymbol(0, Names.fromIdNode(foreachVariable.name),
                                                     this.env.scope.owner.pkgID, foreachVariable.getBType(),
                                                     this.env.scope.owner, pos, VIRTUAL);
             BLangSimpleVarRef foreachVarRef = ASTBuilderUtil.createVariableRef(pos, foreachVariable.symbol);
@@ -1886,7 +1883,7 @@ public class Desugar extends BLangNodeVisitor {
                                                         parentErrorVariable.message.getBType(), convertedErrorVarSymbol,
                                                         null);
 
-            if (names.fromIdNode(parentErrorVariable.message.name) == Names.IGNORE) {
+            if (Names.fromIdNode(parentErrorVariable.message.name) == Names.IGNORE) {
                 parentErrorVariable.message = null;
             } else {
                 BLangSimpleVariableDef messageVariableDef =
@@ -1933,7 +1930,7 @@ public class Desugar extends BLangNodeVisitor {
         detailTempVarDef.setBType(parentErrorVariable.detailExpr.getBType());
         parentBlockStmt.addStatement(detailTempVarDef);
 
-        this.env.scope.define(names.fromIdNode(detailTempVarDef.var.name), detailTempVarDef.var.symbol);
+        this.env.scope.define(Names.fromIdNode(detailTempVarDef.var.name), detailTempVarDef.var.symbol);
 
         for (BLangErrorVariable.BLangErrorDetailEntry detailEntry : parentErrorVariable.detail) {
             BLangExpression detailEntryVar = createErrorDetailVar(detailEntry, detailTempVarDef.var.symbol);
@@ -2465,7 +2462,7 @@ public class Desugar extends BLangNodeVisitor {
                                         BLangLiteral indexExpr, BVarSymbol tupleVarSymbol,
                                         BLangIndexBasedAccess parentArrayAccessExpr) {
 
-        Name varName = names.fromIdNode(simpleVariable.name);
+        Name varName = Names.fromIdNode(simpleVariable.name);
         if (varName == Names.IGNORE) {
             return;
         }
@@ -2609,7 +2606,7 @@ public class Desugar extends BLangNodeVisitor {
 
         final BLangSimpleVariable foreachVariable = ASTBuilderUtil.createVariable(pos,
                 "$foreach$i", foreach.varType);
-        foreachVariable.symbol = new BVarSymbol(0, names.fromIdNode(foreachVariable.name),
+        foreachVariable.symbol = new BVarSymbol(0, Names.fromIdNode(foreachVariable.name),
                 this.env.scope.owner.pkgID, foreachVariable.getBType(),
                 this.env.scope.owner, pos, VIRTUAL);
         BLangSimpleVarRef foreachVarRef = ASTBuilderUtil.createVariableRef(pos, foreachVariable.symbol);
@@ -2735,7 +2732,7 @@ public class Desugar extends BLangNodeVisitor {
                                       BLangIndexBasedAccess parentArrayAccessExpr) {
 
         if (accessibleExpression.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
-            Name varName = names.fromIdNode(((BLangSimpleVarRef) accessibleExpression).variableName);
+            Name varName = Names.fromIdNode(((BLangSimpleVarRef) accessibleExpression).variableName);
             if (varName == Names.IGNORE) {
                 return;
             }
@@ -2918,7 +2915,7 @@ public class Desugar extends BLangNodeVisitor {
     private void createVarRefAssignmentStmts(BLangErrorVarRef parentErrorVarRef, BLangBlockStmt parentBlockStmt,
                                              BVarSymbol errorVarySymbol, BLangIndexBasedAccess parentIndexAccessExpr) {
         if (parentErrorVarRef.message != null &&
-                names.fromIdNode(((BLangSimpleVarRef) parentErrorVarRef.message).variableName) != Names.IGNORE) {
+                Names.fromIdNode(((BLangSimpleVarRef) parentErrorVarRef.message).variableName) != Names.IGNORE) {
             BLangAssignment message = ASTBuilderUtil.createAssignmentStmt(parentBlockStmt.pos, parentBlockStmt);
             message.expr = generateErrorMessageBuiltinFunction(parentErrorVarRef.message.pos,
                     symTable.stringType, errorVarySymbol, parentIndexAccessExpr);
@@ -2927,7 +2924,7 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         if (parentErrorVarRef.cause != null && (parentErrorVarRef.cause.getKind() != NodeKind.SIMPLE_VARIABLE_REF ||
-                names.fromIdNode(((BLangSimpleVarRef) parentErrorVarRef.cause).variableName) != Names.IGNORE)) {
+                Names.fromIdNode(((BLangSimpleVarRef) parentErrorVarRef.cause).variableName) != Names.IGNORE)) {
             BLangAssignment cause = ASTBuilderUtil.createAssignmentStmt(parentBlockStmt.pos, parentBlockStmt);
             cause.expr = generateErrorCauseLanglibFunction(parentErrorVarRef.cause.pos,
                     symTable.errorType, errorVarySymbol, parentIndexAccessExpr);
@@ -2949,7 +2946,7 @@ public class Desugar extends BLangNodeVisitor {
                                                                parentErrorVarRef.pos);
         detailTempVarDef.setBType(symTable.detailType);
         parentBlockStmt.addStatement(detailTempVarDef);
-        this.env.scope.define(names.fromIdNode(detailTempVarDef.var.name), detailTempVarDef.var.symbol);
+        this.env.scope.define(Names.fromIdNode(detailTempVarDef.var.name), detailTempVarDef.var.symbol);
 
         List<String> extractedKeys = new ArrayList<>();
         for (BLangNamedArgsExpression detail : parentErrorVarRef.detail) {
@@ -4924,7 +4921,7 @@ public class Desugar extends BLangNodeVisitor {
         BRecordType detailRecordType = createAnonRecordType(errorFieldMatchPatterns.pos);
         List<BLangSimpleVariable> typeDefFields = new ArrayList<>();
         for (BLangNamedArgMatchPattern bindingPattern : errorFieldMatchPatterns.namedArgMatchPatterns) {
-            Name fieldName = names.fromIdNode(bindingPattern.argName);
+            Name fieldName = Names.fromIdNode(bindingPattern.argName);
             BVarSymbol declaredVarSym = bindingPattern.declaredVars.get(fieldName.value);
             if (declaredVarSym == null) {
                 // constant match pattern expr, not needed for detail record type
@@ -5013,7 +5010,7 @@ public class Desugar extends BLangNodeVisitor {
         BRecordType detailRecordType = createAnonRecordType(errorFieldBindingPatterns.pos);
         List<BLangSimpleVariable> typeDefFields = new ArrayList<>();
         for (BLangNamedArgBindingPattern bindingPattern : errorFieldBindingPatterns.namedArgBindingPatterns) {
-            Name fieldName = names.fromIdNode(bindingPattern.argName);
+            Name fieldName = Names.fromIdNode(bindingPattern.argName);
             BVarSymbol declaredVarSym = bindingPattern.declaredVars.get(fieldName.value);
             if (declaredVarSym == null) {
                 // constant match pattern expr, not needed for detail record type
@@ -8392,7 +8389,7 @@ public class Desugar extends BLangNodeVisitor {
      */
     private BLangFunction createUserDefinedObjectInitFn(BLangClassDefinition classDefn, SymbolEnv env) {
         BLangFunction initFunction =
-                TypeDefBuilderHelper.createInitFunctionForStructureType(classDefn.symbol, env, names,
+                TypeDefBuilderHelper.createInitFunctionForStructureType(classDefn.symbol, env,
                         Names.USER_DEFINED_INIT_SUFFIX, symTable, classDefn.getBType());
         BObjectTypeSymbol typeSymbol = ((BObjectTypeSymbol) classDefn.getBType().tsymbol);
         typeSymbol.initializerFunc = new BAttachedFunction(Names.USER_DEFINED_INIT_SUFFIX, initFunction.symbol,
@@ -9531,7 +9528,7 @@ public class Desugar extends BLangNodeVisitor {
 
             final BLangSimpleVariable foreachVariable = ASTBuilderUtil.createVariable(pos, "$foreach$i",
                                                                                       foreach.varType);
-            foreachVariable.symbol = new BVarSymbol(0, names.fromIdNode(foreachVariable.name),
+            foreachVariable.symbol = new BVarSymbol(0, Names.fromIdNode(foreachVariable.name),
                                                     this.env.scope.owner.pkgID, foreachVariable.getBType(),
                                                     this.env.scope.owner, pos, VIRTUAL);
             BLangSimpleVarRef foreachVarRef = ASTBuilderUtil.createVariableRef(pos, foreachVariable.symbol);
@@ -9920,7 +9917,7 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         for (BLangErrorVariable.BLangErrorDetailEntry detailEntry : detail) {
-            Name fieldName = names.fromIdNode(detailEntry.key);
+            Name fieldName = Names.fromIdNode(detailEntry.key);
             BType fieldType = getStructuredBindingPatternType(detailEntry.valueBindingPattern);
             BVarSymbol fieldSym = new BVarSymbol(Flags.PUBLIC, fieldName, detailRecordType.tsymbol.pkgID, fieldType,
                     detailRecordType.tsymbol, detailEntry.key.pos, VIRTUAL);
@@ -10439,7 +10436,7 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         BLangFunction initFunction =
-                TypeDefBuilderHelper.createInitFunctionForStructureType(classDefinition.symbol, env, names,
+                TypeDefBuilderHelper.createInitFunctionForStructureType(classDefinition.symbol, env,
                         GENERATED_INIT_SUFFIX, classDefinition.getBType(), returnType);
         BObjectTypeSymbol typeSymbol = ((BObjectTypeSymbol) classDefinition.getBType().tsymbol);
         typeSymbol.generatedInitializerFunc = new BAttachedFunction(GENERATED_INIT_SUFFIX, initFunction.symbol,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -667,7 +667,7 @@ public class Desugar extends BLangNodeVisitor {
     private void addUserDefinedModuleInitInvocationAndReturn(BLangPackage pkgNode) {
         Optional<BLangFunction> userDefInitOptional = pkgNode.functions.stream()
                 .filter(bLangFunction -> !bLangFunction.attachedFunction &&
-                            bLangFunction.name.value.equals(Names.USER_DEFINED_INIT_SUFFIX.value))
+                            bLangFunction.name.value.equals(Names.USER_DEFINED_INIT_SUFFIX.getValue()))
                 .findFirst();
 
         BLangBlockFunctionBody initFnBody = (BLangBlockFunctionBody) pkgNode.initFunction.body;
@@ -689,7 +689,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangIdentifier pkgAlias = (BLangIdentifier) TreeBuilder.createIdentifierNode();
         pkgAlias.setLiteral(false);
-        pkgAlias.setValue(pkgNode.packageID.name.value);
+        pkgAlias.setValue(pkgNode.packageID.name.getValue());
         userDefInitInvocation.pkgAlias = pkgAlias;
 
         userDefInitInvocation.setBType(userDefInit.returnTypeNode.getBType());
@@ -875,7 +875,7 @@ public class Desugar extends BLangNodeVisitor {
     private List<BLangConstant> removeDuplicateConstants(BLangPackage pkgNode) {
         HashSet<String> elements = new HashSet<>();
         for (int i = 0; i < pkgNode.constants.size(); i++) {
-            String next = pkgNode.constants.get(i).symbol.name.value;
+            String next = pkgNode.constants.get(i).symbol.name.getValue();
             if (elements.contains(next)) {
                 pkgNode.constants.remove(i);
                 i -= 1;
@@ -1208,7 +1208,7 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangUserDefinedType desugarLocalAnonRecordTypeNode(BLangRecordTypeNode recordTypeNode) {
-        return ASTBuilderUtil.createUserDefineTypeNode(recordTypeNode.symbol.name.value, recordTypeNode.getBType(),
+        return ASTBuilderUtil.createUserDefineTypeNode(recordTypeNode.symbol.name.getValue(), recordTypeNode.getBType(),
                                                        recordTypeNode.pos);
     }
 
@@ -1293,7 +1293,7 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangUserDefinedType desugarLocalAnonRecordTypeNode(BLangErrorType errorTypeNode) {
-        return ASTBuilderUtil.createUserDefineTypeNode(errorTypeNode.getBType().tsymbol.name.value,
+        return ASTBuilderUtil.createUserDefineTypeNode(errorTypeNode.getBType().tsymbol.name.getValue(),
                                                        errorTypeNode.getBType(),
                                                        errorTypeNode.pos);
     }
@@ -1939,7 +1939,8 @@ public class Desugar extends BLangNodeVisitor {
             createAndAddBoundVariableDef(parentBlockStmt, detailEntry, detailEntryVar);
 
         }
-        if (parentErrorVariable.restDetail != null && !parentErrorVariable.restDetail.name.value.equals(IGNORE.value)) {
+        if (parentErrorVariable.restDetail != null &&
+                !parentErrorVariable.restDetail.name.value.equals(IGNORE.getValue())) {
             Location pos = parentErrorVariable.restDetail.pos;
             BLangSimpleVarRef detailVarRef = ASTBuilderUtil.createVariableRef(
                     pos, detailTempVarDef.var.symbol);
@@ -1973,7 +1974,7 @@ public class Desugar extends BLangNodeVisitor {
         } else {
             expr = types.addConversionExprIfRequired(variableRef, targetType);
         }
-        BLangSimpleVariable errorVar = ASTBuilderUtil.createVariable(pos, errorVarSym.name.value, targetType, expr,
+        BLangSimpleVariable errorVar = ASTBuilderUtil.createVariable(pos, errorVarSym.name.getValue(), targetType, expr,
                 errorVarSym);
         return ASTBuilderUtil.createVariableDef(pos, errorVar);
     }
@@ -2988,7 +2989,7 @@ public class Desugar extends BLangNodeVisitor {
             return true;
         }
         if (parentErrorVarRef.restVar.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
-            return (((BLangSimpleVarRef) parentErrorVarRef.restVar).variableName.value.equals(IGNORE.value));
+            return (((BLangSimpleVarRef) parentErrorVarRef.restVar).variableName.value.equals(IGNORE.getValue()));
         }
         return false;
     }
@@ -3302,7 +3303,7 @@ public class Desugar extends BLangNodeVisitor {
     private BAttachedFunction getShouldRetryFunc(BVarSymbol retryManagerSymbol) {
         BObjectTypeSymbol typeSymbol = (BObjectTypeSymbol) retryManagerSymbol.type.tsymbol;
         for (BAttachedFunction bAttachedFunction : typeSymbol.attachedFuncs) {
-            if (bAttachedFunction.funcName.value.equals(RETRY_MANAGER_OBJECT_SHOULD_RETRY_FUNC)) {
+            if (bAttachedFunction.funcName.getValue().equals(RETRY_MANAGER_OBJECT_SHOULD_RETRY_FUNC)) {
                 return bAttachedFunction;
             }
         }
@@ -3599,7 +3600,7 @@ public class Desugar extends BLangNodeVisitor {
             rewrite(matchStatement.onFailClause, env);
         }
 
-        String matchExprVarName = GEN_VAR_PREFIX.value + "t_match_var";
+        String matchExprVarName = GEN_VAR_PREFIX.getValue() + "t_match_var";
 
         BLangExpression matchExpr = matchStatement.expr;
         BLangSimpleVariable matchExprVar =
@@ -3684,11 +3685,11 @@ public class Desugar extends BLangNodeVisitor {
 
     private void defineVars(BLangBlockStmt blockStmt, List<BVarSymbol> vars) {
         for (BVarSymbol var : vars) {
-            BLangSimpleVariable simpleVariable = ASTBuilderUtil.createVariable(var.pos, var.name.value, var.type,
+            BLangSimpleVariable simpleVariable = ASTBuilderUtil.createVariable(var.pos, var.name.getValue(), var.type,
                     null, var);
             BLangSimpleVariableDef simpleVariableDef = ASTBuilderUtil.createVariableDef(var.pos, simpleVariable);
             BLangSimpleVarRef simpleVarRef = ASTBuilderUtil.createVariableRef(var.pos, var);
-            declaredVarDef.put(var.name.value, simpleVarRef);
+            declaredVarDef.put(var.name.getValue(), simpleVarRef);
             blockStmt.addStatement(simpleVariableDef);
         }
     }
@@ -4693,7 +4694,7 @@ public class Desugar extends BLangNodeVisitor {
         recordTypeNode.setBType(recordType);
         List<BLangSimpleVariable> typeDefFields = new ArrayList<>();
         for (BField field : recordType.fields.values()) {
-            typeDefFields.add(ASTBuilderUtil.createVariable(field.pos, field.name.value, field.type, null,
+            typeDefFields.add(ASTBuilderUtil.createVariable(field.pos, field.name.getValue(), field.type, null,
                     field.symbol));
         }
         recordTypeNode.fields = typeDefFields;
@@ -4922,7 +4923,7 @@ public class Desugar extends BLangNodeVisitor {
         List<BLangSimpleVariable> typeDefFields = new ArrayList<>();
         for (BLangNamedArgMatchPattern bindingPattern : errorFieldMatchPatterns.namedArgMatchPatterns) {
             Name fieldName = Names.fromIdNode(bindingPattern.argName);
-            BVarSymbol declaredVarSym = bindingPattern.declaredVars.get(fieldName.value);
+            BVarSymbol declaredVarSym = bindingPattern.declaredVars.get(fieldName.getValue());
             if (declaredVarSym == null) {
                 // constant match pattern expr, not needed for detail record type
                 continue;
@@ -4930,9 +4931,9 @@ public class Desugar extends BLangNodeVisitor {
             BType fieldType = declaredVarSym.type;
             BVarSymbol fieldSym = new BVarSymbol(Flags.PUBLIC, fieldName, detailRecordType.tsymbol.pkgID, fieldType,
                     detailRecordType.tsymbol, bindingPattern.pos, VIRTUAL);
-            detailRecordType.fields.put(fieldName.value, new BField(fieldName, bindingPattern.pos, fieldSym));
+            detailRecordType.fields.put(fieldName.getValue(), new BField(fieldName, bindingPattern.pos, fieldSym));
             detailRecordType.tsymbol.scope.define(fieldName, fieldSym);
-            typeDefFields.add(ASTBuilderUtil.createVariable(null, fieldName.value, fieldType, null, fieldSym));
+            typeDefFields.add(ASTBuilderUtil.createVariable(null, fieldName.getValue(), fieldType, null, fieldSym));
         }
         BLangRecordTypeNode recordTypeNode = TypeDefBuilderHelper.createRecordTypeNode(typeDefFields, detailRecordType,
                 errorFieldMatchPatterns.pos);
@@ -5011,7 +5012,7 @@ public class Desugar extends BLangNodeVisitor {
         List<BLangSimpleVariable> typeDefFields = new ArrayList<>();
         for (BLangNamedArgBindingPattern bindingPattern : errorFieldBindingPatterns.namedArgBindingPatterns) {
             Name fieldName = Names.fromIdNode(bindingPattern.argName);
-            BVarSymbol declaredVarSym = bindingPattern.declaredVars.get(fieldName.value);
+            BVarSymbol declaredVarSym = bindingPattern.declaredVars.get(fieldName.getValue());
             if (declaredVarSym == null) {
                 // constant match pattern expr, not needed for detail record type
                 continue;
@@ -5019,9 +5020,9 @@ public class Desugar extends BLangNodeVisitor {
             BType fieldType = declaredVarSym.type;
             BVarSymbol fieldSym = new BVarSymbol(Flags.PUBLIC, fieldName, detailRecordType.tsymbol.pkgID, fieldType,
                     detailRecordType.tsymbol, bindingPattern.pos, VIRTUAL);
-            detailRecordType.fields.put(fieldName.value, new BField(fieldName, bindingPattern.pos, fieldSym));
+            detailRecordType.fields.put(fieldName.getValue(), new BField(fieldName, bindingPattern.pos, fieldSym));
             detailRecordType.tsymbol.scope.define(fieldName, fieldSym);
-            typeDefFields.add(ASTBuilderUtil.createVariable(null, fieldName.value, fieldType, null, fieldSym));
+            typeDefFields.add(ASTBuilderUtil.createVariable(null, fieldName.getValue(), fieldType, null, fieldSym));
         }
         BLangRecordTypeNode recordTypeNode = TypeDefBuilderHelper.createRecordTypeNode(typeDefFields, detailRecordType,
                 errorFieldBindingPatterns.pos);
@@ -5357,7 +5358,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangStatement handleCaptureBPInOnFail(BLangSimpleVariable varNode, BLangFail fail) {
         BVarSymbol onFailErrorVariableSymbol = varNode.symbol;
         BLangSimpleVariable errorVar = ASTBuilderUtil.createVariable(onFailErrorVariableSymbol.pos,
-                onFailErrorVariableSymbol.name.value, onFailErrorVariableSymbol.type, rewrite(fail.expr, env),
+                onFailErrorVariableSymbol.name.getValue(), onFailErrorVariableSymbol.type, rewrite(fail.expr, env),
                 onFailErrorVariableSymbol);
         BLangSimpleVariableDef errorVarDef = ASTBuilderUtil.createVariableDef(onFailClause.pos, errorVar);
         env.scope.define(onFailErrorVariableSymbol.name, onFailErrorVariableSymbol);
@@ -5425,7 +5426,7 @@ public class Desugar extends BLangNodeVisitor {
         // We know for sure at this point, the object symbol should have the `iterator` method
         BAttachedFunction iteratorFunc = null;
         for (BAttachedFunction func : typeSymbol.attachedFuncs) {
-            if (func.funcName.value.equals(BLangCompilerConstants.ITERABLE_COLLECTION_ITERATOR_FUNC)) {
+            if (func.funcName.getValue().equals(BLangCompilerConstants.ITERABLE_COLLECTION_ITERATOR_FUNC)) {
                 iteratorFunc = func;
                 break;
             }
@@ -6137,7 +6138,7 @@ public class Desugar extends BLangNodeVisitor {
             return;
         }
         for (BField bField : ((BRecordType) type).fields.values()) {
-            fieldNames.add(Utils.unescapeBallerina(bField.name.value));
+            fieldNames.add(Utils.unescapeBallerina(bField.name.getValue()));
         }
     }
 
@@ -6434,7 +6435,8 @@ public class Desugar extends BLangNodeVisitor {
         BInvokableSymbol originalMemberFuncSymbol = (BInvokableSymbol) fieldAccessExpr.symbol;
         // Can we cache this?
         BLangFunction func = (BLangFunction) TreeBuilder.createFunctionNode();
-        String funcName = "$anon$method$delegate$" + originalMemberFuncSymbol.name.value + "$" + lambdaFunctionCount++;
+        String funcName = "$anon$method$delegate$" + originalMemberFuncSymbol.name.getValue() + "$" +
+                lambdaFunctionCount++;
         BInvokableSymbol funcSymbol = new BInvokableSymbol(SymTag.INVOKABLE, (Flags.ANONYMOUS | Flags.LAMBDA),
                                                            Names.fromString(funcName), env.enclPkg.packageID,
                                                            originalMemberFuncSymbol.type, env.scope.owner, pos,
@@ -6479,7 +6481,7 @@ public class Desugar extends BLangNodeVisitor {
             fParam.symbol = new BVarSymbol(0, param.name, env.enclPkg.packageID, param.type,  funcSymbol, pos,
                     VIRTUAL);
             fParam.pos = pos;
-            fParam.name = createIdentifier(pos, param.name.value);
+            fParam.name = createIdentifier(pos, param.name.getValue());
             fParam.setBType(param.type);
             func.requiredParams.add(fParam);
             funcSymbol.params.add(fParam.symbol);
@@ -6494,7 +6496,7 @@ public class Desugar extends BLangNodeVisitor {
             BLangSimpleVariable restParam = (BLangSimpleVariable) TreeBuilder.createSimpleVariableNode();
             func.restParam = restParam;
             BVarSymbol restSym = originalMemberFuncSymbol.restParam;
-            restParam.name = ASTBuilderUtil.createIdentifier(pos, restSym.name.value);
+            restParam.name = ASTBuilderUtil.createIdentifier(pos, restSym.name.getValue());
             restParam.symbol = new BVarSymbol(0, restSym.name, env.enclPkg.packageID, restSym.type, funcSymbol, pos,
                     VIRTUAL);
             restParam.pos = pos;
@@ -6754,7 +6756,7 @@ public class Desugar extends BLangNodeVisitor {
                 arg = invocation.requiredArgs.get(i);
             }
             BVarSymbol param = invokableTypeSymbol.params.get(i);
-            String paramName = param.name.value;
+            String paramName = param.name.getValue();
             if (arg.getKind() != NodeKind.IGNORE_EXPR) {
                 if (invocation.expr == arg) {
                     arguments.put(paramName, arg);
@@ -6780,7 +6782,7 @@ public class Desugar extends BLangNodeVisitor {
             BInvokableSymbol invokableSymbol = defaultValues.get(Utils.unescapeBallerina(paramName));
             BLangInvocation closureInvocation = getFunctionPointerInvocation(invokableSymbol);
             for (int m = 0; m < invokableSymbol.params.size(); m++) {
-                String langLibFuncParam = invokableSymbol.params.get(m).name.value;
+                String langLibFuncParam = invokableSymbol.params.get(m).name.getValue();
                 closureInvocation.requiredArgs.add(arguments.get(langLibFuncParam));
             }
             variableDef = createVarDef("$" + paramName + "$" + funcParamCount++, closureInvocation.getBType(),
@@ -6805,7 +6807,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangInvocation funcInvocation = (BLangInvocation) TreeBuilder.createInvocationNode();
         funcInvocation.setBType(symbol.retType);
         funcInvocation.symbol = symbol;
-        funcInvocation.name = ASTBuilderUtil.createIdentifier(symbol.pos, symbol.name.value);
+        funcInvocation.name = ASTBuilderUtil.createIdentifier(symbol.pos, symbol.name.getValue());
         return visitFunctionPointerInvocation(funcInvocation);
     }
 
@@ -6933,14 +6935,14 @@ public class Desugar extends BLangNodeVisitor {
             Name resourcePathName = pathSegmentSymbols.get(i).name;
             if (firstRequiredArgFromRestArg == null && requiredArg.getKind() == NodeKind.STATEMENT_EXPRESSION) {
                 firstRequiredArgFromRestArg = (BLangStatementExpression) requiredArg;
-                if (resourcePathName.value.equals("^")) {
+                if (resourcePathName.getValue().equals("^")) {
                     isFirstRequiredArgFromRestArgIncluded = true;
                     bLangInvocation.requiredArgs.add(requiredArg);
                     continue;
                 }
             }
 
-            if (resourcePathName.value.equals("^")) {
+            if (resourcePathName.getValue().equals("^")) {
                 if (firstRequiredArgFromRestArg != null && !isFirstRequiredArgFromRestArgIncluded) {
                     BLangStatementExpression statementExpression = new BLangStatementExpression();
                     statementExpression.expr = requiredArg;
@@ -6955,7 +6957,7 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         Name lastResourcePathName = pathSegmentSymbols.get(pathSegmentSymbols.size() - 1).name;
-        if (lastResourcePathName.value.equals("^^")) {
+        if (lastResourcePathName.getValue().equals("^^")) {
             // After reordering pathParamInvocation.restArgs size will always be 0 or 1
             for (BLangExpression restArg : pathParamInvocation.restArgs) {
                 if (firstRequiredArgFromRestArg != null && !isFirstRequiredArgFromRestArgIncluded &&
@@ -7224,7 +7226,7 @@ public class Desugar extends BLangNodeVisitor {
 
         // init() returning nil is the common case and the type test is not needed for it.
         if (initInvocation.getBType().tag == TypeTags.NIL) {
-            initInvocation.name.value = GENERATED_INIT_SUFFIX.value;
+            initInvocation.name.value = GENERATED_INIT_SUFFIX.getValue();
             BLangNode parent = initInvocation.parent;
             if (parent != null && parent.getKind() == NodeKind.OBJECT_CTOR_EXPRESSION) {
                 BLangObjectConstructorExpression oceExpression = (BLangObjectConstructorExpression) parent;
@@ -7905,7 +7907,7 @@ public class Desugar extends BLangNodeVisitor {
         resultVarDef.desugared = true;
         BLangSimpleVarRef resultVarRef = ASTBuilderUtil.createVariableRef(pos, resultVar.symbol);
 
-        String lhsResultVarName = GEN_VAR_PREFIX.value;
+        String lhsResultVarName = GEN_VAR_PREFIX.getValue();
         BLangSimpleVariable lhsResultVar =
                 ASTBuilderUtil.createVariable(pos, lhsResultVarName, elvisExpr.lhsExpr.getBType(), elvisExpr.lhsExpr,
                         new BVarSymbol(0, Names.fromString(lhsResultVarName),
@@ -8350,7 +8352,7 @@ public class Desugar extends BLangNodeVisitor {
 //        BLangTypeDefinition typeDef = TypeDefBuilderHelper.addTypeDefinition(objectClassType, objectClassType.tsymbol,
 //                                                                             objectClassNode, env);
         BLangClassDefinition classDef = TypeDefBuilderHelper.createClassDef(pos, classTSymbol, env);
-        classDef.name = ASTBuilderUtil.createIdentifier(pos, objectClassType.tsymbol.name.value);
+        classDef.name = ASTBuilderUtil.createIdentifier(pos, objectClassType.tsymbol.name.getValue());
 
         // Create a list constructor expr for the strings field. This gets assigned to the corresponding field in the
         // object since this needs to be initialized in the generated init method.
@@ -8406,7 +8408,7 @@ public class Desugar extends BLangNodeVisitor {
             BVarSymbol fieldSym = field.symbol;
             BVarSymbol paramSym = new BVarSymbol(Flags.FINAL, fieldSym.name, this.env.scope.owner.pkgID, fieldSym.type,
                                                  initFunction.symbol, classDefn.pos, VIRTUAL);
-            BLangSimpleVariable param = ASTBuilderUtil.createVariable(classDefn.pos, fieldSym.name.value,
+            BLangSimpleVariable param = ASTBuilderUtil.createVariable(classDefn.pos, fieldSym.name.getValue(),
                                                                       fieldSym.type, null, paramSym);
             param.flagSet.add(Flag.FINAL);
             initFunction.symbol.scope.define(paramSym.name, paramSym);
@@ -8717,7 +8719,7 @@ public class Desugar extends BLangNodeVisitor {
         resultVarDef.desugared = true;
         BLangSimpleVarRef resultVarRef = ASTBuilderUtil.createVariableRef(pos, resultVar.symbol);
 
-        String checkedExprVarName = GEN_VAR_PREFIX.value;
+        String checkedExprVarName = GEN_VAR_PREFIX.getValue();
         BType checkedExprType = checkedExpr.expr.getBType();
         BLangSimpleVariable checkedExprVar =
                 ASTBuilderUtil.createVariable(pos, checkedExprVarName, checkedExprType,
@@ -9076,7 +9078,7 @@ public class Desugar extends BLangNodeVisitor {
     private BAttachedFunction getNextFunc(BObjectType iteratorType) {
         BObjectTypeSymbol iteratorSymbol = (BObjectTypeSymbol) iteratorType.tsymbol;
         for (BAttachedFunction bAttachedFunction : iteratorSymbol.attachedFuncs) {
-            if (bAttachedFunction.funcName.value.equals("next")) {
+            if (bAttachedFunction.funcName.getValue().equals("next")) {
                 return bAttachedFunction;
             }
         }
@@ -9369,7 +9371,7 @@ public class Desugar extends BLangNodeVisitor {
                 || funcBody.stmts.get(funcBody.stmts.size() - 1).getKind() != NodeKind.RETURN)) {
             Location invPos = invokableNode.pos;
             Location returnStmtPos;
-            if (invPos != null && !invokableNode.name.value.contains(GENERATED_INIT_SUFFIX.value)) {
+            if (invPos != null && !invokableNode.name.value.contains(GENERATED_INIT_SUFFIX.getValue())) {
                 returnStmtPos = new BLangDiagnosticLocation(invPos.lineRange().fileName(),
                         invPos.lineRange().endLine().line(),
                         invPos.lineRange().endLine().line(),
@@ -9647,9 +9649,9 @@ public class Desugar extends BLangNodeVisitor {
             if (iExpr.requiredArgs.size() > i && iExpr.requiredArgs.get(i).getKind() != NodeKind.NAMED_ARGS_EXPR) {
                 // If a positional arg is given in the same position, it will be used.
                 args.add(iExpr.requiredArgs.get(i));
-            } else if (namedArgs.containsKey(param.name.value)) {
+            } else if (namedArgs.containsKey(param.name.getValue())) {
                 // Else check if named arg is given.
-                args.add(namedArgs.remove(param.name.value));
+                args.add(namedArgs.remove(param.name.getValue()));
             } else if (param.getFlags().contains(Flag.INCLUDED)) {
                 BLangRecordLiteral recordLiteral = (BLangRecordLiteral) TreeBuilder.createRecordLiteralNode();
                 BType paramType = param.type;
@@ -9671,13 +9673,13 @@ public class Desugar extends BLangNodeVisitor {
                     if (param.isDefaultable) {
                         BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(varargRef.pos);
                         BLangInvocation hasKeyInvocation = createLangLibInvocationNode(HAS_KEY, varargRef,
-                                List.of(createStringLiteral(param.pos, param.name.value)), null, varargRef.pos);
+                                List.of(createStringLiteral(param.pos, param.name.getValue())), null, varargRef.pos);
                         BLangSimpleVariableDef variableDef = createVarDef("$hasKey$", hasKeyInvocation.getBType(),
                                                                           hasKeyInvocation, hasKeyInvocation.pos);
                         blockStmt.stmts.add(variableDef);
                         BLangSimpleVarRef simpleVarRef = ASTBuilderUtil.createVariableRef(variableDef.pos,
                                                                                           variableDef.var.symbol);
-                        BLangExpression indexExpr = rewriteExpr(createStringLiteral(param.pos, param.name.value));
+                        BLangExpression indexExpr = rewriteExpr(createStringLiteral(param.pos, param.name.getValue()));
                         BLangIndexBasedAccess memberAccessExpr =
                                 ASTBuilderUtil.createMemberAccessExprNode(param.type, varargRef, indexExpr);
                         BLangExpression ignoreExpr = ASTBuilderUtil.createIgnoreExprNode(param.type);
@@ -9691,7 +9693,7 @@ public class Desugar extends BLangNodeVisitor {
                     } else {
                         BLangFieldBasedAccess fieldBasedAccessExpression =
                                 ASTBuilderUtil.createFieldAccessExpr(varargRef,
-                                        ASTBuilderUtil.createIdentifier(param.pos, param.name.value));
+                                        ASTBuilderUtil.createIdentifier(param.pos, param.name.getValue()));
                         fieldBasedAccessExpression.setBType(param.type);
                         args.add(fieldBasedAccessExpression);
                     }
@@ -9762,7 +9764,7 @@ public class Desugar extends BLangNodeVisitor {
                 .allMatch(errorType -> returnTypeSet.stream()
                         .anyMatch(retType -> types.isAssignable(errorType, retType)));
 
-        String patternFailureCaseVarName = GEN_VAR_PREFIX.value + "t_failure";
+        String patternFailureCaseVarName = GEN_VAR_PREFIX.getValue() + "t_failure";
         BLangSimpleVariable errorVar =
                 ASTBuilderUtil.createVariable(location, patternFailureCaseVarName, symTable.errorType,
                                                 createTypeCastExpr(ref, symTable.errorType),
@@ -9835,7 +9837,7 @@ public class Desugar extends BLangNodeVisitor {
                                                         recordSymbol, bindingPatternVariable.pos, VIRTUAL);
 
                 //TODO check below field position
-                fields.put(fieldName.value, new BField(fieldName, bindingPatternVariable.pos, fieldSymbol));
+                fields.put(fieldName.getValue(), new BField(fieldName, bindingPatternVariable.pos, fieldSymbol));
                 typeDefFields.add(ASTBuilderUtil.createVariable(null, fieldNameStr, fieldType, null, fieldSymbol));
                 recordSymbol.scope.define(fieldName, fieldSymbol);
             }
@@ -9899,7 +9901,7 @@ public class Desugar extends BLangNodeVisitor {
             }
             BLangSimpleVariable fieldVar = ASTBuilderUtil.createVariable(
                     field.valueBindingPattern.pos,
-                    symbol.name.value,
+                    symbol.name.getValue(),
                     field.valueBindingPattern.getBType(),
                     field.valueBindingPattern.expr,
                     symbol);
@@ -9921,7 +9923,7 @@ public class Desugar extends BLangNodeVisitor {
             BType fieldType = getStructuredBindingPatternType(detailEntry.valueBindingPattern);
             BVarSymbol fieldSym = new BVarSymbol(Flags.PUBLIC, fieldName, detailRecordType.tsymbol.pkgID, fieldType,
                     detailRecordType.tsymbol, detailEntry.key.pos, VIRTUAL);
-            detailRecordType.fields.put(fieldName.value, new BField(fieldName, detailEntry.key.pos, fieldSym));
+            detailRecordType.fields.put(fieldName.getValue(), new BField(fieldName, detailEntry.key.pos, fieldSym));
             detailRecordType.tsymbol.scope.define(fieldName, fieldSym);
         }
 
@@ -9964,7 +9966,7 @@ public class Desugar extends BLangNodeVisitor {
                     (BOperatorSymbol) symResolver
                             .resolveBinaryOperator(OperatorKind.OR, symTable.booleanType, symTable.booleanType));
         } else if (expression.getKind() == NodeKind.SIMPLE_VARIABLE_REF
-                && ((BLangSimpleVarRef) expression).variableName.value.equals(IGNORE.value)) {
+                && ((BLangSimpleVarRef) expression).variableName.value.equals(IGNORE.getValue())) {
             BLangValueType anyType = (BLangValueType) TreeBuilder.createValueTypeNode();
             anyType.setBType(symTable.anyType);
             anyType.typeKind = TypeKind.ANY;
@@ -10051,7 +10053,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangExpression rewriteSafeNavigationExpr(BLangAccessExpression accessExpr) {
         BType originalExprType = accessExpr.getBType();
         // Create a temp variable to hold the intermediate result of the acces expression.
-        String matchTempResultVarName = GEN_VAR_PREFIX.value + "temp_result";
+        String matchTempResultVarName = GEN_VAR_PREFIX.getValue() + "temp_result";
         BLangSimpleVariable tempResultVar =
                 ASTBuilderUtil.createVariable(accessExpr.pos, matchTempResultVarName, accessExpr.getBType(), null,
                                               new BVarSymbol(0, Names.fromString(matchTempResultVarName),
@@ -10165,7 +10167,7 @@ public class Desugar extends BLangNodeVisitor {
         if (isAllTypesRecords) {
             for (BType memberType : memTypes) {
                 BRecordType recordType = (BRecordType) Types.getImpliedType(memberType);
-                if (recordType.fields.containsKey(field.value) || !recordType.sealed) {
+                if (recordType.fields.containsKey(field.getValue()) || !recordType.sealed) {
                     successClause = getSuccessPatternClause(memberType, matchExpr, accessExpr, tempResultVar,
                             accessExpr.errorSafeNavigation);
                     matchStmt.addMatchClause(successClause);
@@ -10222,7 +10224,7 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangMatchClause getMatchErrorClause(BLangExpression matchExpr, BLangSimpleVariable tempResultVar) {
-        String errorPatternVarName = GEN_VAR_PREFIX.value + "t_match_error";
+        String errorPatternVarName = GEN_VAR_PREFIX.getValue() + "t_match_error";
         Location pos = matchExpr.pos;
         BVarSymbol errorPatternVarSymbol = new BVarSymbol(0, Names.fromString(errorPatternVarName),
                 this.env.scope.owner.pkgID, symTable.anyOrErrorType, this.env.scope.owner, pos, VIRTUAL);
@@ -10243,7 +10245,7 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangMatchClause getMatchNullClause(BLangExpression matchExpr, BLangSimpleVariable tempResultVar) {
-        String nullPatternVarName = GEN_VAR_PREFIX.value + "t_match_null";
+        String nullPatternVarName = GEN_VAR_PREFIX.getValue() + "t_match_null";
         Location pos = matchExpr.pos;
         BVarSymbol nullPatternVarSymbol = new BVarSymbol(0, Names.fromString(nullPatternVarName),
                 this.env.scope.owner.pkgID, symTable.anyOrErrorType, this.env.scope.owner, pos, VIRTUAL);
@@ -10281,7 +10283,7 @@ public class Desugar extends BLangNodeVisitor {
                                                      BLangAccessExpression accessExpr,
                                                      BLangSimpleVariable tempResultVar, boolean liftError) {
         type = types.getSafeType(type, true, liftError);
-        String successPatternVarName = GEN_VAR_PREFIX.value + "t_match_success";
+        String successPatternVarName = GEN_VAR_PREFIX.getValue() + "t_match_success";
 
         Location pos = accessExpr.pos;
         BVarSymbol  successPatternSymbol;
@@ -10602,10 +10604,11 @@ public class Desugar extends BLangNodeVisitor {
         if (!env.enclPkg.packageID.equals(PackageID.TRANSACTION_INTERNAL)) {
             BLangImportPackage importDcl = (BLangImportPackage) TreeBuilder.createImportPackageNode();
             List<BLangIdentifier> pkgNameComps = new ArrayList<>();
-            pkgNameComps.add(ASTBuilderUtil.createIdentifier(env.enclPkg.pos, Names.TRANSACTION.value));
+            pkgNameComps.add(ASTBuilderUtil.createIdentifier(env.enclPkg.pos, Names.TRANSACTION.getValue()));
             importDcl.pkgNameComps = pkgNameComps;
             importDcl.pos = env.enclPkg.symbol.pos;
-            importDcl.orgName = ASTBuilderUtil.createIdentifier(env.enclPkg.pos, Names.BALLERINA_INTERNAL_ORG.value);
+            importDcl.orgName = ASTBuilderUtil.createIdentifier(
+                    env.enclPkg.pos, Names.BALLERINA_INTERNAL_ORG.getValue());
             importDcl.alias = ASTBuilderUtil.createIdentifier(env.enclPkg.pos, "trx");
             importDcl.version = ASTBuilderUtil.createIdentifier(env.enclPkg.pos, "");
             importDcl.symbol = symTable.internalTransactionModuleSymbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/LargeMethodSplitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/LargeMethodSplitter.java
@@ -62,7 +62,6 @@ public class LargeMethodSplitter {
 
     private final Desugar desugar;
     private final SymbolTable symTable;
-    private final Names names;
     private final SymbolResolver symResolver;
 
     private static final CompilerContext.Key<LargeMethodSplitter> LARGE_METHOD_SPLITTER_KEY =
@@ -80,7 +79,6 @@ public class LargeMethodSplitter {
         context.put(LARGE_METHOD_SPLITTER_KEY, this);
         this.desugar = Desugar.getInstance(context);
         this.symTable = SymbolTable.getInstance(context);
-        this.names = Names.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
     }
 
@@ -142,7 +140,7 @@ public class LargeMethodSplitter {
                 }
                 newFunc.pos = newFuncPos;
                 newFuncBody = (BLangBlockFunctionBody) newFunc.body;
-                symTable.rootScope.define(names.fromIdNode(newFunc.name), newFunc.symbol);
+                symTable.rootScope.define(Names.fromIdNode(newFunc.name), newFunc.symbol);
             }
             newFuncBody.stmts.add(stmts.get(i));
         }
@@ -209,7 +207,7 @@ public class LargeMethodSplitter {
                 generatedFunctions.add(newFunc);
                 newFunc = createIntermediateStartFunction(packageNode, env);
                 newFuncBody = (BLangBlockFunctionBody) newFunc.body;
-                symTable.rootScope.define(names.fromIdNode(newFunc.name), newFunc.symbol);
+                symTable.rootScope.define(Names.fromIdNode(newFunc.name), newFunc.symbol);
             }
             newFuncBody.stmts.add(stmts.get(i));
         }
@@ -271,7 +269,7 @@ public class LargeMethodSplitter {
                 generatedFunctions.add(newFunc);
                 newFunc = createIntermediateStopFunction(packageNode, env);
                 newFuncBody = (BLangBlockFunctionBody) newFunc.body;
-                symTable.rootScope.define(names.fromIdNode(newFunc.name), newFunc.symbol);
+                symTable.rootScope.define(Names.fromIdNode(newFunc.name), newFunc.symbol);
             }
             newFuncBody.stmts.add(stmts.get(i));
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/LargeMethodSplitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/LargeMethodSplitter.java
@@ -327,7 +327,7 @@ public class LargeMethodSplitter {
         String alias = pkgNode.symbol.pkgID.toString();
         BLangFunction initFunction = ASTBuilderUtil
                 .createInitFunctionWithErrorOrNilReturn(pkgNode.pos, alias,
-                        new Name(Names.INIT_FUNCTION_SUFFIX.value
+                        new Name(Names.INIT_FUNCTION_SUFFIX.getValue()
                                 + this.initFuncIndex++), symTable);
         // Create invokable symbol for init function
         desugar.createInvokableSymbol(initFunction, env);
@@ -346,7 +346,7 @@ public class LargeMethodSplitter {
         BLangFunction startFunction = ASTBuilderUtil
                 .createInitFunctionWithErrorOrNilReturn(new BLangDiagnosticLocation(SPLIT_START_FUNCTIONS_CLASS_NAME,
                                 0, 0, 0, 0, 0, 0),
-                        alias, new Name(Names.START_FUNCTION_SUFFIX.value + this.startFuncIndex++), symTable);
+                        alias, new Name(Names.START_FUNCTION_SUFFIX.getValue() + this.startFuncIndex++), symTable);
         // Create invokable symbol for start function
         desugar.createInvokableSymbol(startFunction, env);
         return startFunction;
@@ -364,7 +364,7 @@ public class LargeMethodSplitter {
         BLangFunction stopFunction = ASTBuilderUtil
                 .createInitFunctionWithNilReturn(new BLangDiagnosticLocation(SPLIT_STOP_FUNCTIONS_CLASS_NAME,
                                 0, 0, 0, 0, 0, 0),
-                        alias, new Name(Names.STOP_FUNCTION_SUFFIX.value + this.stopFuncIndex++));
+                        alias, new Name(Names.STOP_FUNCTION_SUFFIX.getValue() + this.stopFuncIndex++));
         // Create invokable symbol for stop function
         desugar.createInvokableSymbol(stopFunction, env);
         return stopFunction;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ObservabilityDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ObservabilityDesugar.java
@@ -60,10 +60,10 @@ public class ObservabilityDesugar {
                 && !pkgNode.moduleContextDataHolder.projectKind().equals(ProjectKind.BALA_PROJECT))) {
             BLangImportPackage importDcl = (BLangImportPackage) TreeBuilder.createImportPackageNode();
             List<BLangIdentifier> pkgNameComps = new ArrayList<>();
-            pkgNameComps.add(ASTBuilderUtil.createIdentifier(pkgNode.pos, Names.OBSERVE.value));
+            pkgNameComps.add(ASTBuilderUtil.createIdentifier(pkgNode.pos, Names.OBSERVE.getValue()));
             importDcl.pkgNameComps = pkgNameComps;
             importDcl.pos = pkgNode.symbol.pos;
-            importDcl.orgName = ASTBuilderUtil.createIdentifier(pkgNode.pos, Names.BALLERINA_INTERNAL_ORG.value);
+            importDcl.orgName = ASTBuilderUtil.createIdentifier(pkgNode.pos, Names.BALLERINA_INTERNAL_ORG.getValue());
             importDcl.alias = ASTBuilderUtil.createIdentifier(pkgNode.pos, "_");
             importDcl.version = ASTBuilderUtil.createIdentifier(pkgNode.pos, "");
             importDcl.symbol = packageCache.getSymbol(PackageID.OBSERVE_INTERNAL);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -250,7 +250,6 @@ public class QueryDesugar extends BLangNodeVisitor {
     private final Desugar desugar;
     private final SymbolTable symTable;
     private final SymbolResolver symResolver;
-    private final Names names;
     private final Types types;
     private SymbolEnv env;
     private SymbolEnv queryEnv;
@@ -264,7 +263,6 @@ public class QueryDesugar extends BLangNodeVisitor {
         context.put(QUERY_DESUGAR_KEY, this);
         this.symTable = SymbolTable.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
-        this.names = Names.getInstance(context);
         this.types = Types.getInstance(context);
         this.desugar = Desugar.getInstance(context);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -1290,7 +1290,7 @@ public class QueryDesugar extends BLangNodeVisitor {
             env.scope.entries.remove(symbol.name);
             env.enclPkg.globalVariableDependencies.values().forEach(d -> d.remove(symbol));
             BLangStatement addToFrameStmt = getAddToFrameStmt(pos, frameRef,
-                    symbol.name.value, ASTBuilderUtil.createVariableRef(pos, symbol));
+                    symbol.name.getValue(), ASTBuilderUtil.createVariableRef(pos, symbol));
             lambdaBody.stmts.add(0, addToFrameStmt);
         }
     }
@@ -1415,7 +1415,7 @@ public class QueryDesugar extends BLangNodeVisitor {
         BLangSimpleVarRef frame = defineFrameVariable(blockStmt, pos);
         for (BVarSymbol symbol : symbols) {
             BType type = symbol.type;
-            String key = symbol.name.value;
+            String key = symbol.name.getValue();
             BType structureType = Types.getImpliedType(type);
             if (structureType.tag == TypeTags.RECORD || structureType.tag == TypeTags.OBJECT) {
                 List<BVarSymbol> nestedSymbols = new ArrayList<>();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
@@ -76,7 +76,6 @@ public class ServiceDesugar {
 
     private final SymbolTable symTable;
     private final SymbolResolver symResolver;
-    private final Names names;
     private DeclarativeAuthDesugar declarativeAuthDesugar;
     private TransactionDesugar transactionDesugar;
     private final Types types;
@@ -94,7 +93,6 @@ public class ServiceDesugar {
         context.put(SERVICE_DESUGAR_KEY, this);
         this.symTable = SymbolTable.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
-        this.names = Names.getInstance(context);
         this.declarativeAuthDesugar = DeclarativeAuthDesugar.getInstance(context);
         this.transactionDesugar = TransactionDesugar.getInstance(context);
         this.types = Types.getInstance(context);
@@ -154,7 +152,7 @@ public class ServiceDesugar {
 
         final Location pos = service.pos;
 
-        ASTBuilderUtil.defineVariable(service.serviceVariable, env.enclPkg.symbol, names);
+        ASTBuilderUtil.defineVariable(service.serviceVariable, env.enclPkg.symbol);
         env.enclPkg.globalVars.add(service.serviceVariable);
 
         int count = 0;
@@ -169,7 +167,7 @@ public class ServiceDesugar {
                         .createVariable(pos, generateServiceListenerVarName(service) + count, attachExpr.getBType(),
                                         attachExpr,
                                         null);
-                ASTBuilderUtil.defineVariable(listenerVar, env.enclPkg.symbol, names);
+                ASTBuilderUtil.defineVariable(listenerVar, env.enclPkg.symbol);
                 listenerVar.symbol.flags |= Flags.LISTENER;
                 env.enclPkg.globalVars.add(listenerVar);
                 listenerVarRef = ASTBuilderUtil.createVariableRef(pos, listenerVar.symbol);
@@ -184,7 +182,7 @@ public class ServiceDesugar {
                         getListenerTypeWithoutError(listenerVarRef.getBType()),
                         listenerCheckExpr,
                         null);
-                ASTBuilderUtil.defineVariable(listenerWithoutErrors, env.enclPkg.symbol, names);
+                ASTBuilderUtil.defineVariable(listenerWithoutErrors, env.enclPkg.symbol);
                 env.enclPkg.globalVars.add(listenerWithoutErrors);
                 BLangSimpleVarRef checkedRef = ASTBuilderUtil.createVariableRef(pos, listenerWithoutErrors.symbol);
                 listenerVarRef = checkedRef;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
@@ -126,7 +126,7 @@ public class ServiceDesugar {
         BTypeSymbol listenerTypeSymbol = Types.getImpliedType(
                 getListenerType(variable.getBType())).tsymbol;
         final Name functionName = Names
-                .fromString(Symbols.getAttachedFuncSymbolName(listenerTypeSymbol.name.value, method));
+                .fromString(Symbols.getAttachedFuncSymbolName(listenerTypeSymbol.name.getValue(), method));
         BInvokableSymbol methodInvocationSymbol = (BInvokableSymbol) symResolver
                 .lookupMemberSymbol(pos, listenerTypeSymbol.scope, env, functionName,
                         SymTag.INVOKABLE);
@@ -192,7 +192,7 @@ public class ServiceDesugar {
             // Find correct symbol.
             BTypeSymbol listenerTypeSymbol = getListenerType(listenerVarRef.getBType()).tsymbol;
             final Name functionName = Names
-                    .fromString(Symbols.getAttachedFuncSymbolName(listenerTypeSymbol.name.value, ATTACH_METHOD));
+                    .fromString(Symbols.getAttachedFuncSymbolName(listenerTypeSymbol.name.getValue(), ATTACH_METHOD));
             BInvokableSymbol methodRef = (BInvokableSymbol) symResolver
                     .lookupMemberSymbol(pos, listenerTypeSymbol.scope, env, functionName, SymTag.INVOKABLE);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/TransactionDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/TransactionDesugar.java
@@ -94,7 +94,6 @@ public class TransactionDesugar extends BLangNodeVisitor {
     private final Desugar desugar;
     private final SymbolTable symTable;
     private final SymbolResolver symResolver;
-    private final Names names;
     private final PackageCache packageCache;
 
     private BSymbol transactionError;
@@ -115,7 +114,6 @@ public class TransactionDesugar extends BLangNodeVisitor {
         context.put(TRANSACTION_DESUGAR_KEY, this);
         this.symTable = SymbolTable.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
-        this.names = Names.getInstance(context);
         this.desugar = Desugar.getInstance(context);
         this.packageCache = PackageCache.getInstance(context);
         this.types = Types.getInstance(context);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
@@ -91,7 +91,7 @@ public class PathConverter implements Converter<Path> {
                             .toList();
                 }
                 if (packageID != null) {
-                    if (packageID.version.value.isEmpty() && !packageID.orgName.equals(Names.BUILTIN_ORG)
+                    if (packageID.version.getValue().isEmpty() && !packageID.orgName.equals(Names.BUILTIN_ORG)
                             && !packageID.orgName.equals(Names.ANON_ORG) && !pathList.isEmpty()) {
                         packageID.version = new Name(pathList.get(0).toFile().getName());
                     }
@@ -139,7 +139,7 @@ public class PathConverter implements Converter<Path> {
     @Override
     public Stream<CompilerInput> finalize(Path path, PackageID pkgId) {
         // Set package version if its empty
-        if (pkgId.version.value.isEmpty() && !pkgId.orgName.equals(Names.BUILTIN_ORG)
+        if (pkgId.version.getValue().isEmpty() && !pkgId.orgName.equals(Names.BUILTIN_ORG)
                 && !pkgId.orgName.equals(Names.ANON_ORG)) {
             Manifest manifest = TomlParserUtils.getManifest(root);
             pkgId.version = new Name(manifest.getProject().getVersion());
@@ -147,11 +147,11 @@ public class PathConverter implements Converter<Path> {
 
         if ((!ProjectDirs.isProject(root) || RepoUtils.isBallerinaStandaloneFile(path))
                 && Files.isRegularFile(path)) {
-            return Stream.of(new FileSystemSourceInput(path, root.resolve(pkgId.name.value)));
+            return Stream.of(new FileSystemSourceInput(path, root.resolve(pkgId.name.getValue())));
         } else if (Files.isRegularFile(path)) {
             return Stream.of(new FileSystemSourceInput(path,
                     root.resolve(ProjectDirConstants.SOURCE_DIR_NAME)
-                            .resolve(pkgId.name.value)));
+                            .resolve(pkgId.name.getValue())));
         } else {
             return Stream.of();
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/ZipConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/ZipConverter.java
@@ -116,7 +116,7 @@ public class ZipConverter extends PathConverter {
                             .map(SortablePath::getPath)
                             .toList();
                 }
-                if (packageID.version.value.isEmpty() && !packageID.orgName.equals(Names.BUILTIN_ORG)
+                if (packageID.version.getValue().isEmpty() && !packageID.orgName.equals(Names.BUILTIN_ORG)
                         && !packageID.orgName.equals(Names.ANON_ORG) && !pathList.isEmpty()) {
                     // <org-name>/<module-name>/<version>
                     Path modulePath = pathList.get(0);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeRepo.java
@@ -21,9 +21,9 @@ public class HomeRepo extends NonSysRepo<Path> {
 
     @Override
     public Patten calculateNonSysPkg(PackageID pkg) {
-        String orgName = pkg.getOrgName().value;
-        String pkgName = pkg.getName().value;
-        String pkgVersion = pkg.version.value;
+        String orgName = pkg.getOrgName().getValue();
+        String pkgName = pkg.getName().getValue();
+        String pkgVersion = pkg.version.getValue();
 
         return new Patten(Patten.path("repo", orgName, pkgName, pkgVersion, "src"),
                           Patten.WILDCARD_SOURCE);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/JarRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/JarRepo.java
@@ -23,7 +23,7 @@ public class JarRepo implements Repo<Path> {
     @Override
     public Patten calculate(PackageID pkg) {
         return new Patten(Patten.path("META-INF"),
-                          Patten.path(pkg.orgName.value, pkg.name.value),
+                          Patten.path(pkg.orgName.getValue(), pkg.name.getValue()),
                           Patten.WILDCARD_SOURCE);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/ObjRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/ObjRepo.java
@@ -22,9 +22,9 @@ public class ObjRepo extends NonSysRepo<Path> {
     @Override
     public Patten calculateNonSysPkg(PackageID pkg) {
 
-        String orgName = pkg.getOrgName().value;
-        String pkgName = pkg.getName().value;
-        String pkgVersion = pkg.version.value;
+        String orgName = pkg.getOrgName().getValue();
+        String pkgName = pkg.getName().getValue();
+        String pkgVersion = pkg.version.getValue();
 
         return new Patten(Patten.path("repo",
                                       orgName,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/PathBalaRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/PathBalaRepo.java
@@ -65,8 +65,8 @@ public class PathBalaRepo implements Repo<Path> {
         
         Optional<Dependency> tomlDependency =
                 this.manifest.getDependencies().stream()
-                        .filter(dep -> dep.getOrgName().equals(moduleID.orgName.value) &&
-                                       dep.getModuleName().equals(moduleID.name.value) &&
+                        .filter(dep -> dep.getOrgName().equals(moduleID.orgName.getValue()) &&
+                                       dep.getModuleName().equals(moduleID.name.getValue()) &&
                                        null != dep.getMetadata().getPath())
                         .findFirst();
         
@@ -91,7 +91,7 @@ public class PathBalaRepo implements Repo<Path> {
         }
         
         // update version of the dependency from the current(root) project
-        if (moduleID.version.value.isEmpty() && null != dep.getMetadata().getVersion()) {
+        if (moduleID.version.getValue().isEmpty() && null != dep.getMetadata().getVersion()) {
             Matcher semverMatcher = semVerPattern.matcher(dep.getMetadata().getVersion());
             if (semverMatcher.matches()) {
                 moduleID.version = new Name(dep.getMetadata().getVersion());
@@ -100,7 +100,7 @@ public class PathBalaRepo implements Repo<Path> {
 
         Manifest manifestFromBala = RepoUtils.getManifestFromBala(balaPath.toAbsolutePath());
         // if version is not set, then resolve by the bala path's manifest
-        if (moduleID.version.value.isEmpty()) {
+        if (moduleID.version.getValue().isEmpty()) {
             moduleID.version = new Name(manifestFromBala.getProject().getVersion());
         }
     

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/ProgramingSourceRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/ProgramingSourceRepo.java
@@ -25,7 +25,7 @@ public class ProgramingSourceRepo extends NonSysRepo<Path> {
     @Override
     public Patten calculateNonSysPkg(PackageID pkg) {
         if (pkg.isUnnamed) {
-            return new Patten(path(pkg.sourceFileName.value));
+            return new Patten(path(pkg.sourceFileName.getValue()));
         } else {
             return Patten.NULL;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/ProjectSourceRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/ProjectSourceRepo.java
@@ -47,15 +47,15 @@ public class ProjectSourceRepo extends NonSysRepo<Path> {
     @Override
     public Patten calculateNonSysPkg(PackageID moduleID) {
         // check module has same organization
-        if (null != this.manifest && !moduleID.orgName.value.equals(this.manifest.getProject().getOrgName())) {
+        if (null != this.manifest && !moduleID.orgName.getValue().equals(this.manifest.getProject().getOrgName())) {
             return Patten.NULL;
         }
         
         if (testEnabled) {
-            return new Patten(Patten.path(ProjectDirConstants.SOURCE_DIR_NAME), Patten.path(moduleID.getName().value),
-                              Patten.WILDCARD_SOURCE_WITH_TEST);
+            return new Patten(Patten.path(ProjectDirConstants.SOURCE_DIR_NAME),
+                    Patten.path(moduleID.getName().getValue()), Patten.WILDCARD_SOURCE_WITH_TEST);
         }
-        return new Patten(Patten.path(ProjectDirConstants.SOURCE_DIR_NAME), Patten.path(moduleID.getName().value),
+        return new Patten(Patten.path(ProjectDirConstants.SOURCE_DIR_NAME), Patten.path(moduleID.getName().getValue()),
                           Patten.WILDCARD_SOURCE);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/ProjectSourceRepoWithTests.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/ProjectSourceRepoWithTests.java
@@ -21,7 +21,7 @@ public class ProjectSourceRepoWithTests extends NonSysRepo<Path> {
 
     @Override
     public Patten calculateNonSysPkg(PackageID pkg) {
-        return new Patten(Patten.path(pkg.getName().value),
+        return new Patten(Patten.path(pkg.getName().getValue()),
                           Patten.WILDCARD_SOURCE_WITH_TEST);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/RemoteRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/RemoteRepo.java
@@ -60,9 +60,9 @@ public class RemoteRepo extends NonSysRepo<URI> {
             return Patten.NULL;
         }
         
-        String orgName = pkg.getOrgName().value;
-        String pkgName = pkg.getName().value;
-        String pkgVersion = pkg.getPackageVersion().value;
+        String orgName = pkg.getOrgName().getValue();
+        String pkgName = pkg.getName().getValue();
+        String pkgVersion = pkg.getPackageVersion().getValue();
         if (pkgVersion.isEmpty()) {
             pkgVersion = "*";
         }
@@ -73,7 +73,7 @@ public class RemoteRepo extends NonSysRepo<URI> {
     @Override
     public Patten calculate(PackageID pkgId) {
         if (!COMPILE_BALLERINA_ORG &&
-                systemBirRepoPath.resolve(pkgId.orgName.value).resolve(pkgId.name.value).toFile().exists()) {
+                systemBirRepoPath.resolve(pkgId.orgName.getValue()).resolve(pkgId.name.getValue()).toFile().exists()) {
             return Patten.NULL;
         } else {
             return calculateNonSysPkg(pkgId);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangAnonymousModelHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangAnonymousModelHelper.java
@@ -154,7 +154,7 @@ public class BLangAnonymousModelHelper {
     public String getNextRawTemplateTypeKey(PackageID packageID, Name rawTemplateTypeName) {
         Integer nextValue = rawTemplateTypeCount.getOrDefault(packageID, 0);
         rawTemplateTypeCount.put(packageID, nextValue + 1);
-        return RAW_TEMPLATE_TYPE + rawTemplateTypeName.value + "$" + UNDERSCORE + nextValue;
+        return RAW_TEMPLATE_TYPE + rawTemplateTypeName.getValue() + "$" + UNDERSCORE + nextValue;
     }
 
     public String getNextTupleVarKey(PackageID packageID) {
@@ -176,7 +176,7 @@ public class BLangAnonymousModelHelper {
     }
 
     public boolean isAnonymousType(BSymbol symbol) {
-        return symbol.name.value.startsWith(ANON_TYPE);
+        return symbol.name.getValue().startsWith(ANON_TYPE);
     }
 
     public String getNextAnonymousIntersectionErrorDetailTypeName(PackageID packageID) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangMissingNodesHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangMissingNodesHelper.java
@@ -61,7 +61,7 @@ public class BLangMissingNodesHelper {
     }
     
     public boolean isMissingNode(Name nodeName) {
-        return isMissingNode(nodeName.value);
+        return isMissingNode(nodeName.getValue());
     }
     
     public boolean isMissingNode(String nodeName) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
@@ -809,7 +809,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
                 case RESOURCE_PATH_SEGMENT_PARAM:
                     BLangSimpleVariable param = (BLangSimpleVariable) pathSegment.apply(this);
                     bLangPathSegment = TreeBuilder.createResourcePathSegmentNode(NodeKind.RESOURCE_PATH_PARAM_SEGMENT);
-                    if (!param.name.value.equals(Names.EMPTY.value)) {
+                    if (!param.name.value.equals(Names.EMPTY.getValue())) {
                         params.add(param);
                         bLFunction.addPathParam(param);
                         bLangPathSegment.name = createIdentifier(getPosition(pathSegment), "^");
@@ -824,7 +824,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
                     BLangSimpleVariable restParam = (BLangSimpleVariable) pathSegment.apply(this);
                     bLangPathSegment =
                             TreeBuilder.createResourcePathSegmentNode(NodeKind.RESOURCE_PATH_REST_PARAM_SEGMENT);
-                    if (!restParam.name.value.equals(Names.EMPTY.value)) {
+                    if (!restParam.name.value.equals(Names.EMPTY.getValue())) {
                         params.add(restParam);
                         bLFunction.setRestPathParam(restParam);
                         bLangPathSegment.name = createIdentifier(getPosition(pathSegment), "^^");
@@ -1248,7 +1248,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
                 BLangFunction bLangFunction = (BLangFunction) bLangNode;
                 bLangFunction.attachedFunction = true;
                 bLangFunction.flagSet.add(Flag.ATTACHED);
-                if (Names.USER_DEFINED_INIT_SUFFIX.value.equals(bLangFunction.name.value)) {
+                if (Names.USER_DEFINED_INIT_SUFFIX.getValue().equals(bLangFunction.name.value)) {
                     if (objectTypeNode.initFunction == null) {
                         bLangFunction.objInitFunction = true;
                         objectTypeNode.initFunction = bLangFunction;
@@ -1294,7 +1294,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
                 bLangFunction.attachedFunction = true;
                 bLangFunction.flagSet.add(Flag.ATTACHED);
                 bLangFunction.flagSet.add(Flag.OBJECT_CTOR);
-                if (!Names.USER_DEFINED_INIT_SUFFIX.value.equals(bLangFunction.name.value)) {
+                if (!Names.USER_DEFINED_INIT_SUFFIX.getValue().equals(bLangFunction.name.value)) {
                     classDefinition.addFunction(bLangFunction);
                     continue;
                 }
@@ -2739,8 +2739,8 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
 
     private BLangIdentifier createIgnoreIdentifier(Node node) {
         BLangIdentifier ignore = (BLangIdentifier) TreeBuilder.createIdentifierNode();
-        ignore.value = Names.IGNORE.value;
-        ignore.setOriginalValue(Names.IGNORE.value);
+        ignore.value = Names.IGNORE.getValue();
+        ignore.setOriginalValue(Names.IGNORE.getValue());
         ignore.pos = getPosition(node);
         return ignore;
     }
@@ -4324,7 +4324,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
                 BLangFunction bLangFunction = (BLangFunction) bLangNode;
                 bLangFunction.attachedFunction = true;
                 bLangFunction.flagSet.add(Flag.ATTACHED);
-                if (!Names.USER_DEFINED_INIT_SUFFIX.value.equals(bLangFunction.name.value)) {
+                if (!Names.USER_DEFINED_INIT_SUFFIX.getValue().equals(bLangFunction.name.value)) {
                     blangClass.addFunction(bLangFunction);
                     continue;
                 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -2204,7 +2204,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
 
         Set<Flag> flagSet = funcNode.flagSet;
         // Analyze worker interactions inside workers
-        Name workerDerivedName = Names.fromString("0" + otherWorker.name.value);
+        Name workerDerivedName = Names.fromString("0" + otherWorker.name.getValue());
         if (flagSet.contains(Flag.WORKER)) {
             // Interacting with default worker from a worker within a fork.
             if (otherWorkerName.equals(DEFAULT_WORKER_NAME)) {
@@ -3840,7 +3840,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
                         for (BLangWaitForAllExpr.BLangWaitKeyValue keyValuePair : waitForAllExpr.keyValuePairs) {
                             BSymbol workerSymbol = getWorkerSymbol(keyValuePair);
                             if (workerSymbol != null) {
-                                waitingOnWorkerSet.add(workerSymbol.name.value);
+                                waitingOnWorkerSet.add(workerSymbol.name.getValue());
                             }
                         }
                     } else {
@@ -3883,7 +3883,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
                 if (isWorkerSymbol(workerSymbol)) {
                     Name workerName = workerSymbol.name;
                     if (isWorkerFromFunction(workerActionSystem.getActionEnvironment(currentAction), workerName)) {
-                        WorkerActionStateMachine otherSM = workerActionSystem.find(workerName.value);
+                        WorkerActionStateMachine otherSM = workerActionSystem.find(workerName.getValue());
                         allWorkersAreDone = allWorkersAreDone && otherSM.done();
                     }
                 }
@@ -4124,7 +4124,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
     }
 
     private void validateModuleInitFunction(BLangFunction funcNode) {
-        if (funcNode.attachedFunction || !Names.USER_DEFINED_INIT_SUFFIX.value.equals(funcNode.name.value)) {
+        if (funcNode.attachedFunction || !Names.USER_DEFINED_INIT_SUFFIX.getValue().equals(funcNode.name.value)) {
             return;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -294,7 +294,6 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
     private final Types types;
     private final BLangDiagnosticLog dlog;
     private final TypeChecker typeChecker;
-    private final Names names;
     private final ReachabilityAnalyzer reachabilityAnalyzer;
 
     public static CodeAnalyzer getInstance(CompilerContext context) {
@@ -311,7 +310,6 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
         this.types = Types.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
         this.typeChecker = TypeChecker.getInstance(context);
-        this.names = Names.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
         this.reachabilityAnalyzer = ReachabilityAnalyzer.getInstance(context);
     }
@@ -2020,7 +2018,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
     @Override
     public void visit(BLangWorkerAsyncSendExpr asyncSendExpr, AnalyzerData data) {
         BSymbol receiver =
-                symResolver.lookupSymbolInMainSpace(data.env, names.fromIdNode(asyncSendExpr.workerIdentifier));
+                symResolver.lookupSymbolInMainSpace(data.env, Names.fromIdNode(asyncSendExpr.workerIdentifier));
         if ((receiver.tag & SymTag.VARIABLE) != SymTag.VARIABLE) {
             receiver = symTable.notFoundSymbol;
         }
@@ -2111,7 +2109,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
     @Override
     public void visit(BLangWorkerSyncSendExpr syncSendExpr, AnalyzerData data) {
         BSymbol receiver =
-                symResolver.lookupSymbolInMainSpace(data.env, names.fromIdNode(syncSendExpr.workerIdentifier));
+                symResolver.lookupSymbolInMainSpace(data.env, Names.fromIdNode(syncSendExpr.workerIdentifier));
         if ((receiver.tag & SymTag.VARIABLE) != SymTag.VARIABLE) {
             receiver = symTable.notFoundSymbol;
         }
@@ -2168,7 +2166,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
         Location workerReceivePos = workerReceiveNode.pos;
         validateActionParentNode(workerReceivePos, workerReceiveNode);
         BSymbol sender =
-                symResolver.lookupSymbolInMainSpace(data.env, names.fromIdNode(workerReceiveNode.workerIdentifier));
+                symResolver.lookupSymbolInMainSpace(data.env, Names.fromIdNode(workerReceiveNode.workerIdentifier));
         if ((sender.tag & SymTag.VARIABLE) != SymTag.VARIABLE) {
             sender = symTable.notFoundSymbol;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
@@ -303,7 +303,8 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
             // Check whether each annotation type definition is available in the AST.
             List<BAnnotationSymbol> annotationSymbols = getAnnotationSymbols(annPackage);
             annotationSymbols.forEach(annSymbol -> {
-                DefinitionID definitionID = new DefinitionID(annSymbol.pkgID.name.value, annSymbol.name.value);
+                DefinitionID definitionID = new DefinitionID(
+                        annSymbol.pkgID.name.getValue(), annSymbol.name.getValue());
                 Set<CompilerPlugin> processors = processorMap.computeIfAbsent(definitionID, k -> new HashSet<>());
                 processors.add(plugin);
             });
@@ -333,7 +334,7 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
         Map<CompilerPlugin, List<AnnotationAttachmentNode>> attachmentMap = new HashMap<>();
 
         for (BLangAnnotationAttachment attachment : attachments) {
-            DefinitionID aID = new DefinitionID(attachment.annotationSymbol.pkgID.getName().value,
+            DefinitionID aID = new DefinitionID(attachment.annotationSymbol.pkgID.getName().getValue(),
                     attachment.annotationName.value);
             if (!processorMap.containsKey(aID)) {
                 continue;
@@ -427,8 +428,8 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
                     final BLangFunction resourceNode = (BLangFunction) function;
                     if (resourceNode.symbol.params.stream().filter(varSym -> varSym.type.tsymbol != null)
                             .map(varSym -> varSym.type.tsymbol).noneMatch(
-                                    tsym -> definitionID.name.equals(tsym.name.value) && definitionID.pkgName
-                                            .equals(tsym.pkgID.name.value))) {
+                                    tsym -> definitionID.name.equals(tsym.name.getValue()) && definitionID.pkgName
+                                            .equals(tsym.pkgID.name.getValue()))) {
                         continue;
                     }
                     isCurrentPluginProcessed = true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
@@ -86,7 +86,6 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
     private SymbolTable symTable;
     private PackageCache packageCache;
     private SymbolResolver symResolver;
-    private Names names;
     private final Types types;
     private BLangDiagnosticLog dlog;
 
@@ -114,7 +113,6 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
         this.symTable = SymbolTable.getInstance(context);
         this.packageCache = PackageCache.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
-        this.names = Names.getInstance(context);
         this.types = Types.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
         this.context = context;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantAnalyzer.java
@@ -56,7 +56,6 @@ public class ConstantAnalyzer extends BLangNodeVisitor {
             new CompilerContext.Key<>();
 
     private final BLangMissingNodesHelper missingNodesHelper;
-    private final Names names;
     private final SymbolTable symTable;
     private final SymbolResolver symResolver;
     private BLangDiagnosticLog dlog;
@@ -66,7 +65,6 @@ public class ConstantAnalyzer extends BLangNodeVisitor {
 
         context.put(CONSTANT_ANALYZER_KEY, this);
         this.missingNodesHelper = BLangMissingNodesHelper.getInstance(context);
-        this.names = Names.getInstance(context);
         this.symTable = SymbolTable.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
@@ -106,7 +104,7 @@ public class ConstantAnalyzer extends BLangNodeVisitor {
         if (varRef.pkgSymbol != symTable.notFoundSymbol && symbol == symTable.notFoundSymbol) {
             SymbolEnv pkgEnv = symTable.pkgEnvMap.get(varRef.pkgSymbol);
             symbol = pkgEnv == null ? symbol : symResolver.lookupMainSpaceSymbolInPackage(varRef.pos, pkgEnv,
-                    names.fromIdNode(varRef.pkgAlias), names.fromIdNode(varRef.variableName));
+                    Names.fromIdNode(varRef.pkgAlias), Names.fromIdNode(varRef.variableName));
         }
 
         if (symbol == symTable.notFoundSymbol) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantTypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantTypeChecker.java
@@ -744,7 +744,7 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
                 }
                 BRecordType recordType = (BRecordType) type;
                 for (BField recField : recordType.fields.values()) {
-                    if (!addFields(inferredFields, Types.getImpliedType(recField.type), recField.name.value,
+                    if (!addFields(inferredFields, Types.getImpliedType(recField.type), recField.name.getValue(),
                             fieldExpr.pos, recordSymbol)) {
                         containErrors = true;
                     }
@@ -883,7 +883,7 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
                         containErrors = true;
                         continue;
                     }
-                    if (!addFields(inferredFields, Types.getImpliedType(recField.type), recField.name.value,
+                    if (!addFields(inferredFields, Types.getImpliedType(recField.type), recField.name.getValue(),
                             fieldExpr.pos, recordSymbol)) {
                         containErrors = true;
                     }
@@ -957,7 +957,7 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
         boolean hasAllRequiredFields = true;
 
         for (BField field : type.fields.values()) {
-            String fieldName = field.name.value;
+            String fieldName = field.name.getValue();
             if (!specFieldNames.contains(fieldName) && Symbols.isFlagOn(field.symbol.flags, Flags.REQUIRED)
                     && !types.isNeverTypeOrStructureTypeWithARequiredNeverMember(field.type)) {
                 // Check if `field` is explicitly assigned a value in the record literal
@@ -1004,7 +1004,7 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
         List<String> fieldNames = new ArrayList<>();
         for (BField bField : ((BRecordType) spreadType).getFields().values()) {
             if (!Symbols.isOptional(bField.symbol)) {
-                fieldNames.add(bField.name.value);
+                fieldNames.add(bField.name.getValue());
             }
         }
         return fieldNames;
@@ -2000,7 +2000,7 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
         long flags = recordSymbol.flags | Flags.REQUIRED;
         BVarSymbol fieldSymbol = new BVarSymbol(flags, fieldName, recordSymbol.pkgID , keyValueType,
                 recordSymbol, symTable.builtinPos, VIRTUAL);
-        fields.put(fieldName.value, new BField(fieldName, null, fieldSymbol));
+        fields.put(fieldName.getValue(), new BField(fieldName, null, fieldSymbol));
         return true;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantTypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantTypeChecker.java
@@ -127,7 +127,6 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
             new CompilerContext.Key<>();
 
     private final SymbolTable symTable;
-    private final Names names;
     private final NodeCloner nodeCloner;
     private final SymbolResolver symResolver;
     private final BLangDiagnosticLog dlog;
@@ -141,7 +140,6 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
         context.put(CONSTANT_TYPE_CHECKER_KEY, this);
 
         this.symTable = SymbolTable.getInstance(context);
-        this.names = Names.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
         this.nodeCloner = NodeCloner.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
@@ -293,13 +291,13 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
         // Set error type as the actual type.
         BType actualType = symTable.semanticError;
 
-        Name varName = names.fromIdNode(varRefExpr.variableName);
+        Name varName = Names.fromIdNode(varRefExpr.variableName);
         if (varName == Names.IGNORE) {
             varRefExpr.setBType(this.symTable.anyType);
 
             // If the variable name is a wildcard('_'), the symbol should be ignorable.
             varRefExpr.symbol = new BVarSymbol(0, true, varName,
-                    names.originalNameFromIdNode(varRefExpr.variableName),
+                    Names.originalNameFromIdNode(varRefExpr.variableName),
                     data.env.enclPkg.symbol.pkgID, varRefExpr.getBType(), data.env.scope.owner,
                     varRefExpr.pos, VIRTUAL);
 
@@ -309,13 +307,13 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
 
         Name compUnitName = typeChecker.getCurrentCompUnit(varRefExpr);
         varRefExpr.pkgSymbol =
-                symResolver.resolvePrefixSymbol(data.env, names.fromIdNode(varRefExpr.pkgAlias), compUnitName);
+                symResolver.resolvePrefixSymbol(data.env, Names.fromIdNode(varRefExpr.pkgAlias), compUnitName);
         if (varRefExpr.pkgSymbol == symTable.notFoundSymbol) {
             varRefExpr.symbol = symTable.notFoundSymbol;
             dlog.error(varRefExpr.pos, DiagnosticErrorCode.UNDEFINED_MODULE, varRefExpr.pkgAlias);
         } else {
             BSymbol symbol =
-                    typeResolver.getSymbolOfVarRef(varRefExpr.pos, data.env, names.fromIdNode(varRefExpr.pkgAlias),
+                    typeResolver.getSymbolOfVarRef(varRefExpr.pos, data.env, Names.fromIdNode(varRefExpr.pkgAlias),
                             varName);
 
             if (symbol == symTable.notFoundSymbol) {
@@ -353,13 +351,13 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
     public void visit(BLangRecordLiteral.BLangRecordVarNameField varRefExpr, AnalyzerData data) {
         BType actualType = symTable.semanticError;
 
-        Name varName = names.fromIdNode(varRefExpr.variableName);
+        Name varName = Names.fromIdNode(varRefExpr.variableName);
         if (varName == Names.IGNORE) {
             varRefExpr.setBType(this.symTable.anyType);
 
             // If the variable name is a wildcard('_'), the symbol should be ignorable.
             varRefExpr.symbol = new BVarSymbol(0, true, varName,
-                    names.originalNameFromIdNode(varRefExpr.variableName),
+                    Names.originalNameFromIdNode(varRefExpr.variableName),
                     data.env.enclPkg.symbol.pkgID, varRefExpr.getBType(), data.env.scope.owner,
                     varRefExpr.pos, VIRTUAL);
 
@@ -369,7 +367,7 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
 
         Name compUnitName = typeChecker.getCurrentCompUnit(varRefExpr);
         varRefExpr.pkgSymbol =
-                symResolver.resolvePrefixSymbol(data.env, names.fromIdNode(varRefExpr.pkgAlias), compUnitName);
+                symResolver.resolvePrefixSymbol(data.env, Names.fromIdNode(varRefExpr.pkgAlias), compUnitName);
         if (varRefExpr.pkgSymbol == symTable.notFoundSymbol) {
             varRefExpr.symbol = symTable.notFoundSymbol;
             dlog.error(varRefExpr.pos, DiagnosticErrorCode.UNDEFINED_MODULE, varRefExpr.pkgAlias);
@@ -377,7 +375,7 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
 
         if (varRefExpr.pkgSymbol != symTable.notFoundSymbol) {
             BSymbol symbol =
-                    typeResolver.getSymbolOfVarRef(varRefExpr.pos, data.env, names.fromIdNode(varRefExpr.pkgAlias),
+                    typeResolver.getSymbolOfVarRef(varRefExpr.pos, data.env, Names.fromIdNode(varRefExpr.pkgAlias),
                             varName);
 
             if (symbol == symTable.notFoundSymbol) {
@@ -519,8 +517,7 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
         symbol.type = recordType;
         recordType.tsymbol = symbol;
         recordType.sealed = true;
-        TypeDefBuilderHelper.createTypeDefinition(recordType, data.constantSymbol.pos, names, types,
-                symTable, data.env);
+        TypeDefBuilderHelper.createTypeDefinition(recordType, data.constantSymbol.pos, types, symTable, data.env);
         return recordType;
     }
 
@@ -644,15 +641,15 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
             case TypeTags.JSON:
                 return !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.mapJsonType :
                         ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.mapJsonType, data.env,
-                                symTable, anonymousModelHelper, names);
+                                symTable, anonymousModelHelper);
             case TypeTags.ANYDATA:
                 return !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.mapAnydataType :
                         ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.mapAnydataType,
-                                data.env, symTable, anonymousModelHelper, names);
+                                data.env, symTable, anonymousModelHelper);
             case TypeTags.ANY:
                 return !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.mapAllType :
                         ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.mapAllType, data.env,
-                                symTable, anonymousModelHelper, names);
+                                symTable, anonymousModelHelper);
             case TypeTags.INTERSECTION:
                 return ((BIntersectionType) type).effectiveType;
             case TypeTags.TYPEREFDESC:
@@ -1388,13 +1385,13 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
                  TypeTags.TYPEDESC -> type;
             case TypeTags.JSON -> !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.arrayJsonType :
                     ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayJsonType,
-                            data.env, symTable, anonymousModelHelper, names);
+                            data.env, symTable, anonymousModelHelper);
             case TypeTags.ANYDATA -> !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.arrayAnydataType :
                     ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayAnydataType,
-                            data.env, symTable, anonymousModelHelper, names);
+                            data.env, symTable, anonymousModelHelper);
             case TypeTags.ANY -> !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.arrayAllType :
                     ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayAllType, data.env,
-                            symTable, anonymousModelHelper, names);
+                            symTable, anonymousModelHelper);
             case TypeTags.INTERSECTION -> ((BIntersectionType) type).effectiveType;
             default -> symTable.semanticError;
         };
@@ -2160,7 +2157,6 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
         private final SymbolTable symTable;
         private final Types types;
         private final ConstantTypeChecker constantTypeChecker;
-        private final Names names;
         private final BLangDiagnosticLog dlog;
 
         private AnalyzerData data;
@@ -2171,7 +2167,6 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
             this.symTable = SymbolTable.getInstance(context);
             this.types = Types.getInstance(context);
             this.constantTypeChecker = ConstantTypeChecker.getInstance(context);
-            this.names = Names.getInstance(context);
             this.dlog = BLangDiagnosticLog.getInstance(context);
         }
 
@@ -2321,7 +2316,7 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
             resultRecordType.tsymbol = recordSymbol;
             resultRecordType.sealed = true;
             resultRecordType.restFieldType = symTable.neverType;
-            TypeDefBuilderHelper.createTypeDefinition(resultRecordType, data.constantSymbol.pos, names, types,
+            TypeDefBuilderHelper.createTypeDefinition(resultRecordType, data.constantSymbol.pos, types,
                     symTable, data.env);
             data.resultType = resultRecordType;
         }
@@ -2439,7 +2434,7 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
             resultRecordType.tsymbol = recordSymbol;
             resultRecordType.sealed = true;
             resultRecordType.restFieldType = symTable.neverType;
-            TypeDefBuilderHelper.createTypeDefinition(resultRecordType, data.constantSymbol.pos, names, types,
+            TypeDefBuilderHelper.createTypeDefinition(resultRecordType, data.constantSymbol.pos, types,
                     symTable, data.env);
             data.resultType = resultRecordType;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
@@ -205,7 +205,7 @@ public class ConstantValueResolver extends BLangNodeVisitor {
                 return;
             }
             this.unresolvableConstants.add(constSymbol);
-            dlog.error(varRef.pos, DiagnosticErrorCode.CANNOT_RESOLVE_CONST, constSymbol.name.value);
+            dlog.error(varRef.pos, DiagnosticErrorCode.CANNOT_RESOLVE_CONST, constSymbol.name.getValue());
             this.result = null;
             return;
         }
@@ -778,7 +778,7 @@ public class ConstantValueResolver extends BLangNodeVisitor {
         BTypeDefinitionSymbol typeDefinitionSymbol = Symbols.createTypeDefinitionSymbol(type.tsymbol.flags,
                 type.tsymbol.name, pkgID, null, env.scope.owner, pos, VIRTUAL);
         typeDefinitionSymbol.scope = new Scope(typeDefinitionSymbol);
-        typeDefinitionSymbol.scope.define(Names.fromString(typeDefinitionSymbol.name.value), typeDefinitionSymbol);
+        typeDefinitionSymbol.scope.define(Names.fromString(typeDefinitionSymbol.name.getValue()), typeDefinitionSymbol);
 
         type.tsymbol.scope = new Scope(type.tsymbol);
         for (BField field : ((HashMap<String, BField>) type.fields).values()) {
@@ -818,7 +818,7 @@ public class ConstantValueResolver extends BLangNodeVisitor {
 
     private void addAssociatedTypeDefinition(BLangConstant constant, BIntersectionType immutableType) {
         BLangTypeDefinition typeDefinition = findTypeDefinition(symEnv.enclPkg.typeDefinitions,
-                immutableType.effectiveType.tsymbol.name.value);
+                immutableType.effectiveType.tsymbol.name.getValue());
 
         constant.associatedTypeDefinition = typeDefinition;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
@@ -103,7 +103,6 @@ public class ConstantValueResolver extends BLangNodeVisitor {
     private Location currentPos;
     private BLangAnonymousModelHelper anonymousModelHelper;
     private SymbolEnv symEnv;
-    private Names names;
     private SymbolTable symTable;
     private Types types;
     private PackageID pkgID;
@@ -118,7 +117,6 @@ public class ConstantValueResolver extends BLangNodeVisitor {
         context.put(CONSTANT_VALUE_RESOLVER_KEY, this);
         this.dlog = BLangDiagnosticLog.getInstance(context);
         this.symTable = SymbolTable.getInstance(context);
-        this.names = Names.getInstance(context);
         this.anonymousModelHelper = BLangAnonymousModelHelper.getInstance(context);
         this.types = Types.getInstance(context);
     }
@@ -794,7 +792,7 @@ public class ConstantValueResolver extends BLangNodeVisitor {
 
         BLangRecordTypeNode recordTypeNode = TypeDefBuilderHelper.createRecordTypeNode(new ArrayList<>(), type,
                 pos);
-        TypeDefBuilderHelper.populateStructureFieldsAndTypeInclusions(types, symTable, null, names,
+        TypeDefBuilderHelper.populateStructureFieldsAndTypeInclusions(types, symTable, null,
                 recordTypeNode, type, type, pos, env, pkgID, null, 0, false);
         recordTypeNode.sealed = true;
         type.restFieldType = new BNoType(TypeTags.NONE);
@@ -868,7 +866,7 @@ public class ConstantValueResolver extends BLangNodeVisitor {
         BTypeSymbol structureSymbol = recordType.tsymbol;
         for (BField field : recordType.fields.values()) {
             field.type = ImmutableTypeCloner.getImmutableType(pos, types, field.type, env,
-                    env.enclPkg.packageID, env.scope.owner, symTable, anonymousModelHelper, names,
+                    env.enclPkg.packageID, env.scope.owner, symTable, anonymousModelHelper,
                     new HashSet<>());
             Name fieldName = field.symbol.name;
             field.symbol = new BVarSymbol(field.symbol.flags | Flags.READONLY, fieldName,
@@ -1027,7 +1025,7 @@ public class ConstantValueResolver extends BLangNodeVisitor {
                                                                env.scope.owner, pos, VIRTUAL);
 
         return ImmutableTypeCloner.getImmutableIntersectionType(pos, types, new BTupleType(tupleTypeSymbol, tupleTypes),
-                                                                env, symTable, anonymousModelHelper, names,
+                                                                env, symTable, anonymousModelHelper,
                                                                 new HashSet<>());
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -259,7 +259,6 @@ import java.util.stream.Stream;
 public class DataflowAnalyzer extends BLangNodeVisitor {
 
     private final SymbolResolver symResolver;
-    private final Names names;
     private SymbolEnv env;
     private SymbolTable symTable;
     private BLangDiagnosticLog dlog;
@@ -285,7 +284,6 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         this.dlog = BLangDiagnosticLog.getInstance(context);
         this.types = Types.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
-        this.names = Names.getInstance(context);
         this.currDependentSymbolDeque = new ArrayDeque<>();
         this.globalVariableRefAnalyzer = GlobalVariableRefAnalyzer.getInstance(context);
         this.unusedLocalVariables = new HashMap<>();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -379,7 +379,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
     private boolean isModuleInitFunction(BLangNode node) {
         return node.getKind() == NodeKind.FUNCTION &&
-                Names.USER_DEFINED_INIT_SUFFIX.value.equals(((BLangFunction) node).name.value);
+                Names.USER_DEFINED_INIT_SUFFIX.getValue().equals(((BLangFunction) node).name.value);
     }
 
     private void analyzeModuleInitFunc(BLangFunction funcNode) {
@@ -1045,7 +1045,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         analyzeStmtWithOnFail(transactionNode.transactionBody, transactionNode.onFailClause);
 
         // marks the injected import as used
-        Name transactionPkgName = Names.fromString(Names.DOT.value + Names.TRANSACTION_PACKAGE.value);
+        Name transactionPkgName = Names.fromString(Names.DOT.getValue() + Names.TRANSACTION_PACKAGE.getValue());
         Name compUnitName = Names.fromString(transactionNode.pos.lineRange().fileName());
         this.symResolver.resolvePrefixSymbol(env, transactionPkgName, compUnitName);
     }
@@ -1888,10 +1888,10 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
                 }
 
                 if (isFirstUninitializedField) {
-                    uninitializedFields = new StringBuilder(symbol.getName().value);
+                    uninitializedFields = new StringBuilder(symbol.getName().getValue());
                     isFirstUninitializedField = false;
                 } else {
-                    uninitializedFields.append(", ").append(symbol.getName().value);
+                    uninitializedFields.append(", ").append(symbol.getName().getValue());
                 }
             }
             if (!uninitializedFields.isEmpty()) {
@@ -1906,7 +1906,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     private boolean isSelfKeyWordExpr(BLangExpression expr) {
 
         return expr.getKind() == NodeKind.SIMPLE_VARIABLE_REF &&
-                Names.SELF.value.equals(((BLangSimpleVarRef) expr).getVariableName().getValue());
+                Names.SELF.getValue().equals(((BLangSimpleVarRef) expr).getVariableName().getValue());
     }
 
     private StringBuilder getUninitializedFieldsForSelfKeyword(BObjectType objType) {
@@ -1916,10 +1916,10 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         for (BField field : objType.fields.values()) {
             if (this.uninitializedVars.containsKey(field.symbol)) {
                 if (isFirstUninitializedField) {
-                    uninitializedFields = new StringBuilder(field.symbol.getName().value);
+                    uninitializedFields = new StringBuilder(field.symbol.getName().getValue());
                     isFirstUninitializedField = false;
                 } else {
-                    uninitializedFields.append(", ").append(field.symbol.getName().value);
+                    uninitializedFields.append(", ").append(field.symbol.getName().getValue());
                 }
             }
         }
@@ -2617,7 +2617,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         if (fieldAccessExpr.expr.getKind() != NodeKind.SIMPLE_VARIABLE_REF) {
             return false;
         }
-        return Names.SELF.value.equals(((BLangSimpleVarRef) fieldAccessExpr.expr).variableName.value);
+        return Names.SELF.getValue().equals(((BLangSimpleVarRef) fieldAccessExpr.expr).variableName.value);
     }
 
     private void checkAssignment(BLangExpression varRef) {
@@ -2732,7 +2732,8 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
             }
 
             BObjectTypeSymbol objTypeSymbol = (BObjectTypeSymbol) type.tsymbol;
-            Name funcName = Names.fromString(Symbols.getAttachedFuncSymbolName(objTypeSymbol.name.value, fieldName));
+            Name funcName = Names.fromString(
+                    Symbols.getAttachedFuncSymbolName(objTypeSymbol.name.getValue(), fieldName));
             BSymbol funcSymbol = symResolver.resolveObjectMethod(pos, env, funcName, objTypeSymbol);
 
             // Object member functions are inherently final
@@ -2773,7 +2774,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
             String prefixValue = prefix.value;
             Location location = prefix.pos;
             BPackageSymbol symbol = importStmt.symbol;
-            if (symbol != null && !symbol.isUsed && !Names.IGNORE.value.equals(prefixValue)) {
+            if (symbol != null && !symbol.isUsed && !Names.IGNORE.getValue().equals(prefixValue)) {
                 dlog.error(location, DiagnosticErrorCode.UNUSED_MODULE_PREFIX, prefixValue);
             }
         }
@@ -2813,7 +2814,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     }
 
     private boolean isWildCardBindingPattern(BLangSimpleVariable variable) {
-        return Names.IGNORE.value.equals(variable.name.value);
+        return Names.IGNORE.getValue().equals(variable.name.value);
     }
 
     private boolean isWildCardBindingPattern(BVarSymbol symbol) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DocumentationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DocumentationAnalyzer.java
@@ -84,7 +84,6 @@ public class DocumentationAnalyzer extends SimpleBLangNodeAnalyzer<Documentation
     private final BLangDiagnosticLog dlog;
     private final SymbolResolver symResolver;
     private final SymbolTable symTable;
-    private final Names names;
 
     public static DocumentationAnalyzer getInstance(CompilerContext context) {
         DocumentationAnalyzer documentationAnalyzer = context.get(DOCUMENTATION_ANALYZER_KEY);
@@ -98,7 +97,6 @@ public class DocumentationAnalyzer extends SimpleBLangNodeAnalyzer<Documentation
         context.put(DOCUMENTATION_ANALYZER_KEY, this);
         this.symResolver = SymbolResolver.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
-        this.names = Names.getInstance(context);
         this.symTable = SymbolTable.getInstance(context);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/EffectiveTypePopulator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/EffectiveTypePopulator.java
@@ -88,7 +88,6 @@ public class EffectiveTypePopulator implements TypeVisitor {
     private static final CompilerContext.Key<EffectiveTypePopulator> UPDATE_IMMUTABLE_TYPE_KEY =
                 new CompilerContext.Key<>();
     private final SymbolTable symTable;
-    private final Names names;
     private final Types types;
     private final BLangAnonymousModelHelper anonymousModelHelper;
     private Location loc;
@@ -100,7 +99,6 @@ public class EffectiveTypePopulator implements TypeVisitor {
     public EffectiveTypePopulator(CompilerContext context) {
         context.put(UPDATE_IMMUTABLE_TYPE_KEY, this);
         this.symTable = SymbolTable.getInstance(context);
-        this.names = Names.getInstance(context);
         this.types = Types.getInstance(context);
         this.anonymousModelHelper = BLangAnonymousModelHelper.getInstance(context);
     }
@@ -144,7 +142,7 @@ public class EffectiveTypePopulator implements TypeVisitor {
         if (origArrayType != null) {
             if (bArrayType.eType.tag == TypeTags.NEVER || bArrayType.eType == symTable.semanticError) {
                 bArrayType.eType = ImmutableTypeCloner.getImmutableType(loc, types, origArrayType.eType, env,
-                        pkgID, env.scope.owner, symTable, anonymousModelHelper, names, new HashSet<>());
+                        pkgID, env.scope.owner, symTable, anonymousModelHelper, new HashSet<>());
             }
             updateType(bArrayType.eType, loc, pkgID, typeNode, env);
             bArrayType.mutableType = null;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/EffectiveTypePopulator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/EffectiveTypePopulator.java
@@ -66,7 +66,6 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangTupleTypeNode;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.ImmutableTypeCloner;
 import org.wso2.ballerinalang.compiler.util.Name;
-import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeDefBuilderHelper;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
@@ -190,8 +189,7 @@ public class EffectiveTypePopulator implements TypeVisitor {
         if (origMapType != null) {
             if (bMapType.constraint.tag == TypeTags.NEVER || bMapType.constraint == symTable.semanticError) {
                 bMapType.constraint = ImmutableTypeCloner.getImmutableType(loc, types, origMapType.constraint, env,
-                        pkgID, env.scope.owner, symTable, anonymousModelHelper, names,
-                        new HashSet<>());
+                        pkgID, env.scope.owner, symTable, anonymousModelHelper, new HashSet<>());
             }
             updateType(bMapType.constraint, loc, pkgID, typeNode, env);
             bMapType.mutableType = null;
@@ -256,7 +254,7 @@ public class EffectiveTypePopulator implements TypeVisitor {
                         continue;
                     }
                     BType newType = ImmutableTypeCloner.getImmutableType(loc, types, origTupleMemType.type, env,
-                            pkgID, env.scope.owner, symTable, anonymousModelHelper, names, new HashSet<>());
+                            pkgID, env.scope.owner, symTable, anonymousModelHelper, new HashSet<>());
                     BVarSymbol varSymbol = Symbols.createVarSymbolForTupleMember(newType);
                     BTupleMember member = new BTupleMember(newType, varSymbol);
                     bTupleType.addMembers(member);
@@ -268,7 +266,7 @@ public class EffectiveTypePopulator implements TypeVisitor {
             }
 
             BTypeSymbol tsymbol = bTupleType.tsymbol;
-            if (tsymbol != null && tsymbol.name != null && !tsymbol.name.value.isEmpty()
+            if (tsymbol != null && tsymbol.name != null && !tsymbol.name.getValue().isEmpty()
                     && !Symbols.isFlagOn(bTupleType.flags, Flags.EFFECTIVE_TYPE_DEF)) {
                 BLangTupleTypeNode tupleTypeNode = (BLangTupleTypeNode) TreeBuilder.createTupleTypeNode();
                 tupleTypeNode.setBType(bTupleType);
@@ -298,7 +296,7 @@ public class EffectiveTypePopulator implements TypeVisitor {
         if (origXMLType != null) {
             if (bXMLType.constraint == symTable.semanticError) {
                 bXMLType.constraint = ImmutableTypeCloner.getImmutableType(loc, types, origXMLType.constraint, env,
-                        pkgID, env.scope.owner, symTable, anonymousModelHelper, names, new HashSet<>());
+                        pkgID, env.scope.owner, symTable, anonymousModelHelper, new HashSet<>());
             }
             updateType(bXMLType.constraint, loc, pkgID, typeNode, env);
             bXMLType.mutableType = null;
@@ -312,14 +310,14 @@ public class EffectiveTypePopulator implements TypeVisitor {
             if (bTableType.constraint.tag == TypeTags.NEVER ||
                     bTableType.constraint == symTable.semanticError) {
                 bTableType.constraint = ImmutableTypeCloner.getImmutableType(loc, types, origTableType.constraint, env,
-                        pkgID, env.scope.owner, symTable, anonymousModelHelper, names, new HashSet<>());
+                        pkgID, env.scope.owner, symTable, anonymousModelHelper, new HashSet<>());
             }
             updateType(bTableType.constraint, loc, pkgID, typeNode, env);
 
             if (origTableType.keyTypeConstraint != null) {
                 bTableType.keyTypeConstraint = ImmutableTypeCloner.getImmutableType(loc, types,
                         origTableType.keyTypeConstraint, env, pkgID, env.scope.owner, symTable,
-                        anonymousModelHelper, names, new HashSet<>());
+                        anonymousModelHelper, new HashSet<>());
                 updateType(bTableType.keyTypeConstraint, loc, pkgID, typeNode, env);
             }
             bTableType.mutableType = null;
@@ -335,8 +333,7 @@ public class EffectiveTypePopulator implements TypeVisitor {
                 LinkedHashMap<String, BField> fields = new LinkedHashMap<>();
                 for (BField origField : origRecordType.fields.values()) {
                     BType fieldType = ImmutableTypeCloner.getImmutableType(loc, types, origField.type, env,
-                            pkgID, env.scope.owner, symTable, anonymousModelHelper, names,
-                            new HashSet<>());
+                            pkgID, env.scope.owner, symTable, anonymousModelHelper, new HashSet<>());
 
                     Name origFieldName = origField.name;
                     BVarSymbol fieldSymbol;
@@ -361,7 +358,7 @@ public class EffectiveTypePopulator implements TypeVisitor {
                                 fieldType, structureSymbol,
                                 origField.symbol.pos, SOURCE);
                     }
-                    String nameString = origFieldName.value;
+                    String nameString = origFieldName.getValue();
                     fields.put(nameString, new BField(origFieldName, null, fieldSymbol));
                     structureSymbol.scope.define(origFieldName, fieldSymbol);
                 }
@@ -369,11 +366,10 @@ public class EffectiveTypePopulator implements TypeVisitor {
                 bRecordType.restFieldType = origRecordType.restFieldType;
             } else {
                 for (BField immutableField : bRecordType.fields.values()) {
-                    BField origField = origRecordType.fields.get(immutableField.name.value);
+                    BField origField = origRecordType.fields.get(immutableField.name.getValue());
                     if (immutableField.type.tag == TypeTags.NEVER) {
                         immutableField.type = ImmutableTypeCloner.getImmutableType(loc, types, origField.type, env,
-                                pkgID, env.scope.owner, symTable, anonymousModelHelper, names,
-                                new HashSet<>());
+                                pkgID, env.scope.owner, symTable, anonymousModelHelper, new HashSet<>());
                     }
                     Name origFieldName = origField.name;
                     updateType(immutableField.type, loc, pkgID, typeNode, env);
@@ -395,8 +391,7 @@ public class EffectiveTypePopulator implements TypeVisitor {
                 LinkedHashMap<String, BField> fields = new LinkedHashMap<>();
                 for (BField origField : origObjectType.fields.values()) {
                     BType fieldType = ImmutableTypeCloner.getImmutableType(loc, types, origField.type, env,
-                            pkgID, env.scope.owner, symTable, anonymousModelHelper, names,
-                            new HashSet<>());
+                            pkgID, env.scope.owner, symTable, anonymousModelHelper, new HashSet<>());
 
                     Name origFieldName = origField.name;
                     BVarSymbol fieldSymbol;
@@ -416,18 +411,17 @@ public class EffectiveTypePopulator implements TypeVisitor {
                                 fieldType, structureSymbol,
                                 origField.symbol.pos, SOURCE);
                     }
-                    String nameString = origFieldName.value;
+                    String nameString = origFieldName.getValue();
                     fields.put(nameString, new BField(origFieldName, null, fieldSymbol));
                     structureSymbol.scope.define(origFieldName, fieldSymbol);
                 }
                 bObjectType.fields = fields;
             } else {
                 for (BField immutableField : bObjectType.fields.values()) {
-                    BField origField = origObjectType.fields.get(immutableField.name.value);
+                    BField origField = origObjectType.fields.get(immutableField.name.getValue());
                     if (immutableField.type.tag == TypeTags.NEVER) {
                         immutableField.type = ImmutableTypeCloner.getImmutableType(loc, types, origField.type, env,
-                                pkgID, env.scope.owner, symTable, anonymousModelHelper, names,
-                                new HashSet<>());
+                                pkgID, env.scope.owner, symTable, anonymousModelHelper, new HashSet<>());
                     }
                     Name origFieldName = origField.name;
                     updateType(immutableField.type, loc, pkgID, typeNode, env);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
@@ -2272,7 +2272,7 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
                 String name = ((BLangNamedArgsExpression) arg).name.value;
 
                 for (BVarSymbol param : params) {
-                    if (!param.name.value.equals(name)) {
+                    if (!param.name.getValue().equals(name)) {
                         continue;
                     }
 
@@ -3139,9 +3139,9 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
             return false;
         }
 
-        String methodName = invocation.symbol.name.value;
+        String methodName = invocation.symbol.name.getValue();
 
-        return invocation.symbol.pkgID.name.value.equals(VALUE_LANG_LIB) &&
+        return invocation.symbol.pkgID.name.getValue().equals(VALUE_LANG_LIB) &&
                 (methodName.equals(CLONE_LANG_LIB_METHOD) || methodName.equals(CLONE_READONLY_LANG_LIB_METHOD));
     }
 
@@ -3222,7 +3222,7 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
     }
 
     private boolean isSelfOfObject(BLangSimpleVarRef varRefExpr) {
-        if (!Names.SELF.value.equals(varRefExpr.variableName.value)) {
+        if (!Names.SELF.getValue().equals(varRefExpr.variableName.value)) {
             return false;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
@@ -290,7 +290,6 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
     private SymbolEnv env;
     private final SymbolTable symTable;
     private final SymbolResolver symResolver;
-    private final Names names;
     private final Types types;
     private final BLangDiagnosticLog dlog;
 
@@ -306,7 +305,6 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
         context.put(ISOLATION_ANALYZER_KEY, this);
         this.symTable = SymbolTable.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
-        this.names = Names.getInstance(context);
         this.types = Types.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
     }
@@ -3249,7 +3247,7 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
         switch (variableReference.getKind()) {
             case SIMPLE_VARIABLE_REF:
                 BLangSimpleVarRef simpleVarRef = (BLangSimpleVarRef) variableReference;
-                return isDefinedOutsideLock(names.fromIdNode(simpleVarRef.variableName), simpleVarRef.symbol.tag,
+                return isDefinedOutsideLock(Names.fromIdNode(simpleVarRef.variableName), simpleVarRef.symbol.tag,
                                             env);
             case RECORD_VARIABLE_REF:
                 BLangRecordVarRef recordVarRef = (BLangRecordVarRef) variableReference;
@@ -3362,7 +3360,7 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
     }
 
     private boolean isInvalidCopyIn(BLangSimpleVarRef varRefExpr, SymbolEnv currentEnv) {
-        return isInvalidCopyIn(varRefExpr, names.fromIdNode(varRefExpr.variableName), varRefExpr.symbol.tag,
+        return isInvalidCopyIn(varRefExpr, Names.fromIdNode(varRefExpr.variableName), varRefExpr.symbol.tag,
                                currentEnv);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/QueryTypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/QueryTypeChecker.java
@@ -310,7 +310,7 @@ public class QueryTypeChecker extends TypeChecker {
                     actualType = new BMapType(TypeTags.MAP, mapConstraintType, null);
                     if (Symbols.isFlagOn(resolvedTypes.get(0).flags, Flags.READONLY)) {
                         actualType = ImmutableTypeCloner.getImmutableIntersectionType(null, types, actualType, env,
-                                symTable, anonymousModelHelper, names, null);
+                                symTable, anonymousModelHelper, null);
                     }
                 }
             } else {
@@ -498,7 +498,7 @@ public class QueryTypeChecker extends TypeChecker {
         }
         if (Symbols.isFlagOn(resolvedType.flags, Flags.READONLY)) {
             return ImmutableTypeCloner.getImmutableIntersectionType(null, types,
-                    tableType, env, symTable, anonymousModelHelper, names, null);
+                    tableType, env, symTable, anonymousModelHelper, null);
         }
         return tableType;
     }
@@ -647,7 +647,7 @@ public class QueryTypeChecker extends TypeChecker {
         if (initType.tag != TypeTags.SEMANTIC_ERROR && (isReadonly ||
                 Symbols.isFlagOn(expType.flags, Flags.READONLY))) {
             return ImmutableTypeCloner.getImmutableIntersectionType(null, types, initType, env,
-                    symTable, anonymousModelHelper, names, null);
+                    symTable, anonymousModelHelper, null);
         }
         return initType;
     }
@@ -729,7 +729,7 @@ public class QueryTypeChecker extends TypeChecker {
         handleInputClauseVariables(fromClause, fromEnv);
         commonAnalyzerData.breakToParallelQueryEnv = prevBreakToParallelEnv;
         for (Name variable : fromEnv.scope.entries.keySet()) {
-            data.queryVariables.add(variable.value);
+            data.queryVariables.add(variable.getValue());
         }
     }
 
@@ -791,7 +791,7 @@ public class QueryTypeChecker extends TypeChecker {
             joinClause.onClause.accept(this, data);
         }
         for (Name variable : joinEnv.scope.entries.keySet()) {
-            data.queryVariables.add(variable.value);
+            data.queryVariables.add(variable.getValue());
         }
         commonAnalyzerData.breakToParallelQueryEnv = prevBreakEnv;
     }
@@ -822,7 +822,7 @@ public class QueryTypeChecker extends TypeChecker {
             semanticAnalyzer.analyzeNode((BLangNode) letVariable.definitionNode, letEnv, this, commonAnalyzerData);
         }
         for (Name variable : letEnv.scope.entries.keySet()) {
-            data.queryVariables.add(variable.value);
+            data.queryVariables.add(variable.getValue());
         }
     }
 
@@ -1121,7 +1121,7 @@ public class QueryTypeChecker extends TypeChecker {
             BLangType enclType = data.env.enclType;
             if (symbol == symTable.notFoundSymbol && enclType != null && enclType.getBType().tsymbol.scope != null) {
                 Name objFuncName = Names.fromString(Symbols
-                        .getAttachedFuncSymbolName(enclType.getBType().tsymbol.name.value, varName.value));
+                        .getAttachedFuncSymbolName(enclType.getBType().tsymbol.name.getValue(), varName.getValue()));
                 symbol = symResolver.resolveStructField(varRefExpr.pos, data.env, objFuncName,
                         enclType.getBType().tsymbol);
             }
@@ -1171,7 +1171,7 @@ public class QueryTypeChecker extends TypeChecker {
                 }
             } else {
                 varRefExpr.symbol = symbol; // Set notFoundSymbol
-                logUndefinedSymbolError(varRefExpr.pos, varName.value);
+                logUndefinedSymbolError(varRefExpr.pos, varName.getValue());
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/QueryTypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/QueryTypeChecker.java
@@ -116,7 +116,6 @@ public class QueryTypeChecker extends TypeChecker {
     private final TypeParamAnalyzer typeParamAnalyzer;
     private final TypeNarrower typeNarrower;
     private final BLangAnonymousModelHelper anonymousModelHelper;
-    private final Names names;
     private final BLangDiagnosticLog dlog;
     private final NodeCloner nodeCloner;
 
@@ -132,7 +131,6 @@ public class QueryTypeChecker extends TypeChecker {
         super(context, new CompilerContext.Key<>());
         context.put(QUERY_TYPE_CHECKER_KEY, this);
 
-        this.names = Names.getInstance(context);
         this.symTable = SymbolTable.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
         this.types = Types.getInstance(context);
@@ -969,7 +967,7 @@ public class QueryTypeChecker extends TypeChecker {
             super.visit(iExpr, data);
             return;
         }
-        Name pkgAlias = names.fromIdNode(iExpr.pkgAlias);
+        Name pkgAlias = Names.fromIdNode(iExpr.pkgAlias);
         BSymbol pkgSymbol = symResolver.resolvePrefixSymbol(data.env, pkgAlias, getCurrentCompUnit(iExpr));
         if (pkgSymbol == symTable.notFoundSymbol) {
             dlog.error(iExpr.pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias);
@@ -983,7 +981,7 @@ public class QueryTypeChecker extends TypeChecker {
             invocationType =
                     firstArgType.tag == TypeTags.SEQUENCE ? ((BSequenceType) firstArgType).elementType : firstArgType;
         }
-        Name funcName = names.fromIdNode(iExpr.name);
+        Name funcName = Names.fromIdNode(iExpr.name);
         BSymbol symbol = symResolver.lookupLangLibMethod(invocationType, funcName, data.env);
         if (symbol == symTable.notFoundSymbol) {
             symbol = symResolver.lookupMainSpaceSymbolInPackage(iExpr.pos, data.env, pkgAlias, funcName);
@@ -1091,13 +1089,13 @@ public class QueryTypeChecker extends TypeChecker {
         BType actualType = symTable.semanticError;
 
         BLangIdentifier identifier = varRefExpr.variableName;
-        Name varName = names.fromIdNode(identifier);
+        Name varName = Names.fromIdNode(identifier);
         if (varName == Names.IGNORE) {
             varRefExpr.setBType(this.symTable.anyType);
 
             // If the variable name is a wildcard('_'), the symbol should be ignorable.
             varRefExpr.symbol = new BVarSymbol(0, true, varName,
-                    names.originalNameFromIdNode(identifier),
+                    Names.originalNameFromIdNode(identifier),
                     data.env.enclPkg.symbol.pkgID, varRefExpr.getBType(), data.env.scope.owner,
                     varRefExpr.pos, VIRTUAL);
 
@@ -1106,7 +1104,7 @@ public class QueryTypeChecker extends TypeChecker {
         }
 
         Name compUnitName = getCurrentCompUnit(varRefExpr);
-        BSymbol pkgSymbol = symResolver.resolvePrefixSymbol(data.env, names.fromIdNode(varRefExpr.pkgAlias),
+        BSymbol pkgSymbol = symResolver.resolvePrefixSymbol(data.env, Names.fromIdNode(varRefExpr.pkgAlias),
                 compUnitName);
         varRefExpr.pkgSymbol = pkgSymbol;
         if (pkgSymbol == symTable.notFoundSymbol) {
@@ -1118,7 +1116,7 @@ public class QueryTypeChecker extends TypeChecker {
             actualType = symTable.stringType;
         } else if (pkgSymbol != symTable.notFoundSymbol) {
             BSymbol symbol = symResolver.lookupMainSpaceSymbolInPackage(varRefExpr.pos, data.env,
-                    names.fromIdNode(varRefExpr.pkgAlias), varName);
+                    Names.fromIdNode(varRefExpr.pkgAlias), varName);
             // if no symbol, check same for object attached function
             BLangType enclType = data.env.enclType;
             if (symbol == symTable.notFoundSymbol && enclType != null && enclType.getBType().tsymbol.scope != null) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
@@ -124,14 +124,12 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
     private final TypeNarrower typeNarrower;
     private final Types types;
     private final BLangDiagnosticLog dlog;
-    private final Names names;
 
     private ReachabilityAnalyzer(CompilerContext context) {
         context.put(REACHABILITY_ANALYZER_KEY, this);
         this.symTable = SymbolTable.getInstance(context);
         this.types = Types.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
-        this.names = Names.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
         this.typeNarrower = TypeNarrower.getInstance(context);
     }
@@ -883,7 +881,7 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
             return;
         }
 
-        Name name = names.fromIdNode(varRef.variableName);
+        Name name = Names.fromIdNode(varRef.variableName);
         SymbolEnv loopEnv = data.loopAndDoClauseEnvs.peek();
         SymbolEnv currentEnv = data.env;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -546,7 +546,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
 
             BLangExpression expr = param.expr;
             if (expr != null) {
-                funcNode.symbol.paramDefaultValTypes.put(param.symbol.name.value, expr.getBType());
+                funcNode.symbol.paramDefaultValTypes.put(param.symbol.name.getValue(), expr.getBType());
             }
 
             validateIsolatedParamUsage(inIsolatedFunction, param, false, data);
@@ -1226,9 +1226,9 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         String rootModuleName = rootModule.packageName().value();
         Map<String, PackageID> configKeys =  getModuleKeys(configVars, rootOrgName);
         for (BVarSymbol variable : configVars) {
-            String moduleName = variable.pkgID.name.value;
-            String orgName = variable.pkgID.orgName.value;
-            String varName = variable.name.value;
+            String moduleName = variable.pkgID.name.getValue();
+            String orgName = variable.pkgID.orgName.getValue();
+            String varName = variable.name.getValue();
             validateMapConfigVariable(orgName + "." + moduleName + "." + varName, variable, configKeys);
             if (orgName.equals(rootOrgName)) {
                 validateMapConfigVariable(moduleName + "." + varName, variable, configKeys);
@@ -1243,8 +1243,8 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         Map<String, PackageID> configKeys = new HashMap<>();
         for (BVarSymbol variable : configVars) {
             PackageID pkgID = variable.pkgID;
-            String orgName = pkgID.orgName.value;
-            String moduleName = pkgID.name.value;
+            String orgName = pkgID.orgName.getValue();
+            String moduleName = pkgID.name.getValue();
             configKeys.put(orgName + "." + moduleName, pkgID);
             if (!orgName.equals(rootOrg)) {
                 break;
@@ -1257,7 +1257,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
     private void validateMapConfigVariable(String configKey, BVarSymbol variable, Map<String, PackageID> configKeys) {
         if (configKeys.containsKey(configKey) && types.isSubTypeOfMapping(variable.type)) {
             dlog.error(variable.pos, DiagnosticErrorCode.CONFIGURABLE_VARIABLE_MODULE_AMBIGUITY,
-                    variable.name.value, configKeys.get(configKey));
+                    variable.name.getValue(), configKeys.get(configKey));
         }
     }
 
@@ -2033,7 +2033,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
     }
 
     private void handleWildCardBindingVariable(BLangSimpleVariable variable, SymbolEnv env) {
-        if (!variable.name.value.equals(Names.IGNORE.value)) {
+        if (!variable.name.value.equals(Names.IGNORE.getValue())) {
             return;
         }
         BLangExpression bindingExp = variable.expr;
@@ -2715,7 +2715,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         BUnionType wideType = BUnionType.create(null);
         for (BField field : rhsDetailType.fields.values()) {
             // avoid fields extracted from binding pattern
-            if (!extractedKeys.contains(field.name.value)) {
+            if (!extractedKeys.contains(field.name.getValue())) {
                 wideType.add(field.type);
             }
         }
@@ -2727,7 +2727,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
 
     private boolean isIgnoreVar(BLangErrorVarRef lhsRef) {
         if (lhsRef.restVar != null && lhsRef.restVar.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
-            return ((BLangSimpleVarRef) lhsRef.restVar).variableName.value.equals(Names.IGNORE.value);
+            return ((BLangSimpleVarRef) lhsRef.restVar).variableName.value.equals(Names.IGNORE.getValue());
         }
         return false;
     }
@@ -2743,7 +2743,8 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
             return;
         }
 
-        if (detailItem.getKind() == NodeKind.SIMPLE_VARIABLE_REF && detailItem.name.value.equals(Names.IGNORE.value)) {
+        if (detailItem.getKind() == NodeKind.SIMPLE_VARIABLE_REF &&
+                detailItem.name.value.equals(Names.IGNORE.getValue())) {
             return;
         }
 
@@ -3307,7 +3308,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         captureBindingPattern.symbol = symbolEnter.defineVarSymbol(captureBindingPattern.getIdentifier().getPosition(),
                                                                    Flags.unMask(0), captureBindingPattern.getBType(),
                                                                    name, origName, data.env, false);
-        captureBindingPattern.declaredVars.put(name.value, captureBindingPattern.symbol);
+        captureBindingPattern.declaredVars.put(name.getValue(), captureBindingPattern.symbol);
     }
 
     @Override
@@ -3347,7 +3348,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
             symbolEnter.defineSymbol(restBindingPattern.variableName.pos, symbol, currentEnv);
         }
         restBindingPattern.symbol = (BVarSymbol) symbol;
-        restBindingPattern.declaredVars.put(name.value, restBindingPattern.symbol);
+        restBindingPattern.declaredVars.put(name.getValue(), restBindingPattern.symbol);
     }
 
     @Override
@@ -3646,7 +3647,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         restMatchPattern.symbol = symbolEnter.defineVarSymbol(restMatchPattern.variableName.pos, Flags.unMask(0),
                                                               restMatchPattern.getBType(), name, origName, data.env,
                                                               false);
-        restMatchPattern.declaredVars.put(name.value, restMatchPattern.symbol);
+        restMatchPattern.declaredVars.put(name.getValue(), restMatchPattern.symbol);
     }
 
     @Override
@@ -4124,7 +4125,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
             BObjectType objectType = (BObjectType) type;
             BObjectTypeSymbol tsymbol = (BObjectTypeSymbol) objectType.tsymbol;
             for (BAttachedFunction func : tsymbol.attachedFuncs) {
-                if (func.funcName.value.equals("attach")) {
+                if (func.funcName.getValue().equals("attach")) {
                     BType firstParam = func.type.paramTypes.get(0);
                     result.add(firstParam);
                     return;
@@ -4151,7 +4152,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
     private void validateServiceAttachmentOnListener(BLangService serviceNode, BLangExpression attachExpr,
                                                      BObjectType listenerType, BType serviceType) {
         for (var func : ((BObjectTypeSymbol) listenerType.tsymbol).attachedFuncs) {
-            if (func.funcName.value.equals("attach")) {
+            if (func.funcName.getValue().equals("attach")) {
                 List<BType> paramTypes = func.type.paramTypes;
                 if (serviceType != null && serviceType != symTable.noType) {
                     validateServiceTypeAgainstAttachMethod(serviceNode.inferredServiceType, paramTypes.get(0),
@@ -4741,9 +4742,9 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
                 continue;
             }
             String annotationName = attachment.annotationName.value;
-            if (annotationName.equals(Names.ANNOTATION_TYPE_PARAM.value)) {
+            if (annotationName.equals(Names.ANNOTATION_TYPE_PARAM.getValue())) {
                 dlog.error(attachment.pos, DiagnosticErrorCode.TYPE_PARAM_OUTSIDE_LANG_MODULE);
-            } else if (annotationName.equals(Names.ANNOTATION_BUILTIN_SUBTYPE.value)) {
+            } else if (annotationName.equals(Names.ANNOTATION_BUILTIN_SUBTYPE.getValue())) {
                 dlog.error(attachment.pos, DiagnosticErrorCode.BUILTIN_SUBTYPE_OUTSIDE_LANG_MODULE);
             }
         }
@@ -4927,7 +4928,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
     // TODO: 2022-03-05 check if this can be replaced to access info via annot attchments from the symbol
     private void validateIsolatedParamUsage(boolean inIsolatedFunction, BLangSimpleVariable variable,
                                             boolean isRestParam, AnalyzerData data) {
-        if (!hasAnnotation(variable.annAttachments, Names.ANNOTATION_ISOLATED_PARAM.value)) {
+        if (!hasAnnotation(variable.annAttachments, Names.ANNOTATION_ISOLATED_PARAM.getValue())) {
             return;
         }
 
@@ -4997,7 +4998,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         }
 
         return ImmutableTypeCloner.getImmutableIntersectionType(pos, types, fieldType, data.env,
-                symTable, anonModelHelper, names, new HashSet<>());
+                symTable, anonModelHelper, new HashSet<>());
     }
 
     private void setRestMatchPatternConstraintType(BRecordType recordType,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -662,7 +662,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         if (defineReadOnlyInclusionsOnly) {
             for (BAttachedFunction function :
                     ((BObjectTypeSymbol) classDefinition.getBType().tsymbol).referencedFunctions) {
-                includedFunctionNames.add(function.funcName.value);
+                includedFunctionNames.add(function.funcName.getValue());
             }
         }
 
@@ -810,8 +810,8 @@ public class SymbolEnter extends BLangNodeVisitor {
             // to the precedence.
             // Default values of fields are not inherited.
             for (BField field : ((BStructureType) effectiveIncludedType).fields.values()) {
-                if (fieldNames.containsKey(field.name.value)) {
-                    BLangSimpleVariable existingVariable = fieldNames.get(field.name.value);
+                if (fieldNames.containsKey(field.name.getValue())) {
+                    BLangSimpleVariable existingVariable = fieldNames.get(field.name.getValue());
                     if ((existingVariable.flagSet.contains(Flag.PUBLIC) !=
                             Symbols.isFlagOn(field.symbol.flags, Flags.PUBLIC)) ||
                             (existingVariable.flagSet.contains(Flag.PRIVATE) !=
@@ -823,7 +823,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                     continue;
                 }
 
-                BLangSimpleVariable var = ASTBuilderUtil.createVariable(typeRef.pos, field.name.value, field.type);
+                BLangSimpleVariable var = ASTBuilderUtil.createVariable(typeRef.pos, field.name.getValue(), field.type);
                 var.flagSet = field.symbol.getFlags();
                 referencedFields.add(var);
             }
@@ -1018,7 +1018,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                             .map(id -> id.value)
                             .collect(Collectors.joining("."));
                     if (this.sourceDirectory.getSourcePackageNames().contains(pkgNameComps)
-                            && orgName.value.equals(enclPackageID.orgName.value)) {
+                            && orgName.getValue().equals(enclPackageID.orgName.getValue())) {
                         version = enclPackageID.version;
                     } else {
                         version = Names.EMPTY;
@@ -1061,7 +1061,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             // Only peer lang.* modules able to see these two modules.
             // Spec allows to annotation model to be imported, but implementation not support this.
             if (!(enclPackageID.orgName.equals(Names.BALLERINA_ORG)
-                    && enclPackageID.name.value.startsWith(Names.LANG.value))) {
+                    && enclPackageID.name.getValue().startsWith(Names.LANG.getValue()))) {
                 dlog.error(importPkgNode.pos, DiagnosticErrorCode.MODULE_NOT_FOUND,
                         importPkgNode.getQualifiedPackageName());
                 return;
@@ -1147,11 +1147,11 @@ public class SymbolEnter extends BLangNodeVisitor {
             for (int i = index; i < compUnits.size(); i++) {
                 boolean isUndefinedModule = true;
                 String compUnitName = compUnits.get(i).name;
-                if (((BPackageSymbol) entry.symbol).compUnit.value.equals(compUnitName)) {
+                if (((BPackageSymbol) entry.symbol).compUnit.getValue().equals(compUnitName)) {
                     isUndefinedModule = false;
                 }
                 while (entry.next != NOT_FOUND_ENTRY) {
-                    if (((BPackageSymbol) entry.next.symbol).compUnit.value.equals(compUnitName)) {
+                    if (((BPackageSymbol) entry.next.symbol).compUnit.getValue().equals(compUnitName)) {
                         isUndefinedModule = false;
                         break;
                     }
@@ -1192,7 +1192,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         Name prefix = Names.fromIdNode(xmlnsNode.prefix);
-        Location nsSymbolPos = prefix.value.isEmpty() ? xmlnsNode.pos : xmlnsNode.prefix.pos;
+        Location nsSymbolPos = prefix.getValue().isEmpty() ? xmlnsNode.pos : xmlnsNode.prefix.pos;
         BLangIdentifier compUnit = xmlnsNode.compUnit;
         BXMLNSSymbol xmlnsSymbol =
                 Symbols.createXMLNSSymbol(prefix, nsURI, symEnv.enclPkg.symbol.pkgID, symEnv.scope.owner, nsSymbolPos,
@@ -1706,7 +1706,8 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         if (typeDefinition.annAttachments.stream()
-                .anyMatch(attachment -> attachment.annotationName.value.equals(Names.ANNOTATION_TYPE_PARAM.value))) {
+                .anyMatch(attachment ->
+                        attachment.annotationName.value.equals(Names.ANNOTATION_TYPE_PARAM.getValue()))) {
             // TODO : Clean this. Not a nice way to handle this.
             //  TypeParam is built-in annotation, and limited only within lang.* modules.
             if (PackageID.isLangLibPackageID(this.env.enclPkg.packageID)) {
@@ -1960,7 +1961,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     private BType constructDependencyListError(BLangTypeDefinition typeDef, BType member) {
         List<String> dependencyList = new ArrayList<>();
         dependencyList.add(getTypeOrClassName(typeDef));
-        dependencyList.add(member.tsymbol.name.value);
+        dependencyList.add(member.tsymbol.name.getValue());
         dlog.error(typeDef.getPosition(), DiagnosticErrorCode.CYCLIC_TYPE_REFERENCE, dependencyList);
         return symTable.semanticError;
     }
@@ -2010,11 +2011,11 @@ public class SymbolEnter extends BLangNodeVisitor {
             return;
         }
         BLangAnnotationAttachment attachment = typeDefinition.annAttachments.get(0);
-        if (attachment.annotationName.value.equals(Names.ANNOTATION_TYPE_PARAM.value)) {
+        if (attachment.annotationName.value.equals(Names.ANNOTATION_TYPE_PARAM.getValue())) {
             BSymbol typeDefSymbol = typeDefinition.symbol;
             typeDefSymbol.type = typeParamAnalyzer.createTypeParam(typeDefSymbol);
             typeDefSymbol.flags |= Flags.TYPE_PARAM;
-        } else if (attachment.annotationName.value.equals(Names.ANNOTATION_BUILTIN_SUBTYPE.value)) {
+        } else if (attachment.annotationName.value.equals(Names.ANNOTATION_BUILTIN_SUBTYPE.getValue())) {
             // Type is pre-defined in symbol Table.
             BType type = symTable.getLangLibSubType(typeDefinition.name.value);
             typeDefinition.symbol.type = type;
@@ -2038,11 +2039,11 @@ public class SymbolEnter extends BLangNodeVisitor {
             return;
         }
         BLangAnnotationAttachment attachment = typeDefinition.annAttachments.get(0);
-        if (attachment.annotationName.value.equals(Names.ANNOTATION_TYPE_PARAM.value)) {
+        if (attachment.annotationName.value.equals(Names.ANNOTATION_TYPE_PARAM.getValue())) {
             BSymbol typeDefSymbol = typeDefinition.symbol;
             typeDefSymbol.type = typeParamAnalyzer.createTypeParam(typeDefSymbol);
             typeDefSymbol.flags |= Flags.TYPE_PARAM;
-        } else if (attachment.annotationName.value.equals(Names.ANNOTATION_BUILTIN_SUBTYPE.value)) {
+        } else if (attachment.annotationName.value.equals(Names.ANNOTATION_BUILTIN_SUBTYPE.getValue())) {
             // Type is pre-defined in symbol Table.
             BType type = symTable.getLangLibSubType(typeDefinition.name.value);
             typeDefinition.symbol.type = type;
@@ -2076,7 +2077,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     public void visit(BLangService serviceNode) {
         defineNode(serviceNode.serviceVariable, env);
 
-        Name generatedServiceName = Names.fromString("service$" + serviceNode.serviceClass.symbol.name.value);
+        Name generatedServiceName = Names.fromString("service$" + serviceNode.serviceClass.symbol.name.getValue());
         BType type = serviceNode.serviceClass.typeRefs.isEmpty() ? null : serviceNode.serviceClass.typeRefs.get(0)
                 .getBType();
         BServiceSymbol serviceSymbol = new BServiceSymbol((BClassSymbol) serviceNode.serviceClass.symbol,
@@ -2887,7 +2888,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             BField field = new BField(Names.fromString(fieldName), pos,
                     new BVarSymbol(0, Names.fromString(fieldName), env.enclPkg.symbol.pkgID,
                             fieldType, recordSymbol, pos, SOURCE));
-            fields.put(field.name.value, field);
+            fields.put(field.name.getValue(), field);
         }
         return fields;
     }
@@ -3132,14 +3133,14 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         for (BField field : unMappedFields.values()) {
-            if (fields.containsKey(field.name.value)) {
-                BField targetField = fields.get(field.getName().value);
+            if (fields.containsKey(field.name.getValue())) {
+                BField targetField = fields.get(field.getName().getValue());
                 targetField.type = types.mergeTypes(targetField.type, field.type);
             } else {
                 BField newField = new BField(field.name, pos,
                         new BVarSymbol(field.symbol.flags, field.name, env.enclPkg.symbol.pkgID,
                                 field.type, targetRestRecType.tsymbol, pos, VIRTUAL));
-                fields.put(field.name.value, newField);
+                fields.put(field.name.getValue(), newField);
                 targetRestRecType.tsymbol.scope.define(newField.name, newField.symbol);
             }
         }
@@ -3375,7 +3376,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             }
 
             boolean isIgnoredVar = boundVar.getKind() == NodeKind.VARIABLE
-                    && ((BLangSimpleVariable) boundVar).name.value.equals(Names.IGNORE.value);
+                    && ((BLangSimpleVariable) boundVar).name.value.equals(Names.IGNORE.getValue());
             if (!isIgnoredVar) {
                 defineMemberNode(boundVar, env, boundVar.getBType());
             }
@@ -3463,12 +3464,12 @@ public class SymbolEnter extends BLangNodeVisitor {
     }
 
     boolean isIgnoredOrEmpty(BLangSimpleVariable varNode) {
-        return varNode.name.value.equals(Names.IGNORE.value) || varNode.name.value.isEmpty();
+        return varNode.name.value.equals(Names.IGNORE.getValue()) || varNode.name.value.isEmpty();
     }
 
     private boolean isRestDetailBindingAvailable(BLangErrorVariable errorVariable) {
         return errorVariable.restDetail != null &&
-                !errorVariable.restDetail.name.value.equals(Names.IGNORE.value);
+                !errorVariable.restDetail.name.value.equals(Names.IGNORE.getValue());
     }
 
     private BTypeSymbol createTypeSymbol(long type, SymbolEnv env) {
@@ -3602,7 +3603,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         BinaryOperator<BField> mergeFunc = (u, v) -> {
             throw new IllegalStateException(String.format("Duplicate key %s", u));
         };
-        return Collectors.toMap(field -> field.name.value, Function.identity(), mergeFunc, LinkedHashMap::new);
+        return Collectors.toMap(field -> field.name.getValue(), Function.identity(), mergeFunc, LinkedHashMap::new);
     }
 
     // Private methods
@@ -3960,7 +3961,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         for (BLangType typeRef : recordTypeNode.typeRefs) {
             BType refType = Types.getImpliedType(typeRef.getBType());
             if (typeResolver.resolvingStructureTypes.contains((BStructureType) refType)) {
-                BLangTypeDefinition typeDefinition = typeResolver.getTypeDefinition(refType.tsymbol.name.value);
+                BLangTypeDefinition typeDefinition = typeResolver.getTypeDefinition(refType.tsymbol.name.getValue());
                 if (typeDefinition != null) {
                     resolveRestField(typeDefinition);
                 }
@@ -4526,7 +4527,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 }
             }
             if (varNode.flagSet.contains(Flag.INCLUDED)) {
-                requiredParamNames.add(symbol.name.value);
+                requiredParamNames.add(symbol.name.getValue());
                 BType varNodeType = Types.getImpliedType(varNode.getBType());
                 if (varNodeType.getKind() == TypeKind.RECORD) {
                     symbol.flags |= Flags.INCLUDED;
@@ -4543,7 +4544,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                     dlog.error(varNode.typeNode.pos, EXPECTED_RECORD_TYPE_AS_INCLUDED_PARAMETER);
                 }
             } else {
-                requiredParamNames.add(symbol.name.value);
+                requiredParamNames.add(symbol.name.getValue());
             }
             paramSymbols.add(symbol);
         }
@@ -4744,7 +4745,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             invokableSymbol.params = invokableTypeSymbol.params;
             invokableSymbol.restParam = invokableTypeSymbol.restParam;
             invokableSymbol.retType = invokableTypeSymbol.returnType;
-            if (varName.value.startsWith(WORKER_LAMBDA_VAR_PREFIX)) {
+            if (varName.getValue().startsWith(WORKER_LAMBDA_VAR_PREFIX)) {
                 varSymbol.flags |= Flags.WORKER;
             }
         } else if (Symbols.isFlagOn(flags, Flags.WORKER)) {
@@ -4775,7 +4776,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 targetRangePos = env.enclInvokable.pos;
             }
 
-            if (worker.name.value.equals(lambdaFn.function.defaultWorkerName.value)
+            if (worker.name.getValue().equals(lambdaFn.function.defaultWorkerName.value)
                     && withinRange(workerVarPos, targetRangePos.lineRange())
                     && withinRange(workerBodyPos, targetRangePos.lineRange())) {
                 worker.setAssociatedFuncSymbol(lambdaFn.function.symbol);
@@ -4784,7 +4785,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         throw new IllegalStateException(
-                "Matching function node not found for worker: " + worker.name.value + " at " + worker.pos);
+                "Matching function node not found for worker: " + worker.name.getValue() + " at " + worker.pos);
     }
 
     private void defineObjectInitFunction(BLangObjectTypeNode object, SymbolEnv conEnv) {
@@ -4988,7 +4989,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     private Name getFuncSymbolName(BLangFunction funcNode) {
         if (funcNode.receiver != null) {
             return Names.fromString(Symbols.getAttachedFuncSymbolName(
-                    funcNode.receiver.getBType().tsymbol.name.value, funcNode.name.value));
+                    funcNode.receiver.getBType().tsymbol.name.getValue(), funcNode.name.value));
         }
         return Names.fromIdNode(funcNode.name);
     }
@@ -4999,7 +5000,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
     private Name getFieldSymbolName(BLangSimpleVariable receiver, BLangSimpleVariable variable) {
         return Names.fromString(Symbols.getAttachedFuncSymbolName(
-                receiver.getBType().tsymbol.name.value, variable.name.value));
+                receiver.getBType().tsymbol.name.getValue(), variable.name.value));
     }
 
     public MarkdownDocAttachment getMarkdownDocAttachment(BLangMarkdownDocumentation docNode) {
@@ -5113,7 +5114,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             if (referredTypeTag == TypeTags.RECORD || referredTypeTag == TypeTags.OBJECT) {
                 if ((typeResolver.resolvingStructureTypes.contains((BStructureType) referredType))) {
                     List<BLangSimpleVariable> includedFields = new ArrayList<>();
-                    typeResolver.getFieldsOfStructureType(referredType.tsymbol.name.value, includedFields);
+                    typeResolver.getFieldsOfStructureType(referredType.tsymbol.name.getValue(), includedFields);
                     return includedFields.stream().filter(f -> {
                         if (fieldNames.containsKey(f.name.value)) {
                             BLangSimpleVariable existingVariable = fieldNames.get(f.name.value);
@@ -5137,8 +5138,8 @@ public class SymbolEnter extends BLangNodeVisitor {
             }
 
             return ((BStructureType) referredType).fields.values().stream().filter(f -> {
-                if (fieldNames.containsKey(f.name.value)) {
-                    BLangSimpleVariable existingVariable = fieldNames.get(f.name.value);
+                if (fieldNames.containsKey(f.name.getValue())) {
+                    BLangSimpleVariable existingVariable = fieldNames.get(f.name.getValue());
                     if (existingVariable.flagSet.contains(Flag.PUBLIC) !=
                             Symbols.isFlagOn(f.symbol.flags, Flags.PUBLIC)) {
                         dlog.error(existingVariable.pos,
@@ -5149,7 +5150,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 }
                 return true;
             }).map(field -> {
-                BLangSimpleVariable var = ASTBuilderUtil.createVariable(typeRef.pos, field.name.value, field.type);
+                BLangSimpleVariable var = ASTBuilderUtil.createVariable(typeRef.pos, field.name.getValue(), field.type);
                 var.flagSet = field.symbol.getFlags();
                 return var;
             });
@@ -5162,9 +5163,9 @@ public class SymbolEnter extends BLangNodeVisitor {
                                           Set<String> includedFunctionNames, BSymbol typeDefSymbol,
                                           List<BLangFunction> declaredFunctions, boolean isInternal) {
         typeDefSymbol = typeDefSymbol.tag == SymTag.TYPE_DEF ? typeDefSymbol.type.tsymbol : typeDefSymbol;
-        String referencedFuncName = referencedFunc.funcName.value;
+        String referencedFuncName = referencedFunc.funcName.getValue();
         Name funcName = Names.fromString(
-                Symbols.getAttachedFuncSymbolName(typeDefSymbol.name.value, referencedFuncName));
+                Symbols.getAttachedFuncSymbolName(typeDefSymbol.name.getValue(), referencedFuncName));
         BSymbol matchingObjFuncSym = symResolver.lookupSymbolInMainSpace(objEnv, funcName);
 
         BInvokableSymbol referencedFuncSymbol = referencedFunc.symbol;
@@ -5265,7 +5266,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         signatureBuilder.append("function ")
-                .append(funcSymbol.name.value.split("\\.")[1]);
+                .append(funcSymbol.name.getValue().split("\\.")[1]);
 
         funcSymbol.params.forEach(param -> paramListBuilder.add(param.type.toString()));
 
@@ -5302,12 +5303,12 @@ public class SymbolEnter extends BLangNodeVisitor {
     }
 
     private boolean isSameImport(BLangImportPackage importPkgNode, BPackageSymbol importSymbol) {
-        if (!importPkgNode.orgName.value.equals(importSymbol.pkgID.orgName.value)) {
+        if (!importPkgNode.orgName.value.equals(importSymbol.pkgID.orgName.getValue())) {
             return false;
         }
 
         BLangIdentifier pkgName = importPkgNode.pkgNameComps.get(importPkgNode.pkgNameComps.size() - 1);
-        return pkgName.value.equals(importSymbol.pkgID.name.value);
+        return pkgName.value.equals(importSymbol.pkgID.name.getValue());
     }
 
     private void setTypeFromLambdaExpr(BLangVariable variable) {
@@ -5335,7 +5336,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     }
 
     private SymbolOrigin getOrigin(Name name) {
-        return getOrigin(name.value);
+        return getOrigin(name.getValue());
     }
 
     public SymbolOrigin getOrigin(String name) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -154,7 +154,6 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
             new CompilerContext.Key<>();
 
     private final SymbolTable symTable;
-    private final Names names;
     private final BLangDiagnosticLog dlog;
     private final Types types;
 
@@ -179,7 +178,6 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         context.put(SYMBOL_RESOLVER_KEY, this);
 
         this.symTable = SymbolTable.getInstance(context);
-        this.names = Names.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
         this.types = Types.getInstance(context);
         this.symbolEnter = SymbolEnter.getInstance(context);
@@ -1200,8 +1198,8 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                     }
 
                     BLangSimpleVarRef sizeReference = (BLangSimpleVarRef) size;
-                    Name pkgAlias = names.fromIdNode(sizeReference.pkgAlias);
-                    Name typeName = names.fromIdNode(sizeReference.variableName);
+                    Name pkgAlias = Names.fromIdNode(sizeReference.pkgAlias);
+                    Name typeName = Names.fromIdNode(sizeReference.variableName);
 
                     BSymbol sizeSymbol = lookupMainSpaceSymbolInPackage(size.pos, data.env, pkgAlias, typeName);
                     sizeReference.symbol = sizeSymbol;
@@ -1601,9 +1599,9 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         // 3) If the symbol is not found, then lookup in the root scope. e.g. for types such as 'error'
 
         BLangIdentifier pkgAliasIdentifier = userDefinedTypeNode.pkgAlias;
-        Name pkgAlias = names.fromIdNode(pkgAliasIdentifier);
+        Name pkgAlias = Names.fromIdNode(pkgAliasIdentifier);
         BLangIdentifier typeNameIdentifier = userDefinedTypeNode.typeName;
-        Name typeName = names.fromIdNode(typeNameIdentifier);
+        Name typeName = Names.fromIdNode(typeNameIdentifier);
         BSymbol symbol = symTable.notFoundSymbol;
         SymbolEnv env = data.env;
 
@@ -1769,7 +1767,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 }
 
                 if (defaultValueExprKind == NodeKind.SIMPLE_VARIABLE_REF) {
-                    Name varName = names.fromIdNode(((BLangSimpleVarRef) param.expr).variableName);
+                    Name varName = Names.fromIdNode(((BLangSimpleVarRef) param.expr).variableName);
                     BSymbol typeRefSym = lookupSymbolInMainSpace(data.env, varName);
                     if (typeRefSym != symTable.notFoundSymbol) {
                         return new ParameterizedTypeInfo(typeRefSym.type, i);
@@ -2203,7 +2201,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
     }
 
     public BType visitBuiltInTypeNode(BLangType typeNode, AnalyzerData data, TypeKind typeKind) {
-        Name typeName = names.fromTypeKind(typeKind);
+        Name typeName = Names.fromTypeKind(typeKind);
         BSymbol typeSymbol = lookupMemberSymbol(typeNode.pos, symTable.rootScope, data.env, typeName, SymTag.TYPE);
         if (typeSymbol == symTable.notFoundSymbol) {
             dlog.error(typeNode.pos, data.diagCode, typeName);
@@ -2395,7 +2393,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         }
         return ImmutableTypeCloner.getImmutableIntersectionType(intersectionTypeNode.pos, types,
                         potentialIntersectionType,
-                data.env, symTable, anonymousModelHelper, names, flagSet);
+                data.env, symTable, anonymousModelHelper, flagSet);
     }
 
     public BIntersectionType createIntersectionErrorType(BErrorType intersectionErrorType,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -213,9 +213,9 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         }
 
         if (foundSym == symTable.notFoundSymbol && expSymTag == SymTag.FUNCTION) {
-            int dotPosition = symbol.name.value.indexOf('.');
-            if (dotPosition > 0 && dotPosition != symbol.name.value.length()) {
-                String funcName = symbol.name.value.substring(dotPosition + 1);
+            int dotPosition = symbol.name.getValue().indexOf('.');
+            if (dotPosition > 0 && dotPosition != symbol.name.getValue().length()) {
+                String funcName = symbol.name.getValue().substring(dotPosition + 1);
                 foundSym = lookupSymbolForDecl(env, Names.fromString(funcName), SymTag.MAIN);
             }
         }
@@ -341,7 +341,8 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 return false;
             }
             // This prevents `self` symbol crash between multilevel object ctors
-            if (foundSym.name.value.equals(Names.SELF.value) || symbol.name.value.equals(Names.SELF.value)) {
+            if (foundSym.name.getValue().equals(Names.SELF.getValue()) ||
+                    symbol.name.getValue().equals(Names.SELF.getValue())) {
                 return false;
             }
             return true;
@@ -457,7 +458,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         // Lookup for an imported package
         BSymbol pkgSymbol = lookupSymbolInPrefixSpace(env, pkgAlias);
         if (pkgSymbol == symTable.notFoundSymbol) {
-            dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.value);
+            dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.getValue());
         }
 
         return pkgSymbol;
@@ -859,7 +860,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         BSymbol pkgSymbol =
                 resolvePrefixSymbol(env, pkgAlias, Names.fromString(pos.lineRange().fileName()));
         if (pkgSymbol == symTable.notFoundSymbol) {
-            dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.value);
+            dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.getValue());
             return pkgSymbol;
         }
 
@@ -884,7 +885,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         BSymbol pkgSymbol =
                 resolvePrefixSymbol(env, pkgAlias, Names.fromString(pos.lineRange().fileName()));
         if (pkgSymbol == symTable.notFoundSymbol) {
-            dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.value);
+            dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.getValue());
             return pkgSymbol;
         }
 
@@ -905,7 +906,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         BSymbol pkgSymbol =
                 resolvePrefixSymbol(env, pkgAlias, Names.fromString(pos.lineRange().fileName()));
         if (pkgSymbol == symTable.notFoundSymbol) {
-            dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.value);
+            dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.getValue());
             return pkgSymbol;
         }
 
@@ -926,7 +927,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         BSymbol pkgSymbol =
                 resolvePrefixSymbol(env, pkgAlias, Names.fromString(pos.lineRange().fileName()));
         if (pkgSymbol == symTable.notFoundSymbol) {
-            dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.value);
+            dlog.error(pos, DiagnosticErrorCode.UNDEFINED_MODULE, pkgAlias.getValue());
             return pkgSymbol;
         }
 
@@ -1753,7 +1754,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         for (int i = 0; i < params.size(); i++) {
             BLangSimpleVariable param = params.get(i);
 
-            if (param.name.value.equals(varSym.name.value)) {
+            if (param.name.value.equals(varSym.name.getValue())) {
                 if (param.expr == null || param.expr.getKind() == NodeKind.INFER_TYPEDESC_EXPR) {
                     return new ParameterizedTypeInfo(
                             ((BTypedescType) Types.getImpliedType(varSym.type)).constraint, i);
@@ -2484,7 +2485,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
             return false;
         }
 
-        if (unifier.refersInferableParamName(paramWithInferredTypedescDefault.name.value, retType)) {
+        if (unifier.refersInferableParamName(paramWithInferredTypedescDefault.name.getValue(), retType)) {
             return true;
         }
 
@@ -2647,7 +2648,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         boolean isFoundSymModuleXmlns = foundSymCompUnit != null;
         boolean isSymModuleXmlns = symbolCompUnit != null;
         if (isFoundSymModuleXmlns && isSymModuleXmlns) {
-            return !foundSymCompUnit.value.equals(symbolCompUnit.value);
+            return !foundSymCompUnit.getValue().equals(symbolCompUnit.getValue());
         }
         // If only one of the symbols have a compUnit then it is a module level xmlns and the symbols are distinct.
         // If they both don't have a compUnit then it is a redeclared prefix.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1480,7 +1480,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         BinaryOperator<BField> mergeFunc = (u, v) -> {
             throw new IllegalStateException(String.format("Duplicate key %s", u));
         };
-        return Collectors.toMap(field -> field.name.value, Function.identity(), mergeFunc, LinkedHashMap::new);
+        return Collectors.toMap(field -> field.name.getValue(), Function.identity(), mergeFunc, LinkedHashMap::new);
     }
 
     private boolean validateKeySpecifierInTableConstructor(BTableType tableType,
@@ -2509,7 +2509,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                             pos,
                             TypeDefBuilderHelper.getPackageAlias(data.env, pos.lineRange().fileName(),
                                                                  applicableRecordTypeSymbol.pkgID)),
-                    ASTBuilderUtil.createIdentifier(pos, applicableRecordTypeSymbol.name.value));
+                    ASTBuilderUtil.createIdentifier(pos, applicableRecordTypeSymbol.name.getValue()));
             origTypeRef.pos = pos;
             origTypeRef.setBType(applicableRecordType);
             recordTypeNode.typeRefs.add(origTypeRef);
@@ -2748,7 +2748,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         boolean hasMissingRequiredFields = false;
 
         for (BField field : type.fields.values()) {
-            String fieldName = field.name.value;
+            String fieldName = field.name.getValue();
             boolean isFieldRequired = Symbols.isFlagOn(field.symbol.flags, Flags.REQUIRED);
 
             if (hasReadOnlyIntersection && !isFieldRequired) {
@@ -2860,7 +2860,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         List<String> fieldNames = new ArrayList<>();
         for (BField bField : ((BRecordType) spreadType).getFields().values()) {
             if (!Symbols.isOptional(bField.symbol)) {
-                fieldNames.add(bField.name.value);
+                fieldNames.add(bField.name.getValue());
             }
         }
         return fieldNames;
@@ -3062,7 +3062,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         for (BField field : recordType.fields.values()) {
             if (!types.isNeverTypeOrStructureTypeWithARequiredNeverMember(field.type)) {
                 // matching up field names against the record fields
-                if (clonedFieldNames.remove(field.name.value)) {
+                if (clonedFieldNames.remove(field.name.getValue())) {
                     continue;
                 }
 
@@ -3163,7 +3163,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             BLangType enclType = data.env.enclType;
             if (symbol == symTable.notFoundSymbol && enclType != null && enclType.getBType().tsymbol.scope != null) {
                 Name objFuncName = Names.fromString(Symbols
-                        .getAttachedFuncSymbolName(enclType.getBType().tsymbol.name.value, varName.value));
+                        .getAttachedFuncSymbolName(enclType.getBType().tsymbol.name.getValue(), varName.getValue()));
                 symbol = symResolver.resolveStructField(varRefExpr.pos, data.env, objFuncName,
                         enclType.getBType().tsymbol);
             }
@@ -3221,7 +3221,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 }
             } else {
                 varRefExpr.symbol = symbol; // Set notFoundSymbol
-                logUndefinedSymbolError(varRefExpr.pos, varName.value);
+                logUndefinedSymbolError(varRefExpr.pos, varName.getValue());
             }
         }
 
@@ -3262,7 +3262,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                                                      Names.originalNameFromIdNode(recordRefField.variableName),
                                               data.env.enclPkg.symbol.pkgID, bVarSymbol.type, recordSymbol,
                                                      varRefExpr.pos, SOURCE));
-            fields.put(field.name.value, field);
+            fields.put(field.name.getValue(), field);
         }
 
         BLangExpression restParam = varRefExpr.restParam;
@@ -3384,7 +3384,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         if (varRefExpr.restVar == null) {
             errorRefRestFieldType = symTable.anydataOrReadonly;
         } else if (varRefExpr.restVar.getKind() == NodeKind.SIMPLE_VARIABLE_REF
-                && ((BLangSimpleVarRef) varRefExpr.restVar).variableName.value.equals(Names.IGNORE.value)) {
+                && ((BLangSimpleVarRef) varRefExpr.restVar).variableName.value.equals(Names.IGNORE.getValue())) {
             errorRefRestFieldType = symTable.anydataOrReadonly;
         } else if (varRefExpr.restVar.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR
             || varRefExpr.restVar.getKind() == NodeKind.FIELD_BASED_ACCESS_EXPR) {
@@ -3613,7 +3613,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
             BRecordType recordType = (BRecordType) Types.getImpliedType(type);
             for (BField field : recordType.fields.values()) {
-                if (!field.name.value.equals(fieldName)) {
+                if (!field.name.getValue().equals(fieldName)) {
                     continue;
                 }
 
@@ -3836,7 +3836,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
             LinkedList<String> missingRequiredFields = targetErrorDetailRec.fields.values().stream()
                     .filter(f -> (f.symbol.flags & Flags.REQUIRED) == Flags.REQUIRED)
-                    .map(f -> f.name.value)
+                    .map(f -> f.name.getValue())
                     .collect(Collectors.toCollection(LinkedList::new));
 
             LinkedHashMap<String, BField> targetFields = targetErrorDetailRec.fields;
@@ -4060,7 +4060,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         }
 
         // Filter the resource methods in the list by resource access method name
-        resourceFunctions.removeIf(func -> !func.accessor.value.equals(resourceAccessInvocation.name.value));
+        resourceFunctions.removeIf(func -> !func.accessor.getValue().equals(resourceAccessInvocation.name.value));
         int targetResourceFuncCount = resourceFunctions.size();
         if (targetResourceFuncCount == 0) {
             handleResourceAccessError(resourceAccessInvocation.resourceAccessPathSegments,
@@ -4241,13 +4241,13 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             return false;
         }
 
-        String packageId = langLibMethodSymbol.pkgID.name.value;
+        String packageId = langLibMethodSymbol.pkgID.name.getValue();
 
         if (!modifierFunctions.containsKey(packageId)) {
             return false;
         }
 
-        String funcName = langLibMethodSymbol.name.value;
+        String funcName = langLibMethodSymbol.name.getValue();
         if (!modifierFunctions.get(packageId).contains(funcName)) {
             return false;
         }
@@ -4668,7 +4668,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                                                                  streamType.constraint, data.env.scope.owner, pos,
                                                                  VIRTUAL));
         field.type = streamType.constraint;
-        recordType.fields.put(field.name.value, field);
+        recordType.fields.put(field.name.getValue(), field);
 
         recordType.tsymbol = Symbols.createRecordSymbol(Flags.ANONYMOUS, Names.EMPTY, data.env.enclPkg.packageID,
                                                         recordType, data.env.scope.owner, pos, VIRTUAL);
@@ -4844,7 +4844,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             List<BVarSymbol> params = function.symbol.params;
             for (int i = givenRequiredParamCount; i < params.size(); i++) {
                 BVarSymbol functionParam = params.get(i);
-                if (!namedArg.name.value.equals(functionParam.name.value)) {
+                if (!namedArg.name.value.equals(functionParam.name.getValue())) {
                     continue;
                 }
                 foundNamedArg = true;
@@ -4934,7 +4934,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                                                      Names.originalNameFromIdNode(keyVal.key),
                                                      data.env.enclPkg.packageID, fieldType, null,
                                                      keyVal.pos, VIRTUAL));
-            retType.fields.put(field.name.value, field);
+            retType.fields.put(field.name.getValue(), field);
         }
 
         retType.restFieldType = symTable.noType;
@@ -5024,7 +5024,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                                               Location pos) {
         type.fields.values().forEach(field -> {
             // Check if `field` is explicitly assigned a value in the record literal
-            boolean hasField = keyValPairs.stream().anyMatch(keyVal -> field.name.value.equals(keyVal.key.value));
+            boolean hasField = keyValPairs.stream().anyMatch(keyVal -> field.name.getValue().equals(keyVal.key.value));
 
             // If a required field is missing, it's a compile error
             if (!hasField && Symbols.isFlagOn(field.symbol.flags, Flags.REQUIRED)) {
@@ -5178,7 +5178,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         } else if (expression.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
             BLangSimpleVarRef simpleVarRef = (BLangSimpleVarRef) expression;
             BSymbol varRefSymbol = simpleVarRef.symbol;
-            String varRefSymbolName = varRefSymbol.getName().value;
+            String varRefSymbolName = varRefSymbol.getName().getValue();
             if (workerExists(data.env, varRefSymbolName)) {
                 return false;
             }
@@ -6060,7 +6060,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             bLangXMLElementLiteral.defaultNsSymbol = namespaces.remove(defaultNs);
         }
         for (Map.Entry<Name, BXMLNSSymbol> nsEntry : namespaces.entrySet()) {
-            if (usedPrefixes.contains(nsEntry.getKey().value)) {
+            if (usedPrefixes.contains(nsEntry.getKey().getValue())) {
                 bLangXMLElementLiteral.namespacesInScope.put(nsEntry.getKey(), nsEntry.getValue());
             }
         }
@@ -6667,7 +6667,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             }
 
             return ImmutableTypeCloner.getImmutableIntersectionType(pos, types, data.expType, data.env, symTable,
-                    anonymousModelHelper, names, new HashSet<>());
+                    anonymousModelHelper, new HashSet<>());
         }
 
         if (origTargetType.tag != TypeTags.UNION) {
@@ -6699,7 +6699,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         BUnionType nonReadOnlyUnion = BUnionType.create(null, nonReadOnlyTypes);
 
         nonReadOnlyUnion.add(ImmutableTypeCloner.getImmutableIntersectionType(pos, types, data.expType, data.env,
-                             symTable, anonymousModelHelper, names, new HashSet<>()));
+                             symTable, anonymousModelHelper, new HashSet<>()));
         return nonReadOnlyUnion;
     }
 
@@ -7030,8 +7030,8 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             return;
         }
         // check for object attached function
-        Name funcName =
-                Names.fromString(Symbols.getAttachedFuncSymbolName(objectType.tsymbol.name.value, iExpr.name.value));
+        Name funcName = Names.fromString(
+                Symbols.getAttachedFuncSymbolName(objectType.tsymbol.name.getValue(), iExpr.name.value));
         BSymbol funcSymbol =
                 symResolver.resolveObjectMethod(iExpr.pos, data.env, funcName, (BObjectTypeSymbol) objectType.tsymbol);
 
@@ -7059,7 +7059,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
         // init method can be called in a method-call-expr only when the expression
         // preceding the . is self
-        if (iExpr.name.value.equals(Names.USER_DEFINED_INIT_SUFFIX.value) &&
+        if (iExpr.name.value.equals(Names.USER_DEFINED_INIT_SUFFIX.getValue()) &&
                 !(iExpr.expr.getKind() == NodeKind.SIMPLE_VARIABLE_REF &&
                 (Names.SELF.equals(((BLangSimpleVarRef) iExpr.expr).symbol.name)))) {
             dlog.error(iExpr.pos, DiagnosticErrorCode.INVALID_INIT_INVOCATION);
@@ -7088,7 +7088,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         }
 
         Name remoteMethodQName = Names
-                .fromString(Symbols.getAttachedFuncSymbolName(expType.tsymbol.name.value, aInv.name.value));
+                .fromString(Symbols.getAttachedFuncSymbolName(expType.tsymbol.name.getValue(), aInv.name.value));
         Name actionName = Names.fromIdNode(aInv.name);
         BSymbol remoteFuncSymbol = symResolver.resolveObjectMethod(aInv.pos, data.env,
             remoteMethodQName, (BObjectTypeSymbol) Types.getImpliedType(expType).tsymbol);
@@ -7197,7 +7197,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     openIncRecordParams.add(paramSymbol);
                 }
             } else {
-                requiredParamNames.add(paramSymbol.name.value);
+                requiredParamNames.add(paramSymbol.name.getValue());
             }
         }
         return incRecordParamAllowAdditionalFields(openIncRecordParams, requiredParamNames);
@@ -7261,7 +7261,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                         iExpr.requiredArgs.add(expr);
                     } else {
                         boolean referringToARest = invokableSymbol.restParam != null && invokableSymbol.restParam.name
-                                .value.equals(((BLangNamedArgsExpression) expr).name.value);
+                                .getValue().equals(((BLangNamedArgsExpression) expr).name.value);
                         DiagnosticErrorCode errorCode = referringToARest ?
                                 DiagnosticErrorCode.NAMED_ARG_NOT_ALLOWED_FOR_REST_PARAM
                                 : DiagnosticErrorCode.TOO_MANY_ARGS_FUNC_CALL;
@@ -7299,7 +7299,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
     }
 
     private boolean isNamedArgForIncRecordParam(String namedArgName, BVarSymbol incRecordParam) {
-        return incRecordParam != null && namedArgName.equals(incRecordParam.name.value);
+        return incRecordParam != null && namedArgName.equals(incRecordParam.name.getValue());
     }
 
     private BType checkInvocationArgs(BLangInvocation iExpr, List<BType> paramTypes, BLangExpression vararg,
@@ -7330,7 +7330,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             if (Symbols.isFlagOn(Flags.asMask(incRecordParam.getFlags()), Flags.REQUIRED)) {
                 requiredIncRecordParams.add(incRecordParam);
             }
-            includedRecordParamFieldNames.add(incRecordParam.name.value);
+            includedRecordParamFieldNames.add(incRecordParam.name.getValue());
         }
 
         HashSet<String> includedRecordFields = new HashSet<>();
@@ -7393,7 +7393,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 requiredParams.remove(varSym);
                 requiredIncRecordParams.remove(varSym);
                 if (valueProvidedParams.contains(varSym)) {
-                    dlog.error(arg.pos, DiagnosticErrorCode.DUPLICATE_NAMED_ARGS, varSym.name.value);
+                    dlog.error(arg.pos, DiagnosticErrorCode.DUPLICATE_NAMED_ARGS, varSym.name.getValue());
                     continue;
                 }
                 checkTypeParamExpr(arg, varSym.type, iExpr.langLibInvocation, data);
@@ -7472,7 +7472,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                                              add(required ? Flag.REQUIRED : Flag.OPTIONAL); }}), paramName,
                                              nonRestParam.getOriginalName(), pkgID, paramType, recordSymbol,
                                              symTable.builtinPos, VIRTUAL);
-                fields.put(paramName.value, new BField(paramName, null, fieldSymbol));
+                fields.put(paramName.getValue(), new BField(paramName, null, fieldSymbol));
             }
 
             if (referredListTypeRestArg != null) {
@@ -7687,12 +7687,12 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                                                             BVarSymbol incRecordParamAllowAdditionalFields,
                                                             AnalyzerData data) {
         for (BVarSymbol nonRestParam : nonRestParams) {
-            if (nonRestParam.getName().value.equals(argName.value)) {
+            if (nonRestParam.getName().getValue().equals(argName.value)) {
                 return nonRestParam;
             }
         }
         for (BVarSymbol incRecordParam : incRecordParams) {
-            if (incRecordParam.getName().value.equals(argName.value)) {
+            if (incRecordParam.getName().getValue().equals(argName.value)) {
                 return incRecordParam;
             }
         }
@@ -7933,7 +7933,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             if (types.isSelectivelyImmutableType(fieldType, data.env.enclPkg.packageID)) {
                 fieldType =
                         ImmutableTypeCloner.getImmutableIntersectionType(pos, types, fieldType, data.env, symTable,
-                                anonymousModelHelper, names, new HashSet<>());
+                                anonymousModelHelper, new HashSet<>());
             } else if (!types.isInherentlyImmutableType(fieldType)) {
                 dlog.error(pos, DiagnosticErrorCode.INVALID_READONLY_MAPPING_FIELD, fieldName, fieldType);
                 fieldType = symTable.semanticError;
@@ -8113,8 +8113,8 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         }
 
         // check if it is an attached function pointer call
-        Name objFuncName = Names.fromString(Symbols.getAttachedFuncSymbolName(objectType.tsymbol.name.value,
-                fieldName.value));
+        Name objFuncName = Names.fromString(Symbols.getAttachedFuncSymbolName(objectType.tsymbol.name.getValue(),
+                fieldName.getValue()));
         fieldSymbol =
                 symResolver.resolveObjectField(bLangFieldBasedAccess.pos, data.env, objFuncName, objectType.tsymbol);
 
@@ -9394,7 +9394,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
                 BRecordType recordType = (BRecordType) type;
                 for (BField recField : recordType.fields.values()) {
-                    addToNonRestFieldTypes(nonRestFieldTypes, recField.name.value, recField.type,
+                    addToNonRestFieldTypes(nonRestFieldTypes, recField.name.getValue(), recField.type,
                                            !Symbols.isOptional(recField.symbol), false);
                 }
 
@@ -9444,7 +9444,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
             BVarSymbol fieldSymbol = new BVarSymbol(Flags.asMask(flags), fieldName, pkgID, type, recordSymbol,
                                                     symTable.builtinPos, VIRTUAL);
-            fields.put(fieldName.value, new BField(fieldName, null, fieldSymbol));
+            fields.put(fieldName.getValue(), new BField(fieldName, null, fieldSymbol));
             recordSymbol.scope.define(fieldName, fieldSymbol);
         }
 
@@ -9550,7 +9550,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
         BXMLSubType immutableXmlSubType = (BXMLSubType)
                 ImmutableTypeCloner.getEffectiveImmutableType(location, types, mutableXmlSubType, data.env, symTable,
-                                                              anonymousModelHelper, names);
+                                                              anonymousModelHelper);
 
         if (referredExpType == immutableXmlSubType) {
             return expType;
@@ -9607,7 +9607,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 continue;
             }
             modifiedChild.setBType(ImmutableTypeCloner.getEffectiveImmutableType(modifiedChild.pos, types, childType,
-                    data.env, symTable, anonymousModelHelper, names));
+                    data.env, symTable, anonymousModelHelper));
 
             if (modifiedChild.getKind() == NodeKind.XML_ELEMENT_LITERAL) {
                 markChildrenAsImmutable((BLangXMLElementLiteral) modifiedChild, data);
@@ -9659,7 +9659,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         actualObjectType.tsymbol.flags |= Flags.READONLY;
 
         ImmutableTypeCloner.markFieldsAsImmutable(classDefForConstructor, env, actualObjectType, types,
-                                                  anonymousModelHelper, symTable, names, objectCtorExpr.pos);
+                                                  anonymousModelHelper, symTable, objectCtorExpr.pos);
 
         analyzeObjectConstructor(classDefForConstructor, env, data);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeHashVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeHashVisitor.java
@@ -364,7 +364,7 @@ public class TypeHashVisitor implements UniqueTypeVisitor<Integer> {
         if (isCyclic(type)) {
             return 0;
         }
-        Integer hash = hash(baseHash(type), Names.NEVER.value);
+        Integer hash = hash(baseHash(type), Names.NEVER.getValue());
         return addToVisited(type, hash);
     }
 
@@ -376,7 +376,7 @@ public class TypeHashVisitor implements UniqueTypeVisitor<Integer> {
         if (isCyclic(type)) {
             return 0;
         }
-        Integer hash = hash(baseHash(type), Names.NIL_VALUE.value);
+        Integer hash = hash(baseHash(type), Names.NIL_VALUE.getValue());
         return addToVisited(type, hash);
     }
 
@@ -535,7 +535,7 @@ public class TypeHashVisitor implements UniqueTypeVisitor<Integer> {
         if (isCyclic(type)) {
             return 0;
         }
-        Integer hash = hash(baseHash(type), Names.INT.value, type.name.getValue());
+        Integer hash = hash(baseHash(type), Names.INT.getValue(), type.name.getValue());
         return addToVisited(type, hash);
     }
 
@@ -547,7 +547,7 @@ public class TypeHashVisitor implements UniqueTypeVisitor<Integer> {
         if (isCyclic(type)) {
             return 0;
         }
-        Integer hash = hash(baseHash(type), Names.XML.value, type.name.getValue());
+        Integer hash = hash(baseHash(type), Names.XML.getValue(), type.name.getValue());
         return addToVisited(type, hash);
     }
 
@@ -590,7 +590,7 @@ public class TypeHashVisitor implements UniqueTypeVisitor<Integer> {
     private List<Integer> getFieldsHashes(Map<String, BField> fields) {
         List<Integer> list = new ArrayList<>();
         for (BField f : fields.values()) {
-            Integer hash = hash(f.name.value, f.symbol != null ? f.symbol.flags : null, visit(f.type));
+            Integer hash = hash(f.name.getValue(), f.symbol != null ? f.symbol.flags : null, visit(f.type));
             list.add(hash);
         }
         list.sort(Comparator.comparingInt(Integer::intValue));
@@ -611,7 +611,7 @@ public class TypeHashVisitor implements UniqueTypeVisitor<Integer> {
         if (attachedFunction == null) {
             return 0;
         }
-        return hash(attachedFunction.funcName.value,
+        return hash(attachedFunction.funcName.getValue(),
                 attachedFunction.symbol != null ? attachedFunction.symbol.flags : null, visit(attachedFunction.type));
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -672,9 +672,9 @@ public class TypeParamAnalyzer {
                                        SymbolEnv env, HashSet<BType> resolvedTypes, FindTypeParamResult result) {
 
         for (BField exField : expType.fields.values()) {
-            if (actualType.fields.containsKey(exField.name.value)) {
-                findTypeParam(loc, exField.type, actualType.fields.get(exField.name.value).type, env, resolvedTypes,
-                              result);
+            if (actualType.fields.containsKey(exField.name.getValue())) {
+                findTypeParam(loc, exField.type, actualType.fields.get(exField.name.getValue()).type, env,
+                        resolvedTypes, result);
             }
         }
     }
@@ -727,9 +727,9 @@ public class TypeParamAnalyzer {
 
         // Not needed now.
         for (BField exField : expType.fields.values()) {
-            if (actualType.fields.containsKey(exField.name.value)) {
-                findTypeParam(loc, exField.type, actualType.fields.get(exField.name.value).type, env, resolvedTypes,
-                              result);
+            if (actualType.fields.containsKey(exField.name.getValue())) {
+                findTypeParam(loc, exField.type, actualType.fields.get(exField.name.getValue()).type, env,
+                        resolvedTypes, result);
             }
         }
         List<BAttachedFunction> expAttFunctions = ((BObjectTypeSymbol) expType.tsymbol).attachedFuncs;
@@ -972,7 +972,7 @@ public class TypeParamAnalyzer {
             BField field = new BField(expField.name, expField.pos,
                                       new BVarSymbol(0, expField.name, env.enclPkg.packageID,
                                               matchingBoundType, env.scope.owner, expField.pos, VIRTUAL));
-            fields.put(field.name.value, field);
+            fields.put(field.name.getValue(), field);
             recordSymbol.scope.define(expField.name, field.symbol);
         }
 
@@ -1066,7 +1066,7 @@ public class TypeParamAnalyzer {
             BField field = new BField(expField.name, expField.pos,
                                       new BVarSymbol(expField.symbol.flags, expField.name, env.enclPkg.packageID,
                                               matchingBoundType, env.scope.owner, expField.pos, VIRTUAL));
-            objectType.fields.put(field.name.value, field);
+            objectType.fields.put(field.name.getValue(), field);
             objectType.tsymbol.scope.define(expField.name, field.symbol);
         }
 
@@ -1092,8 +1092,8 @@ public class TypeParamAnalyzer {
             matchType.tsymbol = typeSymbol;
 
             actObjectSymbol.attachedFuncs.add(duplicateAttachFunc(expFunc, matchType, invokableSymbol));
-            String funcName = Symbols.getAttachedFuncSymbolName(actObjectSymbol.type.tsymbol.name.value,
-                    expFunc.funcName.value);
+            String funcName = Symbols.getAttachedFuncSymbolName(actObjectSymbol.type.tsymbol.name.getValue(),
+                    expFunc.funcName.getValue());
             actObjectSymbol.scope.define(Names.fromString(funcName), invokableSymbol);
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -103,7 +103,6 @@ public class TypeParamAnalyzer {
 
     private SymbolTable symTable;
     private Types types;
-    private Names names;
     private BLangDiagnosticLog dlog;
     private BLangAnonymousModelHelper anonymousModelHelper;
 
@@ -123,7 +122,6 @@ public class TypeParamAnalyzer {
 
         this.symTable = SymbolTable.getInstance(context);
         this.types = Types.getInstance(context);
-        this.names = Names.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
         this.anonymousModelHelper = BLangAnonymousModelHelper.getInstance(context);
     }
@@ -921,7 +919,7 @@ public class TypeParamAnalyzer {
         }
 
         return ImmutableTypeCloner.getImmutableIntersectionType(intersectionType.tsymbol.pos, types,
-                matchingBoundNonReadOnlyType, env, symTable, anonymousModelHelper, names, new HashSet<>());
+                matchingBoundNonReadOnlyType, env, symTable, anonymousModelHelper, new HashSet<>());
     }
 
     private BTupleType getMatchingTupleBoundType(BTupleType expType, SymbolEnv env, HashSet<BType> resolvedTypes) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -143,7 +143,6 @@ public class TypeResolver {
     private static final CompilerContext.Key<TypeResolver> TYPE_RESOLVER_KEY = new CompilerContext.Key<>();
 
     private final SymbolTable symTable;
-    private final Names names;
     private final SymbolResolver symResolver;
     private final SymbolEnter symEnter;
     private final BLangDiagnosticLog dlog;
@@ -175,7 +174,6 @@ public class TypeResolver {
 
         this.symTable = SymbolTable.getInstance(context);
         this.symEnter = SymbolEnter.getInstance(context);
-        this.names = Names.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
         this.types = Types.getInstance(context);
@@ -318,7 +316,7 @@ public class TypeResolver {
             if (field.symbol.type == symTable.semanticError) {
                 continue;
             }
-            objType.fields.put(field.name.value, new BField(names.fromIdNode(field.name), field.pos, field.symbol));
+            objType.fields.put(field.name.value, new BField(Names.fromIdNode(field.name), field.pos, field.symbol));
         }
     }
 
@@ -348,8 +346,8 @@ public class TypeResolver {
     public void defineClassDef(BLangClassDefinition classDefinition, SymbolEnv env) {
         EnumSet<Flag> flags = EnumSet.copyOf(classDefinition.flagSet);
         boolean isPublicType = flags.contains(Flag.PUBLIC);
-        Name className = names.fromIdNode(classDefinition.name);
-        Name classOrigName = names.originalNameFromIdNode(classDefinition.name);
+        Name className = Names.fromIdNode(classDefinition.name);
+        Name classOrigName = Names.originalNameFromIdNode(classDefinition.name);
 
         BClassSymbol tSymbol = Symbols.createClassSymbol(Flags.asMask(flags), className, env.enclPkg.symbol.pkgID, null,
                 env.scope.owner, classDefinition.name.pos,
@@ -887,8 +885,8 @@ public class TypeResolver {
                     }
 
                     BLangSimpleVarRef sizeReference = (BLangSimpleVarRef) size;
-                    Name pkgAlias = names.fromIdNode(sizeReference.pkgAlias);
-                    Name typeName = names.fromIdNode(sizeReference.variableName);
+                    Name pkgAlias = Names.fromIdNode(sizeReference.pkgAlias);
+                    Name typeName = Names.fromIdNode(sizeReference.variableName);
 
                     BSymbol sizeSymbol =
                             symResolver.lookupMainSpaceSymbolInPackage(size.pos, symEnv, pkgAlias, typeName);
@@ -1155,8 +1153,8 @@ public class TypeResolver {
 
         for (BLangVariable paramNode : paramVars) {
             BLangSimpleVariable param = (BLangSimpleVariable) paramNode;
-            Name paramName = names.fromIdNode(param.name);
-            Name paramOrigName = names.originalNameFromIdNode(param.name);
+            Name paramName = Names.fromIdNode(param.name);
+            Name paramOrigName = Names.originalNameFromIdNode(param.name);
             if (paramName != Names.EMPTY) {
                 if (paramNames.contains(paramName.value)) {
                     dlog.error(param.name.pos, DiagnosticErrorCode.REDECLARED_SYMBOL, paramName.value);
@@ -1194,7 +1192,7 @@ public class TypeResolver {
             BLangIdentifier id = ((BLangSimpleVariable) restVariable).name;
             restVariable.setBType(restType);
             restParam = new BVarSymbol(Flags.asMask(restVariable.flagSet),
-                    names.fromIdNode(id), names.originalNameFromIdNode(id),
+                    Names.fromIdNode(id), Names.originalNameFromIdNode(id),
                     env.enclPkg.symbol.pkgID, restType, env.scope.owner, restVariable.pos, BUILTIN);
             restVariable.symbol = restParam;
         }
@@ -1465,7 +1463,7 @@ public class TypeResolver {
 
             BIntersectionType immutableIntersectionType =
                     ImmutableTypeCloner.getImmutableIntersectionType(intersectionType.tsymbol.pos, types,
-                            intersectionType.effectiveType, env, symTable, anonymousModelHelper, names,
+                            intersectionType.effectiveType, env, symTable, anonymousModelHelper,
                             new HashSet<>());
             intersectionType.effectiveType = immutableIntersectionType.effectiveType;
         }
@@ -1485,8 +1483,8 @@ public class TypeResolver {
         // 3) If the symbol is not found, then lookup in the root scope. e.g. for types such as 'error'
         SymbolResolver.AnalyzerData analyzerData = new SymbolResolver.AnalyzerData(symEnv);
 
-        Name pkgAlias = names.fromIdNode(td.pkgAlias);
-        Name typeName = names.fromIdNode(td.typeName);
+        Name pkgAlias = Names.fromIdNode(td.pkgAlias);
+        Name typeName = Names.fromIdNode(td.typeName);
         BSymbol symbol = symTable.notFoundSymbol;
 
         // 1) Resolve ANNOTATION type if and only current scope inside ANNOTATION definition.
@@ -1783,7 +1781,7 @@ public class TypeResolver {
     }
 
     public BType visitBuiltInTypeNode(BLangType typeNode, SymbolResolver.AnalyzerData data, TypeKind typeKind) {
-        Name typeName = names.fromTypeKind(typeKind);
+        Name typeName = Names.fromTypeKind(typeKind);
         BSymbol typeSymbol =
                 symResolver.lookupMemberSymbol(typeNode.pos, symTable.rootScope, data.env, typeName, SymTag.TYPE);
         if (typeSymbol == symTable.notFoundSymbol) {
@@ -1814,7 +1812,7 @@ public class TypeResolver {
 
         typeDefinition.setPrecedence(this.typePrecedence++);
         BSymbol typeDefSymbol = Symbols.createTypeDefinitionSymbol(Flags.asMask(typeDefinition.flagSet),
-                names.fromIdNode(typeDefinition.name), env.enclPkg.packageID, resolvedType, env.scope.owner,
+                Names.fromIdNode(typeDefinition.name), env.enclPkg.packageID, resolvedType, env.scope.owner,
                 typeDefinition.name.pos, symEnter.getOrigin(typeDefinition.name.value));
         typeDefSymbol.markdownDocumentation =
                 symEnter.getMarkdownDocAttachment(typeDefinition.markdownDocumentationAttachment);
@@ -1831,8 +1829,8 @@ public class TypeResolver {
 
         //todo remove after type ref introduced to runtime
         if (resolvedType.tsymbol.name == Names.EMPTY) {
-            resolvedType.tsymbol.name = names.fromIdNode(typeDefinition.name);
-            resolvedType.tsymbol.originalName = names.originalNameFromIdNode(typeDefinition.name);
+            resolvedType.tsymbol.name = Names.fromIdNode(typeDefinition.name);
+            resolvedType.tsymbol.originalName = Names.originalNameFromIdNode(typeDefinition.name);
             resolvedType.tsymbol.flags |= typeDefSymbol.flags;
 
             resolvedType.tsymbol.markdownDocumentation = typeDefSymbol.markdownDocumentation;
@@ -1917,12 +1915,12 @@ public class TypeResolver {
         }
 
         BEnumSymbol enumSymbol = new BEnumSymbol(enumMembers, Flags.asMask(typeDefinition.flagSet),
-                names.fromIdNode(typeDefinition.name), names.fromIdNode(typeDefinition.name),
+                Names.fromIdNode(typeDefinition.name), Names.fromIdNode(typeDefinition.name),
                 env.enclPkg.symbol.pkgID, definedType, env.scope.owner,
                 typeDefinition.pos, SOURCE);
 
-        enumSymbol.name = names.fromIdNode(typeDefinition.name);
-        enumSymbol.originalName = names.fromIdNode(typeDefinition.name);
+        enumSymbol.name = Names.fromIdNode(typeDefinition.name);
+        enumSymbol.originalName = Names.fromIdNode(typeDefinition.name);
         enumSymbol.flags |= Flags.asMask(typeDefinition.flagSet);
 
         enumSymbol.markdownDocumentation =
@@ -1953,8 +1951,8 @@ public class TypeResolver {
     public void resolveXMLNS(SymbolEnv symEnv, BLangXMLNS xmlnsNode) {
         if (xmlnsNode.namespaceURI.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
             BLangSimpleVarRef varRef = (BLangSimpleVarRef) xmlnsNode.namespaceURI;
-            varRef.symbol = getSymbolOfVarRef(varRef.pos, symEnv, names.fromIdNode(varRef.pkgAlias),
-                            names.fromIdNode(varRef.variableName));
+            varRef.symbol = getSymbolOfVarRef(varRef.pos, symEnv, Names.fromIdNode(varRef.pkgAlias),
+                            Names.fromIdNode(varRef.variableName));
         }
         symEnter.defineXMLNS(symEnv, xmlnsNode);
     }
@@ -2045,12 +2043,12 @@ public class TypeResolver {
         }
 
         if (resolvedType.tag == TypeTags.FINITE) {
-            resolvedType.tsymbol.originalName = names.originalNameFromIdNode(constant.name);
+            resolvedType.tsymbol.originalName = Names.originalNameFromIdNode(constant.name);
         }
 
         // Get immutable type for the narrowed type.
         BType intersectionType = ImmutableTypeCloner.getImmutableType(constant.pos, types, resolvedType, symEnv,
-                symEnv.scope.owner.pkgID, symEnv.scope.owner, symTable, anonymousModelHelper, names,
+                symEnv.scope.owner.pkgID, symEnv.scope.owner, symTable, anonymousModelHelper,
                 new HashSet<>());
 
         // Fix the constant expr types due to tooling requirements.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -1156,10 +1156,10 @@ public class TypeResolver {
             Name paramName = Names.fromIdNode(param.name);
             Name paramOrigName = Names.originalNameFromIdNode(param.name);
             if (paramName != Names.EMPTY) {
-                if (paramNames.contains(paramName.value)) {
-                    dlog.error(param.name.pos, DiagnosticErrorCode.REDECLARED_SYMBOL, paramName.value);
+                if (paramNames.contains(paramName.getValue())) {
+                    dlog.error(param.name.pos, DiagnosticErrorCode.REDECLARED_SYMBOL, paramName.getValue());
                 } else {
-                    paramNames.add(paramName.value);
+                    paramNames.add(paramName.getValue());
                 }
             }
             BType type = resolveTypeDesc(env, typeDefinition, depth + 1, param.getTypeNode(), data);
@@ -1880,7 +1880,8 @@ public class TypeResolver {
         }
 
         if (typeDefinition.annAttachments.stream()
-                .anyMatch(attachment -> attachment.annotationName.value.equals(Names.ANNOTATION_TYPE_PARAM.value))) {
+                .anyMatch(attachment ->
+                        attachment.annotationName.value.equals(Names.ANNOTATION_TYPE_PARAM.getValue()))) {
             // TODO : Clean this. Not a nice way to handle this.
             //  TypeParam is built-in annotation, and limited only within lang.* modules.
             if (PackageID.isLangLibPackageID(env.enclPkg.packageID)) {
@@ -1958,9 +1959,9 @@ public class TypeResolver {
     }
 
     public BSymbol getSymbolOfVarRef(Location pos, SymbolEnv env, Name pkgAlias, Name varName) {
-        if (pkgAlias == Names.EMPTY && modTable.containsKey(varName.value)) {
+        if (pkgAlias == Names.EMPTY && modTable.containsKey(varName.getValue())) {
             // modTable contains the available constants in current module.
-            BLangNode node = modTable.get(varName.value);
+            BLangNode node = modTable.get(varName.getValue());
             if (node.getKind() == NodeKind.CONSTANT) {
                 if (!resolvedConstants.contains((BLangConstant) node)) {
                     resolveConstant(env, modTable, (BLangConstant) node);
@@ -2109,7 +2110,7 @@ public class TypeResolver {
 
             if (immutableType.effectiveType.tag == TypeTags.RECORD) {
                 constant.associatedTypeDefinition = findTypeDefinition(symEnv.enclPkg.typeDefinitions,
-                        immutableType.effectiveType.tsymbol.name.value);
+                        immutableType.effectiveType.tsymbol.name.getValue());
             }
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1854,7 +1854,7 @@ public class Types {
         }
 
         for (BField lhsField : lhsType.fields.values()) {
-            BField rhsField = rhsType.fields.get(lhsField.name.value);
+            BField rhsField = rhsType.fields.get(lhsField.name.getValue());
             if (rhsField == null ||
                     !isInSameVisibilityRegion(lhsField.symbol, rhsField.symbol) ||
                     !isAssignable(rhsField.type, lhsField.type, unresolvedTypes)) {
@@ -2136,7 +2136,7 @@ public class Types {
     public BUnionType getVarTypeFromIterableObject(BObjectType collectionType) {
         BObjectTypeSymbol objectTypeSymbol = (BObjectTypeSymbol) collectionType.tsymbol;
         for (BAttachedFunction func : objectTypeSymbol.attachedFuncs) {
-            if (func.funcName.value.equals(BLangCompilerConstants.ITERABLE_COLLECTION_ITERATOR_FUNC)) {
+            if (func.funcName.getValue().equals(BLangCompilerConstants.ITERABLE_COLLECTION_ITERATOR_FUNC)) {
                 return getVarTypeFromIteratorFunc(func);
             }
         }
@@ -2163,7 +2163,7 @@ public class Types {
 
         objectTypeSymbol = (BObjectTypeSymbol) returnType.tsymbol;
         for (BAttachedFunction func : objectTypeSymbol.attachedFuncs) {
-            if (func.funcName.value.equals(BLangCompilerConstants.NEXT_FUNC)) {
+            if (func.funcName.getValue().equals(BLangCompilerConstants.NEXT_FUNC)) {
                 return getVarTypeFromNextFunc(func);
             }
         }
@@ -2260,7 +2260,7 @@ public class Types {
     public BAttachedFunction getAttachedFuncFromObject(BObjectType objectType, String funcName) {
         BObjectTypeSymbol iteratorSymbol = (BObjectTypeSymbol) objectType.tsymbol;
         for (BAttachedFunction bAttachedFunction : iteratorSymbol.attachedFuncs) {
-            if (funcName.equals(bAttachedFunction.funcName.value)) {
+            if (funcName.equals(bAttachedFunction.funcName.getValue())) {
                 return bAttachedFunction;
             }
         }
@@ -2819,8 +2819,8 @@ public class Types {
             }
 
             for (BField sourceField : sFields.values()) {
-                if (tFields.containsKey(sourceField.name.value)) {
-                    BField targetField = tFields.get(sourceField.name.value);
+                if (tFields.containsKey(sourceField.name.getValue())) {
+                    BField targetField = tFields.get(sourceField.name.getValue());
                     if ((!Symbols.isFlagOn(targetField.symbol.flags, Flags.READONLY) ||
                             Symbols.isFlagOn(sourceField.symbol.flags, Flags.READONLY)) &&
                             hasSameOptionalFlag(sourceField.symbol, targetField.symbol) &&
@@ -3492,7 +3492,7 @@ public class Types {
 
         // Check if the RHS record has corresponding fields to those of the LHS record.
         for (BField lhsField : lhsType.fields.values()) {
-            BField rhsField = rhsFields.get(lhsField.name.value);
+            BField rhsField = rhsFields.get(lhsField.name.getValue());
 
             // If LHS field is required, there should be a corresponding RHS field
             // If LHS field is never typed, RHS rest field type should include never type
@@ -3521,7 +3521,7 @@ public class Types {
                 return false;
             }
 
-            rhsFields.remove(lhsField.name.value);
+            rhsFields.remove(lhsField.name.getValue());
         }
 
         if (lhsType.sealed) {
@@ -4716,10 +4716,10 @@ public class Types {
 
         List<Name> matchedFieldNames = new ArrayList<>();
         for (BField lhsField : lhsFields.values()) {
-            if (rhsFields.containsKey(lhsField.name.value)) {
+            if (rhsFields.containsKey(lhsField.name.getValue())) {
                 if (!equalityIntersectionExists(expandAndGetMemberTypesRecursive(lhsField.type),
                                                 expandAndGetMemberTypesRecursive(
-                                                        rhsFields.get(lhsField.name.value).type))) {
+                                                        rhsFields.get(lhsField.name.getValue()).type))) {
                     return false;
                 }
                 matchedFieldNames.add(lhsField.getName());
@@ -5686,7 +5686,7 @@ public class Types {
         LinkedHashMap<String, BField> fields = new LinkedHashMap<>();
         for (BField origField : originalRecordType.fields.values()) {
             org.wso2.ballerinalang.compiler.util.Name origFieldName = origField.name;
-            String nameString = origFieldName.value;
+            String nameString = origFieldName.getValue();
 
             if (!validateRecordFieldDefaultValueForIntersection(diagnosticContext, origField, originalRecordType)) {
                 return false;
@@ -5760,7 +5760,7 @@ public class Types {
     }
 
     private boolean hasField(BRecordType recordType, BField origField) {
-        return recordType.fields.containsKey(origField.name.value);
+        return recordType.fields.containsKey(origField.name.getValue());
     }
 
     private BType validateOverlappingFields(BRecordType newType, BField origField) {
@@ -5768,7 +5768,7 @@ public class Types {
             return origField.type;
         }
 
-        BField overlappingField = newType.fields.get(origField.name.value);
+        BField overlappingField = newType.fields.get(origField.name.getValue());
         if (isAssignable(overlappingField.type, origField.type)) {
             return overlappingField.type;
         }
@@ -6697,7 +6697,7 @@ public class Types {
 
         private boolean checkMethods(List<BAttachedFunction> rhsFuncs) {
             for (BAttachedFunction func : rhsFuncs) {
-                switch (func.funcName.value) {
+                switch (func.funcName.getValue()) {
                     case "attach":
                         if (!checkAttachMethod(func)) {
                             return false;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -167,7 +167,6 @@ public class Types {
     private SymbolTable symTable;
     private SymbolResolver symResolver;
     private BLangDiagnosticLog dlog;
-    private Names names;
     private int finiteTypeCount = 0;
     private BUnionType expandedXMLBuiltinSubtypes;
     private final BLangAnonymousModelHelper anonymousModelHelper;
@@ -200,7 +199,6 @@ public class Types {
         this.symTable = SymbolTable.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
-        this.names = Names.getInstance(context);
         this.expandedXMLBuiltinSubtypes = BUnionType.create(null,
                                                             symTable.xmlElementType, symTable.xmlCommentType,
                                                             symTable.xmlPIType, symTable.xmlTextType);
@@ -5160,7 +5158,7 @@ public class Types {
                 }
 
                 return ImmutableTypeCloner.getEffectiveImmutableType(intersectionContext.pos, this, bType,
-                                                                     env, symTable, anonymousModelHelper, names);
+                                                                     env, symTable, anonymousModelHelper);
             }
         }
 
@@ -5308,7 +5306,7 @@ public class Types {
 
         if (isImmutable(type)) {
             return (BMapType) ImmutableTypeCloner.getEffectiveImmutableType(null, this, mapType, env, symTable,
-                    anonymousModelHelper, names);
+                    anonymousModelHelper);
         }
         return mapType;
     }
@@ -5319,7 +5317,7 @@ public class Types {
 
         if (isImmutable(type)) {
             return (BArrayType) ImmutableTypeCloner.getEffectiveImmutableType(null, this, arrayType, env, symTable,
-                    anonymousModelHelper, names);
+                    anonymousModelHelper);
         }
         return arrayType;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -244,7 +244,7 @@ public class SymbolTable {
 
         this.rootPkgNode = (BLangPackage) TreeBuilder.createPackageNode();
         this.rootPkgSymbol = new BPackageSymbol(PackageID.ANNOTATIONS, null, null, BUILTIN);
-        this.builtinPos = new BLangDiagnosticLocation(Names.EMPTY.value, -1, -1,
+        this.builtinPos = new BLangDiagnosticLocation(Names.EMPTY.getValue(), -1, -1,
                                             -1, -1);
         this.rootPkgNode.pos = this.builtinPos;
         this.rootPkgNode.symbol = this.rootPkgSymbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -223,7 +223,6 @@ public class SymbolTable {
 
     public BPackageSymbol langRegexpModuleSymbol;
 
-    private Names names;
     private Types types;
     public Map<BPackageSymbol, SymbolEnv> pkgEnvMap = new HashMap<>();
     public Map<Name, BPackageSymbol> predeclaredModules = new HashMap<>();
@@ -241,7 +240,6 @@ public class SymbolTable {
     private SymbolTable(CompilerContext context) {
         context.put(SYM_TABLE_KEY, this);
 
-        this.names = Names.getInstance(context);
         this.types = Types.getInstance(context);
 
         this.rootPkgNode = (BLangPackage) TreeBuilder.createPackageNode();
@@ -314,7 +312,7 @@ public class SymbolTable {
         }});
 
         this.anyAndReadonly =
-                ImmutableTypeCloner.getImmutableIntersectionType(this.anyType, this, names, this.types,
+                ImmutableTypeCloner.getImmutableIntersectionType(this.anyType, this, this.types,
                                                                  rootPkgSymbol.pkgID);
         initializeType(this.anyAndReadonly, this.anyAndReadonly.effectiveType.name.getValue(), BUILTIN);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BResourceFunction.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BResourceFunction.java
@@ -59,7 +59,7 @@ public class BResourceFunction extends BAttachedFunction {
             } else if (pathSym.kind == SymbolKind.RESOURCE_PATH_REST_PARAM_SEGMENT) {
                 resourcePathStrings.add("[" + pathSym.type + "...]");
             } else {
-                resourcePathStrings.add(pathSym.name.value);
+                resourcePathStrings.add(pathSym.name.getValue());
             }
         }
         

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BResourcePathSegmentSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BResourcePathSegmentSymbol.java
@@ -43,11 +43,11 @@ public class BResourcePathSegmentSymbol extends BSymbol {
         super(SymTag.RESOURCE_PATH_SEGMENT, 0, name, pkgID, type, owner, location, origin);
         this.parentResource = parentResource;
         this.resourceMethod = resourceMethod;
-        if (name.value.contains("^^")) {
+        if (name.getValue().contains("^^")) {
             this.kind = SymbolKind.RESOURCE_PATH_REST_PARAM_SEGMENT;
-        } else if (name.value.contains("^")) {
+        } else if (name.getValue().contains("^")) {
             this.kind = SymbolKind.RESOURCE_PATH_PARAM_SEGMENT; 
-        } else if (name.value.equals(".")) {
+        } else if (name.getValue().equals(".")) {
             this.kind = SymbolKind.RESOURCE_ROOT_PATH_SEGMENT;
         } else {
             this.kind = SymbolKind.RESOURCE_PATH_IDENTIFIER_SEGMENT;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BTypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BTypeDefinitionSymbol.java
@@ -56,7 +56,7 @@ public class BTypeDefinitionSymbol extends BSymbol implements Annotatable {
         if (this.pkgID == PackageID.DEFAULT ||
                 this.pkgID.equals(PackageID.ANNOTATIONS) ||
                 this.pkgID.name == Names.DEFAULT_PACKAGE) {
-            return this.name.value;
+            return this.name.getValue();
         }
         return this.pkgID.toString() + ":" + this.name;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BTypeSymbol.java
@@ -49,7 +49,7 @@ public class BTypeSymbol extends BSymbol implements TypeSymbol {
         if (this.pkgID == PackageID.DEFAULT ||
                 this.pkgID.equals(PackageID.ANNOTATIONS) ||
                 this.pkgID.name == Names.DEFAULT_PACKAGE) {
-            return this.name.value;
+            return this.name.getValue();
         }
         return this.pkgID.toString() + ":" + this.name;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
@@ -242,7 +242,7 @@ public final class Symbols {
     }
 
     public static String getAttachedFuncSymbolName(String typeName, String funcName) {
-        return typeName + Names.DOT.value + funcName;
+        return typeName + Names.DOT.getValue() + funcName;
     }
 
     public static boolean isNative(BSymbol sym) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BErrorType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BErrorType.java
@@ -64,8 +64,8 @@ public class BErrorType extends BType implements ErrorType {
 
     @Override
     public String toString() {
-        if (tsymbol != null && tsymbol.name != null && !tsymbol.name.value.startsWith(DOLLAR)
-                && !tsymbol.name.value.isEmpty()) {
+        if (tsymbol != null && tsymbol.name != null && !tsymbol.name.getValue().startsWith(DOLLAR)
+                && !tsymbol.name.getValue().isEmpty()) {
             return String.valueOf(tsymbol);
         }
         return ERROR +  detailType + CLOSE_ERROR;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BIntSubType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BIntSubType.java
@@ -62,14 +62,14 @@ public class BIntSubType extends BType {
     @Override
     public String toString() {
 
-        return Names.INT.value + Names.ALIAS_SEPARATOR + name;
+        return Names.INT.getValue() + Names.ALIAS_SEPARATOR + name;
     }
 
     @Override
     public String getQualifiedTypeName() {
 
-        return Names.BALLERINA_ORG.value + Names.ORG_NAME_SEPARATOR.value
-                + Names.LANG.value + Names.DOT.value + Names.INT.value + Names.ALIAS_SEPARATOR + name;
+        return Names.BALLERINA_ORG.getValue() + Names.ORG_NAME_SEPARATOR.getValue()
+                + Names.LANG.getValue() + Names.DOT.getValue() + Names.INT.getValue() + Names.ALIAS_SEPARATOR + name;
     }
 
     public boolean isAnydata() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BIntersectionType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BIntersectionType.java
@@ -98,8 +98,8 @@ public class BIntersectionType extends BType implements IntersectionType {
     @Override
     public String toString() {
         Name name = this.tsymbol.name;
-        if (!Symbols.isFlagOn(this.tsymbol.flags, Flags.ANONYMOUS) && !name.value.isEmpty()) {
-            return name.value;
+        if (!Symbols.isFlagOn(this.tsymbol.flags, Flags.ANONYMOUS) && !name.getValue().isEmpty()) {
+            return name.getValue();
         }
 
         StringJoiner joiner = new StringJoiner(" & ", "(", ")");

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BNeverType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BNeverType.java
@@ -42,7 +42,7 @@ public class BNeverType extends BType {
 
     @Override
     public String toString() {
-        return Names.NEVER.value;
+        return Names.NEVER.getValue();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BNilType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BNilType.java
@@ -42,7 +42,7 @@ public class BNilType extends BType implements NullType {
 
     @Override
     public String toString() {
-        return Names.NIL_VALUE.value;
+        return Names.NIL_VALUE.getValue();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BRegexpType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BRegexpType.java
@@ -56,13 +56,13 @@ public class BRegexpType extends BType {
 
     @Override
     public String toString() {
-        return Names.REGEXP.value + Names.ALIAS_SEPARATOR + name;
+        return Names.REGEXP.getValue() + Names.ALIAS_SEPARATOR + name;
     }
 
     @Override
     public String getQualifiedTypeName() {
-        return Names.BALLERINA_ORG.value + Names.ORG_NAME_SEPARATOR.value
-                + Names.LANG.value + Names.DOT.value + Names.REGEXP.value + Names.ALIAS_SEPARATOR + name;
+        return Names.BALLERINA_ORG.getValue() + Names.ORG_NAME_SEPARATOR.getValue()
+                + Names.LANG.getValue() + Names.DOT.getValue() + Names.REGEXP.getValue() + Names.ALIAS_SEPARATOR + name;
     }
 
     public boolean isAnydata() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStringSubType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStringSubType.java
@@ -62,14 +62,14 @@ public class BStringSubType extends BType {
     @Override
     public String toString() {
 
-        return Names.STRING.value + Names.ALIAS_SEPARATOR + name;
+        return Names.STRING.getValue() + Names.ALIAS_SEPARATOR + name;
     }
 
     @Override
     public String getQualifiedTypeName() {
 
-        return Names.BALLERINA_ORG.value + Names.ORG_NAME_SEPARATOR.value
-                + Names.LANG.value + Names.DOT.value + Names.STRING.value + Names.ALIAS_SEPARATOR + name;
+        return Names.BALLERINA_ORG.getValue() + Names.ORG_NAME_SEPARATOR.getValue()
+                + Names.LANG.getValue() + Names.DOT.getValue() + Names.STRING.getValue() + Names.ALIAS_SEPARATOR + name;
     }
 
     public boolean isAnydata() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStructureType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStructureType.java
@@ -67,7 +67,7 @@ public abstract class BStructureType extends BType {
             return false;
         }
 
-        String value = name.value;
+        String value = name.getValue();
 
         if (value.isEmpty() || value.startsWith(DOLLAR)) {
             return true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
@@ -496,7 +496,7 @@ public class BUnionType extends BType implements UnionType {
 
         String typeStr = numberOfNotNilTypes > 1 ? "(" + joiner + ")" : joiner.toString();
         boolean hasNilType = uniqueTypes.size() > numberOfNotNilTypes;
-        cachedToString = (nullable && hasNilType && !hasNilableMember) ? (typeStr + Names.QUESTION_MARK.value) :
+        cachedToString = (nullable && hasNilType && !hasNilableMember) ? (typeStr + Names.QUESTION_MARK.getValue()) :
                 typeStr;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BXMLSubType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BXMLSubType.java
@@ -66,14 +66,14 @@ public class BXMLSubType extends BType implements SelectivelyImmutableReferenceT
     @Override
     public String toString() {
 
-        return Names.XML.value + Names.ALIAS_SEPARATOR + name;
+        return Names.XML.getValue() + Names.ALIAS_SEPARATOR + name;
     }
 
     @Override
     public String getQualifiedTypeName() {
 
-        return Names.BALLERINA_ORG.value + Names.ORG_NAME_SEPARATOR.value
-                + Names.LANG.value + Names.DOT.value + Names.XML.value + Names.ALIAS_SEPARATOR + name;
+        return Names.BALLERINA_ORG.getValue() + Names.ORG_NAME_SEPARATOR.getValue()
+                + Names.LANG.getValue() + Names.DOT.getValue() + Names.XML.getValue() + Names.ALIAS_SEPARATOR + name;
     }
 
     public boolean isAnydata() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BXMLType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BXMLType.java
@@ -49,9 +49,9 @@ public class BXMLType extends BBuiltInRefType implements SelectivelyImmutableRef
         if (constraint != null && !(constraint.tag == TypeTags.UNION &&
                 constraint instanceof BUnionType &&
                 ((BUnionType) constraint).getMemberTypes().size() == 4)) {
-            stringRep = Names.XML.value + "<" + constraint + ">";
+            stringRep = Names.XML.getValue() + "<" + constraint + ">";
         } else {
-            stringRep = Names.XML.value;
+            stringRep = Names.XML.getValue();
         }
 
         return !Symbols.isFlagOn(flags, Flags.READONLY) ? stringRep : stringRep.concat(" & readonly");

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangSimpleVariable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangSimpleVariable.java
@@ -78,7 +78,7 @@ public class BLangSimpleVariable extends BLangVariable implements SimpleVariable
     public String toString() {
         String varName = "_";
         if (symbol != null && symbol.name != null) {
-            varName = symbol.name.value;
+            varName = symbol.name.getValue();
         }
         return String.valueOf(getBType()) + " " + varName + (expr != null ? " = " + String.valueOf(expr) : "");
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangConstant.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangConstant.java
@@ -127,8 +127,8 @@ public class BLangConstant extends BLangVariable implements ConstantNode, TypeDe
 
     @Override
     public String toString() {
-        return (typeNode == null ? String.valueOf(getBType()) : String.valueOf(typeNode)) + " " + symbol.name.value +
-                " = " + String.valueOf(expr);
+        return (typeNode == null ? String.valueOf(getBType()) : String.valueOf(typeNode)) + " " +
+                symbol.name.getValue() + " = " + String.valueOf(expr);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangSimpleVarRef.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangSimpleVarRef.java
@@ -111,7 +111,7 @@ public class BLangSimpleVarRef extends BLangVariableReference implements SimpleV
 
         @Override
         public String toString() {
-            return this.symbol.name.value;
+            return this.symbol.name.getValue();
         }
     }
 
@@ -220,7 +220,7 @@ public class BLangSimpleVarRef extends BLangVariableReference implements SimpleV
 
         @Override
         public String toString() {
-            return this.symbol.name.value;
+            return this.symbol.name.getValue();
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangLock.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangLock.java
@@ -123,7 +123,7 @@ public class BLangLock extends BLangStatement implements LockNode {
 
         @Override
         public String toString() {
-            return "lock [" + lockVariables.stream().map(s -> s.name.value).collect(Collectors.joining(", "));
+            return "lock [" + lockVariables.stream().map(s -> s.name.getValue()).collect(Collectors.joining(", "));
         }
 
         public boolean addLockVariable(BVarSymbol variable) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/CompilerUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/CompilerUtils.java
@@ -72,16 +72,17 @@ public final class CompilerUtils {
 
     public static String getPackageIDStringWithMajorVersion(PackageID packageID) {
         if (Names.DOT.equals(packageID.name)) {
-            return packageID.name.value;
+            return packageID.name.getValue();
         }
         String org = "";
         if (packageID.orgName != null && !packageID.orgName.equals(Names.ANON_ORG)) {
-            org = packageID.orgName + Names.ORG_NAME_SEPARATOR.value;
+            org = packageID.orgName + Names.ORG_NAME_SEPARATOR.getValue();
         }
         if (packageID.version.equals(Names.EMPTY)) {
-            return org + packageID.name.value;
+            return org + packageID.name.getValue();
         }
-        return org + packageID.name + Names.VERSION_SEPARATOR.value + getMajorVersion(packageID.version.value);
+        return org + packageID.name + Names.VERSION_SEPARATOR.getValue() +
+                getMajorVersion(packageID.version.getValue());
     }
 
     public static boolean isInParameterList(BSymbol symbol, List<BLangSimpleVariable> params) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
@@ -145,7 +145,7 @@ public final class ImmutableTypeCloner {
 
         while (objectTypeFieldIterator.hasNext()) {
             BField typeField = objectTypeFieldIterator.next();
-            BLangSimpleVariable classField = classFields.get(typeField.name.value);
+            BLangSimpleVariable classField = classFields.get(typeField.name.getValue());
 
             BType type = typeField.type;
 
@@ -429,7 +429,7 @@ public final class ImmutableTypeCloner {
         String originalTypeName = origTupleTypeSymbol == null ? "" : origTupleTypeSymbol.name.getValue();
         Name origTupleTypeSymbolName = Names.EMPTY;
         if (!originalTypeName.isEmpty()) {
-            origTupleTypeSymbolName = origTupleTypeSymbol.name.value.isEmpty() ? Names.EMPTY :
+            origTupleTypeSymbolName = origTupleTypeSymbol.name.getValue().isEmpty() ? Names.EMPTY :
                     getImmutableTypeName(getSymbolFQN(origTupleTypeSymbol));
             tupleEffectiveImmutableType.name = origTupleTypeSymbolName;
         }
@@ -473,7 +473,7 @@ public final class ImmutableTypeCloner {
         BType effectiveType = immutableTupleIntersectionType.effectiveType;
         BTypeSymbol tsymbol = immutableTupleIntersectionType.effectiveType.tsymbol;
         if (Types.getImpliedType(effectiveType).tag != TypeTags.TUPLE || tsymbol == null || tsymbol.name == null ||
-                tsymbol.name.value.isEmpty()) {
+                tsymbol.name.getValue().isEmpty()) {
             return immutableTupleIntersectionType;
         }
 
@@ -678,8 +678,8 @@ public final class ImmutableTypeCloner {
 
         List<BAttachedFunction> immutableFuncs = new ArrayList<>();
         for (BAttachedFunction origFunc : originalObjectAttachedFuncs) {
-            Name funcName = Names.fromString(Symbols.getAttachedFuncSymbolName(immutableObjectSymbol.name.value,
-                                                                               origFunc.funcName.value));
+            Name funcName = Names.fromString(Symbols.getAttachedFuncSymbolName(immutableObjectSymbol.name.getValue(),
+                    origFunc.funcName.getValue()));
             BInvokableSymbol immutableFuncSymbol =
                     ASTBuilderUtil.duplicateFunctionDeclarationSymbol(origFunc.symbol, immutableObjectSymbol,
                                                                       funcName, immutableObjectSymbol.pkgID,
@@ -716,7 +716,7 @@ public final class ImmutableTypeCloner {
         BType effectiveType = immutableType.effectiveType;
         BTypeSymbol tsymbol = effectiveType.tsymbol;
         if (effectiveType.tag != TypeTags.UNION || tsymbol == null || tsymbol.name == null ||
-                tsymbol.name.value.isEmpty()) {
+                tsymbol.name.getValue().isEmpty()) {
             return immutableType;
         }
 
@@ -825,7 +825,7 @@ public final class ImmutableTypeCloner {
         } else if (origUnionTypeSymbol != null) {
             BTypeSymbol immutableUnionTSymbol =
                     getReadonlyTSymbol(origUnionTypeSymbol, env, pkgId, owner,
-                                       origUnionTypeSymbol.name.value.isEmpty() ? Names.EMPTY :
+                                       origUnionTypeSymbol.name.getValue().isEmpty() ? Names.EMPTY :
                                                getImmutableTypeName(getSymbolFQN(origUnionTypeSymbol)));
             immutableType.effectiveType.tsymbol = immutableUnionTSymbol;
             immutableType.effectiveType.flags |= (type.flags | Flags.READONLY);
@@ -870,10 +870,10 @@ public final class ImmutableTypeCloner {
         if (pkgID == PackageID.DEFAULT ||
                 pkgID.equals(PackageID.ANNOTATIONS) ||
                 pkgID.name == Names.DEFAULT_PACKAGE) {
-            return originalTSymbol.name.value;
+            return originalTSymbol.name.getValue();
         }
-        return pkgID.orgName + Names.ORG_NAME_SEPARATOR.value + pkgID.name + Names.VERSION_SEPARATOR +
-                getMajorVersion(pkgID.version.value) + ":" + originalTSymbol.name;
+        return pkgID.orgName + Names.ORG_NAME_SEPARATOR.getValue() + pkgID.name + Names.VERSION_SEPARATOR +
+                getMajorVersion(pkgID.version.getValue()) + ":" + originalTSymbol.name;
     }
 
     private static Name getImmutableTypeName(BTypeSymbol originalTSymbol) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
@@ -95,19 +95,19 @@ public final class ImmutableTypeCloner {
 
     public static BType getEffectiveImmutableType(Location pos, Types types,
                                                   BType type, SymbolEnv env,
-                                                  SymbolTable symTable, BLangAnonymousModelHelper anonymousModelHelper,
-                                                  Names names) {
+                                                  SymbolTable symTable, BLangAnonymousModelHelper anonymousModelHelper
+                                                  ) {
         return getImmutableIntersectionType(pos, types, type, env, env.enclPkg.packageID, env.scope.owner,
-                                            symTable, anonymousModelHelper, names, new HashSet<>(),
+                                            symTable, anonymousModelHelper, new HashSet<>(),
                                             new HashSet<>()).effectiveType;
     }
 
     public static BType getEffectiveImmutableType(Location pos, Types types,
                                                   BType type, PackageID pkgId,
                                                   BSymbol owner, SymbolTable symTable,
-                                                  BLangAnonymousModelHelper anonymousModelHelper, Names names) {
+                                                  BLangAnonymousModelHelper anonymousModelHelper) {
         return getImmutableIntersectionType(pos, types, type, null, pkgId, owner,
-                                            symTable, anonymousModelHelper, names, new HashSet<>(),
+                                            symTable, anonymousModelHelper, new HashSet<>(),
                                             new HashSet<>()).effectiveType;
     }
 
@@ -115,20 +115,20 @@ public final class ImmutableTypeCloner {
                                                                  BType type,
                                                                  SymbolEnv env, SymbolTable symTable,
                                                                  BLangAnonymousModelHelper anonymousModelHelper,
-                                                                 Names names, Set<Flag> origObjFlagSet) {
+                                                                 Set<Flag> origObjFlagSet) {
         return getImmutableIntersectionType(pos, types, type, env, env.enclPkg.packageID, env.scope.owner,
-                                            symTable, anonymousModelHelper, names, origObjFlagSet, new HashSet<>());
+                                            symTable, anonymousModelHelper, origObjFlagSet, new HashSet<>());
     }
 
-    public static BIntersectionType getImmutableIntersectionType(BType type, SymbolTable symbolTable, Names names,
+    public static BIntersectionType getImmutableIntersectionType(BType type, SymbolTable symbolTable,
                                                                  Types types, PackageID pkgId) {
         return getImmutableIntersectionType(null, types, type, null, pkgId, null, symbolTable,
-                null, names, null, new HashSet<>());
+                null, null, new HashSet<>());
     }
 
     public static void markFieldsAsImmutable(BLangClassDefinition classDef, SymbolEnv pkgEnv, BObjectType objectType,
                                              Types types, BLangAnonymousModelHelper anonymousModelHelper,
-                                             SymbolTable symbolTable, Names names, Location pos) {
+                                             SymbolTable symbolTable, Location pos) {
         SymbolEnv typeDefEnv = SymbolEnv.createClassEnv(classDef, objectType.tsymbol.scope, pkgEnv);
 
         Iterator<BField> objectTypeFieldIterator = objectType.fields.values().iterator();
@@ -151,7 +151,7 @@ public final class ImmutableTypeCloner {
 
             if (!types.isInherentlyImmutableType(type)) {
                 BType immutableFieldType = typeField.symbol.type = ImmutableTypeCloner.getImmutableIntersectionType(
-                        pos, types, type, typeDefEnv, symbolTable, anonymousModelHelper, names, classDef.flagSet);
+                        pos, types, type, typeDefEnv, symbolTable, anonymousModelHelper, classDef.flagSet);
                 classField.setBType(typeField.type = immutableFieldType);
             }
 
@@ -163,7 +163,7 @@ public final class ImmutableTypeCloner {
     public static BType getImmutableType(Location pos, Types types, BType type, SymbolEnv env,
                                           PackageID pkgId,
                                           BSymbol owner, SymbolTable symTable,
-                                          BLangAnonymousModelHelper anonymousModelHelper, Names names,
+                                          BLangAnonymousModelHelper anonymousModelHelper,
                                           Set<BType> unresolvedTypes) {
         if (type == null) {
             return symTable.semanticError;
@@ -178,7 +178,7 @@ public final class ImmutableTypeCloner {
         }
 
         return getImmutableIntersectionType(pos, types, type, env, pkgId,
-                                            owner, symTable, anonymousModelHelper, names, new HashSet<>(),
+                                            owner, symTable, anonymousModelHelper, new HashSet<>(),
                                             unresolvedTypes);
     }
 
@@ -187,7 +187,6 @@ public final class ImmutableTypeCloner {
                                                                   SymbolEnv env, PackageID pkgId,
                                                                   BSymbol owner, SymbolTable symTable,
                                                                   BLangAnonymousModelHelper anonymousModelHelper,
-                                                                  Names names,
                                                                   Set<Flag> origObjFlagSet,
                                                                   Set<BType> unresolvedTypes) {
         BType refType = Types.getReferredType(bType);
@@ -202,7 +201,7 @@ public final class ImmutableTypeCloner {
         }
 
         return ImmutableTypeCloner.setImmutableType(pos, types, type, bType, env, pkgId, owner, symTable,
-                                                    anonymousModelHelper, names, origObjFlagSet, unresolvedTypes);
+                                                    anonymousModelHelper, origObjFlagSet, unresolvedTypes);
     }
 
     private static BIntersectionType setImmutableType(Location pos, Types types,
@@ -211,7 +210,6 @@ public final class ImmutableTypeCloner {
                                                       SymbolEnv env, PackageID pkgId, BSymbol owner,
                                                       SymbolTable symTable,
                                                       BLangAnonymousModelHelper anonymousModelHelper,
-                                                      Names names,
                                                       Set<Flag> origObjFlagSet, Set<BType> unresolvedTypes) {
         BType type = (BType) selectivelyImmutableRefType;
         switch (type.tag) {
@@ -231,33 +229,33 @@ public final class ImmutableTypeCloner {
                 Types.addImmutableType(symTable, pkgId, origXmlSubType, immutableXmlSubTypeIntersectionType);
                 return immutableXmlSubTypeIntersectionType;
             case TypeTags.XML:
-                return defineImmutableXMLType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper, names,
+                return defineImmutableXMLType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper,
                         unresolvedTypes, (BXMLType) type, originalType);
             case TypeTags.ARRAY:
             case TypeTags.BYTE_ARRAY:
-                return defineImmutableArrayType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper, names,
+                return defineImmutableArrayType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper,
                         unresolvedTypes, (BArrayType) type, originalType);
             case TypeTags.TUPLE:
-                return defineImmutableTupleType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper, names,
+                return defineImmutableTupleType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper,
                         unresolvedTypes, (BTupleType) type, originalType);
             case TypeTags.MAP:
-                return defineImmutableMapType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper, names,
+                return defineImmutableMapType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper,
                         unresolvedTypes, (BMapType) type, originalType);
             case TypeTags.RECORD:
                 BRecordType origRecordType = (BRecordType) type;
                 return defineImmutableRecordType(pos, origRecordType, originalType, env, symTable,
-                        anonymousModelHelper, names, types, unresolvedTypes);
+                        anonymousModelHelper, types, unresolvedTypes);
             case TypeTags.OBJECT:
                 BObjectType origObjectType = (BObjectType) type;
                 return defineImmutableObjectType(pos, origObjectType, originalType, env, symTable,
-                        anonymousModelHelper, names, types, origObjFlagSet, unresolvedTypes);
+                        anonymousModelHelper, types, origObjFlagSet, unresolvedTypes);
             case TypeTags.TABLE:
-                return defineImmutableTableType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper, names,
+                return defineImmutableTableType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper,
                         unresolvedTypes, (BTableType) type, originalType);
             case TypeTags.ANY:
                 BAnyType origAnyType = (BAnyType) type;
 
-                BTypeSymbol immutableAnyTSymbol = getReadonlyTSymbol(names, origAnyType.tsymbol, env, pkgId, owner);
+                BTypeSymbol immutableAnyTSymbol = getReadonlyTSymbol(origAnyType.tsymbol, env, pkgId, owner);
 
                 BAnyType immutableAnyType;
                 if (immutableAnyTSymbol != null) {
@@ -266,7 +264,7 @@ public final class ImmutableTypeCloner {
                     immutableAnyTSymbol.type = immutableAnyType;
                 } else {
                     immutableAnyType = new BAnyType(origAnyType.tag, immutableAnyTSymbol,
-                                                    getImmutableTypeName(names, TypeKind.ANY.typeName()),
+                                                    getImmutableTypeName(TypeKind.ANY.typeName()),
                                                     origAnyType.flags | Flags.READONLY, origAnyType.isNullable());
                 }
 
@@ -279,11 +277,11 @@ public final class ImmutableTypeCloner {
             case TypeTags.ANYDATA:
             case TypeTags.JSON:
                 return defineImmutableBuiltInUnionType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper,
-                                                       names, unresolvedTypes, (BUnionType) type, originalType);
+                                                       unresolvedTypes, (BUnionType) type, originalType);
             case TypeTags.INTERSECTION:
                 return (BIntersectionType) type;
             default:
-                return defineImmutableUnionType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper, names,
+                return defineImmutableUnionType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper,
                                                 unresolvedTypes, (BUnionType) type, originalType);
         }
     }
@@ -291,10 +289,10 @@ public final class ImmutableTypeCloner {
     private static BIntersectionType defineImmutableTableType(Location pos, Types types, SymbolEnv env,
                                                               PackageID pkgId, BSymbol owner, SymbolTable symTable,
                                                               BLangAnonymousModelHelper anonymousModelHelper,
-                                                              Names names, Set<BType> unresolvedTypes,
+                                                              Set<BType> unresolvedTypes,
                                                               BTableType type,
                                                               BType originalType) {
-        BTypeSymbol immutableTableTSymbol = getReadonlyTSymbol(names, type.tsymbol, env, pkgId, owner);
+        BTypeSymbol immutableTableTSymbol = getReadonlyTSymbol(type.tsymbol, env, pkgId, owner);
         Optional<BIntersectionType> immutableType = Types.getImmutableType(symTable, pkgId, type);
         if (immutableType.isPresent()) {
             return immutableType.get();
@@ -307,13 +305,13 @@ public final class ImmutableTypeCloner {
         BIntersectionType immutableTableType = Types.getImmutableType(symTable, pkgId, type).orElseThrow();
         BTableType tableEffectiveImmutableType = (BTableType) immutableTableType.effectiveType;
         tableEffectiveImmutableType.constraint = getImmutableType(pos, types, type.constraint, env, pkgId, owner,
-                symTable, anonymousModelHelper, names, unresolvedTypes);
+                symTable, anonymousModelHelper, unresolvedTypes);
 
         BType origKeyTypeConstraint = type.keyTypeConstraint;
         if (origKeyTypeConstraint != null) {
             tableEffectiveImmutableType.keyTypeConstraint = getImmutableType(pos, types, origKeyTypeConstraint, env,
                     pkgId, owner, symTable,
-                    anonymousModelHelper, names,
+                    anonymousModelHelper,
                     unresolvedTypes);
         }
 
@@ -333,10 +331,10 @@ public final class ImmutableTypeCloner {
     private static BIntersectionType defineImmutableXMLType(Location pos, Types types, SymbolEnv env,
                                                             PackageID pkgId, BSymbol owner, SymbolTable symTable,
                                                             BLangAnonymousModelHelper anonymousModelHelper,
-                                                            Names names, Set<BType> unresolvedTypes,
+                                                            Set<BType> unresolvedTypes,
                                                             BXMLType type,
                                                             BType originalType) {
-        BTypeSymbol immutableXmlTSymbol = getReadonlyTSymbol(names, type.tsymbol, env, pkgId, owner);
+        BTypeSymbol immutableXmlTSymbol = getReadonlyTSymbol(type.tsymbol, env, pkgId, owner);
         Optional<BIntersectionType> immutableType = Types.getImmutableType(symTable, pkgId, type);
         if (immutableType.isPresent()) {
             return immutableType.get();
@@ -350,17 +348,17 @@ public final class ImmutableTypeCloner {
         BXMLType xmlEffectiveImmutableType = (BXMLType) immutableXMLType.effectiveType;
         xmlEffectiveImmutableType.mutableType = type;
         xmlEffectiveImmutableType.constraint = getImmutableType(pos, types, type.constraint, env, pkgId, owner,
-                symTable, anonymousModelHelper, names, unresolvedTypes);
+                symTable, anonymousModelHelper, unresolvedTypes);
         return immutableXMLType;
     }
 
     private static BIntersectionType defineImmutableArrayType(Location pos, Types types, SymbolEnv env,
                                                               PackageID pkgId, BSymbol owner, SymbolTable symTable,
                                                               BLangAnonymousModelHelper anonymousModelHelper,
-                                                              Names names, Set<BType> unresolvedTypes,
+                                                              Set<BType> unresolvedTypes,
                                                               BArrayType type,
                                                               BType originalType) {
-        BTypeSymbol immutableArrayTSymbol = getReadonlyTSymbol(names, type.tsymbol, env, pkgId, owner);
+        BTypeSymbol immutableArrayTSymbol = getReadonlyTSymbol(type.tsymbol, env, pkgId, owner);
         Optional<BIntersectionType> immutableType = Types.getImmutableType(symTable, pkgId, type);
         if (immutableType.isPresent()) {
             return immutableType.get();
@@ -374,17 +372,17 @@ public final class ImmutableTypeCloner {
         BArrayType arrayEffectiveImmutableType = (BArrayType) immutableArrayType.effectiveType;
         arrayEffectiveImmutableType.mutableType = type;
         arrayEffectiveImmutableType.eType = getImmutableType(pos, types, type.eType, env, pkgId, owner,
-                symTable, anonymousModelHelper, names, unresolvedTypes);
+                symTable, anonymousModelHelper, unresolvedTypes);
         return immutableArrayType;
     }
 
     private static BIntersectionType defineImmutableMapType(Location pos, Types types, SymbolEnv env,
                                                             PackageID pkgId, BSymbol owner, SymbolTable symTable,
                                                             BLangAnonymousModelHelper anonymousModelHelper,
-                                                            Names names, Set<BType> unresolvedTypes,
+                                                            Set<BType> unresolvedTypes,
                                                             BMapType type,
                                                             BType originalType) {
-        BTypeSymbol immutableMapTSymbol = getReadonlyTSymbol(names, type.tsymbol, env, pkgId, owner);
+        BTypeSymbol immutableMapTSymbol = getReadonlyTSymbol(type.tsymbol, env, pkgId, owner);
         Optional<BIntersectionType> immutableType = Types.getImmutableType(symTable, pkgId, type);
         if (immutableType.isPresent()) {
             return immutableType.get();
@@ -399,7 +397,7 @@ public final class ImmutableTypeCloner {
         BMapType mapEffectiveImmutableType = (BMapType) immutableMapType.effectiveType;
         mapEffectiveImmutableType.mutableType = type;
         mapEffectiveImmutableType.constraint = getImmutableType(pos, types, type.constraint, env, pkgId, owner,
-                                                                 symTable, anonymousModelHelper, names,
+                                                                 symTable, anonymousModelHelper,
                                                                  unresolvedTypes);
         return immutableMapType;
     }
@@ -407,7 +405,7 @@ public final class ImmutableTypeCloner {
     private static BIntersectionType defineImmutableTupleType(Location pos, Types types, SymbolEnv env,
                                                               PackageID pkgId, BSymbol owner, SymbolTable symTable,
                                                               BLangAnonymousModelHelper anonymousModelHelper,
-                                                              Names names, Set<BType> unresolvedTypes,
+                                                              Set<BType> unresolvedTypes,
                                                               BTupleType type,
                                                               BType originalType) {
         BTypeSymbol origTupleTypeSymbol = type.tsymbol;
@@ -432,7 +430,7 @@ public final class ImmutableTypeCloner {
         Name origTupleTypeSymbolName = Names.EMPTY;
         if (!originalTypeName.isEmpty()) {
             origTupleTypeSymbolName = origTupleTypeSymbol.name.value.isEmpty() ? Names.EMPTY :
-                    getImmutableTypeName(names, getSymbolFQN(origTupleTypeSymbol));
+                    getImmutableTypeName(getSymbolFQN(origTupleTypeSymbol));
             tupleEffectiveImmutableType.name = origTupleTypeSymbolName;
         }
 
@@ -445,7 +443,7 @@ public final class ImmutableTypeCloner {
                 continue;
             }
             BType newType = getImmutableType(pos, types, origTupleMemType.type, env,
-                    pkgId, owner, symTable, anonymousModelHelper, names, unresolvedTypes);
+                    pkgId, owner, symTable, anonymousModelHelper, unresolvedTypes);
             BVarSymbol varSymbol = Symbols.createVarSymbolForTupleMember(newType);
             BTupleMember member = new BTupleMember(newType, varSymbol);
             tupleEffectiveImmutableType.addMembers(member);
@@ -453,7 +451,7 @@ public final class ImmutableTypeCloner {
 
         if (type.restType != null) {
             tupleEffectiveImmutableType.addRestType(getImmutableType(pos, types, type.restType, env, pkgId,
-                    owner, symTable, anonymousModelHelper, names, unresolvedTypes));
+                    owner, symTable, anonymousModelHelper, unresolvedTypes));
         }
 
         BIntersectionType immutableTupleIntersectionType = Types.getImmutableType(symTable, pkgId, type).get();
@@ -490,8 +488,7 @@ public final class ImmutableTypeCloner {
 
     public static void defineUndefinedImmutableFields(BLangTypeDefinition immutableTypeDefinition,
                                                       Types types, SymbolEnv pkgEnv, SymbolTable symTable,
-                                                      BLangAnonymousModelHelper anonymousModelHelper,
-                                                      Names names) {
+                                                      BLangAnonymousModelHelper anonymousModelHelper) {
         Location pos = immutableTypeDefinition.pos;
         SymbolEnv env = SymbolEnv.createTypeEnv(immutableTypeDefinition.typeNode, immutableTypeDefinition.symbol.scope,
                                                 pkgEnv);
@@ -500,11 +497,11 @@ public final class ImmutableTypeCloner {
         BType immutableType = Types.getImpliedType(immutableTypeDefinition.getBType());
         if (immutableType.tag == TypeTags.RECORD) {
             defineUndefinedImmutableRecordFields((BRecordType) immutableType, pos, pkgID, immutableTypeDefinition,
-                                                 types, env, symTable, anonymousModelHelper, names);
+                                                 types, env, symTable, anonymousModelHelper);
             return;
         }
         defineUndefinedImmutableObjectFields((BObjectType) immutableType, pos, pkgID, immutableTypeDefinition,
-                                             types, env, symTable, anonymousModelHelper, names);
+                                             types, env, symTable, anonymousModelHelper);
     }
 
     private static void defineUndefinedImmutableRecordFields(BRecordType immutableRecordType,
@@ -512,12 +509,11 @@ public final class ImmutableTypeCloner {
                                                              PackageID pkgID,
                                                              BLangTypeDefinition immutableTypeDefinition,
                                                              Types types, SymbolEnv env, SymbolTable symTable,
-                                                             BLangAnonymousModelHelper anonymousModelHelper,
-                                                             Names names) {
+                                                             BLangAnonymousModelHelper anonymousModelHelper) {
         BRecordType origRecordType = immutableRecordType.mutableType;
         if (origRecordType != null && (origRecordType.fields.size() != immutableRecordType.fields.size())) {
 
-            populateImmutableStructureFields(types, symTable, anonymousModelHelper, names,
+            populateImmutableStructureFields(types, symTable, anonymousModelHelper,
                                              (BLangRecordTypeNode) immutableTypeDefinition.typeNode,
                                              immutableRecordType, origRecordType, loc, env, pkgID, new HashSet<>());
         }
@@ -527,7 +523,7 @@ public final class ImmutableTypeCloner {
             return;
         }
 
-        setRestType(types, symTable, anonymousModelHelper, names, immutableRecordType, origRecordType, loc, env,
+        setRestType(types, symTable, anonymousModelHelper, immutableRecordType, origRecordType, loc, env,
                     new HashSet<>());
     }
 
@@ -536,30 +532,29 @@ public final class ImmutableTypeCloner {
                                                              PackageID pkgID,
                                                              BLangTypeDefinition immutableTypeDefinition,
                                                              Types types, SymbolEnv env, SymbolTable symTable,
-                                                             BLangAnonymousModelHelper anonymousModelHelper,
-                                                             Names names) {
+                                                             BLangAnonymousModelHelper anonymousModelHelper) {
         BObjectType origObjectType = immutableObjectType.mutableType;
         if (origObjectType.fields.size() != immutableObjectType.fields.size()) {
 
-            TypeDefBuilderHelper.populateStructureFieldsAndTypeInclusions(types, symTable, anonymousModelHelper, names,
+            TypeDefBuilderHelper.populateStructureFieldsAndTypeInclusions(types, symTable, anonymousModelHelper,
                     (BLangObjectTypeNode) immutableTypeDefinition.typeNode, immutableObjectType, origObjectType,
                     location, env, pkgID, new HashSet<>(), Flags.FINAL, true);
         }
     }
 
     private static void populateImmutableStructureFields(Types types, SymbolTable symTable,
-                                                         BLangAnonymousModelHelper anonymousModelHelper, Names names,
+                                                         BLangAnonymousModelHelper anonymousModelHelper,
                                                          BLangStructureTypeNode immutableStructureTypeNode,
                                                          BStructureType immutableStructureType,
                                                          BStructureType origStructureType, Location pos,
                                                          SymbolEnv env, PackageID pkgID, Set<BType> unresolvedTypes) {
-        TypeDefBuilderHelper.populateStructureFieldsAndTypeInclusions(types, symTable, anonymousModelHelper, names,
+        TypeDefBuilderHelper.populateStructureFieldsAndTypeInclusions(types, symTable, anonymousModelHelper,
                 immutableStructureTypeNode, immutableStructureType, origStructureType, pos, env, pkgID, unresolvedTypes,
                 Flags.READONLY, true);
     }
 
     private static void setRestType(Types types, SymbolTable symTable, BLangAnonymousModelHelper anonymousModelHelper,
-                                    Names names, BRecordType immutableRecordType, BRecordType origRecordType,
+                                    BRecordType immutableRecordType, BRecordType origRecordType,
                                     Location pos, SymbolEnv env, Set<BType> unresolvedTypes) {
         immutableRecordType.sealed = origRecordType.sealed;
 
@@ -570,7 +565,7 @@ public final class ImmutableTypeCloner {
             return;
         }
         BType restFieldImmutableType = getImmutableType(pos, types, origRestFieldType, env, env.enclPkg.packageID,
-                                                        env.scope.owner, symTable, anonymousModelHelper, names,
+                                                        env.scope.owner, symTable, anonymousModelHelper,
                                                         unresolvedTypes);
         immutableRecordType.restFieldType = restFieldImmutableType == symTable.semanticError ?
                 symTable.neverType : restFieldImmutableType;
@@ -580,12 +575,12 @@ public final class ImmutableTypeCloner {
                                                                BType originalType,
                                                                SymbolEnv env, SymbolTable symTable,
                                                                BLangAnonymousModelHelper anonymousModelHelper,
-                                                               Names names, Types types, Set<BType> unresolvedTypes) {
+                                                               Types types, Set<BType> unresolvedTypes) {
         PackageID pkgID = env.enclPkg.symbol.pkgID;
         BTypeSymbol recordTypeSymbol = origRecordType.tsymbol;
         BRecordTypeSymbol recordSymbol =
                 Symbols.createRecordSymbol(recordTypeSymbol.flags | Flags.READONLY,
-                        getImmutableTypeName(names,  getSymbolFQN(recordTypeSymbol)),
+                        getImmutableTypeName(getSymbolFQN(recordTypeSymbol)),
                         pkgID, null, env.scope.owner, pos, VIRTUAL);
 
         BInvokableType bInvokableType = new BInvokableType(new ArrayList<>(), symTable.nilType, null);
@@ -611,10 +606,10 @@ public final class ImmutableTypeCloner {
         BLangRecordTypeNode recordTypeNode = TypeDefBuilderHelper.createRecordTypeNode(new ArrayList<>(),
                                                                                        immutableRecordType, pos);
 
-        populateImmutableStructureFields(types, symTable, anonymousModelHelper, names, recordTypeNode,
+        populateImmutableStructureFields(types, symTable, anonymousModelHelper, recordTypeNode,
                                          immutableRecordType, origRecordType, pos, env, pkgID, unresolvedTypes);
 
-        setRestType(types, symTable, anonymousModelHelper, names, immutableRecordType, origRecordType, pos, env,
+        setRestType(types, symTable, anonymousModelHelper, immutableRecordType, origRecordType, pos, env,
                     unresolvedTypes);
 
         TypeDefBuilderHelper.addTypeDefinition(immutableRecordType, recordSymbol, recordTypeNode, env);
@@ -625,7 +620,7 @@ public final class ImmutableTypeCloner {
                                                                BObjectType origObjectType, BType originalType,
                                                                SymbolEnv env, SymbolTable symTable,
                                                                BLangAnonymousModelHelper anonymousModelHelper,
-                                                               Names names, Types types,
+                                                               Types types,
                                                                Set<Flag> flagSet, Set<BType> unresolvedTypes) {
         PackageID pkgID = env.enclPkg.symbol.pkgID;
         BObjectTypeSymbol origObjectTSymbol = (BObjectTypeSymbol) origObjectType.tsymbol;
@@ -634,13 +629,13 @@ public final class ImmutableTypeCloner {
         flags &= ~Flags.CLASS;
 
         BObjectTypeSymbol objectSymbol = Symbols.createObjectSymbol(flags,
-                                                                    getImmutableTypeName(names,
+                                                                    getImmutableTypeName(
                                                                             getSymbolFQN(origObjectTSymbol)),
                                                                     pkgID, null, env.scope.owner, pos, VIRTUAL);
 
         objectSymbol.scope = new Scope(objectSymbol);
 
-        defineObjectFunctions(objectSymbol, origObjectTSymbol, names, symTable);
+        defineObjectFunctions(objectSymbol, origObjectTSymbol, symTable);
 
         BObjectType immutableObjectType = new BObjectType(objectSymbol, origObjectType.flags | Flags.READONLY);
 
@@ -659,7 +654,7 @@ public final class ImmutableTypeCloner {
                                                                                        immutableObjectType, pos);
         objectTypeNode.flagSet.addAll(flagSet);
 
-        TypeDefBuilderHelper.populateStructureFieldsAndTypeInclusions(types, symTable, anonymousModelHelper, names,
+        TypeDefBuilderHelper.populateStructureFieldsAndTypeInclusions(types, symTable, anonymousModelHelper,
                                                                       objectTypeNode, immutableObjectType,
                                                                       origObjectType, pos, env, pkgID, unresolvedTypes,
                                                                       Flags.FINAL, true);
@@ -671,7 +666,7 @@ public final class ImmutableTypeCloner {
     }
 
     public static void defineObjectFunctions(BObjectTypeSymbol immutableObjectSymbol,
-                                             BObjectTypeSymbol originalObjectSymbol, Names names,
+                                             BObjectTypeSymbol originalObjectSymbol,
                                              SymbolTable symTable) {
         List<BAttachedFunction> originalObjectAttachedFuncs = originalObjectSymbol.attachedFuncs;
         List<BAttachedFunction> immutableObjectAttachedFuncs = immutableObjectSymbol.attachedFuncs;
@@ -699,7 +694,7 @@ public final class ImmutableTypeCloner {
     private static BIntersectionType defineImmutableUnionType(Location pos, Types types, SymbolEnv env,
                                                               PackageID pkgId, BSymbol owner, SymbolTable symTable,
                                                               BLangAnonymousModelHelper anonymousModelHelper,
-                                                              Names names, Set<BType> unresolvedTypes,
+                                                              Set<BType> unresolvedTypes,
                                                               BUnionType type,
                                                               BType originalType) {
         BTypeSymbol origUnionTypeSymbol = type.tsymbol;
@@ -715,7 +710,7 @@ public final class ImmutableTypeCloner {
         }
 
         BIntersectionType immutableType = handleImmutableUnionType(pos, types, env, pkgId, owner, symTable,
-                                                                   anonymousModelHelper, names,
+                                                                   anonymousModelHelper,
                                                                    unresolvedTypes, type, origUnionTypeSymbol,
                                                                    originalMemberList);
         BType effectiveType = immutableType.effectiveType;
@@ -738,7 +733,7 @@ public final class ImmutableTypeCloner {
                                                                      PackageID pkgId, BSymbol owner,
                                                                      SymbolTable symTable,
                                                                      BLangAnonymousModelHelper anonymousModelHelper,
-                                                                     Names names, Set<BType> unresolvedTypes,
+                                                                     Set<BType> unresolvedTypes,
                                                                      BUnionType type, BType originalType) {
         BTypeSymbol origBuiltInUnionTypeSymbol = type.tsymbol;
 
@@ -749,22 +744,22 @@ public final class ImmutableTypeCloner {
 
         BUnionType effectiveType;
         if (type.tag == TypeTags.JSON) {
-            effectiveType = defineImmutableJsonType(env, pkgId, owner, names, (BJSONType) type);
+            effectiveType = defineImmutableJsonType(env, pkgId, owner, (BJSONType) type);
         } else {
-            effectiveType = defineImmutableAnydataType(env, pkgId, owner, names, (BAnydataType) type);
+            effectiveType = defineImmutableAnydataType(env, pkgId, owner, (BAnydataType) type);
         }
 
         BIntersectionType immutableBuiltInUnionIntersectionType =
                 createImmutableIntersectionType(pkgId, owner, originalType, effectiveType, symTable);
         Types.addImmutableType(symTable, pkgId, type, immutableBuiltInUnionIntersectionType);
 
-        return handleImmutableUnionType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper, names,
+        return handleImmutableUnionType(pos, types, env, pkgId, owner, symTable, anonymousModelHelper,
                                         unresolvedTypes, type, origBuiltInUnionTypeSymbol, type.getMemberTypes());
     }
 
-    private static BAnydataType defineImmutableAnydataType(SymbolEnv env, PackageID pkgId, BSymbol owner, Names names,
+    private static BAnydataType defineImmutableAnydataType(SymbolEnv env, PackageID pkgId, BSymbol owner,
                                                            BAnydataType type) {
-        BTypeSymbol immutableAnydataTSymbol = getReadonlyTSymbol(names, type.tsymbol, env, pkgId, owner);
+        BTypeSymbol immutableAnydataTSymbol = getReadonlyTSymbol(type.tsymbol, env, pkgId, owner);
 
         if (immutableAnydataTSymbol != null) {
             BAnydataType immutableAnydataType =
@@ -775,13 +770,13 @@ public final class ImmutableTypeCloner {
             return immutableAnydataType;
         }
          return new BAnydataType(immutableAnydataTSymbol,
-                                 getImmutableTypeName(names, TypeKind.ANYDATA.typeName()),
+                                 getImmutableTypeName(TypeKind.ANYDATA.typeName()),
                                  type.flags | Flags.READONLY, type.isNullable());
     }
 
-    private static BJSONType defineImmutableJsonType(SymbolEnv env, PackageID pkgId, BSymbol owner, Names names,
+    private static BJSONType defineImmutableJsonType(SymbolEnv env, PackageID pkgId, BSymbol owner,
                                                      BJSONType type) {
-        BTypeSymbol immutableJsonTSymbol = getReadonlyTSymbol(names, type.tsymbol, env, pkgId, owner);
+        BTypeSymbol immutableJsonTSymbol = getReadonlyTSymbol(type.tsymbol, env, pkgId, owner);
         BJSONType immutableJsonType = new BJSONType(immutableJsonTSymbol,
                                                     type.isNullable(),
                                                     type.flags | Flags.READONLY);
@@ -794,7 +789,7 @@ public final class ImmutableTypeCloner {
     private static BIntersectionType handleImmutableUnionType(Location pos, Types types, SymbolEnv env, PackageID pkgId,
                                                               BSymbol owner, SymbolTable symTable,
                                                               BLangAnonymousModelHelper anonymousModelHelper,
-                                                              Names names, Set<BType> unresolvedTypes, BUnionType type,
+                                                              Set<BType> unresolvedTypes, BUnionType type,
                                                               BTypeSymbol origUnionTypeSymbol,
                                                               LinkedHashSet<BType> originalMemberList) {
         BIntersectionType immutableType = Types.getImmutableType(symTable, pkgId, type).get();
@@ -806,7 +801,7 @@ public final class ImmutableTypeCloner {
 
         String originalTypeName = origUnionTypeSymbol == null ? "" : origUnionTypeSymbol.name.getValue();
         if (!originalTypeName.isEmpty()) {
-            unionEffectiveImmutableType.name = getImmutableTypeName(names, getSymbolFQN(origUnionTypeSymbol));
+            unionEffectiveImmutableType.name = getImmutableTypeName(getSymbolFQN(origUnionTypeSymbol));
         }
 
         for (BType memberType : originalMemberList) {
@@ -820,7 +815,7 @@ public final class ImmutableTypeCloner {
             }
 
             BType immutableMemberType = getImmutableType(pos, types, memberType, env, pkgId, owner, symTable,
-                                                         anonymousModelHelper, names, unresolvedTypes);
+                                                         anonymousModelHelper, unresolvedTypes);
 
             unionEffectiveImmutableType.add(immutableMemberType);
         }
@@ -831,7 +826,7 @@ public final class ImmutableTypeCloner {
             BTypeSymbol immutableUnionTSymbol =
                     getReadonlyTSymbol(origUnionTypeSymbol, env, pkgId, owner,
                                        origUnionTypeSymbol.name.value.isEmpty() ? Names.EMPTY :
-                                               getImmutableTypeName(names, getSymbolFQN(origUnionTypeSymbol)));
+                                               getImmutableTypeName(getSymbolFQN(origUnionTypeSymbol)));
             immutableType.effectiveType.tsymbol = immutableUnionTSymbol;
             immutableType.effectiveType.flags |= (type.flags | Flags.READONLY);
 
@@ -845,13 +840,13 @@ public final class ImmutableTypeCloner {
         return immutableType;
     }
 
-    private static BTypeSymbol getReadonlyTSymbol(Names names, BTypeSymbol originalTSymbol, SymbolEnv env,
+    private static BTypeSymbol getReadonlyTSymbol(BTypeSymbol originalTSymbol, SymbolEnv env,
                                                   PackageID pkgId, BSymbol owner) {
         if (originalTSymbol == null) {
             return null;
         }
 
-        return getReadonlyTSymbol(originalTSymbol, env, pkgId, owner, getImmutableTypeName(names, originalTSymbol));
+        return getReadonlyTSymbol(originalTSymbol, env, pkgId, owner, getImmutableTypeName(originalTSymbol));
     }
 
     private static BTypeSymbol getReadonlyTSymbol(BTypeSymbol originalTSymbol, SymbolEnv env, PackageID pkgId,
@@ -881,11 +876,11 @@ public final class ImmutableTypeCloner {
                 getMajorVersion(pkgID.version.value) + ":" + originalTSymbol.name;
     }
 
-    private static Name getImmutableTypeName(Names names, BTypeSymbol originalTSymbol) {
-        return getImmutableTypeName(names, originalTSymbol.name.getValue());
+    private static Name getImmutableTypeName(BTypeSymbol originalTSymbol) {
+        return getImmutableTypeName(originalTSymbol.name.getValue());
     }
 
-    private static Name getImmutableTypeName(Names names, String origName) {
+    private static Name getImmutableTypeName(String origName) {
         if (origName.isEmpty()) {
             return Names.EMPTY;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Name.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Name.java
@@ -22,8 +22,7 @@ package org.wso2.ballerinalang.compiler.util;
  */
 public class Name implements org.ballerinalang.model.Name {
 
-    //TODO: Make this field private.
-    public final String value;
+    private final String value;
 
     public Name(String value) {
         this.value = value;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Names.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Names.java
@@ -25,8 +25,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
  */
 public class Names {
 
-    public static final CompilerContext.Key<Names> NAMES_KEY =
-            new CompilerContext.Key<>();
+    public static final CompilerContext.Key<Names> NAMES_KEY = new CompilerContext.Key<>();
 
     public static final String STRING_SIGNED32 = "Signed32";
     public static final String STRING_SIGNED16 = "Signed16";
@@ -168,12 +167,12 @@ public class Names {
         this.context.put(NAMES_KEY, this);
     }
 
-    public Name fromIdNode(BLangIdentifier identifier) {
+    public static Name fromIdNode(BLangIdentifier identifier) {
         // identifier.value cannot be null
         return fromString(identifier.value);
     }
 
-    public Name originalNameFromIdNode(BLangIdentifier identifier) {
+    public static Name originalNameFromIdNode(BLangIdentifier identifier) {
         if (identifier.originalValue == null || identifier.value.equals(identifier.originalValue)) {
             return fromString(identifier.value);
         }
@@ -190,11 +189,11 @@ public class Names {
         return new Name(value);
     }
 
-    public Name fromTypeKind(TypeKind typeKind) {
+    public static Name fromTypeKind(TypeKind typeKind) {
         return fromString(typeKind.typeName());
     }
 
-    public Name merge(Name... names) {
+    public static Name merge(Name... names) {
         StringBuilder builder = new StringBuilder();
         for (Name name : names) {
             builder.append(name.value);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Names.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Names.java
@@ -196,7 +196,7 @@ public class Names {
     public static Name merge(Name... names) {
         StringBuilder builder = new StringBuilder();
         for (Name name : names) {
-            builder.append(name.value);
+            builder.append(name.getValue());
         }
         return new Name(builder.toString());
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/NodeUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/NodeUtils.java
@@ -33,12 +33,10 @@ public final class NodeUtils {
     /**
      * Return the {@code Name} from the give package name components.
      *
-     * @param names        utility class which manages all the names used
-     *                     in the Ballerina compiler.
      * @param pkgNameComps components of the given package name.
      * @return returns the name from the given package name components.
      */
-    public static Name getName(Names names, List<BLangIdentifier> pkgNameComps) {
+    public static Name getName(List<BLangIdentifier> pkgNameComps) {
         String pkgName = String.join(".", pkgNameComps.stream()
                 .map(id -> id.value)
                 .toList());
@@ -50,14 +48,14 @@ public final class NodeUtils {
         return new Name(qname);
     }
 
-    public static PackageID getPackageID(Names names, BLangIdentifier orgNameNode,
+    public static PackageID getPackageID(BLangIdentifier orgNameNode,
                                          List<BLangIdentifier> pkgNameComps, BLangIdentifier versionNode) {
-        List<Name> nameList = pkgNameComps.stream().map(names::fromIdNode).toList();
+        List<Name> nameList = pkgNameComps.stream().map(Names::fromIdNode).toList();
         Name orgName = null;
         if (orgNameNode != null) {
-            orgName = names.fromIdNode(orgNameNode);
+            orgName = Names.fromIdNode(orgNameNode);
         }
-        Name version = names.fromIdNode(versionNode);
+        Name version = Names.fromIdNode(versionNode);
         if (version == Names.EMPTY) {
             version = Names.DEFAULT_VERSION;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirs.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirs.java
@@ -111,7 +111,7 @@ public final class ProjectDirs {
     public static boolean isTestSource(Path sourcePath, Path sourceRoot, String pkg) {
         // CASE 1: Check if it the package name is "." i.e. if its a single ballerina source file, if so it should be
         // added to the bLangPackage
-        if (Names.DOT.value.equals(pkg)) {
+        if (Names.DOT.getValue().equals(pkg)) {
             return false;
         }
     

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeDefBuilderHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeDefBuilderHelper.java
@@ -96,7 +96,7 @@ public final class TypeDefBuilderHelper {
                                         VIRTUAL);
             }
 
-            BLangSimpleVariable fieldVar = ASTBuilderUtil.createVariable(field.pos, symbol.name.value, field.type,
+            BLangSimpleVariable fieldVar = ASTBuilderUtil.createVariable(field.pos, symbol.name.getValue(), field.type,
                                                                          null, symbol);
             fieldList.add(fieldVar);
         }
@@ -107,7 +107,7 @@ public final class TypeDefBuilderHelper {
         List<BLangSimpleVariable> fieldList = new ArrayList<>();
         for (BField field : objectType.fields.values()) {
             BVarSymbol symbol = field.symbol;
-            BLangSimpleVariable fieldVar = ASTBuilderUtil.createVariable(field.pos, symbol.name.value, field.type,
+            BLangSimpleVariable fieldVar = ASTBuilderUtil.createVariable(field.pos, symbol.name.getValue(), field.type,
                                                                          null, symbol);
             fieldList.add(fieldVar);
         }
@@ -149,7 +149,7 @@ public final class TypeDefBuilderHelper {
                                                                    Name suffix,
                                                                    BType type,
                                                                    BType returnType) {
-        String structTypeName = type.tsymbol.name.value;
+        String structTypeName = type.tsymbol.name.getValue();
         BLangFunction initFunction = ASTBuilderUtil.createInitFunctionWithNilReturn(null, structTypeName, suffix);
 
         // Create the receiver and add receiver details to the node
@@ -166,7 +166,7 @@ public final class TypeDefBuilderHelper {
         initFunction.setBType(new BInvokableType(new ArrayList<>(), returnType, null));
 
         // Create the function symbol
-        Name funcSymbolName = Names.fromString(Symbols.getAttachedFuncSymbolName(structTypeName, suffix.value));
+        Name funcSymbolName = Names.fromString(Symbols.getAttachedFuncSymbolName(structTypeName, suffix.getValue()));
         initFunction.symbol = Symbols
                 .createFunctionSymbol(Flags.asMask(initFunction.flagSet), funcSymbolName, funcSymbolName,
                                       env.enclPkg.symbol.pkgID, initFunction.getBType(), symbol,
@@ -174,7 +174,7 @@ public final class TypeDefBuilderHelper {
         initFunction.symbol.scope = new Scope(initFunction.symbol);
         initFunction.symbol.scope.define(receiverSymbol.name, receiverSymbol);
         initFunction.symbol.receiverSymbol = receiverSymbol;
-        initFunction.name = createIdentifier(null, funcSymbolName.value);
+        initFunction.name = createIdentifier(null, funcSymbolName.getValue());
 
         // Create the function type symbol
         BInvokableTypeSymbol tsymbol = Symbols.createInvokableTypeSymbol(SymTag.FUNCTION_TYPE,
@@ -201,7 +201,7 @@ public final class TypeDefBuilderHelper {
         typeDefinition.typeNode = typeNode;
         typeDefinition.setBType(type);
         typeDefinition.symbol = symbol;
-        typeDefinition.name = createIdentifier(symbol.pos, symbol.name.value);
+        typeDefinition.name = createIdentifier(symbol.pos, symbol.name.getValue());
         if (env != null) {
             env.enclPkg.addTypeDefinition(typeDefinition);
         }
@@ -214,9 +214,9 @@ public final class TypeDefBuilderHelper {
         typeDefinition.typeNode = typeNode;
         typeDefinition.setBType(type);
         typeDefinition.symbol = Symbols.createTypeDefinitionSymbol(symbol.flags,
-                    Names.fromString(symbol.name.value), symbol.pkgID, type, symbol.owner,
+                    Names.fromString(symbol.name.getValue()), symbol.pkgID, type, symbol.owner,
                     symbol.pos, symbol.origin);
-        typeDefinition.name = createIdentifier(symbol.pos, symbol.name.value);
+        typeDefinition.name = createIdentifier(symbol.pos, symbol.name.getValue());
         env.enclPkg.addTypeDefinition(typeDefinition);
         return typeDefinition;
     }
@@ -227,7 +227,7 @@ public final class TypeDefBuilderHelper {
         List<BLangSimpleVariable> fieldList = new ArrayList<>();
         for (BField field : objType.fields.values()) {
             BVarSymbol symbol = field.symbol;
-            BLangSimpleVariable fieldVar = ASTBuilderUtil.createVariable(field.pos, symbol.name.value, field.type,
+            BLangSimpleVariable fieldVar = ASTBuilderUtil.createVariable(field.pos, symbol.name.getValue(), field.type,
                                                                          null, symbol);
             fieldList.add(fieldVar);
         }
@@ -270,7 +270,7 @@ public final class TypeDefBuilderHelper {
         }
 
         String typeName = detailType.tsymbol != null
-                ? detailType.tsymbol.name.value
+                ? detailType.tsymbol.name.getValue()
                 : anonymousModelHelper.getNextAnonymousIntersectionErrorDetailTypeName(env.enclPkg.packageID);
 
         userDefinedTypeNode.typeName = createIdentifier(pos, typeName);
@@ -340,7 +340,7 @@ public final class TypeDefBuilderHelper {
                         origField.symbol.pos, SOURCE);
             }
             fieldSymbol.isDefaultable = origField.symbol.isDefaultable;
-            String nameString = fieldName.value;
+            String nameString = fieldName.getValue();
             fields.put(nameString, new BField(fieldName, null, fieldSymbol));
             structureSymbol.scope.define(fieldName, fieldSymbol);
         }
@@ -353,7 +353,7 @@ public final class TypeDefBuilderHelper {
                 ASTBuilderUtil.createIdentifier(pos,
                         TypeDefBuilderHelper.getPackageAlias(env, null,
                                 origStructureType.tsymbol.pkgID)),
-                ASTBuilderUtil.createIdentifier(pos, origStructureType.tsymbol.name.value));
+                ASTBuilderUtil.createIdentifier(pos, origStructureType.tsymbol.name.getValue()));
         origTypeRef.pos = pos;
         origTypeRef.setBType(origStructureType);
 
@@ -370,7 +370,7 @@ public final class TypeDefBuilderHelper {
         BTypeDefinitionSymbol typeDefinitionSymbol = Symbols.createTypeDefinitionSymbol(type.tsymbol.flags,
                 type.tsymbol.name, env.scope.owner.pkgID, null, env.scope.owner, pos, VIRTUAL);
         typeDefinitionSymbol.scope = new Scope(typeDefinitionSymbol);
-        typeDefinitionSymbol.scope.define(Names.fromString(typeDefinitionSymbol.name.value), typeDefinitionSymbol);
+        typeDefinitionSymbol.scope.define(Names.fromString(typeDefinitionSymbol.name.getValue()), typeDefinitionSymbol);
 
         type.tsymbol.scope = new Scope(type.tsymbol);
         for (BField field : ((HashMap<String, BField>) type.fields).values()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeDefBuilderHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeDefBuilderHelper.java
@@ -138,16 +138,14 @@ public final class TypeDefBuilderHelper {
 
     public static BLangFunction createInitFunctionForStructureType(BSymbol symbol,
                                                                    SymbolEnv env,
-                                                                   Names names,
                                                                    Name suffix,
                                                                    SymbolTable symTable,
                                                                    BType type) {
-        return createInitFunctionForStructureType(symbol, env, names, suffix, type, symTable.nilType);
+        return createInitFunctionForStructureType(symbol, env, suffix, type, symTable.nilType);
     }
 
     public static BLangFunction createInitFunctionForStructureType(BSymbol symbol,
                                                                    SymbolEnv env,
-                                                                   Names names,
                                                                    Name suffix,
                                                                    BType type,
                                                                    BType returnType) {
@@ -157,8 +155,8 @@ public final class TypeDefBuilderHelper {
         // Create the receiver and add receiver details to the node
         initFunction.receiver = ASTBuilderUtil.createReceiver(null, type);
         BVarSymbol receiverSymbol = new BVarSymbol(Flags.asMask(EnumSet.noneOf(Flag.class)),
-                                                   names.fromIdNode(initFunction.receiver.name),
-                                                   names.originalNameFromIdNode(initFunction.receiver.name),
+                                                   Names.fromIdNode(initFunction.receiver.name),
+                                                   Names.originalNameFromIdNode(initFunction.receiver.name),
                                                    env.enclPkg.symbol.pkgID, type, null, null, VIRTUAL);
         initFunction.receiver.symbol = receiverSymbol;
         initFunction.attachedFunction = true;
@@ -299,7 +297,7 @@ public final class TypeDefBuilderHelper {
 
     public static void populateStructureFieldsAndTypeInclusions(Types types, SymbolTable symTable,
                                                                 BLangAnonymousModelHelper anonymousModelHelper,
-                                                                Names names, BLangStructureTypeNode structureTypeNode,
+                                                                BLangStructureTypeNode structureTypeNode,
                                                                 BStructureType structureType,
                                                                 BStructureType origStructureType, Location pos,
                                                                 SymbolEnv env, PackageID pkgID,
@@ -312,7 +310,7 @@ public final class TypeDefBuilderHelper {
             BType fieldType;
             if (isImmutable) {
                 fieldType = ImmutableTypeCloner.getImmutableType(pos, types, origField.type, env,
-                        env.enclPkg.packageID, env.scope.owner, symTable, anonymousModelHelper, names, unresolvedTypes);
+                        env.enclPkg.packageID, env.scope.owner, symTable, anonymousModelHelper, unresolvedTypes);
             } else {
                 fieldType = origField.type;
             }
@@ -364,7 +362,7 @@ public final class TypeDefBuilderHelper {
         }
     }
 
-    public static void createTypeDefinition(BRecordType type, Location pos, Names names,
+    public static void createTypeDefinition(BRecordType type, Location pos,
                                             Types types, SymbolTable symTable,
                                             SymbolEnv env) {
         BRecordTypeSymbol recordSymbol = (BRecordTypeSymbol) type.tsymbol;
@@ -386,7 +384,7 @@ public final class TypeDefBuilderHelper {
 
         BLangRecordTypeNode recordTypeNode = TypeDefBuilderHelper.createRecordTypeNode(new ArrayList<>(), type,
                 pos);
-        TypeDefBuilderHelper.populateStructureFieldsAndTypeInclusions(types, symTable, null, names, recordTypeNode,
+        TypeDefBuilderHelper.populateStructureFieldsAndTypeInclusions(types, symTable, null, recordTypeNode,
                                                                       type, type, pos, env, env.scope.owner.pkgID,
                                                                       null, Flags.REQUIRED, false);
         recordTypeNode.sealed = true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Unifier.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Unifier.java
@@ -544,7 +544,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
 
     @Override
     public BType visit(BParameterizedType originalType, BType expType) {
-        String paramVarName = originalType.paramSymbol.name.value;
+        String paramVarName = originalType.paramSymbol.name.getValue();
 
         if (Symbols.isFlagOn(originalType.paramSymbol.flags, Flags.INFER)) {
             BTypedescType paramSymbolTypedescType =
@@ -640,7 +640,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
     private BType getTypeAddingArgIfNotProvided(BParameterizedType originalType, BType expType) {
         BVarSymbol paramSymbol = originalType.paramSymbol;
 
-        String paramName = paramSymbol.name.value;
+        String paramName = paramSymbol.name.getValue();
 
         List<BLangExpression> requiredArgs = invocation.requiredArgs;
 
@@ -727,7 +727,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
 
                 if (arg.getKind() != NodeKind.NAMED_ARGS_EXPR) {
                     // If this is a positional arg, it should correspond to the current param.
-                    paramValueTypes.put(params.get(paramIndex).name.value, arg.getBType());
+                    paramValueTypes.put(params.get(paramIndex).name.getValue(), arg.getBType());
                     argIndex++;
                     continue;
                 } else {
@@ -746,7 +746,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
             }
 
             BVarSymbol param = params.get(paramIndex);
-            String paramName = param.name.value;
+            String paramName = param.name.getValue();
             if (param.isDefaultable && !Symbols.isFlagOn(param.flags, Flags.INFER)) {
                 paramValueTypes.put(paramName, symbol.paramDefaultValTypes.get(paramName));
             }
@@ -764,7 +764,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
                 continue;
             }
 
-            String name = param.name.value;
+            String name = param.name.getValue();
             boolean argProvided = false;
 
             for (int argIndex = currentArgIndex; argIndex < requiredArgs.size(); argIndex++) {
@@ -806,7 +806,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
     private void populateParamMapFromRecordRestArg(List<BVarSymbol> params, int currentParamIndex,
                                                    BRecordType recordType) {
         for (int i = currentParamIndex; i < params.size(); i++) {
-            String paramName = params.get(i).name.value;
+            String paramName = params.get(i).name.getValue();
             paramValueTypes.put(paramName, recordType.fields.get(paramName).type);
         }
     }
@@ -815,7 +815,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
                                                   BArrayType arrayType) {
         BType elementType = arrayType.eType;
         for (int i = currentParamIndex; i < params.size(); i++) {
-            paramValueTypes.put(params.get(i).name.value, elementType);
+            paramValueTypes.put(params.get(i).name.getValue(), elementType);
         }
     }
 
@@ -824,7 +824,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
         int tupleIndex = 0;
         List<BType> tupleTypes = tupleType.getTupleTypes();
         for (int i = currentParamIndex; i < params.size(); i++) {
-            paramValueTypes.put(params.get(i).name.value, tupleTypes.get(tupleIndex++));
+            paramValueTypes.put(params.get(i).name.getValue(), tupleTypes.get(tupleIndex++));
         }
     }
 
@@ -847,7 +847,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
     }
 
     private BType getParamConstraintTypeIfInferred(BLangFunction function, BParameterizedType parameterizedType) {
-        String paramName = parameterizedType.paramSymbol.name.value;
+        String paramName = parameterizedType.paramSymbol.name.getValue();
 
         for (BLangSimpleVariable requiredParam : function.requiredParams) {
             if (!requiredParam.name.value.equals(paramName)) {
@@ -1017,7 +1017,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
         type = Types.getReferredType(type);
         switch (type.tag) {
             case TypeTags.PARAMETERIZED_TYPE:
-                String paramName = ((BParameterizedType) type).paramSymbol.name.value;
+                String paramName = ((BParameterizedType) type).paramSymbol.name.getValue();
                 return paramsWithInferredTypedescDefault.contains(paramName);
             case TypeTags.XML:
                 return refersInferableParamName(paramsWithInferredTypedescDefault, ((BXMLType) type).constraint,
@@ -1127,7 +1127,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
 
         for (BVarSymbol param : params) {
             if (Symbols.isFlagOn(param.flags, Flags.INFER)) {
-                paramsWithInferredTypedescDefault.add(param.name.value);
+                paramsWithInferredTypedescDefault.add(param.name.getValue());
             }
         }
         return paramsWithInferredTypedescDefault;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/diagnotic/DiagnosticPos.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/diagnotic/DiagnosticPos.java
@@ -99,9 +99,9 @@ public class DiagnosticPos implements Location {
     public int compareTo(DiagnosticPos diagnosticPosition) {
 
         // Compare the source first.
-        String thisDiagnosticString = packageID.name.value + packageID.version.value + lineRange().fileName();
-        String otherDiagnosticString = diagnosticPosition.getPackageID().name.value +
-                diagnosticPosition.getPackageID().version.value +
+        String thisDiagnosticString = packageID.name.getValue() + packageID.version.getValue() + lineRange().fileName();
+        String otherDiagnosticString = diagnosticPosition.getPackageID().name.getValue() +
+                diagnosticPosition.getPackageID().version.getValue() +
                 diagnosticPosition.lineRange().fileName();
         int value = thisDiagnosticString.compareTo(otherDiagnosticString);
 

--- a/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/SourceDirectoryManagerTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/SourceDirectoryManagerTest.java
@@ -51,7 +51,6 @@ public class SourceDirectoryManagerTest {
 
     @Test(description = "Return modules list should be equivalence to the expected module list")
     public void testListSourceFilesAndPackages() {
-        Names names = Names.getInstance(context);
         List<PackageID> expectedPackageIds = new ArrayList<>();
         expectedPackageIds.add(new PackageID(Names.fromString("abc"),
                                              Names.fromString("fruits"),
@@ -65,7 +64,6 @@ public class SourceDirectoryManagerTest {
     @Test(description = "Return module should be equivalence to the expected module")
     public void testGetPackageID() {
         PackageID fruits = directoryManager.getPackageID("fruits");
-        Names names = Names.getInstance(context);
         PackageID expectedPackageId = new PackageID(Names.fromString("abc"),
                                                     Names.fromString("fruits"),
                                                     Names.fromString("0.0.1"));
@@ -75,7 +73,6 @@ public class SourceDirectoryManagerTest {
     @Test(description = "Test if module exist in the project")
     public void testIsModuleExists() {
         Project project = context.get(Project.PROJECT_KEY);
-        Names names = Names.getInstance(context);
         PackageID expectedPackageId = new PackageID(Names.fromString("abc"),
                 Names.fromString("fruits"),
                 Names.fromString("0.0.1"));
@@ -97,7 +94,6 @@ public class SourceDirectoryManagerTest {
     @Test(description = "Test if get bala path")
     public void getBalaPath() throws InvalidModuleException {
         Project project = context.get(Project.PROJECT_KEY);
-        Names names = Names.getInstance(context);
         PackageID moduleId = new PackageID(Names.fromString("abc"),
                 Names.fromString("fruits"),
                 Names.fromString("0.0.1"));

--- a/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
+++ b/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
@@ -130,12 +130,12 @@ final class BIRTestUtils {
 
             // assert name
             Bir.ConstantPoolEntry constantPoolEntryName = constantPoolEntries.get(actualFunction.nameCpIndex());
-            assertConstantPoolEntry(constantPoolEntryName, expectedFunction.name.value);
+            assertConstantPoolEntry(constantPoolEntryName, expectedFunction.name.getValue());
 
             // assert original name
             Bir.ConstantPoolEntry constantPoolEntryOrigName =
                     constantPoolEntries.get(actualFunction.originalNameCpIndex());
-            assertConstantPoolEntry(constantPoolEntryOrigName, expectedFunction.originalName.value);
+            assertConstantPoolEntry(constantPoolEntryOrigName, expectedFunction.originalName.getValue());
 
             // assert markdown document
             assertMarkdownDocument(actualFunction.doc(), expectedFunction.markdownDocAttachment, constantPoolEntries);
@@ -252,7 +252,7 @@ final class BIRTestUtils {
 
         for (int i = 0; i < actualGlobalVarCpEntries.size(); i++) {
             Bir.ConstantPoolEntry constantPoolEntry = constantPoolEntries.get(actualGlobalVarCpEntries.get(i));
-            String expectedName = ((BIRNode.BIRGlobalVariableDcl) expectedGlobalVars[i]).name.value;
+            String expectedName = ((BIRNode.BIRGlobalVariableDcl) expectedGlobalVars[i]).name.getValue();
             assertConstantPoolEntry(constantPoolEntry, expectedName);
         }
     }
@@ -322,7 +322,7 @@ final class BIRTestUtils {
             BIRNode.BIRBasicBlock expectedBasicBlock = expectedBasicBlocks.get(i);
 
             Bir.ConstantPoolEntry constantPoolEntry = constantPoolEntries.get(actualBasicBlock.nameCpIndex());
-            assertConstantPoolEntry(constantPoolEntry, expectedBasicBlock.id.value);
+            assertConstantPoolEntry(constantPoolEntry, expectedBasicBlock.id.getValue());
 
             ArrayList<Bir.Instruction> actualInstructions = actualBasicBlock.instructions();
             List<BIRNonTerminator> expectedInstructions = expectedBasicBlock.instructions;
@@ -372,11 +372,11 @@ final class BIRTestUtils {
 
         // assert true bb name
         Bir.ConstantPoolEntry constantPoolEntry = constantPoolEntries.get(actualBranch.trueBbIdNameCpIndex());
-        assertConstantPoolEntry(constantPoolEntry, expectedBranch.trueBB.id.value);
+        assertConstantPoolEntry(constantPoolEntry, expectedBranch.trueBB.id.getValue());
 
         // assert false bb name
         constantPoolEntry = constantPoolEntries.get(actualBranch.falseBbIdNameCpIndex());
-        assertConstantPoolEntry(constantPoolEntry, expectedBranch.falseBB.id.value);
+        assertConstantPoolEntry(constantPoolEntry, expectedBranch.falseBB.id.getValue());
     }
 
     private static void assertCallInstruction(Bir.InstructionCall actualCall, BIRTerminator.Call expectedCall,
@@ -393,18 +393,18 @@ final class BIRTestUtils {
 
         // assert call name
         constantPoolEntry = constantPoolEntries.get(callInstructionInfo.callNameCpIndex());
-        assertConstantPoolEntry(constantPoolEntry, expectedCall.name.value);
+        assertConstantPoolEntry(constantPoolEntry, expectedCall.name.getValue());
 
         // assert then bb id
         constantPoolEntry = constantPoolEntries.get(actualCall.thenBbIdNameCpIndex());
-        assertConstantPoolEntry(constantPoolEntry, expectedCall.thenBB.id.value);
+        assertConstantPoolEntry(constantPoolEntry, expectedCall.thenBB.id.getValue());
     }
 
     private static void assertGotoInstruction(Bir.InstructionGoto actualGoto, BIRTerminator.GOTO expectedInstruction,
                                               ArrayList<Bir.ConstantPoolEntry> constantPoolEntries) {
         // assert goto bb id
         Bir.ConstantPoolEntry constantPoolEntry = constantPoolEntries.get(actualGoto.targetBbIdNameCpIndex());
-        assertConstantPoolEntry(constantPoolEntry, expectedInstruction.targetBB.id.value);
+        assertConstantPoolEntry(constantPoolEntry, expectedInstruction.targetBB.id.getValue());
     }
 
     private static void assertMoveInstruction(Bir.InstructionMove actual, BIRNonTerminator.Move expected,
@@ -430,7 +430,7 @@ final class BIRTestUtils {
 
             // assert var name
             Bir.ConstantPoolEntry constantPoolEntry = constantPoolEntries.get(actualVar.variableDclNameCpIndex());
-            assertConstantPoolEntry(constantPoolEntry, expectedVar.name.value);
+            assertConstantPoolEntry(constantPoolEntry, expectedVar.name.getValue());
         }
     }
 
@@ -445,7 +445,8 @@ final class BIRTestUtils {
             BIRNode.BIRConstant expectedConstant = expectedConstants.get(i);
 
             // assert name
-            assertConstantPoolEntry(constantPoolEntries.get(actualConstant.nameCpIndex()), expectedConstant.name.value);
+            assertConstantPoolEntry(constantPoolEntries.get(actualConstant.nameCpIndex()),
+                    expectedConstant.name.getValue());
 
             // assert flags
             assertFlags(actualConstant.flags(), expectedConstant.flags);
@@ -471,11 +472,11 @@ final class BIRTestUtils {
 
             // assert name
             assertConstantPoolEntry(constantPoolEntries.get(actualTypeDefinition.nameCpIndex()),
-                    expectedTypeDefinition.internalName.value);
+                    expectedTypeDefinition.internalName.getValue());
 
             // assert original name
             assertConstantPoolEntry(constantPoolEntries.get(actualTypeDefinition.originalNameCpIndex()),
-                    expectedTypeDefinition.originalName.value);
+                    expectedTypeDefinition.originalName.getValue());
 
             // assert flags
             assertFlags(actualTypeDefinition.flags(), expectedTypeDefinition.flags);
@@ -508,11 +509,11 @@ final class BIRTestUtils {
 
             // assert name
             assertConstantPoolEntry(constantPoolEntries.get(actualServiceDecl.nameCpIndex()),
-                                    expServiceDecl.generatedName.value);
+                    expServiceDecl.generatedName.getValue());
 
             // assert associated class name
             assertConstantPoolEntry(constantPoolEntries.get(actualServiceDecl.associatedClassNameCpIndex()),
-                                    expServiceDecl.associatedClassName.value);
+                    expServiceDecl.associatedClassName.getValue());
 
             // assert flags
             assertFlags(actualServiceDecl.flags(), expServiceDecl.flags);
@@ -576,11 +577,11 @@ final class BIRTestUtils {
 
             // assert name
             assertConstantPoolEntry(constantPoolEntries.get(actualAnnotation.nameCpIndex()),
-                    expectedAnnotation.name.value);
+                    expectedAnnotation.name.getValue());
 
             // assert original name
             assertConstantPoolEntry(constantPoolEntries.get(actualAnnotation.originalNameCpIndex()),
-                    expectedAnnotation.originalName.value);
+                    expectedAnnotation.originalName.getValue());
 
             // assert type
             assertConstantPoolEntry(constantPoolEntries.get(actualAnnotation.annotationTypeCpIndex()),
@@ -629,9 +630,12 @@ final class BIRTestUtils {
                 PackageID packageID = (PackageID) expectedValue;
                 ArrayList<Bir.ConstantPoolEntry> constantPoolEntries = constantPoolEntry._parent().
                         constantPoolEntries();
-                assertConstantPoolEntry(constantPoolEntries.get(packageCpInfo.orgIndex()), packageID.orgName.value);
-                assertConstantPoolEntry(constantPoolEntries.get(packageCpInfo.nameIndex()), packageID.name.value);
-                assertConstantPoolEntry(constantPoolEntries.get(packageCpInfo.versionIndex()), packageID.version.value);
+                assertConstantPoolEntry(
+                        constantPoolEntries.get(packageCpInfo.orgIndex()), packageID.orgName.getValue());
+                assertConstantPoolEntry(
+                        constantPoolEntries.get(packageCpInfo.nameIndex()), packageID.name.getValue());
+                assertConstantPoolEntry(
+                        constantPoolEntries.get(packageCpInfo.versionIndex()), packageID.version.getValue());
                 break;
             case CP_ENTRY_BYTE:
                 Bir.ByteCpInfo byteCpInfo = (Bir.ByteCpInfo) constantPoolEntry.cpInfo();
@@ -787,7 +791,7 @@ final class BIRTestUtils {
             assertPosition(actualAnnot.position(), expAnnot.pos);
 
             Bir.ConstantPoolEntry annotTag = constantPoolEntries.get(actualAnnot.tagReferenceCpIndex());
-            assertConstantPoolEntry(annotTag, expAnnot.annotTagRef.value);
+            assertConstantPoolEntry(annotTag, expAnnot.annotTagRef.getValue());
 
             boolean constAnnotAttachment = expAnnot instanceof BIRNode.BIRConstAnnotationAttachment;
             Assert.assertEquals(actualAnnot.isConstAnnot() == 1, constAnnotAttachment);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
@@ -235,7 +235,7 @@ public class ImportDeclarationNodeContext extends AbstractCompletionProvider<Imp
                     : CommonUtil.getPackageLabel(pkg);
             String insertText = orgName.isEmpty() ? "" : orgName + Names.ORG_NAME_SEPARATOR.getValue();
 
-            if (orgName.equals(Names.BALLERINA_ORG.value)
+            if (orgName.equals(Names.BALLERINA_ORG.getValue())
                     && pkgName.startsWith(PackageName.LANG_LIB_PACKAGE_NAME_PREFIX + Names.DOT.getValue())) {
                 insertText += getLangLibModuleNameInsertText(pkgName);
             } else {
@@ -343,7 +343,7 @@ public class ImportDeclarationNodeContext extends AbstractCompletionProvider<Imp
             String insertText;
             if (orgName.equals(ballerinaPackage.packageOrg().value()) && !addedPkgNames.contains(packageName)
                     && ModuleUtil.matchingImportedModule(context, ballerinaPackage).isEmpty()) {
-                if (orgName.equals(Names.BALLERINA_ORG.value)
+                if (orgName.equals(Names.BALLERINA_ORG.getValue())
                         && packageName.startsWith(Names.LANG.getValue() + Names.DOT.getValue())) {
                     insertText = getLangLibModuleNameInsertText(packageName);
                 } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportOrgNameNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportOrgNameNodeContext.java
@@ -78,8 +78,8 @@ public class ImportOrgNameNodeContext extends AbstractCompletionProvider<ImportO
             String insertText;
             if (orgName.equals(ballerinaPackage.packageOrg().value()) && !pkgNameLabels.contains(packageName)
                     && ModuleUtil.matchingImportedModule(context, ballerinaPackage).isEmpty()) {
-                if (orgName.equals(Names.BALLERINA_ORG.value)
-                        && packageName.startsWith(Names.LANG.value + ".")) {
+                if (orgName.equals(Names.BALLERINA_ORG.getValue())
+                        && packageName.startsWith(Names.LANG.getValue() + ".")) {
                     insertText = ImportDeclarationContextUtil.getLangLibModuleNameInsertText(packageName);
                 } else {
                     insertText = packageName;

--- a/misc/ls-extensions/modules/performance-analyzer-services/src/main/java/io/ballerina/utils/ParserUtil.java
+++ b/misc/ls-extensions/modules/performance-analyzer-services/src/main/java/io/ballerina/utils/ParserUtil.java
@@ -130,7 +130,7 @@ public final class ParserUtil {
             List<BVarSymbol> params = bInvokableSymbol.getParameters();
             for (int i = 0; i < params.size(); i++) {
                 if (connectorInitExpr.argsExpr.size() > i &&
-                        (CLIENT_URL_ATTR_NAME.equals(params.get(i).name.value.toLowerCase(Locale.ENGLISH))
+                        (CLIENT_URL_ATTR_NAME.equals(params.get(i).name.getValue().toLowerCase(Locale.ENGLISH))
                                 || isRecordObject(params.get(i).type.tsymbol))) {
                     return connectorInitExpr.argsExpr.get(i);
                 }
@@ -147,7 +147,7 @@ public final class ParserUtil {
                 List<BVarSymbol> params = bInvokableSymbol.getParameters();
                 for (int i = 0; i < params.size(); i++) {
                     if (actionInvocation.argExprs.size() > i &&
-                            (ACTION_PATH_ATTR_NAME.equals(params.get(i).name.value.toLowerCase(Locale.ENGLISH)))) {
+                            (ACTION_PATH_ATTR_NAME.equals(params.get(i).name.getValue().toLowerCase(Locale.ENGLISH)))) {
                         return actionInvocation.argExprs.get(i);
                     }
                 }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/MockAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/MockAnnotationProcessor.java
@@ -332,11 +332,12 @@ public class MockAnnotationProcessor extends AbstractCompilerPlugin {
      */
     private String formatPackageName(String value, BLangPackage parent) {
         // If empty or '.' then return the current package ID
-        if (value.isEmpty() || value.equals(Names.DOT.value)) {
+        if (value.isEmpty() || value.equals(Names.DOT.getValue())) {
             value = parent.packageID.toString();
 
             // If value does NOT contain 'ballerina/' then it could be fully qualified
-        } else if (!value.contains(Names.ORG_NAME_SEPARATOR.value) && !value.contains(Names.VERSION_SEPARATOR.value)) {
+        } else if (!value.contains(Names.ORG_NAME_SEPARATOR.getValue()) &&
+                !value.contains(Names.VERSION_SEPARATOR.getValue())) {
             value = new PackageID(parent.packageID.orgName, new Name(value),
                     parent.packageID.version).toString();
         }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
@@ -193,7 +193,7 @@ public class TestProcessor {
 
     public static String getTestModuleName(Module module) {
         PackageID packageID = module.descriptor().moduleTestCompilationId();
-        return packageID.isTestPkg ? packageID.name.value + Names.TEST_PACKAGE : packageID.name.value;
+        return packageID.isTestPkg ? packageID.name.getValue() + Names.TEST_PACKAGE : packageID.name.getValue();
     }
 
     /**
@@ -354,8 +354,8 @@ public class TestProcessor {
                 // Remove the duplicated annotations.
                 boolean testable = functionSymbol.getModule().get().id().isTestable();
                 PackageID moduleTestCompilationId = module.descriptor().moduleTestCompilationId();
-                String testModuleName = testable ? moduleTestCompilationId.name.value + Names.TEST_PACKAGE :
-                        moduleTestCompilationId.name.value;
+                String testModuleName = testable ? moduleTestCompilationId.name.getValue() + Names.TEST_PACKAGE :
+                        moduleTestCompilationId.name.getValue();
                 String className = pos.lineRange().fileName()
                         .replace(ProjectConstants.BLANG_SOURCE_EXT, "")
                         .replace(ProjectConstants.DOT, FILE_NAME_PERIOD_SEPARATOR)

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
@@ -170,7 +170,7 @@ public final class SemanticAPITestUtils {
 
             if (value.symbol != null && (value.symbol.tag & symTag) == symTag
                     && Symbols.isFlagOn(value.symbol.flags, Flags.PUBLIC) && value.symbol.origin == COMPILED_SOURCE) {
-                symbolNames.add(name.value);
+                symbolNames.add(name.getValue());
             }
         }
         return symbolNames;
@@ -183,7 +183,7 @@ public final class SemanticAPITestUtils {
             Scope.ScopeEntry value = entry.getValue();
 
             if (value.symbol != null && (value.symbol.tag & symTag) == symTag && value.symbol.origin == origin) {
-                symbolNames.add(name.value);
+                symbolNames.add(name.getValue());
             }
         }
         return symbolNames;

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
@@ -207,7 +207,7 @@ public final class BRunUtil {
             Scheduler scheduler = new Scheduler(false);
             FutureValue futureValue = scheduler.schedule(jvmArgs, func, null, null, new HashMap<>(),
                     PredefinedTypes.TYPE_ANY, "test",
-                    new StrandMetadata(ANON_ORG, DOT, DEFAULT_MAJOR_VERSION.value, functionName));
+                    new StrandMetadata(ANON_ORG, DOT, DEFAULT_MAJOR_VERSION.getValue(), functionName));
             scheduler.start();
             if (futureValue.panic instanceof RuntimeException) {
                 throw new BLangTestException(futureValue.panic.getMessage(),
@@ -251,7 +251,7 @@ public final class BRunUtil {
         checkAndNotifyCompilationErrors(compileResult);
         BIRNode.BIRPackage birPackage = compileResult.defaultModuleBIR();
         for (BIRNode.BIRFunction function : birPackage.functions) {
-            if (functionName.equals(function.name.value)) {
+            if (functionName.equals(function.name.getValue())) {
                 return function;
             }
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentSymbolsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentSymbolsTest.java
@@ -259,7 +259,7 @@ public class AnnotationAttachmentSymbolsTest {
         // assertAttachmentSymbol(attachments.get(0), "v25", true, "val", "ABC");
         // Replace the assertion for v25 with the line above once fixed.
         BAnnotationAttachmentSymbol annotationAttachmentSymbol = (BAnnotationAttachmentSymbol) attachments.get(0);
-        Assert.assertEquals(annotationAttachmentSymbol.annotTag.value, "v25");
+        Assert.assertEquals(annotationAttachmentSymbol.annotTag.getValue(), "v25");
         Assert.assertTrue(annotationAttachmentSymbol.isConstAnnotation());
         Object constValue =
                 ((BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) annotationAttachmentSymbol)
@@ -269,7 +269,7 @@ public class AnnotationAttachmentSymbolsTest {
         Assert.assertEquals(mapConst.size(), 0);
 
         annotationAttachmentSymbol = (BAnnotationAttachmentSymbol) attachments.get(1);
-        Assert.assertEquals(annotationAttachmentSymbol.annotTag.value, "v26");
+        Assert.assertEquals(annotationAttachmentSymbol.annotTag.getValue(), "v26");
         Assert.assertTrue(annotationAttachmentSymbol.isConstAnnotation());
         constValue =
                 ((BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) annotationAttachmentSymbol)
@@ -287,7 +287,7 @@ public class AnnotationAttachmentSymbolsTest {
         Assert.assertEquals(attachments.size(), 1);
 
         BAnnotationAttachmentSymbol annotationAttachmentSymbol = attachments.get(0);
-        Assert.assertEquals(annotationAttachmentSymbol.annotTag.value, "v1");
+        Assert.assertEquals(annotationAttachmentSymbol.annotTag.getValue(), "v1");
         Assert.assertTrue(annotationAttachmentSymbol.isConstAnnotation());
 
         Object constValue =
@@ -350,7 +350,7 @@ public class AnnotationAttachmentSymbolsTest {
                         listAnnotFieldResult.getAST().getTypeDefinitions(), "Baz").symbol).getAnnotations();
         Assert.assertEquals(attachments.size(), 1);
         BAnnotationAttachmentSymbol annotationAttachmentSymbol = (BAnnotationAttachmentSymbol) attachments.get(0);
-        Assert.assertEquals(annotationAttachmentSymbol.annotTag.value, "v2");
+        Assert.assertEquals(annotationAttachmentSymbol.annotTag.getValue(), "v2");
         Assert.assertTrue(annotationAttachmentSymbol.isConstAnnotation());
         Object constValue =
                 ((BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) annotationAttachmentSymbol)
@@ -407,7 +407,7 @@ public class AnnotationAttachmentSymbolsTest {
     private BLangTypeDefinition getTypeDefinition(List<? extends TypeDefinition> typeDefinitions, String name) {
         for (TypeDefinition typeDefinition : typeDefinitions) {
             BLangTypeDefinition bLangTypeDefinition = (BLangTypeDefinition) typeDefinition;
-            if (name.equals(bLangTypeDefinition.symbol.name.value)) {
+            if (name.equals(bLangTypeDefinition.symbol.name.getValue())) {
                 return bLangTypeDefinition;
             }
         }
@@ -421,7 +421,7 @@ public class AnnotationAttachmentSymbolsTest {
             }
 
             BLangClassDefinition classDefinition = (BLangClassDefinition) topLevelNode;
-            if (name.equals(classDefinition.symbol.name.value)) {
+            if (name.equals(classDefinition.symbol.name.getValue())) {
                 return classDefinition;
             }
         }
@@ -435,7 +435,7 @@ public class AnnotationAttachmentSymbolsTest {
     private void assertAttachmentSymbol(AnnotationAttachmentSymbol attachmentSymbol, String annotationTag,
                                         boolean constAnnot, String key, Object value) {
         BAnnotationAttachmentSymbol annotationAttachmentSymbol = (BAnnotationAttachmentSymbol) attachmentSymbol;
-        Assert.assertEquals(annotationAttachmentSymbol.annotTag.value, annotationTag);
+        Assert.assertEquals(annotationAttachmentSymbol.annotTag.getValue(), annotationTag);
         Assert.assertEquals(annotationAttachmentSymbol.isConstAnnotation(), constAnnot);
 
         if (!constAnnot) {
@@ -477,7 +477,7 @@ public class AnnotationAttachmentSymbolsTest {
     }
 
     private boolean isServiceIntropAnnot(BAnnotationAttachmentSymbol annot) {
-        return AnnotationDesugar.SERVICE_INTROSPECTION_INFO_ANN.equals(annot.annotTag.value);
+        return AnnotationDesugar.SERVICE_INTROSPECTION_INFO_ANN.equals(annot.annotTag.getValue());
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentTest.java
@@ -513,7 +513,7 @@ public class AnnotationAttachmentTest {
             Assert.assertTrue(getConstrainedTypeFromRef(recordLiteral.getBType()).tag == TypeTags.RECORD
                     || getConstrainedTypeFromRef(recordLiteral.getBType()).tag == TypeTags.MAP);
             if (getConstrainedTypeFromRef(recordLiteral.getBType()).tag == TypeTags.RECORD) {
-                Assert.assertEquals(recordLiteral.getBType().tsymbol.name.value, typeName);
+                Assert.assertEquals(recordLiteral.getBType().tsymbol.name.getValue(), typeName);
             } else {
                 Assert.assertEquals(getConstrainedTypeFromRef(recordLiteral.getBType()).tag, TypeTags.MAP);
                 Assert.assertEquals(((BMapType) getConstrainedTypeFromRef(recordLiteral.getBType())).constraint.tag,
@@ -601,7 +601,7 @@ public class AnnotationAttachmentTest {
     private BLangTypeDefinition getTypeDefinition(List<? extends TypeDefinition> typeDefinitions, String name) {
         for (TypeDefinition typeDefinition : typeDefinitions) {
             BLangTypeDefinition bLangTypeDefinition = (BLangTypeDefinition) typeDefinition;
-            if (name.equals(bLangTypeDefinition.symbol.name.value)) {
+            if (name.equals(bLangTypeDefinition.symbol.name.getValue())) {
                 return bLangTypeDefinition;
             }
         }
@@ -615,7 +615,7 @@ public class AnnotationAttachmentTest {
             }
 
             BLangClassDefinition classDefinition = (BLangClassDefinition) topLevelNode;
-            if (name.equals(classDefinition.symbol.name.value)) {
+            if (name.equals(classDefinition.symbol.name.getValue())) {
                 return classDefinition;
             }
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/annotation/AnnotationTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/annotation/AnnotationTests.java
@@ -150,10 +150,10 @@ public class AnnotationTests {
         Assert.assertEquals(annotationAttachmentSymbols.size(), 1);
         BAnnotationAttachmentSymbol attachmentSymbol = (BAnnotationAttachmentSymbol) annotationAttachmentSymbols.get(0);
         PackageID pkgID = attachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "usage");
-        Assert.assertEquals(pkgID.version.value, "0.2.0");
-        Assert.assertEquals(attachmentSymbol.annotTag.value, "Allow");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "usage");
+        Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+        Assert.assertEquals(attachmentSymbol.annotTag.getValue(), "Allow");
         Assert.assertTrue(attachmentSymbol.isConstAnnotation());
         assertTrueAnnot(attachmentSymbol);
         BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol constAttachmentSymbol;
@@ -170,10 +170,10 @@ public class AnnotationTests {
 
         attachmentSymbol = (BAnnotationAttachmentSymbol) annotationAttachmentSymbols.get(0);
         pkgID = attachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "defn");
-        Assert.assertEquals(pkgID.version.value, "0.0.1");
-        Assert.assertEquals(attachmentSymbol.annotTag.value, "Annot");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "defn");
+        Assert.assertEquals(pkgID.version.getValue(), "0.0.1");
+        Assert.assertEquals(attachmentSymbol.annotTag.getValue(), "Annot");
         Assert.assertTrue(attachmentSymbol.isConstAnnotation());
         Object value = ((BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) attachmentSymbol)
                 .attachmentValueSymbol.value.value;
@@ -184,20 +184,20 @@ public class AnnotationTests {
 
         attachmentSymbol = (BAnnotationAttachmentSymbol) annotationAttachmentSymbols.get(1);
         pkgID = attachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "defn");
-        Assert.assertEquals(pkgID.version.value, "0.0.1");
-        Assert.assertEquals(attachmentSymbol.annotTag.value, "NonConstAnnot");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "defn");
+        Assert.assertEquals(pkgID.version.getValue(), "0.0.1");
+        Assert.assertEquals(attachmentSymbol.annotTag.getValue(), "NonConstAnnot");
         Assert.assertFalse(attachmentSymbol.isConstAnnotation());
 
         annotationAttachmentSymbols = otherFunc.restParam.getAnnotations();
         Assert.assertEquals(annotationAttachmentSymbols.size(), 1);
         attachmentSymbol = (BAnnotationAttachmentSymbol) annotationAttachmentSymbols.get(0);
         pkgID = attachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "usage");
-        Assert.assertEquals(pkgID.version.value, "0.2.0");
-        Assert.assertEquals(attachmentSymbol.annotTag.value, "Allow");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "usage");
+        Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+        Assert.assertEquals(attachmentSymbol.annotTag.getValue(), "Allow");
         Assert.assertTrue(attachmentSymbol.isConstAnnotation());
         constAttachmentSymbol = (BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) attachmentSymbol;
         Assert.assertEquals(constAttachmentSymbol.attachmentValueSymbol.type.tag, TypeTags.BOOLEAN);
@@ -210,10 +210,10 @@ public class AnnotationTests {
         Assert.assertEquals(annotationAttachmentSymbols.size(), 1);
         attachmentSymbol = (BAnnotationAttachmentSymbol) annotationAttachmentSymbols.get(0);
         pkgID = attachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "usage");
-        Assert.assertEquals(pkgID.version.value, "0.2.0");
-        Assert.assertEquals(attachmentSymbol.annotTag.value, "NonConstAllow");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "usage");
+        Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+        Assert.assertEquals(attachmentSymbol.annotTag.getValue(), "NonConstAllow");
         Assert.assertFalse(attachmentSymbol.isConstAnnotation());
 
         BClassSymbol testListener =
@@ -228,31 +228,31 @@ public class AnnotationTests {
         for (AnnotationAttachmentSymbol annotationAttachmentSymbol : annotationAttachmentSymbols) {
             attachmentSymbol = (BAnnotationAttachmentSymbol) annotationAttachmentSymbol;
             pkgID = attachmentSymbol.annotPkgID;
-            Assert.assertEquals(pkgID.orgName.value, "annots");
+            Assert.assertEquals(pkgID.orgName.getValue(), "annots");
 
             Assert.assertTrue(attachmentSymbol.isConstAnnotation());
             constAttachmentSymbol = (BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) attachmentSymbol;
             Assert.assertEquals(constAttachmentSymbol.attachmentValueSymbol.type.tag, TypeTags.BOOLEAN);
             Assert.assertEquals(constAttachmentSymbol.attachmentValueSymbol.value.value, Boolean.TRUE);
 
-            String pkgName = pkgID.pkgName.value;
+            String pkgName = pkgID.pkgName.getValue();
 
             if ("defn".equals(pkgName)) {
-                Assert.assertEquals(pkgID.version.value, "0.0.1");
-                Assert.assertEquals(attachmentSymbol.annotTag.value, "Expose");
+                Assert.assertEquals(pkgID.version.getValue(), "0.0.1");
+                Assert.assertEquals(attachmentSymbol.annotTag.getValue(), "Expose");
                 continue;
             }
 
             Assert.assertEquals(pkgName, "usage");
-            Assert.assertEquals(pkgID.version.value, "0.2.0");
-            Assert.assertEquals(attachmentSymbol.annotTag.value, "Allow");
+            Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+            Assert.assertEquals(attachmentSymbol.annotTag.getValue(), "Allow");
         }
 
         BAttachedFunction attachMethod = null;
         BAttachedFunction detachMethod = null;
 
         for (BAttachedFunction attachedFunc : testListener.attachedFuncs) {
-            String funcName = attachedFunc.funcName.value;
+            String funcName = attachedFunc.funcName.getValue();
 
             if ("attach".equals(funcName)) {
                 attachMethod = attachedFunc;
@@ -271,10 +271,10 @@ public class AnnotationTests {
         Assert.assertEquals(annotationAttachmentSymbols.size(), 1);
         attachmentSymbol = (BAnnotationAttachmentSymbol) annotationAttachmentSymbols.get(0);
         pkgID = attachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "defn");
-        Assert.assertEquals(pkgID.version.value, "0.0.1");
-        Assert.assertEquals(attachmentSymbol.annotTag.value, "Annot");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "defn");
+        Assert.assertEquals(pkgID.version.getValue(), "0.0.1");
+        Assert.assertEquals(attachmentSymbol.annotTag.getValue(), "Annot");
         constAttachmentSymbol = (BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) attachmentSymbol;
         value = constAttachmentSymbol.attachmentValueSymbol.value.value;
         Assert.assertTrue(value instanceof Map);
@@ -293,10 +293,10 @@ public class AnnotationTests {
         for (AnnotationAttachmentSymbol annotationAttachmentSymbol : annotationAttachmentSymbols) {
             attachmentSymbol = (BAnnotationAttachmentSymbol) annotationAttachmentSymbol;
             pkgID = attachmentSymbol.annotPkgID;
-            Assert.assertEquals(pkgID.orgName.value, "annots");
-            Assert.assertEquals(pkgID.pkgName.value, "defn");
-            Assert.assertEquals(pkgID.version.value, "0.0.1");
-            Assert.assertEquals(attachmentSymbol.annotTag.value, "Annots");
+            Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+            Assert.assertEquals(pkgID.pkgName.getValue(), "defn");
+            Assert.assertEquals(pkgID.version.getValue(), "0.0.1");
+            Assert.assertEquals(attachmentSymbol.annotTag.getValue(), "Annots");
             constAttachmentSymbol = (BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) attachmentSymbol;
             value = constAttachmentSymbol.attachmentValueSymbol.value.value;
             Assert.assertTrue(value instanceof Map);
@@ -322,20 +322,20 @@ public class AnnotationTests {
         Assert.assertEquals(annotationAttachmentSymbols.size(), 2);
         BAnnotationAttachmentSymbol attachmentSymbol = (BAnnotationAttachmentSymbol) annotationAttachmentSymbols.get(0);
         PackageID pkgID = attachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "usage");
-        Assert.assertEquals(pkgID.version.value, "0.2.0");
-        Assert.assertEquals(attachmentSymbol.annotTag.value, "Allow");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "usage");
+        Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+        Assert.assertEquals(attachmentSymbol.annotTag.getValue(), "Allow");
         Assert.assertTrue(attachmentSymbol.isConstAnnotation());
         assertTrueAnnot(attachmentSymbol);
         BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol constAttachmentSymbol;
 
         attachmentSymbol = (BAnnotationAttachmentSymbol) annotationAttachmentSymbols.get(1);
         pkgID = attachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "defn");
-        Assert.assertEquals(pkgID.version.value, "0.0.1");
-        Assert.assertEquals(attachmentSymbol.annotTag.value, "Annot");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "defn");
+        Assert.assertEquals(pkgID.version.getValue(), "0.0.1");
+        Assert.assertEquals(attachmentSymbol.annotTag.getValue(), "Annot");
         Assert.assertTrue(attachmentSymbol.isConstAnnotation());
         constAttachmentSymbol = (BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) attachmentSymbol;
         Object value = constAttachmentSymbol.attachmentValueSymbol.value.value;
@@ -358,10 +358,10 @@ public class AnnotationTests {
 
         BAnnotationAttachmentSymbol f1a1 = ((BAnnotationAttachmentSymbol) f1.get(0));
         PackageID pkgID = f1a1.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "usage");
-        Assert.assertEquals(pkgID.version.value, "0.2.0");
-        Assert.assertEquals(f1a1.annotTag.value, "Member");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "usage");
+        Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+        Assert.assertEquals(f1a1.annotTag.getValue(), "Member");
         Assert.assertTrue(f1a1.isConstAnnotation());
         BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol constAttachmentSymbol =
                 (BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) f1a1;
@@ -382,10 +382,10 @@ public class AnnotationTests {
 
         BAnnotationAttachmentSymbol m1a1 = ((BAnnotationAttachmentSymbol) m1.get(0));
         PackageID pkgID = m1a1.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "usage");
-        Assert.assertEquals(pkgID.version.value, "0.2.0");
-        Assert.assertEquals(m1a1.annotTag.value, "Member");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "usage");
+        Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+        Assert.assertEquals(m1a1.annotTag.getValue(), "Member");
         Assert.assertTrue(m1a1.isConstAnnotation());
         BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol constAttachmentSymbol =
                 (BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) m1a1;
@@ -398,7 +398,7 @@ public class AnnotationTests {
         m1 = members.get(1).symbol.getAnnotations();
 
         m1a1 = ((BAnnotationAttachmentSymbol) m1.get(0));
-        Assert.assertEquals(m1a1.annotTag.value, "Member");
+        Assert.assertEquals(m1a1.annotTag.getValue(), "Member");
         Assert.assertTrue(m1a1.isConstAnnotation());
         constAttachmentSymbol = (BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) m1a1;
         Assert.assertEquals(constAttachmentSymbol.attachmentValueSymbol.type.tag, TypeTags.BOOLEAN);
@@ -410,7 +410,7 @@ public class AnnotationTests {
         m1 = members.get(1).symbol.getAnnotations();
 
         m1a1 = ((BAnnotationAttachmentSymbol) m1.get(0));
-        Assert.assertEquals(m1a1.annotTag.value, "Member");
+        Assert.assertEquals(m1a1.annotTag.getValue(), "Member");
         Assert.assertTrue(m1a1.isConstAnnotation());
         constAttachmentSymbol = (BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) m1a1;
         Assert.assertEquals(constAttachmentSymbol.attachmentValueSymbol.type.tag, TypeTags.BOOLEAN);
@@ -436,10 +436,10 @@ public class AnnotationTests {
         Assert.assertEquals(annotationAttachmentSymbols.size(), 1);
         BAnnotationAttachmentSymbol attachmentSymbol = (BAnnotationAttachmentSymbol) annotationAttachmentSymbols.get(0);
         PackageID pkgID = attachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "usage");
-        Assert.assertEquals(pkgID.version.value, "0.2.0");
-        Assert.assertEquals(attachmentSymbol.annotTag.value, "Custom");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "usage");
+        Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+        Assert.assertEquals(attachmentSymbol.annotTag.getValue(), "Custom");
         Assert.assertTrue(attachmentSymbol.isConstAnnotation());
         assertTrueAnnot(attachmentSymbol);
     }
@@ -454,10 +454,10 @@ public class AnnotationTests {
         Assert.assertEquals(annotationAttachmentSymbols.size(), 1);
         BAnnotationAttachmentSymbol attachmentSymbol = (BAnnotationAttachmentSymbol) annotationAttachmentSymbols.get(0);
         PackageID pkgID = attachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "defn");
-        Assert.assertEquals(pkgID.version.value, "0.0.1");
-        Assert.assertEquals(attachmentSymbol.annotTag.value, "KnownConst");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "defn");
+        Assert.assertEquals(pkgID.version.getValue(), "0.0.1");
+        Assert.assertEquals(attachmentSymbol.annotTag.getValue(), "KnownConst");
         Assert.assertTrue(attachmentSymbol.isConstAnnotation());
         assertTrueAnnot(attachmentSymbol);
 
@@ -477,10 +477,10 @@ public class AnnotationTests {
 
         BAnnotationAttachmentSymbol annotationAttachmentSymbol = (BAnnotationAttachmentSymbol) attachments.get(0);
         PackageID pkgID = annotationAttachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "usage");
-        Assert.assertEquals(pkgID.version.value, "0.2.0");
-        Assert.assertEquals(annotationAttachmentSymbol.annotTag.value, "ClassAnnot");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "usage");
+        Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+        Assert.assertEquals(annotationAttachmentSymbol.annotTag.getValue(), "ClassAnnot");
         Assert.assertTrue(annotationAttachmentSymbol.isConstAnnotation());
 
         Object constValue =
@@ -538,10 +538,10 @@ public class AnnotationTests {
 
         BAnnotationAttachmentSymbol annotationAttachmentSymbol = (BAnnotationAttachmentSymbol) attachments.get(0);
         PackageID pkgID = annotationAttachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "usage");
-        Assert.assertEquals(pkgID.version.value, "0.2.0");
-        Assert.assertEquals(annotationAttachmentSymbol.annotTag.value, "AnnotWithList");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "usage");
+        Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+        Assert.assertEquals(annotationAttachmentSymbol.annotTag.getValue(), "AnnotWithList");
         Assert.assertTrue(annotationAttachmentSymbol.isConstAnnotation());
 
         Object constValue =
@@ -573,10 +573,10 @@ public class AnnotationTests {
 
         BAnnotationAttachmentSymbol annotationAttachmentSymbol = (BAnnotationAttachmentSymbol) attachments.get(0);
         PackageID pkgID = annotationAttachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "usage");
-        Assert.assertEquals(pkgID.version.value, "0.2.0");
-        Assert.assertEquals(annotationAttachmentSymbol.annotTag.value, "FunctionAnnot");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "usage");
+        Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+        Assert.assertEquals(annotationAttachmentSymbol.annotTag.getValue(), "FunctionAnnot");
         Assert.assertTrue(annotationAttachmentSymbol.isConstAnnotation());
         assertTrueAnnot(annotationAttachmentSymbol);
 
@@ -584,10 +584,10 @@ public class AnnotationTests {
         Assert.assertEquals(attachments.size(), 1);
         annotationAttachmentSymbol = (BAnnotationAttachmentSymbol) attachments.get(0);
         pkgID = annotationAttachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "usage");
-        Assert.assertEquals(pkgID.version.value, "0.2.0");
-        Assert.assertEquals(annotationAttachmentSymbol.annotTag.value, "ReturnAnnot");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "usage");
+        Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+        Assert.assertEquals(annotationAttachmentSymbol.annotTag.getValue(), "ReturnAnnot");
         Assert.assertTrue(annotationAttachmentSymbol.isConstAnnotation());
         assertTrueAnnot(annotationAttachmentSymbol);
 
@@ -603,7 +603,7 @@ public class AnnotationTests {
 
         BClassSymbol classSymbol = (BClassSymbol) importedModuleEntries.get(Names.fromString("Cl2")).symbol;
         BInvokableSymbol invokableSymbol = classSymbol.attachedFuncs.stream()
-                .filter(method -> method.funcName.value.equals("cfn1"))
+                .filter(method -> method.funcName.getValue().equals("cfn1"))
                 .findFirst().get().symbol;
         Assert.assertEquals(invokableSymbol.getAnnotations().size(), 0);
 
@@ -612,23 +612,23 @@ public class AnnotationTests {
         Assert.assertEquals(attachments.size(), 1);
         BAnnotationAttachmentSymbol annotationAttachmentSymbol = (BAnnotationAttachmentSymbol) attachments.get(0);
         PackageID pkgID = annotationAttachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "usage");
-        Assert.assertEquals(pkgID.version.value, "0.2.0");
-        Assert.assertEquals(annotationAttachmentSymbol.annotTag.value, "ReturnAnnot");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "usage");
+        Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+        Assert.assertEquals(annotationAttachmentSymbol.annotTag.getValue(), "ReturnAnnot");
         Assert.assertTrue(annotationAttachmentSymbol.isConstAnnotation());
         assertTrueAnnot(annotationAttachmentSymbol);
 
-        invokableSymbol = classSymbol.attachedFuncs.stream().filter(method -> method.funcName.value.equals("cfn2"))
+        invokableSymbol = classSymbol.attachedFuncs.stream().filter(method -> method.funcName.getValue().equals("cfn2"))
                 .findFirst().get().symbol;
         attachments = invokableSymbol.getAnnotations();
         Assert.assertEquals(attachments.size(), 1);
         annotationAttachmentSymbol = (BAnnotationAttachmentSymbol) attachments.get(0);
         pkgID = annotationAttachmentSymbol.annotPkgID;
-        Assert.assertEquals(pkgID.orgName.value, "annots");
-        Assert.assertEquals(pkgID.pkgName.value, "usage");
-        Assert.assertEquals(pkgID.version.value, "0.2.0");
-        Assert.assertEquals(annotationAttachmentSymbol.annotTag.value, "FunctionAnnot");
+        Assert.assertEquals(pkgID.orgName.getValue(), "annots");
+        Assert.assertEquals(pkgID.pkgName.getValue(), "usage");
+        Assert.assertEquals(pkgID.version.getValue(), "0.2.0");
+        Assert.assertEquals(annotationAttachmentSymbol.annotTag.getValue(), "FunctionAnnot");
         Assert.assertTrue(annotationAttachmentSymbol.isConstAnnotation());
         assertTrueAnnot(annotationAttachmentSymbol);
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/object/ObjectIncludeOverrideBalaTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/object/ObjectIncludeOverrideBalaTest.java
@@ -73,14 +73,14 @@ public class ObjectIncludeOverrideBalaTest {
 
         BVarSymbol aVarParam = fnSymbol.getParameters().get(0);
         assertEquals(aVarParam.getName().getValue(), "aVar");
-        assertEquals(aVarParam.pkgID.name.value, ".");
-        assertEquals(aVarParam.pkgID.orgName.value, "$anon");
+        assertEquals(aVarParam.pkgID.name.getValue(), ".");
+        assertEquals(aVarParam.pkgID.orgName.getValue(), "$anon");
         assertEquals(aVarParam.origin, SymbolOrigin.SOURCE);
 
         BVarSymbol bVarParam = fnSymbol.getParameters().get(1);
         assertEquals(bVarParam.getName().getValue(), "bVar");
-        assertEquals(bVarParam.pkgID.name.value, ".");
-        assertEquals(bVarParam.pkgID.orgName.value, "$anon");
+        assertEquals(bVarParam.pkgID.name.getValue(), ".");
+        assertEquals(bVarParam.pkgID.orgName.getValue(), "$anon");
         assertEquals(bVarParam.origin, SymbolOrigin.SOURCE);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bir/RecordDesugarTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bir/RecordDesugarTest.java
@@ -55,7 +55,7 @@ public class RecordDesugarTest {
     @Test(description = "Test record field set")
     public void testRecordFieldSet() {
         List<String> functions = Arrays.asList("setRequiredField", "setNillableField", "setOptionalField");
-        result.getExpectedBIR().functions.stream().filter(function -> functions.contains(function.name.value))
+        result.getExpectedBIR().functions.stream().filter(function -> functions.contains(function.name.getValue()))
                 .forEach(this::assertFunctions);
     }
 
@@ -63,9 +63,9 @@ public class RecordDesugarTest {
         String actual = BIREmitter.emitFunction(function, 0);
         String expected = null;
         try {
-            expected = readFile(function.name.value);
+            expected = readFile(function.name.getValue());
         } catch (IOException e) {
-            Assert.fail("Failed to read the expected BIR file for function: " + function.name.value, e);
+            Assert.fail("Failed to read the expected BIR file for function: " + function.name.getValue(), e);
         }
         Assert.assertEquals(actual, expected);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationInferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationInferenceTest.java
@@ -145,7 +145,7 @@ public class IsolationInferenceTest {
 
         for (BLangVariable variable : result.getAST().getGlobalVariables()) {
             BVarSymbol symbol = variable.symbol;
-            String name = symbol.name.value;
+            String name = symbol.name.getValue();
             switch (name) {
                 case "ln":
                     lnFlags = symbol.flags;


### PR DESCRIPTION
## Purpose
- Made all methods of the [Names](https://github.com/ballerina-platform/ballerina-lang/blob/904650aa7635fdfbeb8280150ca9f44a0bbddbff/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Names.java) class static, since they access no instance fields.
- Remove all references to local `Names` variables and only use static access
- Encapsulate [Name.value](https://github.com/ballerina-platform/ballerina-lang/blob/281e0d8f9602b8ed939be92797484970624ab553/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Name.java#L25) field (make it private and only use `getValue()`).


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
