### PR TITLE
[2201.10.x] Add telemetry header for TEST_MODE_ACTIVE=true

### DIFF
--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -83,6 +83,7 @@ import static org.ballerinalang.central.client.CentralClientConstants.APPLICATIO
 import static org.ballerinalang.central.client.CentralClientConstants.APPLICATION_OCTET_STREAM;
 import static org.ballerinalang.central.client.CentralClientConstants.AUTHORIZATION;
 import static org.ballerinalang.central.client.CentralClientConstants.BALA_URL;
+import static org.ballerinalang.central.client.CentralClientConstants.BALLERINA_CENTRAL_TELEMETRY_DISABLED;
 import static org.ballerinalang.central.client.CentralClientConstants.BALLERINA_PLATFORM;
 import static org.ballerinalang.central.client.CentralClientConstants.CONTENT_DISPOSITION;
 import static org.ballerinalang.central.client.CentralClientConstants.CONTENT_TYPE;
@@ -99,6 +100,7 @@ import static org.ballerinalang.central.client.CentralClientConstants.SHA256_ALG
 import static org.ballerinalang.central.client.CentralClientConstants.USER_AGENT;
 import static org.ballerinalang.central.client.CentralClientConstants.VERSION;
 import static org.ballerinalang.central.client.Utils.ProgressRequestBody;
+import static org.ballerinalang.central.client.Utils.SET_TEST_MODE_ACTIVE;
 import static org.ballerinalang.central.client.Utils.checkHash;
 import static org.ballerinalang.central.client.Utils.createBalaInHomeRepo;
 import static org.ballerinalang.central.client.Utils.getAsList;
@@ -1681,16 +1683,14 @@ public class CentralAPIClient {
      * @return Http request builder
      */
     protected Request.Builder getNewRequest(String supportedPlatform, String ballerinaVersion) {
-        if (this.accessToken.isEmpty()) {
-            return new Request.Builder()
-                    .addHeader(BALLERINA_PLATFORM, supportedPlatform)
-                    .addHeader(USER_AGENT, ballerinaVersion);
-        } else {
-            return new Request.Builder()
-                    .addHeader(BALLERINA_PLATFORM, supportedPlatform)
-                    .addHeader(USER_AGENT, ballerinaVersion)
-                    .addHeader(AUTHORIZATION, getBearerToken(this.accessToken));
+        Request.Builder requestBuilder = new Request.Builder()
+                .addHeader(BALLERINA_PLATFORM, supportedPlatform)
+                .addHeader(USER_AGENT, ballerinaVersion)
+                .addHeader(BALLERINA_CENTRAL_TELEMETRY_DISABLED, String.valueOf(SET_TEST_MODE_ACTIVE));
+        if (!this.accessToken.isEmpty()) {
+            requestBuilder.addHeader(AUTHORIZATION, getBearerToken(this.accessToken));
         }
+        return requestBuilder;
     }
 
     public String accessToken() {

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralClientConstants.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralClientConstants.java
@@ -60,5 +60,6 @@ public class CentralClientConstants {
     public static final int UPDATE_INTERVAL_MILLIS = 1000;
     public static final String SHA256 = "sha-256=";
     public static final String SHA256_ALGORITHM = "SHA-256";
-
+    public static final String TEST_MODE_ACTIVE = "TEST_MODE_ACTIVE";
+    public static final String BALLERINA_CENTRAL_TELEMETRY_DISABLED = "Ballerina-Central-Telemetry-Disabled";
 }

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
@@ -72,6 +72,7 @@ import static org.ballerinalang.central.client.CentralClientConstants.RESOLVED_R
 import static org.ballerinalang.central.client.CentralClientConstants.SHA256;
 import static org.ballerinalang.central.client.CentralClientConstants.SHA256_ALGORITHM;
 import static org.ballerinalang.central.client.CentralClientConstants.STAGING_REPO;
+import static org.ballerinalang.central.client.CentralClientConstants.TEST_MODE_ACTIVE;
 import static org.ballerinalang.central.client.CentralClientConstants.UPDATE_INTERVAL_MILLIS;
 
 /**
@@ -85,6 +86,7 @@ public class Utils {
             System.getenv(BALLERINA_STAGE_CENTRAL));
     public static final boolean SET_BALLERINA_DEV_CENTRAL = Boolean.parseBoolean(
             System.getenv(BALLERINA_DEV_CENTRAL));
+    public static final boolean SET_TEST_MODE_ACTIVE = Boolean.parseBoolean(System.getenv(TEST_MODE_ACTIVE));
 
     private Utils() {
     }


### PR DESCRIPTION
## Purpose
$ subject
Adding this flag allows us to run project-api tests on the prod, without polluting the telemetry data for the Ballerina Central.

Related to https://github.com/ballerina-platform/ballerina-distribution/issues/5541

2201.10.x PR of https://github.com/ballerina-platform/ballerina-lang/pull/43261

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
