### PR TITLE
[2201.8.x] Add telemetry header for TEST_MODE_ACTIVE=true

### DIFF
--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -80,6 +80,7 @@ import static org.ballerinalang.central.client.CentralClientConstants.APPLICATIO
 import static org.ballerinalang.central.client.CentralClientConstants.APPLICATION_OCTET_STREAM;
 import static org.ballerinalang.central.client.CentralClientConstants.AUTHORIZATION;
 import static org.ballerinalang.central.client.CentralClientConstants.BALA_URL;
+import static org.ballerinalang.central.client.CentralClientConstants.BALLERINA_CENTRAL_TELEMETRY_DISABLED;
 import static org.ballerinalang.central.client.CentralClientConstants.BALLERINA_PLATFORM;
 import static org.ballerinalang.central.client.CentralClientConstants.CONTENT_DISPOSITION;
 import static org.ballerinalang.central.client.CentralClientConstants.CONTENT_TYPE;
@@ -93,6 +94,7 @@ import static org.ballerinalang.central.client.CentralClientConstants.PLATFORM;
 import static org.ballerinalang.central.client.CentralClientConstants.USER_AGENT;
 import static org.ballerinalang.central.client.CentralClientConstants.VERSION;
 import static org.ballerinalang.central.client.Utils.ProgressRequestBody;
+import static org.ballerinalang.central.client.Utils.SET_TEST_MODE_ACTIVE;
 import static org.ballerinalang.central.client.Utils.createBalaInHomeRepo;
 import static org.ballerinalang.central.client.Utils.getAsList;
 import static org.ballerinalang.central.client.Utils.getBearerToken;
@@ -1583,16 +1585,14 @@ public class CentralAPIClient {
      * @return Http request builder
      */
     protected Request.Builder getNewRequest(String supportedPlatform, String ballerinaVersion) {
-        if (this.accessToken.isEmpty()) {
-            return new Request.Builder()
-                    .addHeader(BALLERINA_PLATFORM, supportedPlatform)
-                    .addHeader(USER_AGENT, ballerinaVersion);
-        } else {
-            return new Request.Builder()
-                    .addHeader(BALLERINA_PLATFORM, supportedPlatform)
-                    .addHeader(USER_AGENT, ballerinaVersion)
-                    .addHeader(AUTHORIZATION, getBearerToken(this.accessToken));
+        Request.Builder requestBuilder = new Request.Builder()
+                .addHeader(BALLERINA_PLATFORM, supportedPlatform)
+                .addHeader(USER_AGENT, ballerinaVersion)
+                .addHeader(BALLERINA_CENTRAL_TELEMETRY_DISABLED, String.valueOf(SET_TEST_MODE_ACTIVE));
+        if (!this.accessToken.isEmpty()) {
+            requestBuilder.addHeader(AUTHORIZATION, getBearerToken(this.accessToken));
         }
+        return requestBuilder;
     }
 
     public String accessToken() {

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralClientConstants.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralClientConstants.java
@@ -54,5 +54,6 @@ public class CentralClientConstants {
     static final String DEV_REPO = "dev-central.ballerina.io";
     public static final String BALLERINA_STAGE_CENTRAL = "BALLERINA_STAGE_CENTRAL";
     public static final String BALLERINA_DEV_CENTRAL = "BALLERINA_DEV_CENTRAL";
-
+    public static final String TEST_MODE_ACTIVE = "TEST_MODE_ACTIVE";
+    public static final String BALLERINA_CENTRAL_TELEMETRY_DISABLED = "Ballerina-Central-Telemetry-Disabled";
 }

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
@@ -65,6 +65,7 @@ import static org.ballerinalang.central.client.CentralClientConstants.DEV_REPO;
 import static org.ballerinalang.central.client.CentralClientConstants.PRODUCTION_REPO;
 import static org.ballerinalang.central.client.CentralClientConstants.RESOLVED_REQUESTED_URI;
 import static org.ballerinalang.central.client.CentralClientConstants.STAGING_REPO;
+import static org.ballerinalang.central.client.CentralClientConstants.TEST_MODE_ACTIVE;
 
 /**
  * Utils class for this package.
@@ -76,6 +77,8 @@ public class Utils {
             System.getenv(BALLERINA_STAGE_CENTRAL));
     public static final boolean SET_BALLERINA_DEV_CENTRAL = Boolean.parseBoolean(
             System.getenv(BALLERINA_DEV_CENTRAL));
+    public static final boolean SET_TEST_MODE_ACTIVE = Boolean.parseBoolean(System.getenv(TEST_MODE_ACTIVE));
+
     private Utils() {
     }
 
@@ -447,13 +450,13 @@ public class Utils {
         private final RequestBody reqBody;
         private final String task;
         private final PrintStream out;
-    
+
         public ProgressRequestBody(RequestBody reqBody, String task, PrintStream out) {
             this.reqBody = reqBody;
             this.task = task;
             this.out = out;
         }
-    
+
         @Override
         public MediaType contentType() {
             return this.reqBody.contentType();
@@ -469,7 +472,7 @@ public class Utils {
             final long totalBytes = contentLength();
             long byteConverter;
             String unitName;
-    
+
             if (totalBytes < 1024 * 5) { // use bytes for progress bar if payload is less than 5 KB
                 byteConverter = 1;
                 unitName = " B";
@@ -480,7 +483,7 @@ public class Utils {
                 byteConverter = 1024 * 1024;
                 unitName = " MB";
             }
-    
+
             ProgressBar progressBar = new ProgressBar(task, contentLength(), 1000, out,
                     ProgressBarStyle.ASCII, unitName, byteConverter);
             CountingSink countingSink = new CountingSink(sink, progressBar);
@@ -490,16 +493,16 @@ public class Utils {
             progressBar.close();
         }
     }
-    
+
     private static class CountingSink extends ForwardingSink {
         private long bytesWritten = 0;
         private final ProgressBar progressBar;
-    
+
         public CountingSink(Sink delegate, ProgressBar progressBar) {
             super(delegate);
             this.progressBar = progressBar;
         }
-        
+
         @Override
         public void write(Buffer source, long byteCount) throws IOException {
             super.write(source, byteCount);


### PR DESCRIPTION
## Purpose
$ subject
Adding this flag allows us to run project-api tests on the prod, without polluting the telemetry data for the Ballerina Central.

Related to https://github.com/ballerina-platform/ballerina-distribution/issues/5541

2201.8.x PR of https://github.com/ballerina-platform/ballerina-lang/pull/43261

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
