### PR TITLE
Fix exact equality bug when both values are xmlSequence singletons

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -495,7 +495,7 @@ public class TypeChecker {
         if (lhsValue.getNodeType() == XmlNodeType.TEXT && rhsValue.getNodeType() == XmlNodeType.TEXT) {
             return isEqual(lhsValue, rhsValue);
         }
-        return lhsValue == rhsValue;
+        return false;
     }
 
     private static boolean isXMLSequenceRefEqual(XmlSequence lhsValue, XmlSequence rhsValue) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -477,22 +477,25 @@ public class TypeChecker {
     }
 
     private static boolean isXMLValueRefEqual(XmlValue lhsValue, XmlValue rhsValue) {
-        if (lhsValue.getNodeType() == XmlNodeType.SEQUENCE && lhsValue.isSingleton()) {
+        boolean isLhsXmlSequence = lhsValue.getNodeType() == XmlNodeType.SEQUENCE;
+        boolean isRhsXmlSequence = rhsValue.getNodeType() == XmlNodeType.SEQUENCE;
+
+        if (isLhsXmlSequence && isRhsXmlSequence) {
+            return isXMLSequenceRefEqual((XmlSequence) lhsValue, (XmlSequence) rhsValue);
+        }
+        if (isLhsXmlSequence && lhsValue.isSingleton()) {
             return ((XmlSequence) lhsValue).getChildrenList().get(0) == rhsValue;
         }
-        if (rhsValue.getNodeType() == XmlNodeType.SEQUENCE && rhsValue.isSingleton()) {
+        if (isRhsXmlSequence && rhsValue.isSingleton()) {
             return ((XmlSequence) rhsValue).getChildrenList().get(0) == lhsValue;
         }
         if (lhsValue.getNodeType() != rhsValue.getNodeType()) {
             return false;
         }
-        if (lhsValue.getNodeType() == XmlNodeType.SEQUENCE && rhsValue.getNodeType() == XmlNodeType.SEQUENCE) {
-            return isXMLSequenceRefEqual((XmlSequence) lhsValue, (XmlSequence) rhsValue);
-        }
         if (lhsValue.getNodeType() == XmlNodeType.TEXT && rhsValue.getNodeType() == XmlNodeType.TEXT) {
             return isEqual(lhsValue, rhsValue);
         }
-        return false;
+        return lhsValue == rhsValue;
     }
 
     private static boolean isXMLSequenceRefEqual(XmlSequence lhsValue, XmlSequence rhsValue) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/ref_equal_and_not_equal_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/ref_equal_and_not_equal_operation.bal
@@ -465,8 +465,11 @@ function testXMLSequenceRefEquality() {
     xml x1 = xml `<b>b</b>`;
     xml x2 = x + x1;
     xml x3 = x + x1;
+    xml x4 = xml:concat(x);
+    xml x5 = xml:concat(x);
 
     test:assertTrue(x2 === x3);
+    test:assertTrue(x4 === x5);
 
     xml a1 = xml `<e1/>`;
     xml a2 = xml `<e2/>`;


### PR DESCRIPTION
## Purpose
> $subject
> Please refer to the issue description for more details.

Fixes #43091 

## Approach
Rearranged the logic within `isXMLValueRefEqual()` to first check for both values being `xmlSequences` before returning half way with incorrect result.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [X] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
