### PR TITLE
[2201.10.x] Add observe internal module as first import

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ObservabilityDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ObservabilityDesugar.java
@@ -67,7 +67,7 @@ public class ObservabilityDesugar {
             importDcl.alias = ASTBuilderUtil.createIdentifier(pkgNode.pos, "_");
             importDcl.version = ASTBuilderUtil.createIdentifier(pkgNode.pos, "");
             importDcl.symbol = packageCache.getSymbol(PackageID.OBSERVE_INTERNAL);
-            pkgNode.imports.add(importDcl);
+            pkgNode.imports.add(0, importDcl);
             pkgNode.symbol.imports.add(importDcl.symbol);
         }
     }


### PR DESCRIPTION
## Purpose
We need to add the observe internal module to the first in the imports. Since it will add the metric observer and tracing observer, it will be needed in other imported module init method executions.

Fixes #43342

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
