### PR TITLE
Fix compiler crash with nested queries in select as a field

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -1994,7 +1994,7 @@ public class QueryDesugar extends BLangNodeVisitor {
                     }
                 }
                 identifiers.put(identifier, symbol);
-            } else if (identifiers.containsKey(identifier) && (withinLambdaOrArrowFunc || withinQuery)) {
+            } else if (identifiers.containsKey(identifier)) {
                 symbol = identifiers.get(identifier);
                 bLangSimpleVarRef.symbol = symbol;
                 bLangSimpleVarRef.varSymbol = symbol;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithClosuresTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithClosuresTest.java
@@ -62,7 +62,8 @@ public class QueryWithClosuresTest {
                 "testClosureInQueryActionInDo4",
                 "testClosureInQueryActionInDo5",
                 "testClosureInQueryActionInDo6",
-                "testClosureInQueryActionInDo7"
+                "testClosureInQueryActionInDo7",
+                "testNestedQueryAndClosureFieldInQuerySelect"
         };
     }
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #43336

## Approach
The `identifiers` map in the `QueryDesugar` stores a set of identifiers and their symbols found in the lambda function created for clauses inside the query. When an `identifier` in a `select` clause is first used in a nested query or within a lambda function in a query, the symbol of that `identifier` is marked as a `closure` symbol. For consequent usages of this identifier in the select clause this symbol that has been marked as a closure should be used (i.e. for other fields in the select clause). 
```ballerina
record {|string name; string[] courses;|}[] studentCourses = from Student student in students
        select {
            courses: from Grade grade in student.grades
                select grade.course,
            name: student.name
        };
```
Consider the above code. The student identifier inside the select clause is marked as a closure variable first because it is used within a nested query as in the first field. The second field also uses this student identifier and the variable of this second usage should also refer to the Symbol that is marked as a closure because of that nested field.

The current implementation restricts to using symbols of the identifiers from this `identifiers` map when either on in a nestedQuery or within an arrow function. This fix removes that check usage.  

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
