### PR TITLE
[2201.10.x] Fix immutable object virtual call getting no such method error

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
@@ -200,16 +200,16 @@ public class JvmCodeGenUtil {
 
     public static String rewriteVirtualCallTypeName(String value, BType objectType) {
         objectType = getImpliedType(objectType);
-        // The call name will be in the format of`objectTypeName.funcName` for attached functions of imported modules.
-        // Therefore, We need to remove the type name.
-        Name originalName = objectType.tsymbol.originalName;
-        if (!objectType.tsymbol.name.value.isEmpty() && value.startsWith(objectType.tsymbol.name.value)) {
-            value = value.replace(objectType.tsymbol.name.value + ".", "").trim();
-        }
-        // The call name will be in the format of`objectTypeOriginalName.funcName` for attached functions of
-        // object definitions. Therefore, We need to remove it.
-        if (originalName != null && !originalName.value.isEmpty() && value.startsWith(originalName.value)) {
-            value = value.replace(originalName.value + ".", "").trim();
+        String typeName = objectType.tsymbol.name.value;
+        String originalName = objectType.tsymbol.originalName != null ? objectType.tsymbol.originalName.value : "";
+        if (!typeName.isEmpty() && value.startsWith(typeName)) {
+            // The call name will be in the format of`objectTypeName.funcName` for attached functions of imported
+            // modules. Therefore, We need to remove the type name.
+            value = value.replace(typeName + ".", "").trim();
+        } else if (value.startsWith(originalName)) {
+            // The call name will be in the format of`objectTypeOriginalName.funcName` for attached functions of
+            // object definitions. Therefore, We need to remove it.
+            value = value.replace(originalName + ".", "").trim();
         }
         return Utils.encodeFunctionIdentifier(value);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
@@ -202,8 +202,14 @@ public class JvmCodeGenUtil {
         objectType = getImpliedType(objectType);
         // The call name will be in the format of`objectTypeName.funcName` for attached functions of imported modules.
         // Therefore, We need to remove the type name.
+        Name originalName = objectType.tsymbol.originalName;
         if (!objectType.tsymbol.name.value.isEmpty() && value.startsWith(objectType.tsymbol.name.value)) {
             value = value.replace(objectType.tsymbol.name.value + ".", "").trim();
+        }
+        // The call name will be in the format of`objectTypeOriginalName.funcName` for attached functions of
+        // object definitions. Therefore, We need to remove it.
+        if (originalName != null && !originalName.value.isEmpty() && value.startsWith(originalName.value)) {
+            value = value.replace(originalName.value + ".", "").trim();
         }
         return Utils.encodeFunctionIdentifier(value);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
@@ -201,12 +201,12 @@ public class JvmCodeGenUtil {
     public static String rewriteVirtualCallTypeName(String value, BType objectType) {
         objectType = getImpliedType(objectType);
         String typeName = objectType.tsymbol.name.value;
-        String originalName = objectType.tsymbol.originalName != null ? objectType.tsymbol.originalName.value : "";
+        Name originalName = objectType.tsymbol.originalName;
         if (!typeName.isEmpty() && value.startsWith(typeName)) {
             // The call name will be in the format of`objectTypeName.funcName` for attached functions of imported
             // modules. Therefore, We need to remove the type name.
             value = value.replace(typeName + ".", "").trim();
-        } else if (value.startsWith(originalName)) {
+        } else if (originalName != null && value.startsWith(originalName.value)) {
             // The call name will be in the format of`objectTypeOriginalName.funcName` for attached functions of
             // object definitions. Therefore, We need to remove it.
             value = value.replace(originalName + ".", "").trim();

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ReadonlyObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ReadonlyObjectTest.java
@@ -50,7 +50,8 @@ public class ReadonlyObjectTest {
                 "testReadOnlyServiceClass",
                 "testReadOnlyClassIntersectionWithMismatchedQualifiersRuntimeNegative",
                 "testReadOnlyClassIntersectionWithValidQualifiers",
-                "testRecursiveObjectArrayReadonlyClone"
+                "testRecursiveObjectArrayReadonlyClone",
+                "testReadonlyObjectMethodCall"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/readonly_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/readonly_objects.bal
@@ -315,6 +315,21 @@ public function testRecursiveObjectArrayReadonlyClone() {
    assertTrue(x is readonly & Obj[]);
 }
 
+public function testReadonlyObjectMethodCall() {
+    File file = new VirtualFile();
+    string filename = file.filename();
+    assertEquality("File Name", filename);
+}
+
+public type File readonly & object {
+    public function filename() returns string;
+};
+
+public readonly class VirtualFile {
+    *File;
+    public function filename() returns string => "File Name";
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(any|error actual) {


### PR DESCRIPTION
## Purpose
$subject
Fixes #43323 

## Approach
The fix added for https://github.com/ballerina-platform/ballerina-lang/issues/42988 missed a case where the attached function name generated for immutable object contains a module name prefix. 
A proper fix has to be added after fixing https://github.com/ballerina-platform/ballerina-lang/issues/43050. 

## Samples
```ballerina
public type File readonly & object {
    public function filename() returns string;
};

public function format(File file) {
    string line = file.filename();
}

public readonly class VirtualFile {
    *File;
    public function filename() returns string => "Hello";
}

public function main() {
    File d = new VirtualFile();
    format(d); // function name - (hinduja/test_listener:0:$anonType$File$_0 & readonly).filename
}
```
## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
