### PR TITLE
Fix profiler test for Java 21 migration

### DIFF
--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/profiler/ProfilerTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/profiler/ProfilerTest.java
@@ -137,11 +137,8 @@ public class ProfilerTest extends BaseTest {
             bMainInstance.waitForLeechers(List.of(beforeExecleechers), 20000);
             addLogLeechers(afterExecleechers, serverInfoLogReader);
             Thread.sleep(5000);
-            ProcessHandle profilerHandle = process.children().findFirst().get().children().findFirst().get();
-            long profileId = profilerHandle.pid();
-            long balProcessID = profilerHandle.children().findFirst().get().pid();
-            Runtime.getRuntime().exec("kill -SIGINT " + balProcessID);
-            Runtime.getRuntime().exec("kill -SIGINT " + profileId);
+            long processId = process.pid();
+            Runtime.getRuntime().exec("kill -SIGINT " + processId);
             bMainInstance.waitForLeechers(List.of(afterExecleechers), 20000);
             process.waitFor();
         } catch (InterruptedException | IOException e) {


### PR DESCRIPTION
## Purpose
> $subject

Contributes to #43351 

## Approach
Kill the parent process instead of searching for child processes to kill.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
