### PR TITLE
[Java 21] Remove Gson library usage from the Profiler

### DIFF
--- a/bvm/ballerina-profiler/build.gradle
+++ b/bvm/ballerina-profiler/build.gradle
@@ -25,7 +25,6 @@ configurations {
 dependencies {
     implementation "org.ow2.asm:asm:${project.ow2AsmVersion}"
     implementation "org.ow2.asm:asm-commons:${project.ow2AsmCommonsVersion}"
-    implementation "com.google.code.gson:gson:${project.gsonVersion}"
     implementation "commons-io:commons-io:${project.commonsIoVersion}"
     implementation project(':identifier-util')
     implementation project(':ballerina-runtime')

--- a/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/ui/JsonParser.java
+++ b/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/ui/JsonParser.java
@@ -89,7 +89,7 @@ public class JsonParser {
         }
     }
 
-    private void writeToValueJson(Data output) {;
+    private void writeToValueJson(Data output) {
         int totalTime = getTotalTime(output);
         output.value = totalTime;
         writePerformanceJson(output.toString());
@@ -158,7 +158,8 @@ public class JsonParser {
         @Override
         public String toString() {
             StringBuilder text = new StringBuilder();
-            text.append("{").append("\"name\":\"").append(this.name).append("\",\"value\":").append(this.value).append(",\"children\":[");
+            text.append("{").append("\"name\":\"").append(this.name).append("\",\"value\":").
+                    append(this.value).append(",\"children\":[");
             for(Data child : children) {
                 text.append(child.toString()).append(",");
             }

--- a/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/ui/JsonParser.java
+++ b/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/ui/JsonParser.java
@@ -160,7 +160,7 @@ public class JsonParser {
             StringBuilder text = new StringBuilder();
             text.append("{").append("\"name\":\"").append(this.name).append("\",\"value\":").
                     append(this.value).append(",\"children\":[");
-            for(Data child : children) {
+            for (Data child : children) {
                 text.append(child.toString()).append(",");
             }
             if (!children.isEmpty()) {

--- a/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/ui/JsonParser.java
+++ b/bvm/ballerina-profiler/src/main/java/io/ballerina/runtime/profiler/ui/JsonParser.java
@@ -116,7 +116,6 @@ public class JsonParser {
             stackTraceItems.add(new StackTraceItem(Integer.parseInt(arrItem.get(new BmpStringValue("time")).toString()),
                     List.of(JsonInternalUtils.convertJSONToBArray(arrItem.get(new BmpStringValue("stackTrace")),
                             new BArrayType(TYPE_STRING)).getStringArray())));
-
         }
         return stackTraceItems;
     }
@@ -130,7 +129,6 @@ public class JsonParser {
 
         int time;
         List<String> stackTrace;
-
 
         public StackTraceItem(int time, List<String> stackTrace) {
             this.time = time;
@@ -169,6 +167,5 @@ public class JsonParser {
             text.append("]}");
             return text.toString();
         }
-
     }
 }

--- a/bvm/ballerina-profiler/src/main/java/module-info.java
+++ b/bvm/ballerina-profiler/src/main/java/module-info.java
@@ -3,5 +3,4 @@ module io.ballerina.runtime.profiler {
     requires org.apache.commons.io;
     requires io.ballerina.runtime;
     requires io.ballerina.identifier;
-    requires com.google.gson;
 }

--- a/bvm/ballerina-rt/build.gradle
+++ b/bvm/ballerina-rt/build.gradle
@@ -108,8 +108,6 @@ dependencies {
     //// metrics
     dist project(':metrics-extensions:ballerina-metrics-extension')
 
-    dist "com.google.code.gson:gson:${project.gsonVersion}"
-
     // Transaction related third party jars
     dist "com.atomikos:transactions-jta:${project.atomikosTransactionsJtaVersion}"
     dist "com.atomikos:atomikos-util:${project.atomikosUtilVersion}"

--- a/bvm/ballerina-rt/build.gradle
+++ b/bvm/ballerina-rt/build.gradle
@@ -108,6 +108,8 @@ dependencies {
     //// metrics
     dist project(':metrics-extensions:ballerina-metrics-extension')
 
+    dist "com.google.code.gson:gson:${project.gsonVersion}"
+
     // Transaction related third party jars
     dist "com.atomikos:transactions-jta:${project.atomikosTransactionsJtaVersion}"
     dist "com.atomikos:atomikos-util:${project.atomikosUtilVersion}"

--- a/bvm/ballerina-runtime/src/main/java/module-info.java
+++ b/bvm/ballerina-runtime/src/main/java/module-info.java
@@ -60,10 +60,11 @@ module io.ballerina.runtime {
             io.ballerina.lang.regexp;
     exports io.ballerina.runtime.internal.values to io.ballerina.testerina.core, io.ballerina.testerina.runtime,
             io.ballerina.lang.xml, org.ballerinalang.debugadapter.runtime, io.ballerina.lang.query,
-            io.ballerina.lang.function, io.ballerina.lang.regexp, io.ballerina.lang.value, io.ballerina.lang.internal, io.ballerina.lang.array;
+            io.ballerina.lang.function, io.ballerina.lang.regexp, io.ballerina.lang.value, io.ballerina.lang.internal,
+            io.ballerina.runtime.profiler, io.ballerina.lang.array;
     exports io.ballerina.runtime.internal.configurable to io.ballerina.lang.internal;
     exports io.ballerina.runtime.internal.types to io.ballerina.lang.typedesc, io.ballerina.testerina.runtime,
-            org.ballerinalang.debugadapter.runtime, io.ballerina.lang.function, io.ballerina.lang.regexp, io.ballerina.testerina.core;
+            org.ballerinalang.debugadapter.runtime, io.ballerina.lang.function, io.ballerina.lang.regexp, io.ballerina.testerina.core, io.ballerina.runtime.profiler;
     exports io.ballerina.runtime.observability.metrics.noop;
     exports io.ballerina.runtime.observability.tracer.noop;
     exports io.ballerina.runtime.internal.regexp;

--- a/bvm/ballerina-runtime/src/main/java/module-info.java
+++ b/bvm/ballerina-runtime/src/main/java/module-info.java
@@ -64,7 +64,8 @@ module io.ballerina.runtime {
             io.ballerina.runtime.profiler, io.ballerina.lang.array;
     exports io.ballerina.runtime.internal.configurable to io.ballerina.lang.internal;
     exports io.ballerina.runtime.internal.types to io.ballerina.lang.typedesc, io.ballerina.testerina.runtime,
-            org.ballerinalang.debugadapter.runtime, io.ballerina.lang.function, io.ballerina.lang.regexp, io.ballerina.testerina.core, io.ballerina.runtime.profiler;
+            org.ballerinalang.debugadapter.runtime, io.ballerina.lang.function, io.ballerina.lang.regexp, io.ballerina.testerina.core,
+            io.ballerina.runtime.profiler;
     exports io.ballerina.runtime.observability.metrics.noop;
     exports io.ballerina.runtime.observability.tracer.noop;
     exports io.ballerina.runtime.internal.regexp;


### PR DESCRIPTION
## Purpose
> The suggested changes will refactor the code to remove the use of Gson library from the Profiler tool using other internal alternatives.

## Remarks
> Duplicate of https://github.com/ballerina-platform/ballerina-lang/pull/43103 for Java 21 changes.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
