### PR TITLE
Fix query not working inside arrow functions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6854,7 +6854,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 }
             }
             if (!symbol.closure) {
-                if (searchClosureVariableInExpressions(symbol, pos, env, encInvokable, node)) {
+                if (searchClosureVariableInExpressions(symbol, pos, cEnv, encInvokable, node)) {
                     return;
                 }
             }
@@ -6865,7 +6865,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     // self symbol
                     return;
                 }
-                SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
+                SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(cEnv, encInvokable);
                 BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol);
                 BLangClassDefinition classDef = (BLangClassDefinition) node;
                 if (resolvedSymbol != symTable.notFoundSymbol) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithClosuresTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithClosuresTest.java
@@ -43,6 +43,11 @@ public class QueryWithClosuresTest {
         BRunUtil.invoke(result, functionName);
     }
 
+    @Test
+    public void testQueriesWithinArrowFunctionsAndWithLet() {
+        BRunUtil.invoke(result, "testQueriesWithinArrowFunctionsAndWithLet");
+    }
+
     @DataProvider
     public Object[] dataToTestQueryWithClosures() {
         return new Object[]{


### PR DESCRIPTION
## Purpose
Fixes #43188 

## Approach

When checking for closure variables in the function `searchClosureVariableInExpressions` we do not change the environment we just changed the node that it is in. The changing of the node only affects the case where we are inside an arrow function in the searchClosureVariableInExpressions function. When are inside an arrow function this checks the enclosive invokable of the arrow function for this we should use the environment of the arrow function to check the enclosive invokable. For all nodes inside an arrow function the enclusive invokable is null.  Thus the reason that we must change the env that is passed to this function.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
