### PR TITLE
Fix escaping of spaces in the classpath

### DIFF
--- a/distribution/zip/jballerina-tools/build.gradle
+++ b/distribution/zip/jballerina-tools/build.gradle
@@ -390,7 +390,7 @@ tasks.register('pathingJar', Jar) {
     doFirst {
         manifest {
             attributes "Class-Path": configurations.docerina.files.collect {
-                it.toURL().toString().replaceFirst("file:/", "/")
+                it.toURI().toString()
             }.join(' ')
         }
     }


### PR DESCRIPTION
## Purpose
> If the path to the ballerina repo contains a space the build failed. This was fixed by changing the classPath of the `:jballerina-tools:pathingJar` to use `.toURI()` instead of `.toURL()`. This now escapes the spaces correctly with `%20`

Fixes #41090

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
