### PR TITLE
[2201.10.x] Fix json string to record with union fields conversion

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
@@ -439,6 +439,7 @@ public class JsonParser {
         private void processJsonAnydataType() {
             if (this.nodesStackSizeWhenUnionStarts == this.nodesStack.size()) {
                 this.targetTypes.remove(this.targetTypes.size() - 1);
+                this.nodesStackSizeWhenUnionStarts = -1;
             }
         }
 
@@ -446,6 +447,7 @@ public class JsonParser {
             if (this.nodesStackSizeWhenUnionStarts == this.nodesStack.size()) {
                 this.targetTypes.remove(this.targetTypes.size() - 1);
                 this.currentJsonNode = convert(this.currentJsonNode, targetType);
+                this.nodesStackSizeWhenUnionStarts = -1;
             }
         }
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
@@ -68,6 +68,24 @@ type Foo6 record {
     string x3;
 };
 
+public type EndpointSecurity record {
+    BasicEndpointSecurity|APIKeyEndpointSecurity securityType?;
+};
+
+public type BasicEndpointSecurity record {
+    string secretName;
+    string userNameKey;
+};
+
+public type APIKeyEndpointSecurity record {
+    string secretName;
+    string apiKeyNameKey;
+};
+
+public type EndpointConfiguration record {
+    EndpointSecurity endpointSecurity?;
+};
+
 function testFromJsonWithTypeRecord2() {
     string str = "{\"name\":\"Name\",\"age\":35}";
     json j = <json>checkpanic str.fromJsonString();
@@ -410,6 +428,20 @@ function testFromJsonStringWithTypeRecord() {
     assertEquality(studentOrError is Student3, true);
     Student3 student = checkpanic studentOrError;
     assertEquality(student.name, "Name");
+
+    string security = string `{"securityType":{"secretName":"backend-creds","userNameKey":"username"}}`;
+    EndpointSecurity|error securityOrError = security.fromJsonStringWithType();
+    assertEquality(securityOrError is EndpointSecurity, true);
+    EndpointSecurity epSecurity = <EndpointSecurity> checkpanic securityOrError;
+    assertEquality(epSecurity.securityType.toString(), "{\"secretName\":\"backend-creds\",\"userNameKey\":\"username\"}");
+
+    string epConfig = string `{"endpoint":{},"endpointSecurity":{"securityType":{"secretName":"backend-creds","userNameKey":"username"}}}`;
+    EndpointConfiguration|error epConfigOrError = epConfig.fromJsonStringWithType();
+    assertEquality(epConfigOrError is EndpointConfiguration, true);
+    EndpointConfiguration epConfiguration = <EndpointConfiguration> checkpanic epConfigOrError;
+    assertEquality(epConfiguration.endpointSecurity.toString(), string `{"securityType":{"secretName":"backend-creds","userNameKey":"username"}}`);
+    anydata ep = epConfiguration["endpoint"];
+    assertEquality(ep.toString(), "{}");
 }
 
 function testFromJsonStringWithAmbiguousType() {


### PR DESCRIPTION
## Purpose
$subject 
Fixes #https://github.com/wso2-enterprise/internal-support-ballerina/issues/794
Fixes #43462 

## Approach
The `nodesStackSizeWhenUnionStarts` field in the JsonParser is not updated properly when multiple union fields are involved. 

## Samples
```ballerina
public type EndpointSecurity record {
    BasicEndpointSecurity|APIKeyEndpointSecurity securityType?;
};

public type BasicEndpointSecurity record {
    string secretName;
    string userNameKey;
};

public type APIKeyEndpointSecurity record {
    string secretName;
    string apiKeyNameKey;
};

public type EndpointConfiguration record {
    EndpointSecurity endpointSecurity?;
};

public function main() returns error? {
    string prod = string `{"endpoint":{},"endpointSecurity":{"securityType":{"secretName":"backend-creds","userNameKey":"username"}}}`;
    EndpointConfiguration production = check prod.fromJsonStringWithType();
}
```
## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
