### PR TITLE
Add "proxy script" to be able to run `bal` in Windows Git Bash

### DIFF
--- a/distribution/zip/jballerina/bin/bal.windows.gitbash
+++ b/distribution/zip/jballerina/bin/bal.windows.gitbash
@@ -1,0 +1,1 @@
+cmd "bal.bat"


### PR DESCRIPTION
## Purpose
> When running `bal` inside Windows Git Bash the command is not found. This PR adds a "proxy script" that will execute the `bal.bat` file in Git Bash.

Fixes #13448

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
