### PR TITLE
Improve JSON to Record Conversion

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,6 @@ jaegerThriftVersion="0.31.0"
 jakartaActivationVersion="1.2.2"
 javaDiffUtilsVersion="4.5"
 javassistVersion="3.24.1-GA"
-javaTuplesVersion="1.2"
 javaxMailVersion="1.6.2"
 javaxTransactionApiVersion="1.3"
 javaxWsRsApiVersion="2.1.1"
@@ -197,7 +196,6 @@ jaeger-core = { module = "io.jaegertracing:jaeger-core", version.ref = "jaegerCo
 jaeger-thrift = { module = "io.jaegertracing:jaeger-thrift", version.ref = "jaegerThriftVersion"}
 jakarta-activation = { module = "jakarta.activation:jakarta.activation-api", version.ref = "jakartaActivationVersion"}
 java-diff-utils = { module = "io.github.java-diff-utils:java-diff-utils", version.ref = "javaDiffUtilsVersion"}
-java-tuples = { module = "org.javatuples:javatuples", version.ref = "javaTuplesVersion"}
 javassist = { module = "org.javassist:javassist", version.ref = "javassistVersion"}
 javax-mail = { module = "com.sun.mail:javax.mail", version.ref = "javaxMailVersion"}
 javax-transaction-api = { module = "javax.transaction:javax.transaction-api", version.ref = "javaxTransactionApiVersion"}

--- a/misc/json-to-record-converter/build.gradle
+++ b/misc/json-to-record-converter/build.gradle
@@ -36,13 +36,11 @@ dependencies {
     implementation project(':identifier-util')
     implementation libs.gson
     implementation libs.apache.commons.lang3
-    implementation libs.java.tuples
 
     testImplementation libs.testng
     testImplementation project(':ballerina-lang')
     testImplementation project(':formatter:formatter-core')
     testImplementation project(':language-server:language-server-commons')
-    testImplementation libs.java.tuples
 }
 
 test {

--- a/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/JsonToRecordMapper.java
+++ b/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/JsonToRecordMapper.java
@@ -396,7 +396,7 @@ public final class JsonToRecordMapper {
                 TypeDescriptorNode node1 = (TypeDescriptorNode) entry.getValue().getKey().typeName();
                 TypeDescriptorNode node2 = (TypeDescriptorNode) entry.getValue().getValue().typeName();
 
-                TypeDescriptorNode nonJSONDataNode = null;
+                TypeDescriptorNode nonJsonDataNode = null;
                 IdentifierToken optionalFieldName = null;
                 boolean alreadyOptionalTypeDesc = false;
 
@@ -411,12 +411,12 @@ public final class JsonToRecordMapper {
                 } else if ((node1.kind().equals(SyntaxKind.JSON_KEYWORD) ||
                             node2.kind().equals(SyntaxKind.JSON_KEYWORD))) {
                     if (isNullAsOptional) {
-                        nonJSONDataNode = NodeParser.parseTypeDescriptor(node1.kind().equals(SyntaxKind.JSON_KEYWORD)
+                        nonJsonDataNode = NodeParser.parseTypeDescriptor(node1.kind().equals(SyntaxKind.JSON_KEYWORD)
                                 ? node2.toSourceCode() : node1.toSourceCode());
                         optionalFieldName = AbstractNodeFactory.createIdentifierToken(entry.getKey() +
                                 SyntaxKind.QUESTION_MARK_TOKEN.stringValue());
                     } else {
-                        nonJSONDataNode = NodeParser.parseTypeDescriptor(node1.kind().equals(SyntaxKind.JSON_KEYWORD)
+                        nonJsonDataNode = NodeParser.parseTypeDescriptor(node1.kind().equals(SyntaxKind.JSON_KEYWORD)
                                 ? node2.toSourceCode() + SyntaxKind.QUESTION_MARK_TOKEN.stringValue() :
                         node1.toSourceCode() + SyntaxKind.QUESTION_MARK_TOKEN.stringValue());
                     }
@@ -430,7 +430,7 @@ public final class JsonToRecordMapper {
                 RecordFieldNode recordField =
                         (RecordFieldNode) getRecordField(jsonEntry, existingFieldNames, updatedFieldNames, isOptional);
                 recordField = recordField.modify()
-                        .withTypeName(nonJSONDataNode == null ? unionTypeDescNode : nonJSONDataNode)
+                        .withTypeName(nonJsonDataNode == null ? unionTypeDescNode : nonJsonDataNode)
                         .withFieldName(optionalFieldName == null ? recordField.fieldName() : optionalFieldName)
                         .apply();
                 recordFields.add(recordField);

--- a/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/JsonToRecordMapper.java
+++ b/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/JsonToRecordMapper.java
@@ -38,6 +38,7 @@ import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.OptionalTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.ParenthesisedTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.RecordFieldNode;
+import io.ballerina.compiler.syntax.tree.RecordRestDescriptorNode;
 import io.ballerina.compiler.syntax.tree.RecordTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
@@ -236,8 +237,7 @@ public final class JsonToRecordMapper {
                                         List<DiagnosticMessage> diagnosticMessages,
                                         boolean isNullAsOptional) {
         Token recordKeyWord = AbstractNodeFactory.createToken(SyntaxKind.RECORD_KEYWORD);
-        Token bodyStartDelimiter = AbstractNodeFactory.createToken(isClosed ? SyntaxKind.OPEN_BRACE_PIPE_TOKEN :
-                SyntaxKind.OPEN_BRACE_TOKEN);
+        Token bodyStartDelimiter = AbstractNodeFactory.createToken(SyntaxKind.OPEN_BRACE_PIPE_TOKEN);
 
         List<Node> recordFields = new ArrayList<>();
         if (recordToTypeDescNodes.containsKey(recordName)) {
@@ -269,12 +269,18 @@ public final class JsonToRecordMapper {
                         isNullAsOptional);
             }
         }
+
         NodeList<Node> fieldNodes = AbstractNodeFactory.createNodeList(recordFields);
-        Token bodyEndDelimiter = AbstractNodeFactory.createToken(isClosed ? SyntaxKind.CLOSE_BRACE_PIPE_TOKEN :
-                SyntaxKind.CLOSE_BRACE_TOKEN);
+        Token bodyEndDelimiter = AbstractNodeFactory.createToken(SyntaxKind.CLOSE_BRACE_PIPE_TOKEN);
+        RecordRestDescriptorNode restDescriptorNode = isClosed ? null :
+                NodeFactory.createRecordRestDescriptorNode(
+                        NodeFactory.createBuiltinSimpleNameReferenceNode(SyntaxKind.JSON_KEYWORD,
+                                AbstractNodeFactory.createToken(SyntaxKind.JSON_KEYWORD)),
+                        AbstractNodeFactory.createToken(SyntaxKind.ELLIPSIS_TOKEN),
+                        AbstractNodeFactory.createToken(SyntaxKind.SEMICOLON_TOKEN));
         RecordTypeDescriptorNode recordTypeDescriptorNode =
                 NodeFactory.createRecordTypeDescriptorNode(recordKeyWord, bodyStartDelimiter,
-                        fieldNodes, null, bodyEndDelimiter);
+                        fieldNodes, restDescriptorNode, bodyEndDelimiter);
 
         if (moveBefore == null || moveBefore.equals(recordName)) {
             recordToTypeDescNodes.put(recordName, recordTypeDescriptorNode);

--- a/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/JsonToRecordMapper.java
+++ b/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/JsonToRecordMapper.java
@@ -52,7 +52,6 @@ import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.options.ForceFormattingOptions;
 import org.ballerinalang.formatter.core.options.FormattingOptions;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
-import org.javatuples.Pair;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -376,21 +375,21 @@ public final class JsonToRecordMapper {
                                            Map<String, RecordFieldNode> previousRecordFieldToNodes,
                                            Map<String, RecordFieldNode> newRecordFieldToNodes,
                                            boolean isNullAsOptional) {
-        Map<String, Pair<RecordFieldNode, RecordFieldNode>> intersectingRecordFields =
+        Map<String, Map.Entry<RecordFieldNode, RecordFieldNode>> intersectingRecordFields =
                 intersection(previousRecordFieldToNodes, newRecordFieldToNodes);
         Map<String, RecordFieldNode> differencingRecordFields =
                 difference(previousRecordFieldToNodes, newRecordFieldToNodes);
 
-        for (Map.Entry<String, Pair<RecordFieldNode, RecordFieldNode>> entry : intersectingRecordFields.entrySet()) {
-            boolean isOptional = entry.getValue().getValue0().questionMarkToken().isPresent();
+        for (Map.Entry<String, Map.Entry<RecordFieldNode, RecordFieldNode>> entry : intersectingRecordFields.entrySet()) {
+            boolean isOptional = entry.getValue().getKey().questionMarkToken().isPresent();
             Map<String, String> jsonEscapedFieldToFields = jsonNodes.entrySet().stream()
                     .collect(Collectors.toMap(jsonEntry -> escapeIdentifier(jsonEntry.getKey()), Map.Entry::getKey));
             Map.Entry<String, JsonElement> jsonEntry = new AbstractMap.SimpleEntry<>(jsonEscapedFieldToFields
                     .get(entry.getKey()), jsonNodes.get(jsonEscapedFieldToFields.get(entry.getKey())));
-            if (!entry.getValue().getValue0().typeName().toSourceCode()
-                    .equals(entry.getValue().getValue1().typeName().toSourceCode())) {
-                TypeDescriptorNode node1 = (TypeDescriptorNode) entry.getValue().getValue0().typeName();
-                TypeDescriptorNode node2 = (TypeDescriptorNode) entry.getValue().getValue1().typeName();
+            if (!entry.getValue().getKey().typeName().toSourceCode()
+                    .equals(entry.getValue().getValue().typeName().toSourceCode())) {
+                TypeDescriptorNode node1 = (TypeDescriptorNode) entry.getValue().getKey().typeName();
+                TypeDescriptorNode node2 = (TypeDescriptorNode) entry.getValue().getValue().typeName();
 
                 TypeDescriptorNode nonAnyDataNode = null;
                 IdentifierToken optionalFieldName = null;
@@ -497,8 +496,7 @@ public final class JsonToRecordMapper {
                     fieldTypeName, fieldName,
                     optionalFieldToken, semicolonToken);
         } else if (entry.getValue().isJsonArray()) {
-            Map.Entry<String, JsonArray> jsonArrayEntry =
-                    new AbstractMap.SimpleEntry<>(entry.getKey(), entry.getValue().getAsJsonArray());
+            Map.Entry<String, JsonArray> jsonArrayEntry = Map.entry(entry.getKey(), entry.getValue().getAsJsonArray());
             ArrayTypeDescriptorNode arrayTypeName =
                     getArrayTypeDescriptorNode(jsonArrayEntry, existingFieldNames, updatedFieldNames);
             recordFieldNode = NodeFactory.createRecordFieldNode(null, null,

--- a/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/JsonToRecordMapper.java
+++ b/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/JsonToRecordMapper.java
@@ -384,7 +384,8 @@ public final class JsonToRecordMapper {
         Map<String, RecordFieldNode> differencingRecordFields =
                 difference(previousRecordFieldToNodes, newRecordFieldToNodes);
 
-        for (Map.Entry<String, Map.Entry<RecordFieldNode, RecordFieldNode>> entry : intersectingRecordFields.entrySet()) {
+        for (Map.Entry<String, Map.Entry<RecordFieldNode, RecordFieldNode>> entry :
+                intersectingRecordFields.entrySet()) {
             boolean isOptional = entry.getValue().getKey().questionMarkToken().isPresent();
             Map<String, String> jsonEscapedFieldToFields = jsonNodes.entrySet().stream()
                     .collect(Collectors.toMap(jsonEntry -> escapeIdentifier(jsonEntry.getKey()), Map.Entry::getKey));

--- a/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/util/ListOperationUtils.java
+++ b/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/util/ListOperationUtils.java
@@ -39,9 +39,9 @@ public final class ListOperationUtils {
      */
     public static <K, V> Map<K, Map.Entry<V, V>> intersection(Map<K, V> mapOne, Map<K, V> mapTwo) {
         Map<K, Map.Entry<V, V>> intersection = new LinkedHashMap<>();
-        for (K key: mapOne.keySet()) {
-            if (mapTwo.containsKey(key)) {
-                intersection.put(key, Map.entry(mapOne.get(key), mapTwo.get(key)));
+        for (Map.Entry<K, V> entry: mapOne.entrySet()) {
+            if (mapTwo.containsKey(entry.getKey())) {
+                intersection.put(entry.getKey(), Map.entry(entry.getValue(), mapTwo.get(entry.getKey())));
             }
         }
         return intersection;
@@ -56,9 +56,9 @@ public final class ListOperationUtils {
      */
     public static <K, V> Map<K, V> union(Map<K, V> mapOne, Map<K, V> mapTwo) {
         Map<K, V> union = new LinkedHashMap<>(mapOne);
-        for (Map.Entry<K, V> key: mapTwo.entrySet()) {
-            if (!mapOne.containsKey(key.getKey())) {
-                union.put(key.getKey(), mapTwo.get(key.getKey()));
+        for (Map.Entry<K, V> entry: mapTwo.entrySet()) {
+            if (!mapOne.containsKey(entry.getKey())) {
+                union.put(entry.getKey(), entry.getValue());
             }
         }
         return union;

--- a/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/util/ListOperationUtils.java
+++ b/misc/json-to-record-converter/src/main/java/io/ballerina/jsonmapper/util/ListOperationUtils.java
@@ -18,8 +18,6 @@
 
 package io.ballerina.jsonmapper.util;
 
-import org.javatuples.Pair;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -39,12 +37,11 @@ public final class ListOperationUtils {
      * @param mapTwo Second set of Key, Value pairs to be compared with other
      * @return {@link Map} Intersection of first and second set of Key Value pairs
      */
-    public static <K, V> Map<K, Pair<V, V>> intersection(Map<K, V> mapOne, Map<K, V> mapTwo) {
-        Map<K, Pair<V, V>> intersection = new LinkedHashMap<>();
-        for (Map.Entry<K, V> key: mapOne.entrySet()) {
-            if (mapTwo.containsKey(key.getKey())) {
-                Pair<V, V> valuePair = new Pair<>(mapOne.get(key.getKey()), mapTwo.get(key.getKey()));
-                intersection.put(key.getKey(), valuePair);
+    public static <K, V> Map<K, Map.Entry<V, V>> intersection(Map<K, V> mapOne, Map<K, V> mapTwo) {
+        Map<K, Map.Entry<V, V>> intersection = new LinkedHashMap<>();
+        for (K key: mapOne.keySet()) {
+            if (mapTwo.containsKey(key)) {
+                intersection.put(key, Map.entry(mapOne.get(key), mapTwo.get(key)));
             }
         }
         return intersection;
@@ -76,9 +73,9 @@ public final class ListOperationUtils {
      */
     public static <K, V> Map<K, V> difference(Map<K, V> mapOne, Map<K, V> mapTwo) {
         Map<K, V> unionMap = union(mapOne, mapTwo);
-        Map<K, Pair<V, V>> intersectionMap = intersection(mapOne, mapTwo);
-        for (Map.Entry<K, Pair<V, V>> key: intersectionMap.entrySet()) {
-            unionMap.remove(key.getKey());
+        Map<K, Map.Entry<V, V>> intersectionMap = intersection(mapOne, mapTwo);
+        for (K key: intersectionMap.keySet()) {
+            unionMap.remove(key);
         }
         return unionMap;
     }

--- a/misc/json-to-record-converter/src/main/java/module-info.java
+++ b/misc/json-to-record-converter/src/main/java/module-info.java
@@ -6,7 +6,6 @@ module io.ballerina.jsonmapper {
     requires io.ballerina.language.server.commons;
     requires io.ballerina.parser;
     requires io.ballerina.tools.api;
-    requires javatuples;
     requires org.apache.commons.lang3;
 
     exports io.ballerina.jsonmapper;

--- a/misc/json-to-record-converter/src/test/java/io/ballerina/jsonmapper/JsonToRecordMapperTests.java
+++ b/misc/json-to-record-converter/src/test/java/io/ballerina/jsonmapper/JsonToRecordMapperTests.java
@@ -425,7 +425,8 @@ public class JsonToRecordMapperTests {
         Assert.assertEquals(diagnostics.get(1).message(), diagnosticMessage1);
     }
 
-    private void runPositiveTest(Path json, Path bal, String recordName, boolean isRecordTypeDesc, boolean closed, boolean forceFormatRecField)
+    private void runPositiveTest(Path json, Path bal, String recordName, boolean isRecordTypeDesc, 
+                                 boolean closed, boolean forceFormatRecField)
             throws IOException {
         String jsonFileContent = Files.readString(json);
         String generatedCodeBlock = JsonToRecordMapper.convert(

--- a/misc/json-to-record-converter/src/test/java/io/ballerina/jsonmapper/JsonToRecordMapperTests.java
+++ b/misc/json-to-record-converter/src/test/java/io/ballerina/jsonmapper/JsonToRecordMapperTests.java
@@ -481,7 +481,7 @@ public class JsonToRecordMapperTests {
         for (Map.Entry<Path, Path> sample : samples.entrySet()) {
             String jsonFileContent = Files.readString(sample.getKey());
             JsonToRecordResponse jsonToRecordResponse =
-                    JsonToRecordMapper.convert(jsonFileContent, null, false, false, false, null, null);
+                    JsonToRecordMapper.convert(jsonFileContent, null, false, false, false, null, null, false);
             if (jsonToRecordResponse.getCodeBlock() != null) {
                 String generatedCodeBlock = jsonToRecordResponse.getCodeBlock().replaceAll("\\s+", "");
                 String expectedCodeBlock = Files.readString(sample.getValue()).replaceAll("\\s+", "");

--- a/misc/json-to-record-converter/src/test/java/io/ballerina/jsonmapper/JsonToRecordMapperTests.java
+++ b/misc/json-to-record-converter/src/test/java/io/ballerina/jsonmapper/JsonToRecordMapperTests.java
@@ -113,201 +113,112 @@ public class JsonToRecordMapperTests {
 
     @Test(description = "Test for primitive and null types")
     public void testForPrimitiveAndNullTypes() throws IOException {
-        String jsonFileContent = Files.readString(sample0Json);
-        String generatedCodeBlock =
-                JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null, false)
-                .getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample0Bal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample0Json, sample0Bal, "", false, false, false);
     }
 
     @Test(description = "Test for all number types")
     public void testForJsonNumberTypes() throws IOException {
-        String jsonFileContent = Files.readString(sample1Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample1Bal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample1Json, sample1Bal, "", false, false, false);
     }
 
     @Test(description = "Test for differencing fields in same JSON object")
     public void testForDifferencingFields() throws IOException {
-        String jsonFileContent = Files.readString(sample2Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample2Bal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample2Json, sample2Bal, "", false, false, false);
     }
 
     @Test(description = "Test for differencing fields in same JSON object - inline")
     public void testForDifferencingFieldsInLine() throws IOException {
-        String jsonFileContent = Files.readString(sample2Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample2TypeDescBal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample2Json, sample2TypeDescBal, "", true, false, false);
     }
 
     @Test(description = "Test for differencing field values in same JSON object")
     public void testForDifferencingFieldValues() throws IOException {
-        String jsonFileContent = Files.readString(sample3Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample3Bal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample3Json, sample3Bal, "", false, false, false);
     }
 
     @Test(description = "Test for differencing field values in same JSON object - inline")
     public void testForDifferencingFieldValuesInLIne() throws IOException {
-        String jsonFileContent = Files.readString(sample3Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample3TypeDescBal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample3Json, sample3TypeDescBal, "", true, false, false);
     }
 
     @Test(description = "Test for empty and non-empty JSON array")
     public void testForEmptyNonEmptyJsonArray() throws IOException {
-        String jsonFileContent = Files.readString(sample4Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample4Bal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample4Json, sample4Bal, "", false, false, false);
     }
 
     @Test(description = "Test for empty and non-empty JSON array - inline")
     public void testForEmptyNonEmptyJsonArrayInLIne() throws IOException {
-        String jsonFileContent = Files.readString(sample4Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample4TypeDescBal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample4Json, sample4TypeDescBal, "", true, false, false);
     }
 
     @Test(description = "Test for JSON array with values of same and different type")
     public void testForSameAndDifferentTypeValuesInArray() throws IOException {
-        String jsonFileContent = Files.readString(sample5Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample5Bal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample5Json, sample5Bal, "", false, false, false);
     }
 
     @Test(description = "Test for different objects in JSON array")
     public void testForDifferentObjectsInJsonArray() throws IOException {
-        String jsonFileContent = Files.readString(sample6Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample6Bal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample6Json, sample6Bal, "", false, false, false);
     }
 
     @Test(description = "Test for different objects in JSON array - inline")
     public void testForDifferentObjectsInJsonArrayInLIne() throws IOException {
-        String jsonFileContent = Files.readString(sample6Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample6TypeDescBal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample6Json, sample6TypeDescBal, "", true, false, false);
     }
 
     @Test(description = "Test for different objects in JSON array - closed")
     public void testForDifferentObjectsInJsonArrayClosed() throws IOException {
-        String jsonFileContent = Files.readString(sample6Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", false, true, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample6ClosedBal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample6Json, sample6ClosedBal, "", false, true, false);
     }
 
     @Test(description = "Test for different objects in JSON array - inline/closed")
     public void testForDifferentObjectsInJsonArrayInLineClosed() throws IOException {
-        String jsonFileContent = Files.readString(sample6Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", true, true, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample6TypeDescClosedBal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample6Json, sample6TypeDescClosedBal, "", true, true, false);
     }
 
     @Test(description = "Test for different objects in JSON array - inline/closed/forceFormatRecField")
     public void testForDifferentObjectsInJsonArrayInLineClosedForceFormatRecFields() throws IOException {
-        String jsonFileContent = Files.readString(sample6Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", true, true, true, null, null, false).getCodeBlock();
-        String expectedCodeBlock = Files.readString(sample6TypeDescClosedBal);
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample6Json, sample6TypeDescClosedBal, "", true, true, true);
     }
 
     @Test(description = "Test for multi dimensional JSON array")
     public void testForMultiDimensionalJsonArray() throws IOException {
-        String jsonFileContent = Files.readString(sample7Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample7Bal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample7Json, sample7Bal, "", false, false, false);
     }
 
     @Test(description = "Test for complex JSON object")
     public void testForComplexJsonObject() throws IOException {
-        String jsonFileContent = Files.readString(sample8Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample8Bal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample8Json, sample8Bal, "", false, false, false);
     }
 
     @Test(description = "Test for complex JSON object - inline")
     public void testForComplexJsonObjectInLIne() throws IOException {
-        String jsonFileContent = Files.readString(sample8Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample8TypeDescBal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample8Json, sample8TypeDescBal, "", true, false, false);
     }
 
     @Test(description = "Test for many types in JSON array")
     public void testForMultipleItemsJsonArray() throws IOException {
-        String jsonFileContent = Files.readString(sample9Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample9Bal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample9Json, sample9Bal, "", false, false, false);
     }
 
     @Test(description = "Test for many types in JSON array - inline")
     public void testForMultipleItemsJsonArrayInLIne() throws IOException {
-        String jsonFileContent = Files.readString(sample9Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample9TypeDescBal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample9Json, sample9TypeDescBal, "", true, false, false);
     }
 
     @Test(description = "Test for JSON array of objects")
     public void testForJsonArrayOfObjects() throws IOException {
-        String jsonFileContent = Files.readString(sample10Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample10Bal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample10Json, sample10Bal, "", false, false, false);
     }
 
     @Test(description = "Test for JSON array of objects - inline")
     public void testForJsonArrayOfObjectsInLIne() throws IOException {
-        String jsonFileContent = Files.readString(sample10Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample10TypeDescBal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample10Json, sample10TypeDescBal, "", true, false, false);
     }
 
     @Test(description = "Test for JSON field names with special characters")
     public void testForJsonFieldsOfSpecialChars() throws IOException {
-        String jsonFileContent = Files.readString(sample11Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample11Bal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample11Json, sample11Bal, "", false, false, false);
     }
 
     @Test(description = "Test for Invalid JSON")
@@ -334,40 +245,22 @@ public class JsonToRecordMapperTests {
 
     @Test(description = "Test for JSON with user defined record name")
     public void testForUserDefinedRecordName() throws IOException {
-        String jsonFileContent = Files.readString(sample3Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "Person", false, false, false, null, null, false)
-                .getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample3PersonBal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample3Json, sample3PersonBal, "Person", false, false, false);
     }
 
     @Test(description = "Test for JSON with user defined record name - inline")
     public void testForUserDefinedRecordNameInLIne() throws IOException {
-        String jsonFileContent = Files.readString(sample3Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "Person", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample3PersonTypeDescBal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample3Json, sample3PersonTypeDescBal, "Person", true, false, false);
     }
 
     @Test(description = "Test for JSON with user defined record name with special chars")
     public void testForUserDefinedRecordNameWithSpecialChars() throws IOException {
-        String jsonFileContent = Files.readString(sample3Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "Special Person", false, false, false, null, null, false)
-                .getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample3SpecialCharBal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample3Json, sample3SpecialCharBal, "Special Person", false, false, false);
     }
 
     @Test(description = "Test for nested JSON with same recurring field")
     public void testForJsonWithRecurringFieldName() throws IOException {
-        String jsonFileContent = Files.readString(sample14Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample14Bal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample14Json, sample14Bal, "", false, false, false);
     }
 
     @Test(description = "Test for nested JSON with same recurring field to generate inline record")
@@ -394,11 +287,7 @@ public class JsonToRecordMapperTests {
 
     @Test(description = "Test for JSON array of nested objects - inline")
     public void testForJsonArrayOfNestedObjectsInLIne() throws IOException {
-        String jsonFileContent = Files.readString(sample15Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(
-                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
-        String expectedCodeBlock = Files.readString(sample15TypeDescBal).replaceAll("\\s+", "");
-        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+        runPositiveTest(sample15Json, sample15TypeDescBal, "", true, false, false);
     }
 
     @Test(description = "Test for JSON with optional fields")
@@ -534,5 +423,19 @@ public class JsonToRecordMapperTests {
         Assert.assertEquals(diagnostics.size(), 2);
         Assert.assertEquals(diagnostics.get(0).message(), diagnosticMessage0);
         Assert.assertEquals(diagnostics.get(1).message(), diagnosticMessage1);
+    }
+
+    private void runPositiveTest(Path json, Path bal, String recordName, boolean isRecordTypeDesc, boolean closed, boolean forceFormatRecField)
+            throws IOException {
+        String jsonFileContent = Files.readString(json);
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, recordName, isRecordTypeDesc, closed, forceFormatRecField, null, null, false)
+                .getCodeBlock();
+        String expectedCodeBlock = Files.readString(bal);
+        if (!forceFormatRecField) {
+            generatedCodeBlock = generatedCodeBlock.replaceAll("\\s+", "");
+            expectedCodeBlock = expectedCodeBlock.replaceAll("\\s+", "");
+        }
+        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
 }

--- a/misc/json-to-record-converter/src/test/java/io/ballerina/jsonmapper/JsonToRecordMapperTests.java
+++ b/misc/json-to-record-converter/src/test/java/io/ballerina/jsonmapper/JsonToRecordMapperTests.java
@@ -36,138 +36,86 @@ import java.util.Map;
 public class JsonToRecordMapperTests {
 
     private static final Path RES_DIR = Path.of("src/test/resources/").toAbsolutePath();
-    private static final String BAL_DIR = "ballerina";
-    private static final String JSON_DIR = "json";
-    private static final String PROJECT_DIR = "project";
-    private static final String SOURCE_DIR = "source";
-    private static final String ASSERT_DIR = "assert";
 
-    private final Path sample0Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_0.json");
-    private final Path sample0Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_0.bal");
+    private final Path sample0Json = RES_DIR.resolve("json/sample_0.json");
+    private final Path sample0Bal = RES_DIR.resolve("ballerina/sample_0.bal");
 
-    private final Path sample1Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_1.json");
-    private final Path sample1Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_1.bal");
+    private final Path sample1Json = RES_DIR.resolve("json/sample_1.json");
+    private final Path sample1Bal = RES_DIR.resolve("ballerina/sample_1.bal");
 
-    private final Path sample2Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_2.json");
-    private final Path sample2Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_2.bal");
-    private final Path sample2TypeDescBal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_2_type_desc.bal");
+    private final Path sample2Json = RES_DIR.resolve("json/sample_2.json");
+    private final Path sample2Bal = RES_DIR.resolve("ballerina/sample_2.bal");
+    private final Path sample2TypeDescBal = RES_DIR.resolve("ballerina/sample_2_type_desc.bal");
 
-    private final Path sample3Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_3.json");
-    private final Path sample3Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_3.bal");
-    private final Path sample3TypeDescBal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_3_type_desc.bal");
-    private final Path sample3PersonBal = RES_DIR.resolve("ballerina")
-            .resolve("sample_3_person.bal");
-    private final Path sample3PersonTypeDescBal = RES_DIR.resolve("ballerina")
-            .resolve("sample_3_person_type_desc.bal");
-    private final Path sample3SpecialCharBal = RES_DIR.resolve("ballerina")
-            .resolve("sample_3_special_char.bal");
+    private final Path sample3Json = RES_DIR.resolve("json/sample_3.json");
+    private final Path sample3Bal = RES_DIR.resolve("ballerina/sample_3.bal");
+    private final Path sample3TypeDescBal = RES_DIR.resolve("ballerina/sample_3_type_desc.bal");
+    private final Path sample3PersonBal = RES_DIR.resolve("ballerina/sample_3_person.bal");
+    private final Path sample3PersonTypeDescBal = RES_DIR.resolve("ballerina/sample_3_person_type_desc.bal");
+    private final Path sample3SpecialCharBal = RES_DIR.resolve("ballerina/sample_3_special_char.bal");
 
-    private final Path sample4Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_4.json");
-    private final Path sample4Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_4.bal");
-    private final Path sample4TypeDescBal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_4_type_desc.bal");
+    private final Path sample4Json = RES_DIR.resolve("json/sample_4.json");
+    private final Path sample4Bal = RES_DIR.resolve("ballerina/sample_4.bal");
+    private final Path sample4TypeDescBal = RES_DIR.resolve("ballerina/sample_4_type_desc.bal");
 
-    private final Path sample5Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_5.json");
-    private final Path sample5Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_5.bal");
+    private final Path sample5Json = RES_DIR.resolve("json/sample_5.json");
+    private final Path sample5Bal = RES_DIR.resolve("ballerina/sample_5.bal");
 
-    private final Path sample6Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_6.json");
-    private final Path sample6Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_6.bal");
-    private final Path sample6TypeDescBal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_6_type_desc.bal");
-    private final Path sample6ClosedBal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_6_closed.bal");
-    private final Path sample6TypeDescClosedBal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_6_type_desc_closed.bal");
+    private final Path sample6Json = RES_DIR.resolve("json/sample_6.json");
+    private final Path sample6Bal = RES_DIR.resolve("ballerina/sample_6.bal");
+    private final Path sample6TypeDescBal = RES_DIR.resolve("ballerina/sample_6_type_desc.bal");
+    private final Path sample6ClosedBal = RES_DIR.resolve("ballerina/sample_6_closed.bal");
+    private final Path sample6TypeDescClosedBal = RES_DIR.resolve("ballerina/sample_6_type_desc_closed.bal");
 
-    private final Path sample7Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_7.json");
-    private final Path sample7Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_7.bal");
+    private final Path sample7Json = RES_DIR.resolve("json/sample_7.json");
+    private final Path sample7Bal = RES_DIR.resolve("ballerina/sample_7.bal");
 
-    private final Path sample8Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_8.json");
-    private final Path sample8Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_8.bal");
-    private final Path sample8TypeDescBal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_8_type_desc.bal");
+    private final Path sample8Json = RES_DIR.resolve("json/sample_8.json");
+    private final Path sample8Bal = RES_DIR.resolve("ballerina/sample_8.bal");
+    private final Path sample8TypeDescBal = RES_DIR.resolve("ballerina/sample_8_type_desc.bal");
 
-    private final Path sample9Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_9.json");
-    private final Path sample9Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_9.bal");
-    private final Path sample9TypeDescBal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_9_type_desc.bal");
+    private final Path sample9Json = RES_DIR.resolve("json/sample_9.json");
+    private final Path sample9Bal = RES_DIR.resolve("ballerina/sample_9.bal");
+    private final Path sample9TypeDescBal = RES_DIR.resolve("ballerina/sample_9_type_desc.bal");
 
-    private final Path sample10Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_10.json");
-    private final Path sample10Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_10.bal");
-    private final Path sample10TypeDescBal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_10_type_desc.bal");
+    private final Path sample10Json = RES_DIR.resolve("json/sample_10.json");
+    private final Path sample10Bal = RES_DIR.resolve("ballerina/sample_10.bal");
+    private final Path sample10TypeDescBal = RES_DIR.resolve("ballerina/sample_10_type_desc.bal");
 
-    private final Path sample11Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_11.json");
-    private final Path sample11Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_11.bal");
+    private final Path sample11Json = RES_DIR.resolve("json/sample_11.json");
+    private final Path sample11Bal = RES_DIR.resolve("ballerina/sample_11.bal");
 
-    private final Path sample12Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_12.json");
+    private final Path sample12Json = RES_DIR.resolve("json/sample_12.json");
 
-    private final Path sample13Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_13.json");
+    private final Path sample13Json = RES_DIR.resolve("json/sample_13.json");
 
-    private final Path sample14Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_14.json");
-    private final Path sample14Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_14.bal");
+    private final Path sample14Json = RES_DIR.resolve("json/sample_14.json");
+    private final Path sample14Bal = RES_DIR.resolve("ballerina/sample_14.bal");
 
-    private final Path sample15Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_15.json");
-    private final Path sample15TypeDescBal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_15_type_desc.bal");
+    private final Path sample15Json = RES_DIR.resolve("json/sample_15.json");
+    private final Path sample15TypeDescBal = RES_DIR.resolve("ballerina/sample_15_type_desc.bal");
 
-    private final Path sample16Json = RES_DIR.resolve(JSON_DIR)
-            .resolve("sample_16.json");
+    private final Path sample16Json = RES_DIR.resolve("json/sample_16.json");
 
-    private final Path sample16Bal = RES_DIR.resolve(BAL_DIR)
-            .resolve("sample_16.bal");
+    private final Path sample16Bal = RES_DIR.resolve("ballerina/sample_16.bal");
 
-    private final Path singleBalFile = RES_DIR.resolve(PROJECT_DIR).resolve(SOURCE_DIR)
-            .resolve("singleFileProject").resolve("SingleBalFile.bal");
+    private final Path singleBalFile = RES_DIR.resolve("project/source/singleFileProject/SingleBalFile.bal");
 
-    private final Path invalidBalFile = RES_DIR.resolve(PROJECT_DIR).resolve(SOURCE_DIR)
-            .resolve("InvalidBalFile.txt");
+    private final Path invalidBalFile = RES_DIR.resolve("project/source/InvalidBalFile.txt");
 
-    private final Path balProjectFileDefaultModule = RES_DIR.resolve(PROJECT_DIR).resolve(SOURCE_DIR)
-            .resolve("balProject").resolve("main.bal");
-    private final Path balProjectFileDefaultModuleAssert = RES_DIR.resolve(PROJECT_DIR).resolve(ASSERT_DIR)
-            .resolve("balProject").resolve("sample_bal_project_default.bal");
+    private final Path balProjectFileDefaultModule = RES_DIR.resolve("project/source/balProject/main.bal");
+    private final Path balProjectFileDefaultModuleAssert =
+            RES_DIR.resolve("project/assert/balProject/sample_bal_project_default.bal");
 
-    private final Path balProjectFileUtilModule = RES_DIR.resolve(PROJECT_DIR).resolve(SOURCE_DIR)
-            .resolve("balProject").resolve("modules").resolve("util").resolve("util.bal");
-    private final Path balProjectFileUtilModuleAssert = RES_DIR.resolve(PROJECT_DIR).resolve(ASSERT_DIR)
-            .resolve("balProject").resolve("sample_bal_project_util.bal");
+    private final Path balProjectFileUtilModule = RES_DIR.resolve("project/source/balProject/modules/util/util.bal");
+    private final Path balProjectFileUtilModuleAssert =
+            RES_DIR.resolve("project/assert/balProject/sample_bal_project_util.bal");
 
     @Test(description = "Test for primitive and null types")
     public void testForPrimitiveAndNullTypes() throws IOException {
         String jsonFileContent = Files.readString(sample0Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null)
+        String generatedCodeBlock =
+                JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null, false)
                 .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample0Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
@@ -176,8 +124,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for all number types")
     public void testForJsonNumberTypes() throws IOException {
         String jsonFileContent = Files.readString(sample1Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample1Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -185,8 +133,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for differencing fields in same JSON object")
     public void testForDifferencingFields() throws IOException {
         String jsonFileContent = Files.readString(sample2Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample2Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -194,8 +142,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for differencing fields in same JSON object - inline")
     public void testForDifferencingFieldsInLine() throws IOException {
         String jsonFileContent = Files.readString(sample2Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", true, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample2TypeDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -203,8 +151,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for differencing field values in same JSON object")
     public void testForDifferencingFieldValues() throws IOException {
         String jsonFileContent = Files.readString(sample3Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample3Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -212,8 +160,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for differencing field values in same JSON object - inline")
     public void testForDifferencingFieldValuesInLIne() throws IOException {
         String jsonFileContent = Files.readString(sample3Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", true, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample3TypeDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -221,8 +169,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for empty and non-empty JSON array")
     public void testForEmptyNonEmptyJsonArray() throws IOException {
         String jsonFileContent = Files.readString(sample4Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample4Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -230,8 +178,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for empty and non-empty JSON array - inline")
     public void testForEmptyNonEmptyJsonArrayInLIne() throws IOException {
         String jsonFileContent = Files.readString(sample4Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", true, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample4TypeDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -239,8 +187,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for JSON array with values of same and different type")
     public void testForSameAndDifferentTypeValuesInArray() throws IOException {
         String jsonFileContent = Files.readString(sample5Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample5Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -248,8 +196,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for different objects in JSON array")
     public void testForDifferentObjectsInJsonArray() throws IOException {
         String jsonFileContent = Files.readString(sample6Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample6Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -257,8 +205,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for different objects in JSON array - inline")
     public void testForDifferentObjectsInJsonArrayInLIne() throws IOException {
         String jsonFileContent = Files.readString(sample6Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", true, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample6TypeDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -266,8 +214,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for different objects in JSON array - closed")
     public void testForDifferentObjectsInJsonArrayClosed() throws IOException {
         String jsonFileContent = Files.readString(sample6Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, true, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, true, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample6ClosedBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -275,8 +223,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for different objects in JSON array - inline/closed")
     public void testForDifferentObjectsInJsonArrayInLineClosed() throws IOException {
         String jsonFileContent = Files.readString(sample6Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", true, true, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", true, true, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample6TypeDescClosedBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -284,8 +232,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for different objects in JSON array - inline/closed/forceFormatRecField")
     public void testForDifferentObjectsInJsonArrayInLineClosedForceFormatRecFields() throws IOException {
         String jsonFileContent = Files.readString(sample6Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", true, true, true, null, null)
-                .getCodeBlock();
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", true, true, true, null, null, false).getCodeBlock();
         String expectedCodeBlock = Files.readString(sample6TypeDescClosedBal);
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -293,8 +241,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for multi dimensional JSON array")
     public void testForMultiDimensionalJsonArray() throws IOException {
         String jsonFileContent = Files.readString(sample7Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample7Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -302,8 +250,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for complex JSON object")
     public void testForComplexJsonObject() throws IOException {
         String jsonFileContent = Files.readString(sample8Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample8Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -311,8 +259,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for complex JSON object - inline")
     public void testForComplexJsonObjectInLIne() throws IOException {
         String jsonFileContent = Files.readString(sample8Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", true, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample8TypeDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -320,8 +268,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for many types in JSON array")
     public void testForMultipleItemsJsonArray() throws IOException {
         String jsonFileContent = Files.readString(sample9Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample9Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -329,8 +277,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for many types in JSON array - inline")
     public void testForMultipleItemsJsonArrayInLIne() throws IOException {
         String jsonFileContent = Files.readString(sample9Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", true, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample9TypeDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -338,8 +286,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for JSON array of objects")
     public void testForJsonArrayOfObjects() throws IOException {
         String jsonFileContent = Files.readString(sample10Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample10Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -347,8 +295,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for JSON array of objects - inline")
     public void testForJsonArrayOfObjectsInLIne() throws IOException {
         String jsonFileContent = Files.readString(sample10Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", true, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample10TypeDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -356,8 +304,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for JSON field names with special characters")
     public void testForJsonFieldsOfSpecialChars() throws IOException {
         String jsonFileContent = Files.readString(sample11Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample11Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -365,8 +313,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for Invalid JSON")
     public void testForInvalidJson() throws IOException {
         String jsonFileContent = Files.readString(sample12Json);
-        List<JsonToRecordMapperDiagnostic> diagnostics =
-                JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null).getDiagnostics();
+        List<JsonToRecordMapperDiagnostic> diagnostics = JsonToRecordMapper.convert(
+                        jsonFileContent, "", false, false, false, null, null, false).getDiagnostics();
         String diagnosticMessage =
                 "Provided JSON is invalid : Unterminated object at line 15 column 8 path $.friend.address.city";
         Assert.assertEquals(diagnostics.size(), 1);
@@ -376,8 +324,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for JSON with a fieldName similar to recordName")
     public void testForSimilarRecordNameAndFieldName() throws IOException {
         String jsonFileContent = Files.readString(sample13Json);
-        List<JsonToRecordMapperDiagnostic> diagnostics =
-                JsonToRecordMapper.convert(jsonFileContent, "Person", false, false, false, null, null).getDiagnostics();
+        List<JsonToRecordMapperDiagnostic> diagnostics = JsonToRecordMapper.convert(
+                        jsonFileContent, "Person", false, false, false, null, null, false).getDiagnostics();
         String diagnosticMessage = "Provided record name 'Person' conflicts with the other generated records. " +
                 "Consider providing a different name.";
         Assert.assertEquals(diagnostics.size(), 1);
@@ -387,8 +335,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for JSON with user defined record name")
     public void testForUserDefinedRecordName() throws IOException {
         String jsonFileContent = Files.readString(sample3Json);
-        String generatedCodeBlock = JsonToRecordMapper
-                .convert(jsonFileContent, "Person", false, false, false, null, null)
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "Person", false, false, false, null, null, false)
                 .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample3PersonBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
@@ -397,9 +345,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for JSON with user defined record name - inline")
     public void testForUserDefinedRecordNameInLIne() throws IOException {
         String jsonFileContent = Files.readString(sample3Json);
-        String generatedCodeBlock = JsonToRecordMapper
-                .convert(jsonFileContent, "Person", true, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "Person", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample3PersonTypeDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -407,8 +354,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for JSON with user defined record name with special chars")
     public void testForUserDefinedRecordNameWithSpecialChars() throws IOException {
         String jsonFileContent = Files.readString(sample3Json);
-        String generatedCodeBlock =
-                JsonToRecordMapper.convert(jsonFileContent, "Special Person", false, false, false, null, null)
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "Special Person", false, false, false, null, null, false)
                 .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample3SpecialCharBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
@@ -417,8 +364,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for nested JSON with same recurring field")
     public void testForJsonWithRecurringFieldName() throws IOException {
         String jsonFileContent = Files.readString(sample14Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample14Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -426,8 +373,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for nested JSON with same recurring field to generate inline record")
     public void testForJsonWithRecurringFieldNameToGenerateInlineRecord() throws IOException {
         String jsonFileContent = Files.readString(sample14Json);
-        List<JsonToRecordMapperDiagnostic> diagnostics =
-                JsonToRecordMapper.convert(jsonFileContent, "", true, false, false, null, null).getDiagnostics();
+        List<JsonToRecordMapperDiagnostic> diagnostics = JsonToRecordMapper.convert(
+                jsonFileContent, "", true, false, false, null, null, false).getDiagnostics();
         String diagnosticMessage = "Proper inline record cannot be generated due to the nested structure " +
                 "of the JSON. This will cause infinite record nesting. Consider renaming field 'items'.";
         Assert.assertEquals(diagnostics.size(), 1);
@@ -437,8 +384,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for nested JSON with same recurring field to generate inline record - 1")
     public void testForJsonWithRecurringFieldNameToGenerateInlineRecord1() throws IOException {
         String jsonFileContent = Files.readString(sample16Json);
-        List<JsonToRecordMapperDiagnostic> diagnostics =
-                JsonToRecordMapper.convert(jsonFileContent, "", true, false, false, null, null).getDiagnostics();
+        List<JsonToRecordMapperDiagnostic> diagnostics = JsonToRecordMapper.convert(
+                jsonFileContent, "", true, false, false, null, null, false).getDiagnostics();
         String diagnosticMessage = "Proper inline record cannot be generated due to the nested structure " +
                 "of the JSON. This will cause infinite record nesting. Consider renaming field 'productRef'.";
         Assert.assertEquals(diagnostics.size(), 1);
@@ -448,8 +395,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for JSON array of nested objects - inline")
     public void testForJsonArrayOfNestedObjectsInLIne() throws IOException {
         String jsonFileContent = Files.readString(sample15Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", true, false, false, null, null)
-                .getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", true, false, false, null, null, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample15TypeDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -457,8 +404,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for JSON with optional fields")
     public void testForJsonWithOptionalFields() throws IOException {
         String jsonFileContent = Files.readString(sample6Json);
-        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "", false, false, false, null, null,
-                        true).getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, null, null, true).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample16Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -467,21 +414,21 @@ public class JsonToRecordMapperTests {
     public void testChoreoTransPayloads() throws IOException {
         Map<Path, Path> samples = new HashMap<>();
         for (int i = 0; i <= 3; i++) {
-            Path jsonInputPath = RES_DIR.resolve(JSON_DIR).resolve("ChoreoTransPayloads")
+            Path jsonInputPath = RES_DIR.resolve("json/ChoreoTransPayloads")
                     .resolve(String.format("sample_%d_input.json", i));
-            Path balInputPath = RES_DIR.resolve(BAL_DIR).resolve("ChoreoTransPayloads")
+            Path balInputPath = RES_DIR.resolve("ballerina/ChoreoTransPayloads")
                     .resolve(String.format("sample_%d_input.bal", i));
-            Path jsonOutputPath = RES_DIR.resolve(JSON_DIR).resolve("ChoreoTransPayloads")
+            Path jsonOutputPath = RES_DIR.resolve("json/ChoreoTransPayloads")
                     .resolve(String.format("sample_%d_output.json", i));
-            Path balOutputPath = RES_DIR.resolve(BAL_DIR).resolve("ChoreoTransPayloads")
+            Path balOutputPath = RES_DIR.resolve("ballerina/ChoreoTransPayloads")
                     .resolve(String.format("sample_%d_output.bal", i));
             samples.put(jsonInputPath, balInputPath);
             samples.put(jsonOutputPath, balOutputPath);
         }
         for (Map.Entry<Path, Path> sample : samples.entrySet()) {
             String jsonFileContent = Files.readString(sample.getKey());
-            JsonToRecordResponse jsonToRecordResponse =
-                    JsonToRecordMapper.convert(jsonFileContent, null, false, false, false, null, null, false);
+            JsonToRecordResponse jsonToRecordResponse = JsonToRecordMapper.convert(
+                    jsonFileContent, null, false, false, false, null, null, false);
             if (jsonToRecordResponse.getCodeBlock() != null) {
                 String generatedCodeBlock = jsonToRecordResponse.getCodeBlock().replaceAll("\\s+", "");
                 String expectedCodeBlock = Files.readString(sample.getValue()).replaceAll("\\s+", "");
@@ -497,8 +444,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for conflicting record names in invalid bal file")
     public void testForConflictingRecordNamesInInvalidBalFile() throws IOException {
         String jsonFileContent = Files.readString(sample2Json);
-        JsonToRecordResponse response = JsonToRecordMapper
-                .convert(jsonFileContent, null, false, false, false, invalidBalFile.toUri().toString(), null);
+        JsonToRecordResponse response = JsonToRecordMapper.convert(
+                jsonFileContent, null, false, false, false, invalidBalFile.toUri().toString(), null, false);
         String generatedCodeBlock = response.getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample2Bal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
@@ -506,38 +453,36 @@ public class JsonToRecordMapperTests {
 
     @Test(description = "Test for conflicting record names in single bal file project")
     public void testForConflictingRecordNamesInSingleBalFileProject() throws IOException {
-        Map<String, Map.Entry<Path, Path>> existingRecordsToJsonSamples = new HashMap<>() {{
-            put("sample_4.bal", Map.entry(sample4Bal, sample4Json));
-            put("sample_8.bal", Map.entry(sample8Bal, sample8Json));
-            put("sample_10.bal", Map.entry(sample10Bal, sample10Json));
-            put("sample_11.bal", Map.entry(sample11Bal, sample11Json));
-        }};
-        Map<String, Map.Entry<Path, Path>> existingRecordsToJsonTypeDescSamples = new HashMap<>() {{
-            put("sample_4_type_desc.bal", Map.entry(sample4Bal, sample4Json));
-            put("sample_9_type_desc.bal", Map.entry(sample9Bal, sample9Json));
-            put("sample_10_type_desc.bal", Map.entry(sample10Bal, sample10Json));
-        }};
+        Map<String, Map.Entry<Path, Path>> existingRecordsToJsonSamples = Map.of(
+            "sample_4.bal", Map.entry(sample4Bal, sample4Json),
+            "sample_8.bal", Map.entry(sample8Bal, sample8Json),
+            "sample_10.bal", Map.entry(sample10Bal, sample10Json),
+            "sample_11.bal", Map.entry(sample11Bal, sample11Json)
+        );
+        Map<String, Map.Entry<Path, Path>> existingRecordsToJsonTypeDescSamples = Map.of(
+            "sample_4_type_desc.bal", Map.entry(sample4Bal, sample4Json),
+            "sample_9_type_desc.bal", Map.entry(sample9Bal, sample9Json),
+            "sample_10_type_desc.bal", Map.entry(sample10Bal, sample10Json)
+        );
 
         for (Map.Entry<String, Map.Entry<Path, Path>> entry : existingRecordsToJsonSamples.entrySet()) {
             Path jsonFilePath = entry.getValue().getValue();
-            Path balFilePath = RES_DIR.resolve(PROJECT_DIR).resolve(ASSERT_DIR).resolve("singleFileProject")
-                    .resolve(entry.getKey());
+            Path balFilePath = RES_DIR.resolve("project/assert/singleFileProject").resolve(entry.getKey());
             String balExistingFilePath = entry.getValue().getKey().toUri().toString();
             String jsonFileContent = Files.readString(jsonFilePath);
-            JsonToRecordResponse jsonToRecordResponse = JsonToRecordMapper
-                    .convert(jsonFileContent, null, false, false, false, balExistingFilePath, null);
+            JsonToRecordResponse jsonToRecordResponse = JsonToRecordMapper.convert(
+                    jsonFileContent, null, false, false, false, balExistingFilePath, null, false);
             String generatedCodeBlock = jsonToRecordResponse.getCodeBlock().replaceAll("\\s+", "");
             String expectedCodeBlock = Files.readString(balFilePath).replaceAll("\\s+", "");
             Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
         }
         for (Map.Entry<String, Map.Entry<Path, Path>> entry : existingRecordsToJsonTypeDescSamples.entrySet()) {
             Path jsonFilePath = entry.getValue().getValue();
-            Path balFilePath = RES_DIR.resolve(PROJECT_DIR).resolve(ASSERT_DIR).resolve("singleFileProject")
-                    .resolve(entry.getKey());
+            Path balFilePath = RES_DIR.resolve("project/assert/singleFileProject").resolve(entry.getKey());
             String balExistingFilePath = entry.getValue().getKey().toUri().toString();
             String jsonFileContent = Files.readString(jsonFilePath);
-            JsonToRecordResponse jsonToRecordResponse =
-                    JsonToRecordMapper.convert(jsonFileContent, null, true, false, false, balExistingFilePath, null);
+            JsonToRecordResponse jsonToRecordResponse = JsonToRecordMapper.convert(
+                    jsonFileContent, null, true, false, false, balExistingFilePath, null, false);
             String generatedCodeBlock = jsonToRecordResponse.getCodeBlock().replaceAll("\\s+", "");
             String expectedCodeBlock = Files.readString(balFilePath).replaceAll("\\s+", "");
             Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
@@ -547,8 +492,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for conflicting parent record name")
     public void testForConflictingParentRecordName() throws IOException {
         String jsonFileContent = Files.readString(sample2Json);
-        List<JsonToRecordMapperDiagnostic> diagnostics = JsonToRecordMapper
-                .convert(jsonFileContent, "Friend", false, false, false, sample2Bal.toUri().toString(), null)
+        List<JsonToRecordMapperDiagnostic> diagnostics = JsonToRecordMapper.convert(
+                jsonFileContent, "Friend", false, false, false, sample2Bal.toUri().toString(), null, false)
                 .getDiagnostics();
         String diagnosticMessage = "Provided record name 'Friend' conflicts with already existing records. " +
                 "Consider providing a different name.";
@@ -559,9 +504,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for conflicting record names in bal project default module")
     public void testForConflictingRecordNamesInBalProjectDefault() throws IOException {
         String jsonFileContent = Files.readString(sample2Json);
-        String generatedCodeBlock = JsonToRecordMapper
-                .convert(jsonFileContent, null, false, false, false,
-                        balProjectFileDefaultModule.toUri().toString(), null)
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, null, false, false, false, balProjectFileDefaultModule.toUri().toString(), null, false)
                 .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(balProjectFileDefaultModuleAssert).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
@@ -570,8 +514,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for conflicting record names in bal project non-default module")
     public void testForConflictingRecordNamesInBalProjectNonDefault() throws IOException {
         String jsonFileContent = Files.readString(sample6Json);
-        String generatedCodeBlock = JsonToRecordMapper
-                .convert(jsonFileContent, "", false, false, false, balProjectFileUtilModule.toUri().toString(), null)
+        String generatedCodeBlock = JsonToRecordMapper.convert(
+                jsonFileContent, "", false, false, false, balProjectFileUtilModule.toUri().toString(), null, false)
                 .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(balProjectFileUtilModuleAssert).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
@@ -580,9 +524,8 @@ public class JsonToRecordMapperTests {
     @Test(description = "Test for conflicting record name rename diagnostics")
     public void testForConflictingRecordNameRenameDiagnostics() throws IOException {
         String jsonFileContent = Files.readString(sample6Json);
-        List<JsonToRecordMapperDiagnostic> diagnostics = JsonToRecordMapper
-                .convert(jsonFileContent, "NewRecord", false, false, false,
-                        balProjectFileUtilModule.toUri().toString(), null)
+        List<JsonToRecordMapperDiagnostic> diagnostics = JsonToRecordMapper.convert(jsonFileContent, "NewRecord",
+                        false, false, false, balProjectFileUtilModule.toUri().toString(), null, false)
                 .getDiagnostics();
         String diagnosticMessage0 = "The record name 'State' is renamed as 'State_01'. " +
                 "Consider rename it back to a meaningful name.";

--- a/misc/json-to-record-converter/src/test/java/io/ballerina/jsonmapper/JsonToRecordMapperTests.java
+++ b/misc/json-to-record-converter/src/test/java/io/ballerina/jsonmapper/JsonToRecordMapperTests.java
@@ -20,7 +20,6 @@ package io.ballerina.jsonmapper;
 
 
 import io.ballerina.jsonmapper.diagnostic.JsonToRecordMapperDiagnostic;
-import org.javatuples.Pair;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -507,23 +506,23 @@ public class JsonToRecordMapperTests {
 
     @Test(description = "Test for conflicting record names in single bal file project")
     public void testForConflictingRecordNamesInSingleBalFileProject() throws IOException {
-        Map<String, Pair<Path, Path>> existingRecordsToJsonSamples = new HashMap<>() {{
-            put("sample_4.bal", new Pair<>(sample4Bal, sample4Json));
-            put("sample_8.bal", new Pair<>(sample8Bal, sample8Json));
-            put("sample_10.bal", new Pair<>(sample10Bal, sample10Json));
-            put("sample_11.bal", new Pair<>(sample11Bal, sample11Json));
+        Map<String, Map.Entry<Path, Path>> existingRecordsToJsonSamples = new HashMap<>() {{
+            put("sample_4.bal", Map.entry(sample4Bal, sample4Json));
+            put("sample_8.bal", Map.entry(sample8Bal, sample8Json));
+            put("sample_10.bal", Map.entry(sample10Bal, sample10Json));
+            put("sample_11.bal", Map.entry(sample11Bal, sample11Json));
         }};
-        Map<String, Pair<Path, Path>> existingRecordsToJsonTypeDescSamples = new HashMap<>() {{
-            put("sample_4_type_desc.bal", new Pair<>(sample4Bal, sample4Json));
-            put("sample_9_type_desc.bal", new Pair<>(sample9Bal, sample9Json));
-            put("sample_10_type_desc.bal", new Pair<>(sample10Bal, sample10Json));
+        Map<String, Map.Entry<Path, Path>> existingRecordsToJsonTypeDescSamples = new HashMap<>() {{
+            put("sample_4_type_desc.bal", Map.entry(sample4Bal, sample4Json));
+            put("sample_9_type_desc.bal", Map.entry(sample9Bal, sample9Json));
+            put("sample_10_type_desc.bal", Map.entry(sample10Bal, sample10Json));
         }};
 
-        for (Map.Entry<String, Pair<Path, Path>> entry : existingRecordsToJsonSamples.entrySet()) {
-            Path jsonFilePath = entry.getValue().getValue1();
+        for (Map.Entry<String, Map.Entry<Path, Path>> entry : existingRecordsToJsonSamples.entrySet()) {
+            Path jsonFilePath = entry.getValue().getValue();
             Path balFilePath = RES_DIR.resolve(PROJECT_DIR).resolve(ASSERT_DIR).resolve("singleFileProject")
                     .resolve(entry.getKey());
-            String balExistingFilePath = entry.getValue().getValue0().toUri().toString();
+            String balExistingFilePath = entry.getValue().getKey().toUri().toString();
             String jsonFileContent = Files.readString(jsonFilePath);
             JsonToRecordResponse jsonToRecordResponse = JsonToRecordMapper
                     .convert(jsonFileContent, null, false, false, false, balExistingFilePath, null);
@@ -531,11 +530,11 @@ public class JsonToRecordMapperTests {
             String expectedCodeBlock = Files.readString(balFilePath).replaceAll("\\s+", "");
             Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
         }
-        for (Map.Entry<String, Pair<Path, Path>> entry : existingRecordsToJsonTypeDescSamples.entrySet()) {
-            Path jsonFilePath = entry.getValue().getValue1();
+        for (Map.Entry<String, Map.Entry<Path, Path>> entry : existingRecordsToJsonTypeDescSamples.entrySet()) {
+            Path jsonFilePath = entry.getValue().getValue();
             Path balFilePath = RES_DIR.resolve(PROJECT_DIR).resolve(ASSERT_DIR).resolve("singleFileProject")
                     .resolve(entry.getKey());
-            String balExistingFilePath = entry.getValue().getValue0().toUri().toString();
+            String balExistingFilePath = entry.getValue().getKey().toUri().toString();
             String jsonFileContent = Files.readString(jsonFilePath);
             JsonToRecordResponse jsonToRecordResponse =
                     JsonToRecordMapper.convert(jsonFileContent, null, true, false, false, balExistingFilePath, null);

--- a/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_0_input.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_0_input.bal
@@ -1,35 +1,41 @@
-type AssetsItem record {
+type AssetsItem record {|
     int Type;
     string Id;
-};
+    json...;
+|};
 
-type RecipientsItem record {
+type RecipientsItem record {|
     string UserId;
     string Name;
-    anydata EmailAddress;
-};
+    json EmailAddress;
+    json...;
+|};
 
-type HeaderInformation record {
+type HeaderInformation record {|
     string CreateDateUtc;
-};
+    json...;
+|};
 
-type Content record {
+type Content record {|
     string Message;
     RecipientsItem[] Recipients;
-    anydata TripInformation;
+    json TripInformation;
     HeaderInformation HeaderInformation;
-};
+    json...;
+|};
 
-type MessageProperties record {
+type MessageProperties record {|
     string EventType;
     string AuditId;
     string MessageId;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     AssetsItem[] Assets;
     string CreateDate;
     string ContentType;
     Content Content;
     MessageProperties MessageProperties;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_0_output.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_0_output.bal
@@ -1,48 +1,56 @@
-type RecipientsItem record {
+type RecipientsItem record {|
     string UserId;
     string Name;
     string EmailAddress;
-};
+    json...;
+|};
 
-type AssetsItem record {
+type AssetsItem record {|
     int Type;
     string Id;
     boolean Confirmed;
-};
+    json...;
+|};
 
-type TripInformation record {
+type TripInformation record {|
     string TripName;
     decimal Move;
     decimal Leg;
     decimal Stop;
     decimal OrderHeader;
     AssetsItem[] Assets;
-    anydata[] AdditionalDataElements;
-};
+    json[] AdditionalDataElements;
+    json...;
+|};
 
-type HeaderInformation record {
+type HeaderInformation record {|
     string CreateDateUtc;
-};
+    json...;
+|};
 
-type MessageContent record {
+type MessageContent record {|
     string Message;
     RecipientsItem[] Recipients;
     TripInformation TripInformation;
     HeaderInformation HeaderInformation;
-};
+    json...;
+|};
 
-type Data record {
+type Data record {|
     string MessageGuid;
     string ParentMessageGuid;
     string MessageContentType;
     MessageContent MessageContent;
-};
+    json...;
+|};
 
-type DtosItem record {
+type DtosItem record {|
     string 'type;
     Data data;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     DtosItem[] dtos;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_1_input.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_1_input.bal
@@ -1,18 +1,21 @@
-type AssetsItem record {
+type AssetsItem record {|
     int Type;
     string Id;
-};
+    json...;
+|};
 
-type Position record {
+type Position record {|
     decimal Latitude;
     decimal Longitude;
-};
+    json...;
+|};
 
-type HeaderInformation record {
+type HeaderInformation record {|
     string CreateDateUtc;
-};
+    json...;
+|};
 
-type Content record {
+type Content record {|
     string StatusDate;
     Position Position;
     int Speed;
@@ -20,21 +23,24 @@ type Content record {
     string IgnitionStatus;
     decimal Odometer;
     string Description;
-    anydata AdditionalDataElements;
-    anydata TripInformation;
+    json AdditionalDataElements;
+    json TripInformation;
     HeaderInformation HeaderInformation;
-};
+    json...;
+|};
 
-type MessageProperties record {
+type MessageProperties record {|
     string EventType;
     string AuditId;
     string MessageId;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     AssetsItem[] Assets;
     string ContentType;
     string CreateDate;
     Content Content;
     MessageProperties MessageProperties;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_1_output.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_1_output.bal
@@ -1,30 +1,34 @@
-type Position record {
+type Position record {|
     decimal Latitude;
     decimal Longitude;
-};
+    json...;
+|};
 
-type AssetsItem record {
+type AssetsItem record {|
     int Type;
     string Id;
     boolean Confirmed;
-};
+    json...;
+|};
 
-type TripInformation record {
+type TripInformation record {|
     string TripName;
     decimal Move;
     decimal Leg;
     decimal Stop;
     decimal OrderHeader;
     AssetsItem[] Assets;
-    anydata[] AdditionalDataElements;
-};
+    json[] AdditionalDataElements;
+    json...;
+|};
 
-type HeaderInformation record {
+type HeaderInformation record {|
     string CreateDateUtc;
-};
+    json...;
+|};
 
-type MessageContent record {
-    anydata[] Assets;
+type MessageContent record {|
+    json[] Assets;
     string StatusDate;
     int Speed;
     int Heading;
@@ -32,26 +36,30 @@ type MessageContent record {
     string Description;
     string IgnitionStatus;
     int Odometer;
-    anydata Zip;
-    anydata City;
-    anydata State;
-    anydata Distance;
+    json Zip;
+    json City;
+    json State;
+    json Distance;
     TripInformation TripInformation;
     HeaderInformation HeaderInformation;
-};
+    json...;
+|};
 
-type Data record {
+type Data record {|
     string MessageGuid;
     string ParentMessageGuid;
     string MessageContentType;
     MessageContent MessageContent;
-};
+    json...;
+|};
 
-type DtosItem record {
+type DtosItem record {|
     string 'type;
     Data data;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     DtosItem[] dtos;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_2_input.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_2_input.bal
@@ -1,42 +1,48 @@
-type AssetsItem record {
+type AssetsItem record {|
     int Type;
     string Id;
     boolean Confirmed?;
-};
+    json...;
+|};
 
-type TripInformation record {
-    anydata TripName;
-    anydata Move;
+type TripInformation record {|
+    json TripName;
+    json Move;
     int Leg;
-    anydata Stop;
+    json Stop;
     int OrderHeader;
     AssetsItem[] Assets;
-    anydata AdditionalDataElements;
-};
+    json AdditionalDataElements;
+    json...;
+|};
 
-type HeaderInformation record {
+type HeaderInformation record {|
     string CreateDateUtc;
-};
+    json...;
+|};
 
-type Content record {
+type Content record {|
     int Response;
     boolean RedispatchNow;
     string Reason;
-    anydata AdditionalDataElements;
+    json AdditionalDataElements;
     TripInformation TripInformation;
     HeaderInformation HeaderInformation;
-};
+    json...;
+|};
 
-type MessageProperties record {
+type MessageProperties record {|
     string EventType;
     string AuditId;
     string MessageId;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     AssetsItem[] Assets;
     string ContentType;
     string CreateDate;
     Content Content;
     MessageProperties MessageProperties;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_2_output.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_2_output.bal
@@ -1,44 +1,51 @@
-type AssetsItem record {
+type AssetsItem record {|
     int Type;
     string Id;
     boolean Confirmed;
-};
+    json...;
+|};
 
-type TripInformation record {
+type TripInformation record {|
     string TripName;
     decimal Move;
     int Leg;
     decimal Stop;
     int OrderHeader;
     AssetsItem[] Assets;
-    anydata[] AdditionalDataElements;
-};
+    json[] AdditionalDataElements;
+    json...;
+|};
 
-type HeaderInformation record {
+type HeaderInformation record {|
     string CreateDateUtc;
-};
+    json...;
+|};
 
-type MessageContent record {
+type MessageContent record {|
     int Response;
     string RedispatchNow;
     string Reason;
-    anydata[] AdditionalDataElements;
+    json[] AdditionalDataElements;
     TripInformation TripInformation;
     HeaderInformation HeaderInformation;
-};
+    json...;
+|};
 
-type Data record {
+type Data record {|
     string MessageGuid;
     string ParentMessageGuid;
     string MessageContentType;
     MessageContent MessageContent;
-};
+    json...;
+|};
 
-type DtosItem record {
+type DtosItem record {|
     string 'type;
     Data data;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     DtosItem[] dtos;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_3_input.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_3_input.bal
@@ -1,41 +1,47 @@
-type AssetsItem record {
+type AssetsItem record {|
     int Type;
     string Id;
     boolean Confirmed;
-};
+    json...;
+|};
 
-type TripInformation record {
-    anydata TripName;
-    anydata Move;
-    anydata Leg;
-    anydata Stop;
+type TripInformation record {|
+    json TripName;
+    json Move;
+    json Leg;
+    json Stop;
     int OrderHeader;
     AssetsItem[] Assets;
-    anydata[] AdditionalDataElements;
-};
+    json[] AdditionalDataElements;
+    json...;
+|};
 
-type HeaderInformation record {
+type HeaderInformation record {|
     string CreateDateUtc;
-};
+    json...;
+|};
 
-type Content record {
+type Content record {|
     int Odometer;
-    anydata UnitTrips;
-    anydata Position;
+    json UnitTrips;
+    json Position;
     TripInformation TripInformation;
     HeaderInformation HeaderInformation;
-};
+    json...;
+|};
 
-type MessageProperties record {
+type MessageProperties record {|
     string EventType;
     string AuditId;
     string MessageId;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     AssetsItem[] Assets;
     string CreateDate;
     string ContentType;
     Content Content;
     MessageProperties MessageProperties;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_3_output.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/ChoreoTransPayloads/sample_3_output.bal
@@ -1,10 +1,11 @@
-type AssetsItem record {
+type AssetsItem record {|
     int Type;
     string Id;
     boolean Confirmed;
-};
+    json...;
+|};
 
-type TripInformation record {
+type TripInformation record {|
     string TripName;
     decimal Move;
     decimal Leg;
@@ -12,32 +13,38 @@ type TripInformation record {
     int OrderHeader;
     AssetsItem[] Assets;
     string AdditionalDataElements;
-};
+    json...;
+|};
 
-type HeaderInformation record {
+type HeaderInformation record {|
     string CreateDateUtc;
-};
+    json...;
+|};
 
-type MessageContent record {
+type MessageContent record {|
     int Odometer;
     string UnitTrips;
     string Position;
     TripInformation TripInformation;
     HeaderInformation HeaderInformation;
-};
+    json...;
+|};
 
-type Data record {
+type Data record {|
     string MessageGuid;
     string ParentMessageGuid;
     string MessageContentType;
     MessageContent MessageContent;
-};
+    json...;
+|};
 
-type DtosItem record {
+type DtosItem record {|
     string 'type;
     Data data;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     DtosItem[] dtos;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_0.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_0.bal
@@ -1,7 +1,8 @@
-type NewRecord record {
+type NewRecord record {|
     string firstName;
     string lastName;
     boolean married;
     int age;
-    anydata phoneNumber;
-};
+    json phoneNumber;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_1.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_1.bal
@@ -1,4 +1,4 @@
-type NewRecord record {
+type NewRecord record {|
     string equationName;
     int energy;
     int negativeEnergy;
@@ -6,4 +6,5 @@ type NewRecord record {
     decimal negativeConstant;
     decimal frequency;
     decimal negativeFrequency;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_10.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_10.bal
@@ -1,26 +1,31 @@
-type BatterItem record {
+type BatterItem record {|
     string id;
     string 'type;
-};
+    json...;
+|};
 
-type Batters record {
+type Batters record {|
     BatterItem[] batter;
-};
+    json...;
+|};
 
-type ToppingItem record {
+type ToppingItem record {|
     string id;
     string 'type;
-};
+    json...;
+|};
 
-type NewRecordItem record {
+type NewRecordItem record {|
     string id;
     string 'type;
     string name;
     decimal ppu;
     Batters batters;
     ToppingItem[] topping;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     NewRecordItem[] newRecord;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_10_type_desc.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_10_type_desc.bal
@@ -1,3 +1,4 @@
-type NewRecord record {
-    record {string id; string 'type; string name; decimal ppu; record {record {string id; string 'type;}[] batter;} batters; record {string id; string 'type;}[] topping;}[] newRecord;
-};
+type NewRecord record {|
+    record {|string id; string 'type; string name; decimal ppu; record {|record {|string id; string 'type; json...;|}[] batter; json...;|} batters; record {|string id; string 'type; json...;|}[] topping; json...;|}[] newRecord;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_11.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_11.bal
@@ -1,16 +1,18 @@
-type Special\ object record {
+type Special\ object record {|
     string name;
     int age;
-};
+    json...;
+|};
 
-type Special\\array\-\?Item record {
+type Special\\array\-\?Item record {|
     string date;
     int value;
     string 'type?;
     string[] \2\ favourite\-colors?;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     string first\ Name;
     string last\+Name\?;
     string \007;
@@ -18,4 +20,5 @@ type NewRecord record {
     boolean ōŊĖ;
     Special\ object special\ object;
     (Special\\array\-\?Item[]|Special\\array\-\?Item[][])[] special\\array\-\?;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_14.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_14.bal
@@ -1,33 +1,38 @@
-type Items record {
+type Items record {|
     string 'type;
     string default?;
     string example?;
     int minItems?;
     Items items?;
-};
+    json...;
+|};
 
-type OneOfItem record {
+type OneOfItem record {|
     string 'type;
     string example?;
     Items items?;
     int minItems?;
     string default?;
-};
+    json...;
+|};
 
-type Foo record {
+type Foo record {|
     (Bar|string) bar;
-};
+    json...;
+|};
 
-type Bar record {
+type Bar record {|
     Foo foo;
     (int|string) baz;
     Bar bar?;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     string description;
     string default;
     boolean nullable;
     OneOfItem[] oneOf;
     Foo foo;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_15_type_desc.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_15_type_desc.bal
@@ -1,11 +1,14 @@
-type NewRecord record {
+type NewRecord record {|
     string id;
-    record {
+    record {|
         string name;
-        (record {
+        (record {|
             string id?;
             string description?;
             string cid?;
-        }|string) value;
-    }[] characteristic;
-};
+            json...;
+        |}|string) value;
+        json...;
+    |}[] characteristic;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_16.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_16.bal
@@ -1,39 +1,44 @@
-type SportsItem record {
+type SportsItem record {|
     string sport?;
     string position?;
     boolean reserve?;
     string game?;
     string 'type?;
-};
+    json...;
+|};
 
-type Author record {
+type Author record {|
     string name;
     string country;
     (boolean|int|string) period?;
-    anydata language?;
-};
+    json language?;
+    json...;
+|};
 
-type BooksItem record {
+type BooksItem record {|
     string name;
     Author author;
     int publishedYear?;
     decimal price?;
-};
+    json...;
+|};
 
-type State record {
+type State record {|
     string name;
     string code;
-};
+    json...;
+|};
 
-type Address record {
+type Address record {|
     string number;
     string street;
     string neighborhood;
     string city;
     State state;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     string name;
     string school;
     int age;
@@ -42,4 +47,5 @@ type NewRecord record {
     string year;
     boolean honors;
     Address address;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_2.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_2.bal
@@ -1,19 +1,22 @@
-type Address record {
+type Address record {|
     string city;
     string country;
     int zip?;
     int houseNo?;
-};
+    json...;
+|};
 
-type Friend record {
+type Friend record {|
     string firstName;
     string lastName;
     Address address;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     string firstName;
     string lastName;
     Address address;
     Friend friend;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_2_type_desc.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_2_type_desc.bal
@@ -1,20 +1,24 @@
-type NewRecord record {
+type NewRecord record {|
     string firstName;
     string lastName;
-    record {
+    record {|
         string city;
         string country;
         int zip?;
         int houseNo?;
-    } address;
-    record {
+        json...;
+    |} address;
+    record {|
         string firstName;
         string lastName;
-        record {
+        record {|
             string city;
             string country;
             int zip?;
             int houseNo?;
-        } address;
-    } friend;
-};
+            json...;
+        |} address;
+        json...;
+    |} friend;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_3.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_3.bal
@@ -1,21 +1,24 @@
-type Address record {
+type Address record {|
     (int|string) streetAddress;
     string city;
     string state;
-};
+    json...;
+|};
 
-type Friend record {
+type Friend record {|
     string firstName;
     string lastName;
     Address address;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     string firstName;
     string lastName;
     string gender;
     int age;
     Address address;
-    anydata phoneNumber;
+    json phoneNumber;
     Friend friend;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_3_person.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_3_person.bal
@@ -1,21 +1,24 @@
-type Address record {
+type Address record {|
     (int|string) streetAddress;
     string city;
     string state;
-};
+    json...;
+|};
 
-type Friend record {
+type Friend record {|
     string firstName;
     string lastName;
     Address address;
-};
+    json...;
+|};
 
-type Person record {
+type Person record {|
     string firstName;
     string lastName;
     string gender;
     int age;
     Address address;
-    anydata phoneNumber;
+    json phoneNumber;
     Friend friend;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_3_person_type_desc.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_3_person_type_desc.bal
@@ -1,21 +1,25 @@
-type Person record {
+type Person record {|
     string firstName;
     string lastName;
     string gender;
     int age;
-    record {
+    record {|
         (int|string) streetAddress;
         string city;
         string state;
-    } address;
-    anydata phoneNumber;
-    record {
+        json...;
+    |} address;
+    json phoneNumber;
+    record {|
         string firstName;
         string lastName;
-        record {
+        record {|
             (int|string) streetAddress;
             string city;
             string state;
-        } address;
-    } friend;
-};
+            json...;
+        |} address;
+        json...;
+    |} friend;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_3_special_char.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_3_special_char.bal
@@ -1,21 +1,24 @@
-type Address record {
+type Address record {|
     (int|string) streetAddress;
     string city;
     string state;
-};
+    json...;
+|};
 
-type Friend record {
+type Friend record {|
     string firstName;
     string lastName;
     Address address;
-};
+    json...;
+|};
 
-type Special\ Person record {
+type Special\ Person record {|
     string firstName;
     string lastName;
     string gender;
     int age;
     Address address;
-    anydata phoneNumber;
+    json phoneNumber;
     Friend friend;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_3_type_desc.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_3_type_desc.bal
@@ -1,21 +1,25 @@
-type NewRecord record {
+type NewRecord record {|
     string firstName;
     string lastName;
     string gender;
     int age;
-    record {
+    record {|
         (int|string) streetAddress;
         string city;
         string state;
-    } address;
-    anydata phoneNumber;
-    record {
+        json...;
+    |} address;
+    json phoneNumber;
+    record {|
         string firstName;
         string lastName;
-        record {
+        record {|
             (int|string) streetAddress;
             string city;
             string state;
-        } address;
-    } friend;
-};
+            json...;
+        |} address;
+        json...;
+    |} friend;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_4.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_4.bal
@@ -1,12 +1,14 @@
-type PeopleItem record {
+type PeopleItem record {|
     string firstName;
     string lastName;
     string gender;
     int age;
     string number;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     PeopleItem[] people;
-    anydata[] addresses;
-};
+    json[] addresses;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_4_type_desc.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_4_type_desc.bal
@@ -1,4 +1,5 @@
-type NewRecord record {
-    record {string firstName; string lastName; string gender; int age; string number;}[] people;
-    anydata[] addresses;
-};
+type NewRecord record {|
+    record {|string firstName; string lastName; string gender; int age; string number; json...;|}[] people;
+    json[] addresses;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_5.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_5.bal
@@ -1,6 +1,7 @@
-type NewRecord record {
+type NewRecord record {|
     string[] students;
     int[] mathScores;
     (decimal|int)[] averages;
     (decimal|int|string)[] position;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_6.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_6.bal
@@ -1,39 +1,44 @@
-type SportsItem record {
+type SportsItem record {|
     string? sport;
     string position?;
     boolean reserve?;
     string game?;
     string 'type?;
-};
+    json...;
+|};
 
-type Author record {
+type Author record {|
     string name;
     string country;
     (boolean|int|string)? period;
-    anydata language?;
-};
+    json language?;
+    json...;
+|};
 
-type BooksItem record {
+type BooksItem record {|
     string name;
     Author author;
     int publishedYear?;
     decimal price?;
-};
+    json...;
+|};
 
-type State record {
+type State record {|
     string name;
     string code;
-};
+    json...;
+|};
 
-type Address record {
+type Address record {|
     string number;
     string street;
     string neighborhood;
     string city;
     State state;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     string name;
     string school;
     int age;
@@ -42,4 +47,5 @@ type NewRecord record {
     string year;
     boolean honors;
     Address address;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_6_closed.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_6_closed.bal
@@ -10,7 +10,7 @@ type Author record {|
     string name;
     string country;
     (boolean|int|string)? period;
-    anydata language?;
+    json language?;
 |};
 
 type BooksItem record {|

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_6_type_desc.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_6_type_desc.bal
@@ -1,35 +1,41 @@
-type NewRecord record {
+type NewRecord record {|
     string name;
     string school;
     int age;
-    record {
+    record {|
         string? sport;
         string position?;
         boolean reserve?;
         string game?;
         string 'type?;
-    }[] sports;
-    record {
+        json...;
+    |}[] sports;
+    record {|
         string name;
-        record {
+        record {|
             string name;
             string country;
             (boolean|int|string)? period;
-            anydata language?;
-        } author;
+            json language?;
+            json...;
+        |} author;
         int publishedYear?;
         decimal price?;
-    }[] books;
+        json...;
+    |}[] books;
     string year;
     boolean honors;
-    record {
+    record {|
         string number;
         string street;
         string neighborhood;
         string city;
-        record {
+        record {|
             string name;
             string code;
-        } state;
-    } address;
-};
+            json...;
+        |} state;
+        json...;
+    |} address;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_6_type_desc_closed.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_6_type_desc_closed.bal
@@ -15,7 +15,7 @@ type NewRecord record {|
             string name;
             string country;
             (boolean|int|string)? period;
-            anydata language?;
+            json language?;
         |} author;
         int publishedYear?;
         decimal price?;

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_7.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_7.bal
@@ -1,4 +1,5 @@
-type NewRecord record {
+type NewRecord record {|
     int[][] matrix;
     string[][][] threeDimensionStr;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_8.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_8.bal
@@ -1,98 +1,118 @@
-type Text record {
+type Text record {|
     string status;
     string div;
-};
+    json...;
+|};
 
-type IdentifierItem record {
+type IdentifierItem record {|
     string system;
     string value;
-};
+    json...;
+|};
 
-type CodingItem record {
+type CodingItem record {|
     string code;
     string system?;
-};
+    json...;
+|};
 
-type Type record {
+type Type record {|
     CodingItem[] coding;
-};
+    json...;
+|};
 
-type Patient record {
+type Patient record {|
     string reference;
-};
+    json...;
+|};
 
-type Insurer record {
+type Insurer record {|
     string reference;
-};
+    json...;
+|};
 
-type Provider record {
+type Provider record {|
     string reference;
-};
+    json...;
+|};
 
-type Priority record {
+type Priority record {|
     CodingItem[] coding;
-};
+    json...;
+|};
 
-type Prescription record {
+type Prescription record {|
     string reference;
-};
+    json...;
+|};
 
-type Payee record {
+type Payee record {|
     Type 'type;
-};
+    json...;
+|};
 
-type CareTeamItem record {
+type CareTeamItem record {|
     int sequence;
     Provider provider;
-};
+    json...;
+|};
 
-type DiagnosisCodeableConcept record {
+type DiagnosisCodeableConcept record {|
     CodingItem[] coding;
-};
+    json...;
+|};
 
-type DiagnosisItem record {
+type DiagnosisItem record {|
     int sequence;
     DiagnosisCodeableConcept diagnosisCodeableConcept;
-};
+    json...;
+|};
 
-type Coverage record {
+type Coverage record {|
     string reference;
-};
+    json...;
+|};
 
-type InsuranceItem record {
+type InsuranceItem record {|
     int sequence;
     boolean focal;
     Coverage coverage;
-};
+    json...;
+|};
 
-type ProductOrService record {
+type ProductOrService record {|
     CodingItem[] coding;
-};
+    json...;
+|};
 
-type UnitPrice record {
+type UnitPrice record {|
     decimal value;
     string currency;
-};
+    json...;
+|};
 
-type Net record {
+type Net record {|
     decimal value;
     string currency;
-};
+    json...;
+|};
 
-type Quantity record {
+type Quantity record {|
     int value;
-};
+    json...;
+|};
 
-type DetailItem record {
+type DetailItem record {|
     int sequence;
     ProductOrService productOrService;
     UnitPrice unitPrice;
     Net net;
     Quantity quantity?;
     decimal factor?;
-};
+    json...;
+|};
 
-type ItemItem record {
+type ItemItem record {|
     int sequence;
     int[] careTeamSequence;
     ProductOrService productOrService;
@@ -100,9 +120,10 @@ type ItemItem record {
     UnitPrice unitPrice;
     Net net;
     DetailItem[] detail;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     string resourceType;
     string id;
     Text text;
@@ -121,4 +142,5 @@ type NewRecord record {
     DiagnosisItem[] diagnosis;
     InsuranceItem[] insurance;
     ItemItem[] item;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_8_type_desc.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_8_type_desc.bal
@@ -1,109 +1,141 @@
-type NewRecord record {
+type NewRecord record {|
     string resourceType;
     string id;
-    record {
+    record {|
         string status;
         string div;
-    } text;
-    record {
+        json...;
+    |} text;
+    record {|
         string system;
         string value;
-    }[] identifier;
+        json...;
+    |}[] identifier;
     string status;
-    record {
-        record {
+    record {|
+        record {|
             string code;
             string system?;
-        }[] coding;
-    } 'type;
+            json...;
+        |}[] coding;
+        json...;
+    |} 'type;
     string use;
-    record {
+    record {|
         string reference;
-    } patient;
+        json...;
+    |} patient;
     string created;
-    record {
+    record {|
         string reference;
-    } insurer;
-    record {
+        json...;
+    |} insurer;
+    record {|
         string reference;
-    } provider;
-    record {
-        record {
+        json...;
+    |} provider;
+    record {|
+        record {|
             string code;
             string system?;
-        }[] coding;
-    } priority;
-    record {
+            json...;
+        |}[] coding;
+        json...;
+    |} priority;
+    record {|
         string reference;
-    } prescription;
-    record {
-        record {
-            record {
+        json...;
+    |} prescription;
+    record {|
+        record {|
+            record {|
                 string code;
                 string system?;
-            }[] coding;
-        } 'type;
-    } payee;
-    record {
+                json...;
+            |}[] coding;
+            json...;
+        |} 'type;
+        json...;
+    |} payee;
+    record {|
         int sequence;
-        record {
+        record {|
             string reference;
-        } provider;
-    }[] careTeam;
-    record {
+            json...;
+        |} provider;
+        json...;
+    |}[] careTeam;
+    record {|
         int sequence;
-        record {
-            record {
+        record {|
+            record {|
                 string code;
                 string system?;
-            }[] coding;
-        } diagnosisCodeableConcept;
-    }[] diagnosis;
-    record {
+                json...;
+            |}[] coding;
+            json...;
+        |} diagnosisCodeableConcept;
+        json...;
+    |}[] diagnosis;
+    record {|
         int sequence;
         boolean focal;
-        record {
+        record {|
             string reference;
-        } coverage;
-    }[] insurance;
-    record {
+            json...;
+        |} coverage;
+        json...;
+    |}[] insurance;
+    record {|
         int sequence;
         int[] careTeamSequence;
-        record {
-            record {
+        record {|
+            record {|
                 string code;
                 string system?;
-            }[] coding;
-        } productOrService;
+                json...;
+            |}[] coding;
+            json...;
+        |} productOrService;
         string servicedDate;
-        record {
+        record {|
             decimal value;
             string currency;
-        } unitPrice;
-        record {
+            json...;
+        |} unitPrice;
+        record {|
             decimal value;
             string currency;
-        } net;
-        record {
+            json...;
+        |} net;
+        record {|
             int sequence;
-            record {
-                record {
+            record {|
+                record {|
                     string code;
                     string system?;
-                }[] coding;
-            } productOrService;
-            record {
+                    json...;
+                |}[] coding;
+                json...;
+            |} productOrService;
+            record {|
                 decimal value;
                 string currency;
-            } unitPrice;
-            record {
+                json...;
+            |} unitPrice;
+            record {|
                 decimal value;
                 string currency;
-            } net;
-            record {
+                json...;
+            |} net;
+            record {|
                 int value;
-            } quantity?;
+                json...;
+            |} quantity?;
             decimal factor?;
-        }[] detail;
-    }[] item;
-};
+            json...;
+        |}[] detail;
+        json...;
+    |}[] item;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_9.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_9.bal
@@ -1,26 +1,30 @@
-type BatterItem record {
+type BatterItem record {|
     string id;
     string 'type;
     boolean fresh?;
-};
+    json...;
+|};
 
-type Batters record {
+type Batters record {|
     (BatterItem|decimal|int|string)[] batter;
-};
+    json...;
+|};
 
-type ToppingItem record {
+type ToppingItem record {|
     string id;
     string 'type;
     string color?;
-};
+    json...;
+|};
 
-type BaseItem record {
+type BaseItem record {|
     string id;
     string 'type;
     string color?;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     string id;
     string 'type;
     string name;
@@ -28,4 +32,5 @@ type NewRecord record {
     Batters batters;
     (ToppingItem|string|ToppingItem[]|string[])[] topping;
     BaseItem[][] base;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_9_type_desc.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_9_type_desc.bal
@@ -1,9 +1,10 @@
-type NewRecord record {
+type NewRecord record {|
     string id;
     string 'type;
     string name;
     decimal ppu;
-    record {(decimal|int|record {string id; string 'type; boolean fresh?;}|string)[] batter;} batters;
-    (record {string id; string 'type; string color?;}|string|record {string id; string 'type; string color?;}[]|string[])[] topping;
-    record {stringid ; string 'type; stringcolor? ;}[][] base;
-};
+    record {|(decimal|int|record {|string id; string 'type; boolean fresh?; json...;|}|string)[] batter; json...;|} batters;
+    (record {|string id; string 'type; string color?; json...;|}|string|record {|string id; string 'type; string color?; json...;|}[]|string[])[] topping;
+    record {|stringid ; string 'type; stringcolor?; json...;|}[][] base;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/project/assert/balProject/sample_bal_project_default.bal
+++ b/misc/json-to-record-converter/src/test/resources/project/assert/balProject/sample_bal_project_default.bal
@@ -1,19 +1,22 @@
-type Address record {
+type Address record {|
     string city;
     string country;
     int zip?;
     int houseNo?;
-};
+    json...;
+|};
 
-type Friend_01 record {
+type Friend_01 record {|
     string firstName;
     string lastName;
     Address address;
-};
+    json...;
+|};
 
-type NewRecord_01 record {
+type NewRecord_01 record {|
     string firstName;
     string lastName;
     Address address;
     Friend_01 friend;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/project/assert/balProject/sample_bal_project_util.bal
+++ b/misc/json-to-record-converter/src/test/resources/project/assert/balProject/sample_bal_project_util.bal
@@ -1,39 +1,44 @@
-type SportsItem record {
+type SportsItem record {|
     string? sport;
     string position?;
     boolean reserve?;
     string game?;
     string 'type?;
-};
+    json...;
+|};
 
-type Author_01 record {
+type Author_01 record {|
     string name;
     string country;
     (boolean|int|string)? period;
-    anydata language?;
-};
+    json language?;
+    json...;
+|};
 
-type BooksItem record {
+type BooksItem record {|
     string name;
     Author_01 author;
     int publishedYear?;
     decimal price?;
-};
+    json...;
+|};
 
-type State_01 record {
+type State_01 record {|
     string name;
     string code;
-};
+    json...;
+|};
 
-type Address record {
+type Address record {|
     string number;
     string street;
     string neighborhood;
     string city;
     State_01 state;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     string name;
     string school;
     int age;
@@ -42,4 +47,5 @@ type NewRecord record {
     string year;
     boolean honors;
     Address address;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_10.bal
+++ b/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_10.bal
@@ -1,26 +1,31 @@
-type BatterItem_01 record {
+type BatterItem_01 record {|
     string id;
     string 'type;
-};
+    json...;
+|};
 
-type Batters_01 record {
+type Batters_01 record {|
     BatterItem_01[] batter;
-};
+    json...;
+|};
 
-type ToppingItem_01 record {
+type ToppingItem_01 record {|
     string id;
     string 'type;
-};
+    json...;
+|};
 
-type NewRecordItem_01 record {
+type NewRecordItem_01 record {|
     string id;
     string 'type;
     string name;
     decimal ppu;
     Batters_01 batters;
     ToppingItem_01[] topping;
-};
+    json...;
+|};
 
-type NewRecord_01 record {
+type NewRecord_01 record {|
     NewRecordItem_01[] newRecord;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_10_type_desc.bal
+++ b/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_10_type_desc.bal
@@ -1,3 +1,4 @@
-type NewRecord_01 record {
-    record {string id; string 'type; string name; decimal ppu; record {record {string id; string 'type;}[] batter;} batters; record {string id; string 'type;}[] topping;}[] newRecord;
-};
+type NewRecord_01 record {|
+    record {|string id; string 'type; string name; decimal ppu; record {|record {|string id; string 'type; json...;|}[] batter; json...;|} batters; record {|string id; string 'type; json...;|}[] topping; json...;|}[] newRecord;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_11.bal
+++ b/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_11.bal
@@ -1,16 +1,18 @@
-type Special\ object_01 record {
+type Special\ object_01 record {|
     string name;
     int age;
-};
+    json...;
+|};
 
-type Special\\array\-\?Item_01 record {
+type Special\\array\-\?Item_01 record {|
     string date;
     int value;
     string 'type?;
     string[] \2\ favourite\-colors?;
-};
+    json...;
+|};
 
-type NewRecord_01 record {
+type NewRecord_01 record {|
     string first\ Name;
     string last\+Name\?;
     string \007;
@@ -18,4 +20,5 @@ type NewRecord_01 record {
     boolean ōŊĖ;
     Special\ object_01 special\ object;
     (Special\\array\-\?Item_01[]|Special\\array\-\?Item_01[][])[] special\\array\-\?;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_4.bal
+++ b/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_4.bal
@@ -1,12 +1,14 @@
-type PeopleItem_01 record {
+type PeopleItem_01 record {|
     string firstName;
     string lastName;
     string gender;
     int age;
     string number;
-};
+    json...;
+|};
 
-type NewRecord_01 record {
+type NewRecord_01 record {|
     PeopleItem_01[] people;
-    anydata[] addresses;
-};
+    json[] addresses;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_4_type_desc.bal
+++ b/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_4_type_desc.bal
@@ -1,4 +1,5 @@
-type NewRecord_01 record {
-    record {string firstName; string lastName; string gender; int age; string number;}[] people;
-    anydata[] addresses;
-};
+type NewRecord_01 record {|
+    record {|string firstName; string lastName; string gender; int age; string number; json...;|}[] people;
+    json[] addresses;
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_8.bal
+++ b/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_8.bal
@@ -1,98 +1,118 @@
-type Text_01 record {
+type Text_01 record {|
     string status;
     string div;
-};
+    json...;
+|};
 
-type IdentifierItem_01 record {
+type IdentifierItem_01 record {|
     string system;
     string value;
-};
+    json...;
+|};
 
-type CodingItem_01 record {
+type CodingItem_01 record {|
     string code;
     string system?;
-};
+    json...;
+|};
 
-type Type_01 record {
+type Type_01 record {|
     CodingItem_01[] coding;
-};
+    json...;
+|};
 
-type Patient_01 record {
+type Patient_01 record {|
     string reference;
-};
+    json...;
+|};
 
-type Insurer_01 record {
+type Insurer_01 record {|
     string reference;
-};
+    json...;
+|};
 
-type Provider_01 record {
+type Provider_01 record {|
     string reference;
-};
+    json...;
+|};
 
-type Priority_01 record {
+type Priority_01 record {|
     CodingItem_01[] coding;
-};
+    json...;
+|};
 
-type Prescription_01 record {
+type Prescription_01 record {|
     string reference;
-};
+    json...;
+|};
 
-type Payee_01 record {
+type Payee_01 record {|
     Type_01 'type;
-};
+    json...;
+|};
 
-type CareTeamItem_01 record {
+type CareTeamItem_01 record {|
     int sequence;
     Provider_01 provider;
-};
+    json...;
+|};
 
-type DiagnosisCodeableConcept_01 record {
+type DiagnosisCodeableConcept_01 record {|
     CodingItem_01[] coding;
-};
+    json...;
+|};
 
-type DiagnosisItem_01 record {
+type DiagnosisItem_01 record {|
     int sequence;
     DiagnosisCodeableConcept_01 diagnosisCodeableConcept;
-};
+    json...;
+|};
 
-type Coverage_01 record {
+type Coverage_01 record {|
     string reference;
-};
+    json...;
+|};
 
-type InsuranceItem_01 record {
+type InsuranceItem_01 record {|
     int sequence;
     boolean focal;
     Coverage_01 coverage;
-};
+    json...;
+|};
 
-type ProductOrService_01 record {
+type ProductOrService_01 record {|
     CodingItem_01[] coding;
-};
+    json...;
+|};
 
-type UnitPrice_01 record {
+type UnitPrice_01 record {|
     decimal value;
     string currency;
-};
+    json...;
+|};
 
-type Net_01 record {
+type Net_01 record {|
     decimal value;
     string currency;
-};
+    json...;
+|};
 
-type Quantity_01 record {
+type Quantity_01 record {|
     int value;
-};
+    json...;
+|};
 
-type DetailItem_01 record {
+type DetailItem_01 record {|
     int sequence;
     ProductOrService_01 productOrService;
     UnitPrice_01 unitPrice;
     Net_01 net;
     Quantity_01 quantity?;
     decimal factor?;
-};
+    json...;
+|};
 
-type ItemItem_01 record {
+type ItemItem_01 record {|
     int sequence;
     int[] careTeamSequence;
     ProductOrService_01 productOrService;
@@ -100,9 +120,10 @@ type ItemItem_01 record {
     UnitPrice_01 unitPrice;
     Net_01 net;
     DetailItem_01[] detail;
-};
+    json...;
+|};
 
-type NewRecord_01 record {
+type NewRecord_01 record {|
     string resourceType;
     string id;
     Text_01 text;
@@ -121,4 +142,5 @@ type NewRecord_01 record {
     DiagnosisItem_01[] diagnosis;
     InsuranceItem_01[] insurance;
     ItemItem_01[] item;
-};
+    json...;
+|};

--- a/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_9_type_desc.bal
+++ b/misc/json-to-record-converter/src/test/resources/project/assert/singleFileProject/sample_9_type_desc.bal
@@ -1,9 +1,10 @@
-type NewRecord_01 record {
+type NewRecord_01 record {|
     string id;
     string 'type;
     string name;
     decimal ppu;
-    record {(decimal|int|record {string id; string 'type; boolean fresh?;}|string)[] batter;} batters;
-    (record {string id; string 'type; string color?;}|string|record {string id; string 'type; string color?;}[]|string[])[] topping;
-    record {stringid ; string 'type; stringcolor? ;}[][] base;
-};
+    record {|(decimal|int|record {|string id; string 'type; boolean fresh?; json...;|}|string)[] batter; json...;|} batters;
+    (record {|string id; string 'type; string color?; json...;|}|string|record {|string id; string 'type; string color?; json...;|}[]|string[])[] topping;
+    record {|stringid ; string 'type; stringcolor? ; json...;|}[][] base;
+    json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/util/ConverterUtils.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/util/ConverterUtils.java
@@ -39,9 +39,9 @@ public final class ConverterUtils {
      */
     public static String convertOpenAPITypeToBallerina(String type) {
 
-        //In the case where type is not specified return anydata by default
+        //In the case where type is not specified return json by default
         if (type == null || type.isEmpty()) {
-            return "anydata";
+            return "json";
         }
 
         return switch (type) {
@@ -54,7 +54,7 @@ public final class ConverterUtils {
                  Constants.NUMBER,
                  Constants.DOUBLE -> "decimal";
             case Constants.FLOAT -> "float";
-            default -> "anydata";
+            default -> "json";
         };
     }
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/util/SchemaGenerator.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/util/SchemaGenerator.java
@@ -82,7 +82,7 @@ public final class SchemaGenerator {
         }
 
         if (json.getNodeType() == JsonNodeType.NULL) {
-            schema.put("type", "anydata");
+            schema.put("type", "json");
             return schema;
         }
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/java/io/ballerina/converters/JsonToRecordConverterTests.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/java/io/ballerina/converters/JsonToRecordConverterTests.java
@@ -62,7 +62,8 @@ public class JsonToRecordConverterTests {
 
     private static final Path nullObjectJson = RES_DIR.resolve("json/null_object.json");
     private static final Path nullObjectBal = RES_DIR.resolve("ballerina/null_object.bal");
-    private static final Path nullObjectDirectConversionBal = RES_DIR.resolve("ballerina/null_object_direct_conversion.bal");
+    private static final Path nullObjectDirectConversionBal = RES_DIR.resolve(
+            "ballerina/null_object_direct_conversion.bal");
 
     private static final Path sample1Json = RES_DIR.resolve("json/sample_1.json");
     private static final Path sample1Bal = RES_DIR.resolve("ballerina/sample_1.bal");
@@ -230,7 +231,8 @@ public class JsonToRecordConverterTests {
     }
 
     @Test(description = "Test with sample json objects for fields", dataProvider = "samples")
-    public void testFieldForSamples(Path json, Path bal) throws JsonToRecordConverterException, IOException, FormatterException {
+    public void testFieldForSamples(Path json, Path bal) throws JsonToRecordConverterException, IOException,
+            FormatterException {
         String jsonFileContent = Files.readString(json);
         String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "Person", true, false, false)
                 .getCodeBlock().replaceAll("\\s+", "");

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/java/io/ballerina/converters/JsonToRecordConverterTests.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/java/io/ballerina/converters/JsonToRecordConverterTests.java
@@ -42,125 +42,77 @@ public class JsonToRecordConverterTests {
     private static final Path RES_DIR = Path.of("src/test/resources/").toAbsolutePath();
     private static final String JsonToRecordService = "jsonToRecord/convert";
 
-    private final Path basicSchemaJson = RES_DIR.resolve("json")
-            .resolve("basic_schema.json");
-    private final Path basicSchemaBal = RES_DIR.resolve("ballerina")
-            .resolve("basic_schema.bal");
+    private final Path basicSchemaJson = RES_DIR.resolve("json/basic_schema.json");
+    private final Path basicSchemaBal = RES_DIR.resolve("ballerina/basic_schema.bal");
 
-    private final Path invalidSchemaJson = RES_DIR.resolve("json")
-            .resolve("invalid_json_schema.json");
+    private final Path invalidSchemaJson = RES_DIR.resolve("json/invalid_json_schema.json");
 
-    private final Path invalidJson = RES_DIR.resolve("json")
-            .resolve("invalid_json.json");
+    private final Path invalidJson = RES_DIR.resolve("json/invalid_json.json");
 
-    private final Path nullJson = RES_DIR.resolve("json")
-            .resolve("null_json.json");
+    private final Path nullJson = RES_DIR.resolve("json/null_json.json");
 
-    private final Path basicObjectJson = RES_DIR.resolve("json")
-            .resolve("basic_object.json");
-    private final Path basicObjectBal = RES_DIR.resolve("ballerina")
-            .resolve("basic_object.bal");
+    private final Path basicObjectJson = RES_DIR.resolve("json/basic_object.json");
+    private final Path basicObjectBal = RES_DIR.resolve("ballerina/basic_object.bal");
 
-    private final Path nestedSchemaJson = RES_DIR.resolve("json")
-            .resolve("nested_schema.json");
-    private final Path nestedSchemaBal = RES_DIR.resolve("ballerina")
-            .resolve("nested_schema.bal");
+    private final Path nestedSchemaJson = RES_DIR.resolve("json/nested_schema.json");
+    private final Path nestedSchemaBal = RES_DIR.resolve("ballerina/nested_schema.bal");
 
-    private final Path nestedObjectJson = RES_DIR.resolve("json")
-            .resolve("nested_object.json");
-    private final Path nestedObjectBal = RES_DIR.resolve("ballerina")
-            .resolve("nested_object.bal");
+    private final Path nestedObjectJson = RES_DIR.resolve("json/nested_object.json");
+    private final Path nestedObjectBal = RES_DIR.resolve("ballerina/nested_object.bal");
 
-    private final Path nullObjectJson = RES_DIR.resolve("json")
-            .resolve("null_object.json");
-    private final Path nullObjectBal = RES_DIR.resolve("ballerina")
-            .resolve("null_object.bal");
-    private final Path nullObjectDirectConversionBal = RES_DIR.resolve("ballerina")
-            .resolve("null_object_direct_conversion.bal");
+    private final Path nullObjectJson = RES_DIR.resolve("json/null_object.json");
+    private final Path nullObjectBal = RES_DIR.resolve("ballerina/null_object.bal");
+    private final Path nullObjectDirectConversionBal = RES_DIR.resolve("ballerina/null_object_direct_conversion.bal");
 
-    private final Path sample1Json = RES_DIR.resolve("json")
-            .resolve("sample_1.json");
-    private final Path sample1Bal = RES_DIR.resolve("ballerina")
-            .resolve("sample_1.bal");
+    private final Path sample1Json = RES_DIR.resolve("json/sample_1.json");
+    private final Path sample1Bal = RES_DIR.resolve("ballerina/sample_1.bal");
 
-    private final Path sample2Json = RES_DIR.resolve("json")
-            .resolve("sample_2.json");
-    private final Path sample2Bal = RES_DIR.resolve("ballerina")
-            .resolve("sample_2.bal");
+    private final Path sample2Json = RES_DIR.resolve("json/sample_2.json");
+    private final Path sample2Bal = RES_DIR.resolve("ballerina/sample_2.bal");
 
-    private final Path sample3Json = RES_DIR.resolve("json")
-            .resolve("sample_3.json");
-    private final Path sample3Bal = RES_DIR.resolve("ballerina")
-            .resolve("sample_3.bal");
-    private final Path sample3TypeDescBal = RES_DIR.resolve("ballerina")
-            .resolve("sample_3_type_desc.bal");
+    private final Path sample3Json = RES_DIR.resolve("json/sample_3.json");
+    private final Path sample3Bal = RES_DIR.resolve("ballerina/sample_3.bal");
+    private final Path sample3TypeDescBal = RES_DIR.resolve("ballerina/sample_3_type_desc.bal");
 
-    private final Path sample4Json = RES_DIR.resolve("json")
-            .resolve("sample_4.json");
-    private final Path sample4Bal = RES_DIR.resolve("ballerina")
-            .resolve("sample_4.bal");
+    private final Path sample4Json = RES_DIR.resolve("json/sample_4.json");
+    private final Path sample4Bal = RES_DIR.resolve("ballerina/sample_4.bal");
 
-    private final Path sample5Json = RES_DIR.resolve("json")
-            .resolve("sample_5.json");
-    private final Path sample5Bal = RES_DIR.resolve("ballerina")
-            .resolve("sample_5.bal");
+    private final Path sample5Json = RES_DIR.resolve("json/sample_5.json");
+    private final Path sample5Bal = RES_DIR.resolve("ballerina/sample_5.bal");
 
-    private final Path sample6Json = RES_DIR.resolve("json")
-            .resolve("sample_6.json");
-    private final Path sample6Bal = RES_DIR.resolve("ballerina")
-            .resolve("sample_6.bal");
-    private final Path sample6TypeDescBal = RES_DIR.resolve("ballerina")
-            .resolve("sample_6_type_desc.bal");
+    private final Path sample6Json = RES_DIR.resolve("json/sample_6.json");
+    private final Path sample6Bal = RES_DIR.resolve("ballerina/sample_6.bal");
+    private final Path sample6TypeDescBal = RES_DIR.resolve("ballerina/sample_6_type_desc.bal");
 
-    private final Path sample7Json = RES_DIR.resolve("json")
-            .resolve("sample_7.json");
-    private final Path sample7TypeDescBal = RES_DIR.resolve("ballerina")
-            .resolve("sample_7_type_desc.bal");
+    private final Path sample7Json = RES_DIR.resolve("json/sample_7.json");
+    private final Path sample7TypeDescBal = RES_DIR.resolve("ballerina/sample_7_type_desc.bal");
 
-    private final Path sample8Json = RES_DIR.resolve("json")
-            .resolve("sample_8.json");
-    private final Path sample8Bal = RES_DIR.resolve("ballerina")
-            .resolve("sample_8.bal");
-    private final Path sample8TypeDescBal = RES_DIR.resolve("ballerina")
-            .resolve("sample_8_type_desc.bal");
+    private final Path sample8Json = RES_DIR.resolve("json/sample_8.json");
+    private final Path sample8Bal = RES_DIR.resolve("ballerina/sample_8.bal");
+    private final Path sample8TypeDescBal = RES_DIR.resolve("ballerina/sample_8_type_desc.bal");
 
-    private final Path sample9Json = RES_DIR.resolve("json")
-            .resolve("sample_9.json");
-    private final Path sample9Bal = RES_DIR.resolve("ballerina")
-            .resolve("sample_9.bal");
-    private final Path sample9TypeDescBal = RES_DIR.resolve("ballerina")
-            .resolve("sample_9_type_desc.bal");
+    private final Path sample9Json = RES_DIR.resolve("json/sample_9.json");
+    private final Path sample9Bal = RES_DIR.resolve("ballerina/sample_9.bal");
+    private final Path sample9TypeDescBal = RES_DIR.resolve("ballerina/sample_9_type_desc.bal");
 
-    private final Path sample10Json = RES_DIR.resolve("json")
-            .resolve("sample_10.json");
-    private final Path sample10Bal = RES_DIR.resolve("ballerina")
-            .resolve("sample_10.bal");
-    private final Path sample10TypeDescBal = RES_DIR.resolve("ballerina")
-            .resolve("sample_10_type_desc.bal");
-    private final Path sample10WithoutConflictBal = RES_DIR.resolve("ballerina")
-            .resolve("sample_10_without_conflict.bal");
+    private final Path sample10Json = RES_DIR.resolve("json/sample_10.json");
+    private final Path sample10Bal = RES_DIR.resolve("ballerina/sample_10.bal");
+    private final Path sample10TypeDescBal = RES_DIR.resolve("ballerina/sample_10_type_desc.bal");
+    private final Path sample10WithoutConflictBal = RES_DIR.resolve("ballerina/sample_10_without_conflict.bal");
 
-    private final Path sample11Json = RES_DIR.resolve("json")
-            .resolve("sample_11.json");
-    private final Path sample11TypeDescBal = RES_DIR.resolve("ballerina")
-            .resolve("sample_11_type_desc.bal");
+    private final Path sample11Json = RES_DIR.resolve("json/sample_11.json");
+    private final Path sample11TypeDescBal = RES_DIR.resolve("ballerina/sample_11_type_desc.bal");
 
-    private final Path crlfJson = RES_DIR.resolve("json")
-            .resolve("crlf.json");
-    private final Path crlfBal = RES_DIR.resolve("ballerina")
-            .resolve("from_crlf.bal");
+    private final Path crlfJson = RES_DIR.resolve("json/crlf.json");
+    private final Path crlfBal = RES_DIR.resolve("ballerina/from_crlf.bal");
 
-    private final Path nestedObjectTypeDescBal = RES_DIR.resolve("ballerina")
-            .resolve("nested_object_type_desc.bal");
+    private final Path nestedObjectTypeDescBal = RES_DIR.resolve("ballerina/nested_object_type_desc.bal");
 
-    private final Path nestedObjectClosedDescBal = RES_DIR.resolve("ballerina")
-            .resolve("nested_object_closed_desc.bal");
+    private final Path nestedObjectClosedDescBal = RES_DIR.resolve("ballerina/nested_object_closed_desc.bal");
 
-    private final Path closedRecordBal = RES_DIR.resolve("ballerina")
-            .resolve("closed_record.bal");
+    private final Path closedRecordBal = RES_DIR.resolve("ballerina/closed_record.bal");
 
-    private final Path emptyArrayJson = RES_DIR.resolve("json")
-            .resolve("empty_array.json");
+    private final Path emptyArrayJson = RES_DIR.resolve("json/empty_array.json");
 
     @Test(description = "Test with basic json schema string")
     public void testBasicSchema() throws JsonToRecordConverterException, IOException, FormatterException {

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/java/io/ballerina/converters/JsonToRecordConverterTests.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/java/io/ballerina/converters/JsonToRecordConverterTests.java
@@ -24,12 +24,12 @@ import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.langserver.util.TestUtil;
 import org.eclipse.lsp4j.jsonrpc.Endpoint;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -42,83 +42,94 @@ public class JsonToRecordConverterTests {
     private static final Path RES_DIR = Path.of("src/test/resources/").toAbsolutePath();
     private static final String JsonToRecordService = "jsonToRecord/convert";
 
-    private final Path basicSchemaJson = RES_DIR.resolve("json/basic_schema.json");
-    private final Path basicSchemaBal = RES_DIR.resolve("ballerina/basic_schema.bal");
+    private static final Path basicSchemaJson = RES_DIR.resolve("json/basic_schema.json");
+    private static final Path basicSchemaBal = RES_DIR.resolve("ballerina/basic_schema.bal");
 
-    private final Path invalidSchemaJson = RES_DIR.resolve("json/invalid_json_schema.json");
+    private static final Path invalidSchemaJson = RES_DIR.resolve("json/invalid_json_schema.json");
 
-    private final Path invalidJson = RES_DIR.resolve("json/invalid_json.json");
+    private static final Path invalidJson = RES_DIR.resolve("json/invalid_json.json");
 
-    private final Path nullJson = RES_DIR.resolve("json/null_json.json");
+    private static final Path nullJson = RES_DIR.resolve("json/null_json.json");
 
-    private final Path basicObjectJson = RES_DIR.resolve("json/basic_object.json");
-    private final Path basicObjectBal = RES_DIR.resolve("ballerina/basic_object.bal");
+    private static final Path basicObjectJson = RES_DIR.resolve("json/basic_object.json");
+    private static final Path basicObjectBal = RES_DIR.resolve("ballerina/basic_object.bal");
 
-    private final Path nestedSchemaJson = RES_DIR.resolve("json/nested_schema.json");
-    private final Path nestedSchemaBal = RES_DIR.resolve("ballerina/nested_schema.bal");
+    private static final Path nestedSchemaJson = RES_DIR.resolve("json/nested_schema.json");
+    private static final Path nestedSchemaBal = RES_DIR.resolve("ballerina/nested_schema.bal");
 
-    private final Path nestedObjectJson = RES_DIR.resolve("json/nested_object.json");
-    private final Path nestedObjectBal = RES_DIR.resolve("ballerina/nested_object.bal");
+    private static final Path nestedObjectJson = RES_DIR.resolve("json/nested_object.json");
+    private static final Path nestedObjectBal = RES_DIR.resolve("ballerina/nested_object.bal");
 
-    private final Path nullObjectJson = RES_DIR.resolve("json/null_object.json");
-    private final Path nullObjectBal = RES_DIR.resolve("ballerina/null_object.bal");
-    private final Path nullObjectDirectConversionBal = RES_DIR.resolve("ballerina/null_object_direct_conversion.bal");
+    private static final Path nullObjectJson = RES_DIR.resolve("json/null_object.json");
+    private static final Path nullObjectBal = RES_DIR.resolve("ballerina/null_object.bal");
+    private static final Path nullObjectDirectConversionBal = RES_DIR.resolve("ballerina/null_object_direct_conversion.bal");
 
-    private final Path sample1Json = RES_DIR.resolve("json/sample_1.json");
-    private final Path sample1Bal = RES_DIR.resolve("ballerina/sample_1.bal");
+    private static final Path sample1Json = RES_DIR.resolve("json/sample_1.json");
+    private static final Path sample1Bal = RES_DIR.resolve("ballerina/sample_1.bal");
 
-    private final Path sample2Json = RES_DIR.resolve("json/sample_2.json");
-    private final Path sample2Bal = RES_DIR.resolve("ballerina/sample_2.bal");
+    private static final Path sample2Json = RES_DIR.resolve("json/sample_2.json");
+    private static final Path sample2Bal = RES_DIR.resolve("ballerina/sample_2.bal");
 
-    private final Path sample3Json = RES_DIR.resolve("json/sample_3.json");
-    private final Path sample3Bal = RES_DIR.resolve("ballerina/sample_3.bal");
-    private final Path sample3TypeDescBal = RES_DIR.resolve("ballerina/sample_3_type_desc.bal");
+    private static final Path sample3Json = RES_DIR.resolve("json/sample_3.json");
+    private static final Path sample3Bal = RES_DIR.resolve("ballerina/sample_3.bal");
+    private static final Path sample3TypeDescBal = RES_DIR.resolve("ballerina/sample_3_type_desc.bal");
 
-    private final Path sample4Json = RES_DIR.resolve("json/sample_4.json");
-    private final Path sample4Bal = RES_DIR.resolve("ballerina/sample_4.bal");
+    private static final Path sample4Json = RES_DIR.resolve("json/sample_4.json");
+    private static final Path sample4Bal = RES_DIR.resolve("ballerina/sample_4.bal");
 
-    private final Path sample5Json = RES_DIR.resolve("json/sample_5.json");
-    private final Path sample5Bal = RES_DIR.resolve("ballerina/sample_5.bal");
+    private static final Path sample5Json = RES_DIR.resolve("json/sample_5.json");
+    private static final Path sample5Bal = RES_DIR.resolve("ballerina/sample_5.bal");
 
-    private final Path sample6Json = RES_DIR.resolve("json/sample_6.json");
-    private final Path sample6Bal = RES_DIR.resolve("ballerina/sample_6.bal");
-    private final Path sample6TypeDescBal = RES_DIR.resolve("ballerina/sample_6_type_desc.bal");
+    private static final Path sample6Json = RES_DIR.resolve("json/sample_6.json");
+    private static final Path sample6Bal = RES_DIR.resolve("ballerina/sample_6.bal");
+    private static final Path sample6TypeDescBal = RES_DIR.resolve("ballerina/sample_6_type_desc.bal");
 
-    private final Path sample7Json = RES_DIR.resolve("json/sample_7.json");
-    private final Path sample7TypeDescBal = RES_DIR.resolve("ballerina/sample_7_type_desc.bal");
+    private static final Path sample7Json = RES_DIR.resolve("json/sample_7.json");
+    private static final Path sample7TypeDescBal = RES_DIR.resolve("ballerina/sample_7_type_desc.bal");
 
-    private final Path sample8Json = RES_DIR.resolve("json/sample_8.json");
-    private final Path sample8Bal = RES_DIR.resolve("ballerina/sample_8.bal");
-    private final Path sample8TypeDescBal = RES_DIR.resolve("ballerina/sample_8_type_desc.bal");
+    private static final Path sample8Json = RES_DIR.resolve("json/sample_8.json");
+    private static final Path sample8Bal = RES_DIR.resolve("ballerina/sample_8.bal");
+    private static final Path sample8TypeDescBal = RES_DIR.resolve("ballerina/sample_8_type_desc.bal");
 
-    private final Path sample9Json = RES_DIR.resolve("json/sample_9.json");
-    private final Path sample9Bal = RES_DIR.resolve("ballerina/sample_9.bal");
-    private final Path sample9TypeDescBal = RES_DIR.resolve("ballerina/sample_9_type_desc.bal");
+    private static final Path sample9Json = RES_DIR.resolve("json/sample_9.json");
+    private static final Path sample9Bal = RES_DIR.resolve("ballerina/sample_9.bal");
+    private static final Path sample9TypeDescBal = RES_DIR.resolve("ballerina/sample_9_type_desc.bal");
 
-    private final Path sample10Json = RES_DIR.resolve("json/sample_10.json");
-    private final Path sample10Bal = RES_DIR.resolve("ballerina/sample_10.bal");
-    private final Path sample10TypeDescBal = RES_DIR.resolve("ballerina/sample_10_type_desc.bal");
-    private final Path sample10WithoutConflictBal = RES_DIR.resolve("ballerina/sample_10_without_conflict.bal");
+    private static final Path sample10Json = RES_DIR.resolve("json/sample_10.json");
+    private static final Path sample10Bal = RES_DIR.resolve("ballerina/sample_10.bal");
+    private static final Path sample10TypeDescBal = RES_DIR.resolve("ballerina/sample_10_type_desc.bal");
+    private static final Path sample10WithoutConflictBal = RES_DIR.resolve("ballerina/sample_10_without_conflict.bal");
 
-    private final Path sample11Json = RES_DIR.resolve("json/sample_11.json");
-    private final Path sample11TypeDescBal = RES_DIR.resolve("ballerina/sample_11_type_desc.bal");
+    private static final Path sample11Json = RES_DIR.resolve("json/sample_11.json");
+    private static final Path sample11TypeDescBal = RES_DIR.resolve("ballerina/sample_11_type_desc.bal");
 
-    private final Path crlfJson = RES_DIR.resolve("json/crlf.json");
-    private final Path crlfBal = RES_DIR.resolve("ballerina/from_crlf.bal");
+    private static final Path crlfJson = RES_DIR.resolve("json/crlf.json");
+    private static final Path crlfBal = RES_DIR.resolve("ballerina/from_crlf.bal");
 
-    private final Path nestedObjectTypeDescBal = RES_DIR.resolve("ballerina/nested_object_type_desc.bal");
+    private static final Path nestedObjectTypeDescBal = RES_DIR.resolve("ballerina/nested_object_type_desc.bal");
 
-    private final Path nestedObjectClosedDescBal = RES_DIR.resolve("ballerina/nested_object_closed_desc.bal");
+    private static final Path nestedObjectClosedDescBal = RES_DIR.resolve("ballerina/nested_object_closed_desc.bal");
 
-    private final Path closedRecordBal = RES_DIR.resolve("ballerina/closed_record.bal");
+    private static final Path closedRecordBal = RES_DIR.resolve("ballerina/closed_record.bal");
 
-    private final Path emptyArrayJson = RES_DIR.resolve("json/empty_array.json");
+    private static final Path emptyArrayJson = RES_DIR.resolve("json/empty_array.json");
+
+    @DataProvider
+    public static Object[][] samples() {
+        return new Object[][] {
+                new Path[]{sample3Json, sample3TypeDescBal},
+                new Path[]{sample6Json, sample6TypeDescBal},
+                new Path[]{sample8Json, sample8TypeDescBal},
+                new Path[]{sample9Json, sample9TypeDescBal},
+                new Path[]{sample10Json, sample10TypeDescBal}
+        };
+    }
 
     @Test(description = "Test with basic json schema string")
     public void testBasicSchema() throws JsonToRecordConverterException, IOException, FormatterException {
         String jsonFileContent = Files.readString(basicSchemaJson);
-        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", false,
-                false, false).getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", false, false, false)
+                .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(basicSchemaBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -126,8 +137,8 @@ public class JsonToRecordConverterTests {
     @Test(description = "Test with basic json object")
     public void testBasicJson() throws JsonToRecordConverterException, IOException, FormatterException {
         String jsonFileContent = Files.readString(basicObjectJson);
-        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", false,
-                false, false).getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", false, false, false)
+                .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(basicObjectBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -135,8 +146,8 @@ public class JsonToRecordConverterTests {
     @Test(description = "Test get type record descriptor nested objects")
     public void testNestedSchema() throws JsonToRecordConverterException, IOException, FormatterException {
         String jsonFileContent = Files.readString(nestedSchemaJson);
-        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", false,
-                false, false).getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", false, false, false)
+                .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(nestedSchemaBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -145,8 +156,8 @@ public class JsonToRecordConverterTests {
     public void testBasicObjectForRecordTypeDesc() throws
             JsonToRecordConverterException, IOException, FormatterException {
         String jsonFileContent = Files.readString(basicObjectJson);
-        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "",
-                true, false, false).getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", true, false, false)
+                .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(basicObjectBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -155,8 +166,8 @@ public class JsonToRecordConverterTests {
     public void testTypeDescCodeForNestedObjects() throws
             JsonToRecordConverterException, IOException, FormatterException {
         String jsonFileContent = Files.readString(nestedObjectJson);
-        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "",
-                true, false, false).getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", true, false, false)
+                .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(nestedObjectTypeDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -165,8 +176,8 @@ public class JsonToRecordConverterTests {
     public void testClosedNestedSchemaForRecordTypeDesc() throws
             JsonToRecordConverterException, IOException, FormatterException {
         String jsonFileContent = Files.readString(nestedObjectJson);
-        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", true,
-                true, false).getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", true, true, false)
+                .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(nestedObjectClosedDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -174,8 +185,8 @@ public class JsonToRecordConverterTests {
     @Test(description = "Test json with nested objects")
     public void testNestedJson() throws JsonToRecordConverterException, IOException, FormatterException {
         String jsonFileContent = Files.readString(nestedObjectJson);
-        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", false,
-                false, false).getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", false, false, false)
+                .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(nestedObjectBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -190,24 +201,24 @@ public class JsonToRecordConverterTests {
     @Test(description = "Test with CRLF formatted json file")
     public void testCRLFJson() throws JsonToRecordConverterException, IOException, FormatterException {
         String jsonFileContent = Files.readString(crlfJson);
-        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", false,
-                false, false).getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", false, false, false)
+                .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(crlfBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
 
     @Test(description = "Test with sample json objects")
     public void testSamples() throws JsonToRecordConverterException, IOException, FormatterException {
-        Map<Path, Path> samples = new HashMap<>();
-        samples.put(sample1Json, sample1Bal);
-        samples.put(sample2Json, sample2Bal);
-        samples.put(sample3Json, sample3Bal);
-        samples.put(sample4Json, sample4Bal);
-        samples.put(sample5Json, sample5Bal);
-        samples.put(sample6Json, sample6Bal);
-        samples.put(sample8Json, sample8Bal);
-        samples.put(sample9Json, sample9Bal);
-        samples.put(sample10Json, sample10Bal);
+        Map<Path, Path> samples = Map.of(
+            sample1Json, sample1Bal,
+            sample2Json, sample2Bal,
+            sample3Json, sample3Bal,
+            sample4Json, sample4Bal,
+            sample5Json, sample5Bal,
+            sample6Json, sample6Bal,
+            sample8Json, sample8Bal,
+            sample9Json, sample9Bal,
+            sample10Json, sample10Bal);
         for (Map.Entry<Path, Path> sample : samples.entrySet()) {
             String jsonFileContent = Files.readString(sample.getKey());
             String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "",
@@ -218,28 +229,20 @@ public class JsonToRecordConverterTests {
         }
     }
 
-    @Test(description = "Test with sample json objects for fields")
-    public void testFieldForSamples() throws JsonToRecordConverterException, IOException, FormatterException {
-        Map<Path, Path> samples = new HashMap<>();
-        samples.put(sample3Json, sample3TypeDescBal);
-        samples.put(sample6Json, sample6TypeDescBal);
-        samples.put(sample8Json, sample8TypeDescBal);
-        samples.put(sample9Json, sample9TypeDescBal);
-        samples.put(sample10Json, sample10TypeDescBal);
-        for (Map.Entry<Path, Path> sample : samples.entrySet()) {
-            String jsonFileContent = Files.readString(sample.getKey());
-            String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "Person",
-                    true, false, false).getCodeBlock().replaceAll("\\s+", "");
-            String expectedCodeBlock = Files.readString(sample.getValue()).replaceAll("\\s+", "");
-            Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
-        }
+    @Test(description = "Test with sample json objects for fields", dataProvider = "samples")
+    public void testFieldForSamples(Path json, Path bal) throws JsonToRecordConverterException, IOException, FormatterException {
+        String jsonFileContent = Files.readString(json);
+        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "Person", true, false, false)
+                .getCodeBlock().replaceAll("\\s+", "");
+        String expectedCodeBlock = Files.readString(bal).replaceAll("\\s+", "");
+        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
 
     @Test(description = "Test a sample json for a closed record")
     public void testClosedRecord() throws JsonToRecordConverterException, IOException, FormatterException {
         String jsonFileContent = Files.readString(sample7Json);
-        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "",
-                false, true, false).getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", false, true, false)
+                .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(closedRecordBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -247,8 +250,8 @@ public class JsonToRecordConverterTests {
     @Test(description = "Test with sample json for a closed record and objects for fields")
     public void testFieldForClosedRecord() throws JsonToRecordConverterException, IOException, FormatterException {
         String jsonFileContent = Files.readString(sample7Json);
-        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "",
-                true, false, false).getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", true, false, false)
+                .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample7TypeDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
@@ -257,8 +260,7 @@ public class JsonToRecordConverterTests {
     public void testNullObject() throws IOException, FormatterException {
         String jsonFileContent = Files.readString(nullObjectJson);
         try {
-            JsonToRecordConverter.convert(jsonFileContent, "",
-                            true, false, false).getCodeBlock()
+            JsonToRecordConverter.convert(jsonFileContent, "", true, false, false).getCodeBlock()
                     .replaceAll("\\s+", "");
             Assert.assertTrue(true);
         } catch (JsonToRecordConverterException e) {
@@ -314,8 +316,7 @@ public class JsonToRecordConverterTests {
         Endpoint serviceEndpoint = TestUtil.initializeLanguageSever();
         String jsonString = Files.readString(basicSchemaJson);
 
-        JsonToRecordRequest request = new JsonToRecordRequest(jsonString, null,
-                false, false, false, null, false);
+        JsonToRecordRequest request = new JsonToRecordRequest(jsonString, null, false, false, false, null, false);
         CompletableFuture<?> result = serviceEndpoint.request(JsonToRecordService, request);
         io.ballerina.jsonmapper.JsonToRecordResponse response =
                 (io.ballerina.jsonmapper.JsonToRecordResponse) result.get();
@@ -329,8 +330,7 @@ public class JsonToRecordConverterTests {
         Endpoint serviceEndpoint = TestUtil.initializeLanguageSever();
         String jsonString = Files.readString(invalidSchemaJson);
 
-        JsonToRecordRequest request = new JsonToRecordRequest(jsonString, null,
-                false, false, false, null, false);
+        JsonToRecordRequest request = new JsonToRecordRequest(jsonString, null, false, false, false, null, false);
         CompletableFuture<?> result = serviceEndpoint.request(JsonToRecordService, request);
         io.ballerina.jsonmapper.JsonToRecordResponse response =
                 (io.ballerina.jsonmapper.JsonToRecordResponse) result.get();
@@ -344,8 +344,7 @@ public class JsonToRecordConverterTests {
         Endpoint serviceEndpoint = TestUtil.initializeLanguageSever();
         String jsonString = Files.readString(invalidJson);
 
-        JsonToRecordRequest request = new JsonToRecordRequest(jsonString, null,
-                false, false, false, null, false);
+        JsonToRecordRequest request = new JsonToRecordRequest(jsonString, null, false, false, false, null, false);
         CompletableFuture<?> result = serviceEndpoint.request(JsonToRecordService, request);
         io.ballerina.jsonmapper.JsonToRecordResponse response =
                 (io.ballerina.jsonmapper.JsonToRecordResponse) result.get();
@@ -361,8 +360,7 @@ public class JsonToRecordConverterTests {
         Endpoint serviceEndpoint = TestUtil.initializeLanguageSever();
         String jsonString = Files.readString(nullJson);
 
-        JsonToRecordRequest request = new JsonToRecordRequest(jsonString, null,
-                false, false, false, null, false);
+        JsonToRecordRequest request = new JsonToRecordRequest(jsonString, null, false, false, false, null, false);
         CompletableFuture<?> result = serviceEndpoint.request(JsonToRecordService, request);
         io.ballerina.jsonmapper.JsonToRecordResponse response =
                 (io.ballerina.jsonmapper.JsonToRecordResponse) result.get();
@@ -379,8 +377,8 @@ public class JsonToRecordConverterTests {
         Endpoint serviceEndpoint = TestUtil.initializeLanguageSever();
         String jsonString = Files.readString(sample10Json);
 
-        JsonToRecordRequest request = new JsonToRecordRequest(jsonString, null,
-                false, false, false, sample10Bal.toUri().toString(), false);
+        JsonToRecordRequest request = new JsonToRecordRequest(jsonString, null, false, false, false,
+                sample10Bal.toUri().toString(), false);
         CompletableFuture<?> result = serviceEndpoint.request(JsonToRecordService, request);
         io.ballerina.jsonmapper.JsonToRecordResponse response =
                 (io.ballerina.jsonmapper.JsonToRecordResponse) result.get();
@@ -392,8 +390,8 @@ public class JsonToRecordConverterTests {
     @Test(description = "Test null and empty array field type extraction")
     public void testNullAndEmptyArray() throws JsonToRecordConverterException, IOException, FormatterException {
         String jsonFileContent = Files.readString(sample11Json);
-        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "",
-                true, false, false).getCodeBlock().replaceAll("\\s+", "");
+        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "", true, false, false)
+                .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample11TypeDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/basic_object.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/basic_object.bal
@@ -1,7 +1,8 @@
-type NewRecord record {
+type NewRecord record {|
     string[] teams;
     string name;
     string position;
     int age;
-};
+    json...;
+|};
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/basic_schema.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/basic_schema.bal
@@ -1,7 +1,8 @@
-type NewRecord record {
+type NewRecord record {|
     string name;
     int id;
     boolean bark?;
     string breed?;
-};
+    json...;
+|};
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/closed_record.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/closed_record.bal
@@ -1,13 +1,13 @@
-type City record {
+type City record {|
     string code;
     string name;
-};
+|};
 
-type Address record {
+type Address record {|
     string country;
     City city;
     string Lane;
-};
+|};
 
 type NewRecord record {|
     Address address;

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/from_crlf.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/from_crlf.bal
@@ -1,19 +1,21 @@
-type Image record {
+type Image record {|
 	int vOffset;
 	string src;
 	string name;
 	string alignment;
 	int hOffset;
-};
+    json...;
+|};
 
-type Window record {
+type Window record {|
 	string name;
 	int width;
 	string title;
 	int height;
-};
+    json...;
+|};
 
-type Text record {
+type Text record {|
 	int vOffset;
 	string data;
 	int size;
@@ -22,16 +24,19 @@ type Text record {
 	string alignment;
 	string onMouseUp;
 	int hOffset;
-};
+    json...;
+|};
 
-type Widget record {
+type Widget record {|
 	Image image;
 	string debug;
 	Window window;
 	Text text;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
 	Widget widget;
-};
+    json...;
+|};
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/nested_object.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/nested_object.bal
@@ -1,18 +1,21 @@
-type ColorsItem record {
+type ColorsItem record {|
     string name;
     int id;
-};
+    json...;
+|};
 
-type Dimensions record {
+type Dimensions record {|
     int width;
     int height;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     string name;
     boolean checked;
     string id;
     ColorsItem[] colors;
     Dimensions dimensions;
-};
+    json...;
+|};
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/nested_object_closed_desc.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/nested_object_closed_desc.bal
@@ -2,12 +2,12 @@ type NewRecord record {|
     string name;
     boolean checked;
     string id;
-    record {
+    record {|
         string name;
         int id;
-    }[] colors;
-    record {
+    |}[] colors;
+    record {|
         int width;
         int height;
-    } dimensions;
+    |} dimensions;
 |};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/nested_object_type_desc.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/nested_object_type_desc.bal
@@ -1,15 +1,18 @@
-type NewRecord record {
+type NewRecord record {|
     string name;
     boolean checked;
     string id;
 
-    record {
+    record {|
         string name;
         int id;
-    }[] colors;
+        json...;
+    |}[] colors;
 
-    record {
+    record {|
         int width;
         int height;
-    } dimensions;
-};
+        json...;
+    |} dimensions;
+    json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/nested_schema.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/nested_schema.bal
@@ -1,12 +1,14 @@
-type Dimensions record {
+type Dimensions record {|
     int width;
     int height;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     boolean checked;
     Dimensions dimensions;
     int id;
     string name;
-};
+    json...;
+|};
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/null_object.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/null_object.bal
@@ -1,3 +1,3 @@
 type NewRecord record {
-    any id;
+    json id;
 };

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/null_object.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/null_object.bal
@@ -1,3 +1,4 @@
-type NewRecord record {
+type NewRecord record {|
     json id;
-};
+    json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/null_object_direct_conversion.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/null_object_direct_conversion.bal
@@ -1,3 +1,4 @@
-type NewRecord record {
+type NewRecord record {|
     json id;
-};
+    json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/null_object_direct_conversion.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/null_object_direct_conversion.bal
@@ -1,3 +1,3 @@
 type NewRecord record {
-    anydata id;
+    json id;
 };

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_1.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_1.bal
@@ -1,17 +1,20 @@
-type SportsItem record {
+type SportsItem record {|
 	string question;
 	string answer;
 	string[] options;
-};
+    json...;
+|};
 
-type MathsItem record {
+type MathsItem record {|
 	string question;
 	string answer;
 	string[] options;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
 	SportsItem[] sports;
 	MathsItem[] maths;
-};
+    json...;
+|};
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_10.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_10.bal
@@ -1,26 +1,31 @@
-type BatterItem record {
+type BatterItem record {|
     string id;
     string 'type;
-};
+    json...;
+|};
 
-type Batters record {
+type Batters record {|
     BatterItem[] batter;
-};
+    json...;
+|};
 
-type ToppingItem record {
+type ToppingItem record {|
     string id;
     string 'type;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     decimal ppu;
     Batters batters;
     string name;
     string id;
     string 'type;
     ToppingItem[] topping;
-};
+    json...;
+|};
 
-type NewRecordList record {
+type NewRecordList record {|
     NewRecord[] newrecordlist;
-};
+    json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_10_type_desc.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_10_type_desc.bal
@@ -1,22 +1,27 @@
-type Person record {
+type Person record {|
 
-    record {
+    record {|
         decimal ppu;
 
-        record {
-            record {
+        record {|
+            record {|
                 string id;
                 string 'type;
-            }[] batter;
-        } batters;
+                json...;
+            |}[] batter;
+            json...;
+        |} batters;
 
         string name;
         string id;
         string 'type;
 
-        record {
+        record {|
             string id;
             string 'type;
-        }[] topping;
-    }[] personlist;
-};
+            json...;
+        |}[] topping;
+        json...;
+    |}[] personlist;
+    json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_10_without_conflict.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_10_without_conflict.bal
@@ -1,26 +1,31 @@
-type BatterItem_01 record {
+type BatterItem_01 record {|
     string id;
     string 'type;
-};
+    json...;
+|};
 
-type Batters_01 record {
+type Batters_01 record {|
     BatterItem_01[] batter;
-};
+    json...;
+|};
 
-type ToppingItem_01 record {
+type ToppingItem_01 record {|
     string id;
     string 'type;
-};
+    json...;
+|};
 
-type NewRecordItem record {
+type NewRecordItem record {|
     string id;
     string' type;
     string name;
     decimal ppu;
     Batters_01 batters;
     ToppingItem_01[] topping;
-};
+    json...;
+|};
 
-type NewRecord_01 record {
+type NewRecord_01 record {|
     NewRecordItem[] newRecord;
-};
+    json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_11_type_desc.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_11_type_desc.bal
@@ -1,9 +1,11 @@
-type NewRecord record {
-    record {
-        anydata[] donations;
-        any subscription;
-    } contributions;
+type NewRecord record {|
+    record {|
+        json[] donations;
+        json subscription;
+        json...;
+    |} contributions;
     string school;
     string name;
     int age;
-};
+    json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_2.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_2.bal
@@ -1,20 +1,23 @@
-type Address record {
+type Address record {|
 	string streetAddress;
 	string city;
 	string state;
-};
+    json...;
+|};
 
-type PhoneNumbersItem record {
+type PhoneNumbersItem record {|
 	string number;
 	string 'type;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
 	string firstName;
 	string lastName;
 	Address address;
 	string gender;
 	int age;
 	PhoneNumbersItem[] phoneNumbers;
-};
+    json...;
+|};
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_3.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_3.bal
@@ -1,8 +1,10 @@
-type NewRecord record {
+type NewRecord record {|
 	string color;
 	string value;
-};
+	json...;
+|};
 
-type NewRecordList record {
+type NewRecordList record {|
 	NewRecord[] newrecordlist;
-};
+	json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_3_type_desc.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_3_type_desc.bal
@@ -1,5 +1,6 @@
-type Person record {
-    record {
-        string color; string value;
-    }[] personlist;
-};
+type Person record {|
+    record {|
+        string color; string value; json...;
+    |}[] personlist;
+	json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_4.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_4.bal
@@ -1,12 +1,14 @@
-type PeopleItem record {
+type PeopleItem record {|
 	string firstName;
 	string lastName;
 	string number;
 	string gender;
 	int age;
-};
+	json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
 	PeopleItem[] people;
-};
+	json...;
+|};
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_5.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_5.bal
@@ -1,6 +1,7 @@
-type NewRecord record {
+type NewRecord record {|
 	string size;
 	string color;
 	string fruit;
-};
+	json...;
+|};
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_6.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_6.bal
@@ -1,33 +1,38 @@
-type Author record {
+type Author record {|
 	string country;
 	string period;
 	string name;
-};
+	json...;
+|};
 
-type BooksItem record {
+type BooksItem record {|
 	Author author;
 	string name;
-};
+	json...;
+|};
 
-type State record {
+type State record {|
 	string code;
 	string name;
-};
+	json...;
+|};
 
-type Address record {
+type Address record {|
 	string number;
 	string city;
 	string street;
 	string neighborhood;
 	State state;
-};
+	json...;
+|};
 
-type SportsItem record {
+type SportsItem record {|
 	string position;
 	string sport;
-};
+	json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
 	BooksItem[] books;
 	Address address;
 	SportsItem[] sports;
@@ -36,5 +41,6 @@ type NewRecord record {
 	string name;
 	int age;
 	boolean honors;
-};
+	json...;
+|};
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_6_type_desc.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_6_type_desc.bal
@@ -1,32 +1,38 @@
-type Person record {
-    record {
-        record {
+type Person record {|
+    record {|
+        record {|
             string country;
             string period;
             string name;
-        } author;
+            json...;
+        |} author;
         string name;
-    }[] books;
+        json...;
+    |}[] books;
 
-    record {
+    record {|
         string number;
         string city;
         string street;
         string neighborhood;
-        record {
+        record {|
             string code;
             string name;
-        } state;
-    } address;
+            json...;
+        |} state;
+        json...;
+    |} address;
 
-    record {
+    record {|
         string position;
         string sport;
-    }[] sports;
+        json...;
+    |}[] sports;
 
     string school;
     string year;
     string name;
     int age;
     boolean honors;
-};
+    json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_7_type_desc.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_7_type_desc.bal
@@ -1,14 +1,15 @@
-type NewRecord record {
-    record {
+type NewRecord record {|
+    record {|
         string country;
 
-        record {
-            string code; string name;
-        } city; string Lane;
-
-    } address;
+        record {|
+            string code; string name; json...;
+        |} city; string Lane;
+        json...;
+    |} address;
 
     string school;
     string name;
     int age;
-};
+    json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_8.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_8.bal
@@ -1,44 +1,52 @@
-type Coverage record {
+type Coverage record {|
     string reference;
-};
+    json...;
+|};
 
-type InsuranceItem record {
+type InsuranceItem record {|
     Coverage coverage;
     int sequence;
     boolean focal;
-};
+    json...;
+|};
 
-type IdentifierItem record {
+type IdentifierItem record {|
     string system;
     string value;
-};
+    json...;
+|};
 
-type UnitPrice record {
+type UnitPrice record {|
     string currency;
     decimal value;
-};
+    json...;
+|};
 
-type CodingItem record {
+type CodingItem record {|
     string code;
-};
+    json...;
+|};
 
-type ProductOrService record {
+type ProductOrService record {|
     CodingItem[] coding;
-};
+    json...;
+|};
 
-type Net record {
+type Net record {|
     string currency;
     decimal value;
-};
+    json...;
+|};
 
-type DetailItem record {
+type DetailItem record {|
     UnitPrice unitPrice;
     int sequence;
     ProductOrService productOrService;
     Net net;
-};
+    json...;
+|};
 
-type ItemItem record {
+type ItemItem record {|
     UnitPrice unitPrice;
     int sequence;
     int[] careTeamSequence;
@@ -46,56 +54,68 @@ type ItemItem record {
     string servicedDate;
     DetailItem[] detail;
     Net net;
-};
+    json...;
+|};
 
-type DiagnosisCodeableConcept record {
+type DiagnosisCodeableConcept record {|
     CodingItem[] coding;
-};
+    json...;
+|};
 
-type DiagnosisItem record {
+type DiagnosisItem record {|
     int sequence;
     DiagnosisCodeableConcept diagnosisCodeableConcept;
-};
+    json...;
+|};
 
-type Type record {
+type Type record {|
     CodingItem[] coding;
-};
+    json...;
+|};
 
-type Priority record {
+type Priority record {|
     CodingItem[] coding;
-};
+    json...;
+|};
 
-type Payee record {
+type Payee record {|
     Type 'type;
-};
+    json...;
+|};
 
-type Provider record {
+type Provider record {|
     string reference;
-};
+    json...;
+|};
 
-type Prescription record {
+type Prescription record {|
     string reference;
-};
+    json...;
+|};
 
-type Patient record {
+type Patient record {|
     string reference;
-};
+    json...;
+|};
 
-type Insurer record {
+type Insurer record {|
     string reference;
-};
+    json...;
+|};
 
-type Text record {
+type Text record {|
     string div;
     string status;
-};
+    json...;
+|};
 
-type CareTeamItem record {
+type CareTeamItem record {|
     int sequence;
     Provider provider;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     InsuranceItem[] insurance;
     IdentifierItem[] identifier;
     ItemItem[] item;
@@ -114,4 +134,5 @@ type NewRecord record {
     CareTeamItem[] careTeam;
     string resourceType;
     string status;
-};
+    json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_8_type_desc.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_8_type_desc.bal
@@ -1,124 +1,155 @@
-type Person record {
-    record {
-        record {
+type Person record {|
+    record {|
+        record {|
             string reference;
-        } coverage;
+            json...;
+        |} coverage;
         int sequence;
         boolean focal;
-    }[] insurance;
+        json...;
+    |}[] insurance;
 
-    record {
+    record {|
         string system;
         string value;
-    }[] identifier;
+        json...;
+    |}[] identifier;
 
-    record {
-        record {
+    record {|
+        record {|
             string currency;
             decimal value;
-        } unitPrice;
+            json...;
+        |} unitPrice;
         int sequence;
         int[] careTeamSequence;
 
-        record {
-            record {
+        record {|
+            record {|
                 string system;
                 string code;
-            }[] coding;
-        } productOrService;
+                json...;
+            |}[] coding;
+            json...;
+        |} productOrService;
 
         string servicedDate;
 
-        record {
-            record {
+        record {|
+            record {|
                 string currency;
                 decimal value;
-            } unitPrice;
+                json...;
+            |} unitPrice;
             int sequence;
 
-            record {
-                record {
+            record {|
+                record {|
                     string system;
                     string code;
-                }[] coding;
-            } productOrService;
+                    json...;
+                |}[] coding;
+                json...;
+            |} productOrService;
 
-            record {
+            record {|
                 string currency;
                 decimal value;
-            } net;
-        }[] detail;
+                json...;
+            |} net;
+            json...;
+        |}[] detail;
 
-        record {
+        record {|
             string currency;
             decimal value;
-        } net;
-    }[] item;
+            json...;
+        |} net;
+        json...;
+    |}[] item;
 
     string use;
     string created;
 
-    record {
+    record {|
         int sequence;
 
-        record {
-            record {
+        record {|
+            record {|
                 string code;
-            }[] coding;
-        } diagnosisCodeableConcept;
-    }[] diagnosis;
+                json...;
+            |}[] coding;
+            json...;
+        |} diagnosisCodeableConcept;
+        json...;
+    |}[] diagnosis;
 
-    record {
-        record {
+    record {|
+        record {|
             string system;
             string code;
-        }[] coding;
-    } 'type;
+            json...;
+        |}[] coding;
+        json...;
+    |} 'type;
 
-    record {
-        record {
+    record {|
+        record {|
             string code;
-        }[] coding;
-    } priority;
+            json...;
+        |}[] coding;
+        json...;
+    |} priority;
 
-    record {
-        record {
-            record {
+    record {|
+        record {|
+            record {|
                 string code;
-            }[] coding;
-        } 'type;
-    } payee;
+                json...;
+            |}[] coding;
+            json...;
+        |} 'type;
+        json...;
+    |} payee;
 
-    record {
+    record {|
         string reference;
-    } provider;
+        json...;
+    |} provider;
 
-    record {
+    record {|
         string reference;
-    } prescription;
+        json...;
+    |} prescription;
 
-    record {
+    record {|
         string reference;
-    } patient;
+        json...;
+    |} patient;
 
-    record {
+    record {|
         string reference;
-    } insurer;
+        json...;
+    |} insurer;
 
     string id;
 
-    record {
+    record {|
         string div;
         string status;
-    } text;
+        json...;
+    |} text;
 
-    record {
+    record {|
         int sequence;
-        record {
+        record {|
             string reference;
-        } provider;
-    }[] careTeam;
+            json...;
+        |} provider;
+        json...;
+    |}[] careTeam;
 
     string resourceType;
     string status;
-};
+    json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_9.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_9.bal
@@ -1,95 +1,114 @@
-type Coverage record {
+type Coverage record {|
     string reference;
-};
+    json...;
+|};
 
-type Identifier record {
+type Identifier record {|
     string system;
     string value;
-};
+    json...;
+|};
 
-type InsuranceItem record {
+type InsuranceItem record {|
     Coverage coverage;
     int sequence;
     Identifier identifier;
     boolean focal;
-};
+    json...;
+|};
 
-type IdentifierItem record {
+type IdentifierItem record {|
     string system;
     string value;
-};
+    json...;
+|};
 
-type UnitPrice record {
+type UnitPrice record {|
     string currency;
     decimal value;
-};
+    json...;
+|};
 
-type CodingItem record {
+type CodingItem record {|
     string code;
-};
+    json...;
+|};
 
-type ProductOrService record {
+type ProductOrService record {|
     CodingItem[] coding;
-};
+    json...;
+|};
 
-type Net record {
+type Net record {|
     string currency;
     decimal value;
-};
+    json...;
+|};
 
-type ItemItem record {
+type ItemItem record {|
     UnitPrice unitPrice;
     int sequence;
     int[] careTeamSequence;
     ProductOrService productOrService;
     string servicedDate;
     Net net;
-};
+    json...;
+|};
 
-type DiagnosisCodeableConcept record {
+type DiagnosisCodeableConcept record {|
     CodingItem[] coding;
-};
+    json...;
+|};
 
-type DiagnosisItem record {
+type DiagnosisItem record {|
     int sequence;
     DiagnosisCodeableConcept diagnosisCodeableConcept;
-};
+    json...;
+|};
 
-type Type record {
+type Type record {|
     CodingItem[] coding;
-};
+    json...;
+|};
 
-type Priority record {
+type Priority record {|
     CodingItem[] coding;
-};
+    json...;
+|};
 
-type Payee record {
+type Payee record {|
     Type 'type;
-};
+    json...;
+|};
 
-type Provider record {
+type Provider record {|
     string reference;
-};
+    json...;
+|};
 
-type Patient record {
+type Patient record {|
     string reference;
-};
+    json...;
+|};
 
-type Insurer record {
+type Insurer record {|
     string reference;
-};
+    json...;
+|};
 
-type Text record {
+type Text record {|
     string div;
     string status;
-};
+    json...;
+|};
 
-type CareTeamItem record {
+type CareTeamItem record {|
     int sequence;
     Provider provider;
-};
+    json...;
+|};
 
-type NewRecord record {
+type NewRecord record {|
     InsuranceItem[] insurance;
     IdentifierItem[] identifier;
     ItemItem[] item;
@@ -107,4 +126,5 @@ type NewRecord record {
     CareTeamItem[] careTeam;
     string resourceType;
     string status;
-};
+    json...;
+|};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_9_type_desc.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_9_type_desc.bal
@@ -1,109 +1,135 @@
-type Person record {
-    record {
+type Person record {|
+    record {|
 
-        record {
+        record {|
             string reference;
-        } coverage;
+            json...;
+        |} coverage;
 
         int sequence;
 
-        record {
+        record {|
             string system;
             string value;
-        } identifier;
+            json...;
+        |} identifier;
 
         boolean focal;
-    }[] insurance;
+        json...;
+    |}[] insurance;
 
-    record {
+    record {|
         string system;
         string value;
-    }[] identifier;
+        json...;
+    |}[] identifier;
 
-    record {
+    record {|
 
-        record {
+        record {|
             string currency;
             decimal value;
-        } unitPrice;
+            json...;
+        |} unitPrice;
 
         int sequence;
         int[] careTeamSequence;
 
-        record {
-            record {
+        record {|
+            record {|
                 string code;
-            }[] coding;
-        } productOrService;
+                json...;
+            |}[] coding;
+            json...;
+        |} productOrService;
 
         string servicedDate;
-        record {
+        record {|
             string currency;
             decimal value;
-        } net;
-    }[] item;
+            json...;
+        |} net;
+        json...;
+    |}[] item;
 
     string use;
     string created;
 
-    record {
+    record {|
         int sequence;
 
-        record {
-            record {
+        record {|
+            record {|
                 string code;
-            }[] coding;
-        } diagnosisCodeableConcept;
-    }[] diagnosis;
+                json...;
+            |}[] coding;
+            json...;
+        |} diagnosisCodeableConcept;
+        json...;
+    |}[] diagnosis;
 
-    record {
-        record {
+    record {|
+        record {|
             string system;
             string code;
-        }[] coding;
-    } 'type;
+            json...;
+        |}[] coding;
+        json...;
+    |} 'type;
 
-    record {
-        record {
+    record {|
+        record {|
             string code;
-        }[] coding;
-    } priority;
+            json...;
+        |}[] coding;
+        json...;
+    |} priority;
 
-    record {
-        record {
-            record {
+    record {|
+        record {|
+            record {|
                 string code;
-            }[] coding;
-        } 'type;
-    } payee;
+                json...;
+            |}[] coding;
+            json...;
+        |} 'type;
+        json...;
+    |} payee;
 
-    record {
+    record {|
         string reference;
-    } provider;
+        json...;
+    |} provider;
 
-    record {
+    record {|
         string reference;
-    } patient;
+        json...;
+    |} patient;
 
-    record {
+    record {|
         string reference;
-    } insurer;
+        json...;
+    |} insurer;
 
     string id;
 
-    record {
+    record {|
         string div;
         string status;
-    } text;
+        json...;
+    |} text;
 
-    record {
+    record {|
         int sequence;
 
-        record {
+        record {|
             string reference;
-        } provider;
-    }[] careTeam;
+            json...;
+        |} provider;
+        json...;
+    |}[] careTeam;
 
     string resourceType;
     string status;
-};
+    json...;
+|};

--- a/misc/xml-to-record-converter/build.gradle
+++ b/misc/xml-to-record-converter/build.gradle
@@ -36,13 +36,11 @@ dependencies {
     implementation project(':ballerina-tools-api')
     implementation project(':identifier-util')
     implementation libs.apache.commons.lang3
-    implementation libs.java.tuples
 
     testImplementation libs.testng
     testImplementation project(':ballerina-lang')
     testImplementation project(':formatter:formatter-core')
     testImplementation project(':language-server:language-server-core')
-    testImplementation libs.java.tuples
     testImplementation libs.eclipse.lsp4j
 }
 

--- a/misc/xml-to-record-converter/src/main/java/module-info.java
+++ b/misc/xml-to-record-converter/src/main/java/module-info.java
@@ -6,7 +6,6 @@ module io.ballerina.xmltorecordconverter {
     requires io.ballerina.parser;
     requires io.ballerina.tools.api;
     requires java.xml;
-    requires javatuples;
     requires org.apache.commons.lang3;
     requires org.eclipse.lsp4j.jsonrpc;
 


### PR DESCRIPTION
## Purpose
> I modified both `json-mapper` and `json-to-record-converter` (in the Language Server) to have the desired behaviour from the issue. Records are now always closed and might have a rest field with `json...;`. Also, no `any` or `anydata` is produced but only `json`.

Fixes #42610 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
