### PR TITLE
[Java 21] Add missing methods in `TransactionResourceManager` Class

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionConstants.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/transactions/TransactionConstants.java
@@ -70,4 +70,7 @@ public class TransactionConstants {
 
     public static final String ANN_NAME_TRX_PARTICIPANT_CONFIG = "Participant";
     public static final String TIMESTAMP_OBJECT_VALUE_FIELD = "timeValue";
+
+    public static final int DEFAULT_TRX_AUTO_COMMIT_TIMEOUT = 120;
+    public static final int DEFAULT_TRX_CLEANUP_TIMEOUT = 600;
 }


### PR DESCRIPTION
## Purpose
> Add the methods `getTransactionAutoCommitTimeout()` and `getTransactionCleanupTimeout()` (including relevant util methods) to the `TransactionResourceManager` Class.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
