### PR TITLE
Change the resource function signature

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -4884,7 +4884,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         BResourcePathSegmentSymbol parentResource = null;
         for (int i = 0; i < resourcePathCount; i++) {
             BLangResourcePathSegment pathSegment = pathSegments.get(i);
-            Name resourcePathSymbolName = Names.fromString(pathSegment.name.value);
+            Name resourcePathSymbolName = Names.fromString(pathSegment.name.originalValue);
             BType resourcePathSegmentType = pathSegment.typeNode == null ?
                     symTable.noType : symResolver.resolveTypeNode(pathSegment.typeNode, env);
             pathSegment.setBType(resourcePathSegmentType);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ResourceSignatureTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ResourceSignatureTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://wso2.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ResourceMethodSymbol;
+import io.ballerina.compiler.api.symbols.resourcepath.ResourcePath;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static io.ballerina.tools.text.LinePosition.from;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for class symbols.
+ *
+ * @since 2.0.0
+ */
+public class ResourceSignatureTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/resource_signature_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test
+    public void testResourceSignature() {
+        ResourceMethodSymbol method = (ResourceMethodSymbol) model.symbol(srcFile, from(17, 22)).get();
+        assertEquals(method.resourcePath().kind(), ResourcePath.Kind.PATH_SEGMENT_LIST);
+        assertEquals(method.resourcePath().signature(), "store/'order");
+        assertEquals(method.signature(), "resource function get store/'order () returns string");
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/resource_signature_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/resource_signature_test.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+service class ServiceClass {
+    resource function get store/'order() returns string {
+        return self.message + "dot";
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -44,6 +44,7 @@
             <class name="io.ballerina.semantic.api.test.TypesTest" />
             <class name="io.ballerina.semantic.api.test.TypeBuildersTest" />
             <class name="io.ballerina.semantic.api.test.WorkspaceSymbolLookupTest" />
+            <class name="io.ballerina.semantic.api.test.ResourceSignatureTest" />
 
             <class name="io.ballerina.semantic.api.test.allreferences.AnnotationRefsTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.CyclicUnionRefsTest" />


### PR DESCRIPTION
## Purpose
```ballerina
resource function post store/'order(@http:Payload Order|xml|map<string> payload) returns OrderOk|http:MethodNotAllowed;
```

Let's say we have a resource function as shown above, `signature()` API omit `'`.
This PR fixes this issue.  