### PR TITLE
Consider persist dir in ProjectAPI ProjectPaths APIs

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
@@ -71,6 +71,8 @@ public final class ProjectConstants {
     public static final String IMPORT_PREFIX = "import ";
     public static final String EMPTY_STRING = "";
 
+    public static final String PERSIST_DIR_NAME = "persist";
+
     // Bala specific constants
     public static final String MODULES_ROOT = "modules";
     public static final String GENERATED_MODULES_ROOT = "generated";

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectPaths.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectPaths.java
@@ -113,6 +113,10 @@ public final class ProjectPaths {
                 Path modulesRoot = Optional.of(Optional.of(testsRoot.getParent()).get().getParent()).get();
                 return modulesRoot.getParent();
             }
+            // check if the file is a source file used to define a specification
+            if (isToolSpecificationBalFile(filepath)) {
+                return Optional.of(Optional.of(absFilePath.getParent()).get().getParent()).get();
+            }
         } else {
             // check if the file is a source file in a bala project
             if (isBalaProjectSrcFile(filepath)) {
@@ -289,6 +293,29 @@ public final class ProjectPaths {
         }
 
         return true;
+    }
+
+    /**
+     * Checks if the provided path is a source file used to define a specification for a tool.
+     *
+     * @param filePath path to bal filepath
+     * @return true if the filepath is tool specification bal file
+     */
+    public static boolean isToolSpecificationBalFile(Path filePath) {
+        Path absFilePath = filePath.toAbsolutePath().normalize();
+        if (!isBalFile(absFilePath)) {
+            return false;
+        }
+        Path toolDirPath = absFilePath.getParent();
+        if (toolDirPath == null) {
+            return false;
+        }
+        Path projectRoot = toolDirPath.getParent();
+        // if there are multiple directories dedicated for tools in the future,
+        // we should check if the toolDir is one of them. But for now, its only `persist`.
+        return  projectRoot != null
+                && ProjectConstants.PERSIST_DIR_NAME.equals(toolDirPath.toFile().getName())
+                && hasBallerinaToml(projectRoot);
     }
 
     static boolean isDefaultModuleSrcFile(Path filePath) {


### PR DESCRIPTION
## Purpose
$ subject

Fixes https://github.com/wso2-enterprise/internal-support-ballerina/issues/803

## Approach
Now the `ProjectPaths->packageRoot(Path filePath)` method recognizes the persist/model.bal file as a part of the project hence successfully returns the root path.

Also I have introduced a new `ProjectPaths->isToolSpecificationBalFile(Path filePath)` method where it will return true if the given path is of a ballerina source file that acts as a tool specification dir. Currently this is only persist/*.bal.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
