### PR TITLE
[2201.9.x] Fix typecast error thrown for default record field

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -311,7 +311,7 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
     protected void populateInitialValues(BMapInitialValueEntry[] initialValues) {
         Map<String, BFunctionPointer<Object, ?>> defaultValues = new HashMap<>();
         if (referredType.getTag() == TypeTags.RECORD_TYPE_TAG) {
-            defaultValues.putAll(((BRecordType) type).getDefaultValues());
+            defaultValues.putAll(((BRecordType) referredType).getDefaultValues());
         }
 
         for (BMapInitialValueEntry initialValue : initialValues) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -310,7 +310,7 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
 
     protected void populateInitialValues(BMapInitialValueEntry[] initialValues) {
         Map<String, BFunctionPointer<Object, ?>> defaultValues = new HashMap<>();
-        if (type.getTag() == TypeTags.RECORD_TYPE_TAG) {
+        if (referredType.getTag() == TypeTags.RECORD_TYPE_TAG) {
             defaultValues.putAll(((BRecordType) type).getDefaultValues());
         }
 


### PR DESCRIPTION
## Purpose
$subject 

Fixes #43541

## Approach
when populating the default values with record type, we need to handle the type-reference type as well.

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
