### PR TITLE
[2201.10.x] Fix typecast error thrown for default record field 

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -320,7 +320,7 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
     protected void populateInitialValues(BMapInitialValueEntry[] initialValues) {
         Map<String, BFunctionPointer<Object, ?>> defaultValues = new HashMap<>();
         if (referredType.getTag() == TypeTags.RECORD_TYPE_TAG) {
-            defaultValues.putAll(((BRecordType) type).getDefaultValues());
+            defaultValues.putAll(((BRecordType) referredType).getDefaultValues());
         }
 
         for (BMapInitialValueEntry initialValue : initialValues) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -319,7 +319,7 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
 
     protected void populateInitialValues(BMapInitialValueEntry[] initialValues) {
         Map<String, BFunctionPointer<Object, ?>> defaultValues = new HashMap<>();
-        if (type.getTag() == TypeTags.RECORD_TYPE_TAG) {
+        if (referredType.getTag() == TypeTags.RECORD_TYPE_TAG) {
             defaultValues.putAll(((BRecordType) type).getDefaultValues());
         }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -312,7 +312,8 @@ public class MappingConstructorExprTest {
                 { "testSpreadOpInGlobalMap" },
                 { "testMappingConstrExprAsSpreadExpr" },
                 { "testSpreadFieldWithRecordTypeHavingNeverField" },
-                { "testSpreadFieldWithRecordTypeHavingRestDescriptor" }
+                { "testSpreadFieldWithRecordTypeHavingRestDescriptor" },
+                {"testSpreadFieldWithRecordTypeReference"}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -313,7 +313,7 @@ public class MappingConstructorExprTest {
                 { "testMappingConstrExprAsSpreadExpr" },
                 { "testSpreadFieldWithRecordTypeHavingNeverField" },
                 { "testSpreadFieldWithRecordTypeHavingRestDescriptor" },
-                {"testSpreadFieldWithRecordTypeReference"}
+                { "testSpreadFieldWithRecordTypeReference" }
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
@@ -298,6 +298,32 @@ function testSpreadFieldWithRecordTypeHavingRestDescriptor() {
     assertEquality("s", r4.s);
 }
 
+type RetryConfig record {|
+    int count;
+    decimal interval;
+    float backOffFactor;
+|};
+
+public type RetryConfigClone record {|
+    int count = 0;
+    decimal interval = 0;
+    float backOffFactor = 0.0;
+    decimal maxWaitInterval = 0;
+    int[] statusCodes = [];
+|};
+
+type RetryTyperef RetryConfigClone;
+
+function testSpreadFieldWithRecordTypeReference() {
+    RetryConfig rc = {count: 3, interval: 0.5, backOffFactor: 0.5};
+    RetryTyperef re = {...rc};
+    assertEquality(3, re.count);
+    assertEquality(0.5, re.interval);
+    assertEquality(0.5, re.backOffFactor);
+    assertEquality(0, re.maxWaitInterval);
+    assertEquality(0, re.statusCodes.length());
+}
+
 function assertEquality(any|error expected, any|error actual) {
     if expected is anydata && actual is anydata && expected == actual {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
@@ -318,9 +318,9 @@ function testSpreadFieldWithRecordTypeReference() {
     RetryConfig rc = {count: 3, interval: 0.5, backOffFactor: 0.5};
     RetryTyperef re = {...rc};
     assertEquality(3, re.count);
-    assertEquality(0.5, re.interval);
+    assertEquality(0.5d, re.interval);
     assertEquality(0.5, re.backOffFactor);
-    assertEquality(0, re.maxWaitInterval);
+    assertEquality(0d, re.maxWaitInterval);
     assertEquality(0, re.statusCodes.length());
 }
 


### PR DESCRIPTION
## Purpose
$subject 

Fixes #43541

## Approach
when populating the default values with record type, we need to handle the type-reference type as well.

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
