### PR TITLE
Fix dead code elimination removing `fpLoadInstruction`s from test modules

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/UsedBIRNodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/UsedBIRNodeAnalyzer.java
@@ -403,7 +403,7 @@ public final class UsedBIRNodeAnalyzer extends BIRVisitor {
 
     public InvocationData getInvocationData(PackageID pkgId) {
         if (currentPkgID.equals(pkgId)) {
-            return pkgId.isTestPkg ? currentInvocationData.testablePkgInvocationData : currentInvocationData;
+            return isTestablePkgAnalysis ? currentInvocationData.testablePkgInvocationData : currentInvocationData;
         }
         return pkgCache.getInvocationData(pkgId);
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/OptimizedTestRunWithEmptyBuildPkgTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/OptimizedTestRunWithEmptyBuildPkgTest.java
@@ -1,0 +1,70 @@
+package org.ballerinalang.testerina.test;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.ballerinalang.test.context.BMainInstance;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.testerina.test.utils.AssertionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+
+/**
+ * Test case to check `bal test --eliminate-dead-code` command with an empty buildPkg and a test with a FP to a lang
+ * module function.
+ *
+ * @since 2201.11.0
+ */
+public class OptimizedTestRunWithEmptyBuildPkgTest extends BaseTestCase{
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OptimizedExecutableTestingTest.class);
+    private BMainInstance balClient;
+    private String projectPath;
+    private static final String TARGET = "target";
+    private static final String PROJECT_NAME = "optimized-test-run-with-empty-build-pkg-test";
+    private static final String DEAD_CODE_ELIMINATION_REPORT = "dead_code_elimination_report.json";
+    private static final Path EXPECTED_CODEGEN_OPTIMIZATION_REPORTS_DIR =
+            Paths.get("src", "test", "resources", "codegen-optimization-reports", PROJECT_NAME);
+
+    @BeforeClass
+    public void setup() throws BallerinaTestException {
+        balClient = new BMainInstance(balServer);
+        projectPath = projectBasedTestsPath.resolve(PROJECT_NAME).toString();
+    }
+
+    @Test()
+    public void testWithEmptyBuildPkg() throws BallerinaTestException, IOException {
+        String output = balClient.runMainAndReadStdOut("test",
+                new String[]{"--eliminate-dead-code", "--dead-code-elimination-report"}, new HashMap<>(), projectPath,
+                true);
+        AssertionUtils.assertOutput("OptimizedExecutableTestingTest-testWithEmptyBuildPkg.txt",
+                AssertionUtils.replaceBIRNodeAnalysisTime(output));
+        assertBuildProjectJsonReportsAreSimilar(Path.of(projectPath));
+    }
+
+    private void assertBuildProjectJsonReportsAreSimilar(Path buildProjectPath) {
+        Path actualJsonPath = buildProjectPath.resolve(TARGET).resolve(DEAD_CODE_ELIMINATION_REPORT);
+        JsonObject expectedJsonObject =
+                fileContentAsObject(EXPECTED_CODEGEN_OPTIMIZATION_REPORTS_DIR.resolve(DEAD_CODE_ELIMINATION_REPORT));
+        JsonObject actualJsonObject = fileContentAsObject(actualJsonPath);
+        Assert.assertEquals(actualJsonObject, expectedJsonObject);
+    }
+
+    private static JsonObject fileContentAsObject(Path filePath) {
+        String contentAsString = "";
+        try {
+            contentAsString = new String(Files.readAllBytes(filePath));
+        } catch (IOException ex) {
+            LOGGER.error(ex.getMessage());
+        }
+        return JsonParser.parseString(contentAsString).getAsJsonObject();
+    }
+}

--- a/tests/testerina-integration-test/src/test/resources/codegen-optimization-reports/optimized-test-run-with-empty-build-pkg-test/dead_code_elimination_report.json
+++ b/tests/testerina-integration-test/src/test/resources/codegen-optimization-reports/optimized-test-run-with-empty-build-pkg-test/dead_code_elimination_report.json
@@ -1,0 +1,25 @@
+{
+  "test_org/optimized_test_run_with_empty_build_pkg_test:0.1.0": {
+    "usedFunctionNames": {
+      "sourceFunctions": [],
+      "virtualFunctions": [
+        ".<init>",
+        ".<start>",
+        ".<stop>"
+      ]
+    },
+    "unusedFunctionNames": {
+      "sourceFunctions": [],
+      "virtualFunctions": []
+    },
+    "usedTypeDefNames": {
+      "sourceTypeDefinitions": [],
+      "virtualTypeDefinitions": []
+    },
+    "unusedTypeDefNames": {
+      "sourceTypeDefinitions": [],
+      "virtualTypeDefinitions": []
+    },
+    "usedNativeClassPaths": []
+  }
+}

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/unix/OptimizedExecutableTestingTest-testWithEmptyBuildPkg.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/unix/OptimizedExecutableTestingTest-testWithEmptyBuildPkg.txt
@@ -1,0 +1,25 @@
+Compiling source
+	test_org/optimized_test_run_with_empty_build_pkg_test:0.1.0
+Running Tests
+
+	optimized_test_run_with_empty_build_pkg_test
+
+	ttt: has failed.
+
+
+		[fail] ttt:
+
+		    error {ballerina/test:0}TestError ("Assertion Failed!")
+				callableName: createBallerinaError moduleName: ballerina.test.0 fileName: assert.bal lineNumber: 41
+				callableName: assertTrue moduleName: ballerina.test.0 fileName: assert.bal lineNumber: 61
+				callableName: ttt moduleName: test_org.optimized_test_run_with_empty_build_pkg_test$test.0.tests.tests_test fileName: tests/tests_test.bal lineNumber: 6
+				callableName: ttt$lambda0$ moduleName: test_org.optimized_test_run_with_empty_build_pkg_test$test.0.tests.test_execute-generated_1 fileName: tests/test_execute-generated_1.bal lineNumber: 4
+
+
+
+		0 passing
+		1 failing
+		0 skipped
+
+		Test execution time :*****s
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/windows/OptimizedExecutableTestingTest-testWithEmptyBuildPkg.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/windows/OptimizedExecutableTestingTest-testWithEmptyBuildPkg.txt
@@ -1,0 +1,25 @@
+Compiling source
+	test_org/optimized_test_run_with_empty_build_pkg_test:0.1.0
+Running Tests
+
+	optimized_test_run_with_empty_build_pkg_test
+
+	ttt: has failed.
+
+
+		[fail] ttt:
+
+		    error {ballerina/test:0}TestError ("Assertion Failed!")
+				callableName: createBallerinaError moduleName: ballerina.test.0 fileName: assert.bal lineNumber: 41
+				callableName: assertTrue moduleName: ballerina.test.0 fileName: assert.bal lineNumber: 61
+				callableName: ttt moduleName: test_org.optimized_test_run_with_empty_build_pkg_test$test.0.tests.tests_test fileName: tests/tests_test.bal lineNumber: 6
+				callableName: ttt$lambda0$ moduleName: test_org.optimized_test_run_with_empty_build_pkg_test$test.0.tests.test_execute-generated_1 fileName: tests/test_execute-generated_1.bal lineNumber: 4
+			
+
+
+		0 passing
+		1 failing
+		0 skipped
+
+		Test execution time :*****s
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/optimized-test-run-with-empty-build-pkg-test/Ballerina.toml
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/optimized-test-run-with-empty-build-pkg-test/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "test_org"
+name = "optimized_test_run_with_empty_build_pkg_test"
+version = "0.1.0"

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/optimized-test-run-with-empty-build-pkg-test/tests/tests_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/optimized-test-run-with-empty-build-pkg-test/tests/tests_test.bal
@@ -1,0 +1,7 @@
+import ballerina/test;
+
+@test:Config
+public function ttt() {
+    string result = "a";
+    test:assertTrue(result.includes(" "));
+}

--- a/tests/testerina-integration-test/src/test/resources/testng.xml
+++ b/tests/testerina-integration-test/src/test/resources/testng.xml
@@ -62,6 +62,7 @@ under the License.
             <class name="org.ballerinalang.testerina.test.TestExecutionWithInitFailuresTest"/>
             <class name="org.ballerinalang.testerina.test.EscapedIdentifiersValidationTest"/>
             <class name="org.ballerinalang.testerina.test.OptimizedExecutableTestingTest" />
+            <class name="org.ballerinalang.testerina.test.OptimizedTestRunWithEmptyBuildPkgTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
$title

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/43552 

## Approach
The reason for the NPE is due to a bug in dead code elimination removing used `fpLoadInstructions` from test modules. This was due to implementation depending on `pkgId.isTestPkg` to detect `testablePkg` analysis. 

The expected behavior should be not removing any nodes from `testablePkgs`. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
