### PR TITLE
Fix deletion of `buildPkg` functions invoked only by `testablePkg`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/UsedBIRNodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/UsedBIRNodeAnalyzer.java
@@ -130,6 +130,8 @@ public final class UsedBIRNodeAnalyzer extends BIRVisitor {
 
     private void analyzeTestablePkg(BPackageSymbol testableSymbol) {
         isTestablePkgAnalysis = true;
+        PackageID originalPkgId = currentPkgID;
+        currentPkgID = testableSymbol.pkgID;
         // since the testablePkg can access the nodes of parent package, we can merge the invocationData of both
         // testable and parent packages
         currentInvocationData.testablePkgInvocationData = testableSymbol.invocationData;
@@ -139,6 +141,7 @@ public final class UsedBIRNodeAnalyzer extends BIRVisitor {
         for (BIRNode.BIRDocumentableNode node : testableSymbol.invocationData.startPointNodes) {
             visitNode(node);
         }
+        currentPkgID = originalPkgId;
         isTestablePkgAnalysis = false;
     }
 
@@ -403,7 +406,7 @@ public final class UsedBIRNodeAnalyzer extends BIRVisitor {
 
     public InvocationData getInvocationData(PackageID pkgId) {
         if (currentPkgID.equals(pkgId)) {
-            return isTestablePkgAnalysis ? currentInvocationData.testablePkgInvocationData : currentInvocationData;
+            return pkgId.isTestPkg ? currentInvocationData.testablePkgInvocationData : currentInvocationData;
         }
         return pkgCache.getInvocationData(pkgId);
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/utils/AssertionUtils.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/utils/AssertionUtils.java
@@ -66,7 +66,7 @@ public final class AssertionUtils {
         } else {
             output = CommonUtils.replaceExecutionTime(output);
             String fileContent = Files.readString(commandOutputsDir.resolve("unix").resolve(outputFileName));
-            Assert.assertEquals(output.stripTrailing(), fileContent.stripTrailing());
+            Assert.assertEquals(output.stripTrailing().stripIndent(), fileContent.stripTrailing().stripIndent());
         }
     }
 }

--- a/tests/testerina-integration-test/src/test/resources/codegen-optimization-reports/optimized_test_run_test/dead_code_elimination_report.json
+++ b/tests/testerina-integration-test/src/test/resources/codegen-optimization-reports/optimized_test_run_test/dead_code_elimination_report.json
@@ -4,6 +4,7 @@
       "sourceFunctions": [
         "foo",
         "fn",
+        "testUsageFunction",
         "main",
         "bar"
       ],
@@ -22,6 +23,7 @@
     "usedTypeDefNames": {
       "sourceTypeDefinitions": [
         "RecA",
+        "RecB",
         "TupleB"
       ],
       "virtualTypeDefinitions": [

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/unix/OptimizedExecutableTestingTest-testWithCommonDependencies.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/unix/OptimizedExecutableTestingTest-testWithCommonDependencies.txt
@@ -6,9 +6,10 @@ Running Tests
 		[pass] importUsageTest
 		[pass] simpleTest
 		[pass] testFn
+		[pass] unusedFunctionInvoker
 
 
-		3 passing
+		4 passing
 		0 failing
 		0 skipped
 

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/optimized_test_run_test/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/optimized_test_run_test/main.bal
@@ -47,3 +47,12 @@ type RecC record {
 };
 
 function fn() returns table<record {}>|error => error("err!");
+
+type RecB record {|
+    int name;
+|};
+
+function testUsageFunction() returns RecB{
+    RecB recB = {name: 0};
+    return recB;
+}

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/optimized_test_run_test/tests/test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/optimized_test_run_test/tests/test.bal
@@ -40,3 +40,8 @@ function testFn() {
     table<record {}>|error fnResult = fn();
     test:assertTrue(fnResult is error);
 }
+
+@test:Config
+function unusedFunctionInvoker(){
+    test:assertEquals(0, testUsageFunction().name);
+}


### PR DESCRIPTION
## Purpose
Fixes  a bug introduced by https://github.com/ballerina-platform/ballerina-lang/pull/43559. This bug causes buildPkg functions used only by testablePkg to be marked as unused. This causes a NPE for `bal test --eliminate-dead-code --dead-code-elimination-report` command.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
