### PR TITLE
Update `OptimizedExecutableTestingTest` output for windows

### DIFF
--- a/tests/testerina-integration-test/src/test/resources/command-outputs/windows/OptimizedExecutableTestingTest-testWithCommonDependencies.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/windows/OptimizedExecutableTestingTest-testWithCommonDependencies.txt
@@ -6,9 +6,10 @@ Running Tests
 		[pass] importUsageTest
 		[pass] simpleTest
 		[pass] testFn
+		[pass] unusedFunctionInvoker
 
 
-		3 passing
+		4 passing
 		0 failing
 		0 skipped
 


### PR DESCRIPTION
## Purpose
$title

Fixes the failing `org.ballerinalang.testerina.test.OptimizedExecutableTestingTest` in https://github.com/ballerina-platform/ballerina-lang/pull/43560 windows build. 

This was due to not updating the windows specific output file of a test properly.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
