### PR TITLE
Fix records with function calls for default values failing code generation

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRRecordValueOptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRRecordValueOptimizer.java
@@ -196,8 +196,10 @@ public class BIRRecordValueOptimizer extends BIRVisitor {
             return false;
         }
         return switch (firstBB.instructions.size()) {
-            case 1 -> firstBB.instructions.get(0).kind == CONST_LOAD;
-            case 2 -> firstBB.instructions.get(0).kind == CONST_LOAD && firstBB.instructions.get(1).kind == TYPE_CAST;
+            case 1 -> firstBB.instructions.get(0).kind == CONST_LOAD && firstBB.instructions.get(0).lhsOp.variableDcl
+                    .kind == VarKind.RETURN;
+            case 2 -> firstBB.instructions.get(0).kind == CONST_LOAD && firstBB.instructions.get(1).kind == TYPE_CAST
+                    && firstBB.instructions.get(1).lhsOp.variableDcl.kind == VarKind.RETURN;
             default -> false;
         };
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordDefaultFunctionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordDefaultFunctionsTest.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.test.record;
+
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.BRunUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for record default functions in Ballerina.
+ */
+public class RecordDefaultFunctionsTest {
+
+    private CompileResult compileResult;
+
+    @BeforeClass
+    public void setup() {
+        compileResult = BCompileUtil.compile("test-src/record/record_default_functions.bal");
+    }
+
+    @Test(description = "Test record type with function invocations for default values")
+    public void testRecordWithDefaultFunction() {
+        Object returns = BRunUtil.invoke(compileResult, "recordDefaultFunctionWithArgument");
+        Object returns2 = BRunUtil.invoke(compileResult, "recordDefaultFunction");
+        Assert.assertNotNull(returns);
+        Assert.assertNotNull(returns2);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/record_default_functions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/record_default_functions.bal
@@ -1,0 +1,39 @@
+// Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+isolated function getAsInt(string s) returns int {
+    return 777;
+}
+
+type Bar record {
+    int a = getAsInt("777");
+};
+
+function recordDefaultFunctionWithArgument() returns Bar {
+    return {};
+}
+
+isolated function returnString() returns string {
+    return "hello";
+}
+
+type Foo record {
+    string b = returnString();
+};
+
+function recordDefaultFunction () returns Foo {
+    return {};
+}


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/43531

## Remarks
The codegen failure was due to corrupted `BIRInstructions` originated from `BIRRecordValueOptimizer`. `BIRRecordValueOptimizer` tries to optimize default functions with other function invocations inside their bodies. This was fixed by updating the logic used to identify functions with only constant loads. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
