### PR TITLE
Fix testable pkg `InvocationData` handling logic for Dead Code Elimination

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/UsedTypeDefAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/UsedTypeDefAnalyzer.java
@@ -86,7 +86,7 @@ public final class UsedTypeDefAnalyzer extends SimpleBTypeAnalyzer<UsedTypeDefAn
     @Override
     public void analyzeType(BType bType, AnalyzerData data) {
         Set<UsedBIRNodeAnalyzer.FunctionPointerData> fpDataSet =
-                usedBIRNodeAnalyzer.currentInvocationData.getFpData(bType);
+                usedBIRNodeAnalyzer.getCurrentInvocationData().getFpData(bType);
         if (fpDataSet != null) {
             fpDataSet.forEach(fpData -> {
                 fpData.lambdaPointerVar.markAsUsed();

--- a/tests/testerina-integration-test/src/test/resources/codegen-optimization-reports/optimized_test_run_test/dead_code_elimination_report.json
+++ b/tests/testerina-integration-test/src/test/resources/codegen-optimization-reports/optimized_test_run_test/dead_code_elimination_report.json
@@ -5,6 +5,7 @@
         "foo",
         "fn",
         "testUsageFunction",
+        "buildPkgFn",
         "main",
         "bar"
       ],

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/unix/OptimizedExecutableTestingTest-testWithCommonDependencies.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/unix/OptimizedExecutableTestingTest-testWithCommonDependencies.txt
@@ -5,11 +5,12 @@ Running Tests
 	optimized_test_run_test
 		[pass] importUsageTest
 		[pass] simpleTest
+		[pass] testFPCallToBuildPkgFromTestablePkg
 		[pass] testFn
 		[pass] unusedFunctionInvoker
 
 
-		4 passing
+		5 passing
 		0 failing
 		0 skipped
 

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/windows/OptimizedExecutableTestingTest-testWithCommonDependencies.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/windows/OptimizedExecutableTestingTest-testWithCommonDependencies.txt
@@ -5,11 +5,12 @@ Running Tests
 	optimized_test_run_test
 		[pass] importUsageTest
 		[pass] simpleTest
+		[pass] testFPCallToBuildPkgFromTestablePkg
 		[pass] testFn
 		[pass] unusedFunctionInvoker
 
 
-		4 passing
+		5 passing
 		0 failing
 		0 skipped
 

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/optimized_test_run_test/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/optimized_test_run_test/main.bal
@@ -56,3 +56,7 @@ function testUsageFunction() returns RecB{
     RecB recB = {name: 0};
     return recB;
 }
+
+public function buildPkgFn (string a) returns string{
+    return "hello";
+};

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/optimized_test_run_test/tests/test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/optimized_test_run_test/tests/test.bal
@@ -45,3 +45,11 @@ function testFn() {
 function unusedFunctionInvoker(){
     test:assertEquals(0, testUsageFunction().name);
 }
+
+@test:Config {}
+function testFPCallToBuildPkgFromTestablePkg() {
+    worker StdInReader returns string {
+        string word = buildPkgFn("foo");
+        return word;
+    }
+}


### PR DESCRIPTION
## Purpose
Fixes a bug causing function pointers from testable pkgs pointing to build pkg functions not being marked as used. 

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/43564

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
