### PR TITLE
Fix thin jar caching when testing the optimized executable

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/repos/FileSystemCache.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/repos/FileSystemCache.java
@@ -98,9 +98,19 @@ public class FileSystemCache extends CompilationCache {
     public Optional<Path> getPlatformSpecificLibrary(CompilerBackend compilerBackend, String libraryName,
                                                      boolean isOptimizedLibrary) {
         String libraryFileName = libraryName + compilerBackend.libraryFileExtension();
-        Path targetPlatformCacheDirPath = isOptimizedLibrary ? getOptimizedTargetPlatformCacheDirPath(compilerBackend) :
-                getTargetPlatformCacheDirPath(compilerBackend);
-        Path jarFilePath = targetPlatformCacheDirPath.resolve(libraryFileName);
+        Path optimizedJarFilePath = getOptimizedTargetPlatformCacheDirPath(compilerBackend).resolve(libraryFileName);
+        if (isOptimizedLibrary) {
+            return Optional.of(optimizedJarFilePath);
+        }
+
+        Path jarFilePath = getTargetPlatformCacheDirPath(compilerBackend).resolve(libraryFileName);
+        // getPlatformSpecificLibrary gets invoked from TestUtils class and there is no proper way to check whether a
+        // given module is `optimized`, `unoptimized` or `duplicated optimized`. Maybe we can lift the logic to
+        // JarResolver somehow.
+        // TODO Find a cleaner way to handle JarPaths for bal test with dead code elimination.
+        if (!Files.exists(jarFilePath) && Files.exists(optimizedJarFilePath)) {
+            return Optional.of(optimizedJarFilePath);
+        }
         return Files.exists(jarFilePath) ? Optional.of(jarFilePath) : Optional.empty();
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/repos/FileSystemCache.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/repos/FileSystemCache.java
@@ -108,10 +108,12 @@ public class FileSystemCache extends CompilationCache {
         // given module is `optimized`, `unoptimized` or `duplicated optimized`. Maybe we can lift the logic to
         // JarResolver somehow.
         // TODO Find a cleaner way to handle JarPaths for bal test with dead code elimination.
-        if (!Files.exists(jarFilePath) && Files.exists(optimizedJarFilePath)) {
+        if (Files.exists(jarFilePath)) {
+            return Optional.of(jarFilePath);
+        } else if (Files.exists(optimizedJarFilePath)) {
             return Optional.of(optimizedJarFilePath);
         }
-        return Files.exists(jarFilePath) ? Optional.of(jarFilePath) : Optional.empty();
+        return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
## Purpose
$title
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/43579

## Approach
When we run the `bal test --eliminate-dead-code` command, we have to duplicate certain modules to avoid false positive test results. During DCE we categorize modules into three categories,
- Optimized modules :- These are used only by the build project. If there are no test cases, all modules will fall under this category. These are cached in the `target/cache` directory of the project.
- Unoptimized modules :- Modules used by the testable pkg. We have to keep these modules pure to avoid false positive test results. See [this document](https://docs.google.com/document/d/1WNBN9hI7rbCL6wpozDAwImagUrM-sn7F/) for more details. Since these are pure modules, they are cached in the `.ballerina` file system cache.
- Optimized duplicated modules:- Common dependencies used by both build project and testable project. These duplicated modules are optimized and used by the build project. They are bytecode instrumented to avoid clashing with their counterparts in testable pkg dependencies. References in build pkg are also bytecode instrumented to make them visible only to build pkg. These are cached in the `target/cache` directory of the project along with a `_OPTIMIZED` suffix for the thin jar.

The error was due to a bug in the retrieval of the cache locations during test execution.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
