### PR TITLE
Support passing a custom truststore with central calls

### DIFF
--- a/cli/central-client/src/test/java/org/ballerinalang/central/client/TestCustomRetryInterceptor.java
+++ b/cli/central-client/src/test/java/org/ballerinalang/central/client/TestCustomRetryInterceptor.java
@@ -23,6 +23,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import org.ballerinalang.central.client.exceptions.CentralClientException;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -49,7 +50,7 @@ public class TestCustomRetryInterceptor {
 
 
     @BeforeClass
-    public void setUp() {
+    public void setUp() throws CentralClientException {
         this.console = new ByteArrayOutputStream();
         PrintStream outStream = new PrintStream(this.console);
         CentralAPIClient centralAPIClient = new CentralAPIClient("https://localhost:9090/registry",


### PR DESCRIPTION
## Purpose
> Support passing a custom truststore with central calls

## Approach
> A custom truststore path can be set with the below environment variables:
 `BALLERINA_CA_BUNDLE`
 `BALLERINA_CA_PASSWORD`
 `BALLERINA_CA_CERT`

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
