### PR TITLE
[Debugger] Add support for restart requests

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
@@ -629,6 +629,7 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
         commands.add(System.getProperty("java.command"));
         commands.add("-XX:+HeapDumpOnOutOfMemoryError");
         commands.add("-XX:HeapDumpPath=" + System.getProperty(USER_DIR));
+        commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
         commands.add("-cp");
         commands.add(getAllClassPaths(jarResolver));
         commands.add(initClassName);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
@@ -629,7 +629,6 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
         commands.add(System.getProperty("java.command"));
         commands.add("-XX:+HeapDumpOnOutOfMemoryError");
         commands.add("-XX:HeapDumpPath=" + System.getProperty(USER_DIR));
-        commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
         commands.add("-cp");
         commands.add(getAllClassPaths(jarResolver));
         commands.add(initClassName);

--- a/misc/debug-adapter/modules/debug-adapter-core/spotbugs-exclude.xml
+++ b/misc/debug-adapter/modules/debug-adapter-core/spotbugs-exclude.xml
@@ -31,13 +31,13 @@
                     </And>
                     <And>
                         <Bug pattern="DE_MIGHT_IGNORE"/>
-                        <Method name="terminateDebugServer"/>
+                        <Method name="terminateDebuggee"/>
                     </And>
                     <And>
                         <Bug pattern="BC_UNCONFIRMED_CAST"/>
                         <Or>
                             <Method name="attach"/>
-                            <Method name="launch"/>
+                            <Method name="launchDebuggeeProgram"/>
                         </Or>
                     </And>
                 </Or>

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/DebugExecutionManager.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/DebugExecutionManager.java
@@ -43,6 +43,7 @@ public class DebugExecutionManager {
     private static final String SOCKET_CONNECTOR_NAME = "com.sun.jdi.SocketAttach";
     private static final String CONNECTOR_ARGS_HOST = "hostname";
     private static final String CONNECTOR_ARGS_PORT = "port";
+    private static final String VALUE_UNKNOWN = "unknown";
     private static final Logger LOGGER = LoggerFactory.getLogger(DebugExecutionManager.class);
 
     DebugExecutionManager(JBallerinaDebugServer server) {
@@ -59,6 +60,12 @@ public class DebugExecutionManager {
 
     public Optional<Integer> getPort() {
         return Optional.ofNullable(port);
+    }
+
+    public String getRemoteVMAddress() {
+        String host = getHost().orElse(VALUE_UNKNOWN);
+        String port = getPort().map(String::valueOf).orElse(VALUE_UNKNOWN);
+        return String.format("%s:%s", host, port);
     }
 
     /**

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/DebugOutputLogger.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/DebugOutputLogger.java
@@ -36,6 +36,7 @@ public class DebugOutputLogger {
 
     public DebugOutputLogger(IDebugProtocolClient client) {
         this.client = client;
+        this.isCompilationDone = false;
     }
 
     /**
@@ -128,5 +129,9 @@ public class DebugOutputLogger {
                 || output.startsWith("Please start the remote debugging client to continue")
                 || output.startsWith("JAVACMD")
                 || output.startsWith("Stream closed");
+    }
+
+    public void reset() {
+        isCompilationDone = false;
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/DebugProjectCache.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/DebugProjectCache.java
@@ -52,20 +52,8 @@ public class DebugProjectCache {
     public Project getProject(Path filePath) {
         Map.Entry<ProjectKind, Path> projectKindAndRoot = computeProjectKindAndRoot(filePath);
         Path projectRoot = projectKindAndRoot.getValue();
-        if (!loadedProjects.containsKey(projectRoot)) {
-            addProject(loadProject(filePath.toAbsolutePath().toString()));
-        }
-        return loadedProjects.get(projectRoot);
-    }
 
-    /**
-     * Adds the given project instance into the cache.
-     *
-     * @param project project instance.
-     */
-    public void addProject(Project project) {
-        Path projectSourceRoot = project.sourceRoot().toAbsolutePath();
-        loadedProjects.put(projectSourceRoot, project);
+        return loadedProjects.computeIfAbsent(projectRoot, key -> loadProject(projectKindAndRoot));
     }
 
     /**
@@ -78,13 +66,10 @@ public class DebugProjectCache {
     /**
      * Loads the target ballerina source project instance using the Project API, from the file path of the open/active
      * editor instance in the client(plugin) side.
-     *
-     * @param filePath file path of the open/active editor instance in the plugin side.
      */
-    private static Project loadProject(String filePath) {
-        Map.Entry<ProjectKind, Path> projectKindAndProjectRootPair = computeProjectKindAndRoot(Path.of(filePath));
-        ProjectKind projectKind = projectKindAndProjectRootPair.getKey();
-        Path projectRoot = projectKindAndProjectRootPair.getValue();
+    private static Project loadProject(Map.Entry<ProjectKind, Path> projectKindAndRoot) {
+        ProjectKind projectKind = projectKindAndRoot.getKey();
+        Path projectRoot = projectKindAndRoot.getValue();
         BuildOptions options = BuildOptions.builder().setOffline(true).build();
         if (projectKind == ProjectKind.BUILD_PROJECT) {
             return BuildProject.load(projectRoot, options);

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/DebugProjectCache.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/DebugProjectCache.java
@@ -69,6 +69,13 @@ public class DebugProjectCache {
     }
 
     /**
+     * Clears the project cache.
+     */
+    public void clear() {
+        loadedProjects.clear();
+    }
+
+    /**
      * Loads the target ballerina source project instance using the Project API, from the file path of the open/active
      * editor instance in the client(plugin) side.
      *

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/ExecutionContext.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/ExecutionContext.java
@@ -171,6 +171,19 @@ public class ExecutionContext {
         return supportsRunInTerminalRequest;
     }
 
+    public void clear() {
+        this.projectCache.clear();
+        this.debugMode = null;
+        this.debuggeeVM = null;
+        this.prevLocation = null;
+        this.sourceProject = null;
+        this.launchedProcess = null;
+        this.sourceProjectRoot = null;
+        this.terminateRequestReceived = false;
+        this.supportsRunInTerminalRequest = false;
+        this.prevInstruction = DebugInstruction.CONTINUE;
+    }
+
     /**
      * Currently supported debug configuration modes.
      */

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/ExecutionContext.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/ExecutionContext.java
@@ -144,15 +144,10 @@ public class ExecutionContext {
     public void setSourceProject(Project sourceProject) {
         this.sourceProject = sourceProject;
         this.setSourceProjectRoot(sourceProject.sourceRoot().toAbsolutePath().toString());
-        updateProjectCache(sourceProject);
     }
 
     public DebugProjectCache getProjectCache() {
         return projectCache;
-    }
-
-    public void updateProjectCache(Project project) {
-        this.projectCache.addProject(project);
     }
 
     public String getSourceProjectRoot() {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/ExecutionContext.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/ExecutionContext.java
@@ -171,7 +171,7 @@ public class ExecutionContext {
         return supportsRunInTerminalRequest;
     }
 
-    public void clear() {
+    public void reset() {
         this.projectCache.clear();
         this.debugMode = null;
         this.debuggeeVM = null;

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -74,6 +74,7 @@ import org.eclipse.lsp4j.debug.ExitedEventArguments;
 import org.eclipse.lsp4j.debug.InitializeRequestArguments;
 import org.eclipse.lsp4j.debug.NextArguments;
 import org.eclipse.lsp4j.debug.PauseArguments;
+import org.eclipse.lsp4j.debug.RestartArguments;
 import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
 import org.eclipse.lsp4j.debug.RunInTerminalResponse;
 import org.eclipse.lsp4j.debug.Scope;
@@ -146,10 +147,10 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
     private DebugExecutionManager executionManager;
     private JDIEventProcessor eventProcessor;
     private final ExecutionContext context;
-    private ThreadReferenceProxyImpl activeThread;
     private SuspendedContext suspendedContext;
     private DebugOutputLogger outputLogger;
     private DebugExpressionEvaluator evaluator;
+    private ThreadReferenceProxyImpl activeThread;
 
     private final AtomicInteger nextVarReference = new AtomicInteger();
     private final Map<Integer, StackFrameProxyImpl> stackFrames = new HashMap<>();
@@ -196,8 +197,7 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
         capabilities.setSupportsLogPoints(true);
         capabilities.setSupportsCompletionsRequest(true);
         capabilities.setCompletionTriggerCharacters(getTriggerCharacters().toArray(String[]::new));
-        // Todo - Implement
-        capabilities.setSupportsRestartRequest(false);
+        capabilities.setSupportsRestartRequest(true);
         // unsupported capabilities
         capabilities.setSupportsHitConditionalBreakpoints(false);
         capabilities.setSupportsModulesRequest(false);
@@ -265,7 +265,6 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
     @Override
     public CompletableFuture<Void> launch(Map<String, Object> args) {
         try {
-            clearState();
             context.setDebugMode(ExecutionContext.DebugMode.LAUNCH);
             clientConfigHolder = new ClientLaunchConfigHolder(args);
             Project sourceProject = context.getProjectCache().getProject(Path.of(clientConfigHolder.getSourcePath()));
@@ -291,7 +290,7 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
     @Override
     public CompletableFuture<Void> attach(Map<String, Object> args) {
         try {
-            clearState();
+            resetServer();
             context.setDebugMode(ExecutionContext.DebugMode.ATTACH);
             clientConfigHolder = new ClientAttachConfigHolder(args);
             Project sourceProject = context.getProjectCache().getProject(Path.of(clientConfigHolder.getSourcePath()));
@@ -312,7 +311,7 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
             LOGGER.error(e.getMessage());
             outputLogger.sendErrorOutput(String.format("Failed to attach to the target VM, address: '%s:%s'.",
                     host, portName));
-            terminateDebugServer(context.getDebuggeeVM() != null, false);
+            terminateDebugSession(context.getDebuggeeVM() != null, false);
         }
         return CompletableFuture.completedFuture(null);
     }
@@ -459,6 +458,36 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
     }
 
     @Override
+    public CompletableFuture<Void> restart(RestartArguments args) {
+        if (context.getDebugMode() == ExecutionContext.DebugMode.ATTACH) {
+            outputLogger.sendErrorOutput("Restart is not supported in remote debug mode.");
+            return CompletableFuture.completedFuture(null);
+        }
+
+        try {
+            resetServer();
+            context.setDebugMode(ExecutionContext.DebugMode.LAUNCH);
+            Project sourceProject = context.getProjectCache().getProject(Path.of(clientConfigHolder.getSourcePath()));
+            context.setSourceProject(sourceProject);
+            String sourceProjectRoot = context.getSourceProjectRoot();
+            BProgramRunner programRunner = context.getSourceProject() instanceof SingleFileProject ?
+                    new BSingleFileRunner((ClientLaunchConfigHolder) clientConfigHolder, sourceProjectRoot) :
+                    new BPackageRunner((ClientLaunchConfigHolder) clientConfigHolder, sourceProjectRoot);
+
+            if (context.getSupportsRunInTerminalRequest() && clientConfigHolder.getRunInTerminalKind() != null) {
+                launchInTerminal(programRunner);
+            } else {
+                context.setLaunchedProcess(programRunner.start());
+                startListeningToProgramOutput();
+            }
+            return CompletableFuture.completedFuture(null);
+        } catch (Throwable e) {
+            outputLogger.sendErrorOutput("Failed to restart the ballerina program due to: " + e);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    @Override
     public CompletableFuture<Void> setExceptionBreakpoints(SetExceptionBreakpointsArguments args) {
         return CompletableFuture.completedFuture(null);
     }
@@ -569,14 +598,14 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
     public CompletableFuture<Void> disconnect(DisconnectArguments args) {
         context.setTerminateRequestReceived(true);
         boolean terminateDebuggee = Objects.requireNonNullElse(args.getTerminateDebuggee(), true);
-        terminateDebugServer(terminateDebuggee, true);
+        terminateDebugSession(terminateDebuggee, true);
         return CompletableFuture.completedFuture(null);
     }
 
     @Override
     public CompletableFuture<Void> terminate(TerminateArguments args) {
         context.setTerminateRequestReceived(true);
-        terminateDebugServer(true, true);
+        terminateDebugSession(true, true);
         return CompletableFuture.completedFuture(null);
     }
 
@@ -602,7 +631,7 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
             if (context.getDebuggeeVM() == null) {
                 // shut down debug server
                 outputLogger.sendErrorOutput("Failed to attach to the target VM");
-                terminateDebugServer(false, true);
+                terminateDebugSession(false, true);
 
                 // shut down client terminal
                 int shellProcessId = ((RunInTerminalResponse) response).getShellProcessId();
@@ -641,24 +670,41 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
      * Terminates the debug server.
      *
      * @param terminateDebuggee indicates whether the remote VM should also be terminated
-     * @param logsEnabled       indicates whether the debug server logs should be sent to the client
+     * @param enableClientLogs  indicates whether the debug server logs should be sent to the client
      */
-    void terminateDebugServer(boolean terminateDebuggee, boolean logsEnabled) {
+    void terminateDebugSession(boolean terminateDebuggee, boolean enableClientLogs) {
         // Destroys launched process, if presents.
         if (context.getLaunchedProcess().isPresent() && context.getLaunchedProcess().get().isAlive()) {
             killProcessWithDescendants(context.getLaunchedProcess().get());
         }
         // Destroys remote VM process, if `terminateDebuggee' flag is set.
-        if (terminateDebuggee && context.getDebuggeeVM() != null) {
-            int exitCode = 0;
-            if (context.getDebuggeeVM().process() != null) {
-                exitCode = killProcessWithDescendants(context.getDebuggeeVM().process());
-            }
-            try {
-                context.getDebuggeeVM().exit(exitCode);
-            } catch (Exception ignored) {
-                // It is okay to ignore the VM exit Exceptions, in-case the remote debuggee is already terminated.
-            }
+        if (terminateDebuggee) {
+            terminateDebuggee(enableClientLogs);
+        }
+
+        // Exits from the debug server VM.
+        new java.lang.Thread(() -> {
+            JDIUtils.sleepMillis(500);
+            System.exit(0);
+        }).start();
+    }
+
+    /**
+     * Terminates the debuggee VM.
+     */
+    private void terminateDebuggee(boolean logsEnabled) {
+        if (Objects.isNull(context.getDebuggeeVM())) {
+            return;
+        }
+
+        int exitCode = 0;
+        if (context.getDebuggeeVM().process() != null) {
+            exitCode = killProcessWithDescendants(context.getDebuggeeVM().process());
+        }
+        try {
+            context.getDebuggeeVM().exit(exitCode);
+        } catch (Exception ignored) {
+            // It is okay to ignore the VM exit Exceptions, in-case the remote debuggee is already terminated.
         }
 
         // If 'terminationRequestReceived' is false, debug server termination should have been triggered from the
@@ -671,17 +717,9 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
 
         // Notifies user.
         if (executionManager != null && logsEnabled) {
-            String address = (executionManager.getHost().isPresent() && executionManager.getPort().isPresent()) ?
-                    executionManager.getHost().get() + ":" + executionManager.getPort().get() : VALUE_UNKNOWN;
             outputLogger.sendDebugServerOutput(String.format(System.lineSeparator() + "Disconnected from the target " +
-                    "VM, address: '%s'", address));
+                    "VM, address: '%s'", executionManager.getRemoteVMAddress()));
         }
-
-        // Exits from the debug server VM.
-        new java.lang.Thread(() -> {
-            JDIUtils.sleepMillis(500);
-            System.exit(0);
-        }).start();
     }
 
     private static int killProcessWithDescendants(Process parent) {
@@ -781,7 +819,7 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
             threadsMap.put((int) threadReference.uniqueID(), new ThreadReferenceProxyImpl(context.getDebuggeeVM(),
                     threadReference));
         }
-        for (ThreadReference threadReference: eventProcessor.getVirtualThreads()) {
+        for (ThreadReference threadReference : eventProcessor.getVirtualThreads()) {
             threadsMap.put((int) threadReference.uniqueID(), new ThreadReferenceProxyImpl(context.getDebuggeeVM(),
                     threadReference));
         }
@@ -872,7 +910,7 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
                     //  the STDOUT stream.
                     outputLogger.sendConsoleOutput(line);
                     if (context.getDebuggeeVM() == null && line.contains(COMPILATION_ERROR_MESSAGE)) {
-                        terminateDebugServer(false, true);
+                        terminateDebugSession(false, true);
                     }
                 }
             } catch (IOException ignored) {
@@ -892,7 +930,7 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
                     if (line.contains("Listening for transport dt_socket")) {
                         attachToRemoteVM("", clientConfigHolder.getDebuggePort());
                     } else if (context.getDebuggeeVM() == null && line.contains(COMPILATION_ERROR_MESSAGE)) {
-                        terminateDebugServer(false, true);
+                        terminateDebugSession(false, true);
                     }
                     outputLogger.sendProgramOutput(line);
                 }
@@ -908,7 +946,7 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
                 LOGGER.error(e.getMessage());
                 outputLogger.sendDebugServerOutput(String.format("Failed to attach to the target VM, address: '%s:%s'.",
                         host, portName));
-                terminateDebugServer(context.getDebuggeeVM() != null, true);
+                terminateDebugSession(context.getDebuggeeVM() != null, true);
             }
         });
     }
@@ -928,14 +966,14 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
         erm.createClassPrepareRequest().enable();
         erm.createThreadStartRequest().enable();
         erm.createThreadDeathRequest().enable();
-        eventProcessor.listenAsync();
+        eventProcessor.startListenAsync();
     }
 
     /**
      * Clears previous state information and prepares for the given debug instruction type execution.
      */
     private void prepareFor(DebugInstruction instruction, int threadId) {
-        clearState();
+        clearSuspendedState();
         BreakpointProcessor bpProcessor = eventProcessor.getBreakpointProcessor();
         DebugInstruction prevInstruction = context.getPrevInstruction();
         if (prevInstruction == DebugInstruction.STEP_OVER && instruction == DebugInstruction.CONTINUE) {
@@ -1187,9 +1225,9 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
     }
 
     /**
-     * Clears state information.
+     * Clears the suspended state information.
      */
-    private void clearState() {
+    private void clearSuspendedState() {
         suspendedContext = null;
         evaluator = null;
         activeThread = null;
@@ -1199,5 +1237,16 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
         scopeIdToFrameIds.clear();
         threadStackTraces.clear();
         nextVarReference.set(1);
+    }
+
+    /**
+     * Clears all state information.
+     */
+    private void resetServer() {
+        eventProcessor.reset();
+        outputLogger.reset();
+        terminateDebuggee(false);
+        clearSuspendedState();
+        context.reset();
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -455,8 +455,9 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
             resetServer();
             launchDebuggeeProgram();
             return CompletableFuture.completedFuture(null);
-        } catch (Throwable e) {
-            outputLogger.sendErrorOutput("Failed to restart the ballerina program due to: " + e);
+        } catch (Exception e) {
+            LOGGER.error("Failed to restart the ballerina program due to: " + e.getMessage(), e);
+            outputLogger.sendErrorOutput("Failed to restart the ballerina program");
             return CompletableFuture.completedFuture(null);
         }
     }
@@ -668,7 +669,7 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
         if (context.getLaunchedProcess().isPresent() && context.getLaunchedProcess().get().isAlive()) {
             killProcessWithDescendants(context.getLaunchedProcess().get());
         }
-        // Destroys remote VM process, if `shouldTerminateDebuggee' flag is set.
+        // Destroys remote VM process, if 'shouldTerminateDebuggee' flag is set.
         if (shouldTerminateDebuggee) {
             terminateDebuggee();
         }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
@@ -71,6 +71,7 @@ public class JDIEventProcessor {
         this.breakpointProcessor = new BreakpointProcessor(context, this);
         this.isRemoteVmAttached = true;
         this.interruptFlag = false;
+        this.listeningTask = null;
     }
 
     BreakpointProcessor getBreakpointProcessor() {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
@@ -96,9 +96,7 @@ public class JDIEventProcessor {
                         processEvent(eventSet, eventIterator.next());
                     }
                 } catch (Exception e) {
-                    LOGGER.error(e.getMessage(), e);
-                    // Break the loop on serious errors
-                    break;
+                    LOGGER.error("Error occurred while processing JDI events.", e);
                 }
             }
 

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -57,22 +58,23 @@ public class JDIEventProcessor {
 
     private final ExecutionContext context;
     private final BreakpointProcessor breakpointProcessor;
-    private boolean isRemoteVmAttached = false;
+    private volatile boolean isRemoteVmAttached;
+    private volatile boolean interruptFlag;
     private final List<EventRequest> stepRequests = new CopyOnWriteArrayList<>();
     private static final List<ThreadReference> virtualThreads = new CopyOnWriteArrayList<>();
     private static final Logger LOGGER = LoggerFactory.getLogger(JDIEventProcessor.class);
 
+    private CompletableFuture<Void> listeningTask;
+
     JDIEventProcessor(ExecutionContext context) {
         this.context = context;
-        breakpointProcessor = new BreakpointProcessor(context, this);
+        this.breakpointProcessor = new BreakpointProcessor(context, this);
+        this.isRemoteVmAttached = true;
+        this.interruptFlag = false;
     }
 
     BreakpointProcessor getBreakpointProcessor() {
         return breakpointProcessor;
-    }
-
-    List<EventRequest> getStepRequests() {
-        return stepRequests;
     }
 
     List<ThreadReference> getVirtualThreads() {
@@ -82,28 +84,52 @@ public class JDIEventProcessor {
     /**
      * Asynchronously listens and processes the incoming JDI events.
      */
-    void listenAsync() {
-        CompletableFuture.runAsync(() -> {
-            isRemoteVmAttached = true;
-            while (isRemoteVmAttached) {
+    void startListenAsync() {
+        // Store the future for potential cancellation
+        listeningTask = CompletableFuture.runAsync(() -> {
+            while (isRemoteVmAttached && !interruptFlag) {
                 try {
                     EventSet eventSet = context.getDebuggeeVM().eventQueue().remove();
                     EventIterator eventIterator = eventSet.eventIterator();
-                    while (eventIterator.hasNext() && isRemoteVmAttached) {
+                    while (eventIterator.hasNext() && isRemoteVmAttached && !interruptFlag) {
                         processEvent(eventSet, eventIterator.next());
                     }
                 } catch (Exception e) {
                     LOGGER.error(e.getMessage(), e);
+                    // Break the loop on serious errors
+                    break;
                 }
             }
-            // Tries terminating the debug server, only if there is no any termination requests received from the
-            // debug client.
-            if (!context.isTerminateRequestReceived()) {
-                // It is not required to terminate the debuggee (remote VM) in here, since it must be disconnected or
-                // dead by now.
-                context.getAdapter().terminateDebugServer(false, true);
-            }
+
+            cleanupAfterListening();
         });
+    }
+
+    /**
+     * Stops the async listening process.
+     *
+     * @param force if true, immediately stops listening;
+     *              if false, allows current event processing to complete
+     */
+    private void stopListening(boolean force) {
+        interruptFlag = true;
+        if (Objects.nonNull(listeningTask) && !listeningTask.isDone() && force) {
+            // Attempt to interrupt the task if possible
+            listeningTask.cancel(true);
+        }
+    }
+
+    /**
+     * Performs cleanup after listening stops.
+     */
+    private void cleanupAfterListening() {
+        if (!context.isTerminateRequestReceived() && !interruptFlag) {
+            // It is not required to terminate the debuggee (remote VM) at this point, since it must be disconnected or
+            // dead by now.
+            context.getAdapter().terminateDebugSession(false, true);
+        }
+        isRemoteVmAttached = true;
+        interruptFlag = false;
     }
 
     private void processEvent(EventSet eventSet, Event event) {
@@ -252,5 +278,11 @@ public class JDIEventProcessor {
         stoppedEventArguments.setThreadId((int) threadId);
         stoppedEventArguments.setAllThreadsStopped(true);
         context.getClient().stopped(stoppedEventArguments);
+    }
+
+    public void reset() {
+        stopListening(true);
+        stepRequests.clear();
+        virtualThreads.clear();
     }
 }

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
@@ -35,6 +35,7 @@ import org.eclipse.lsp4j.debug.NextArguments;
 import org.eclipse.lsp4j.debug.OutputEventArguments;
 import org.eclipse.lsp4j.debug.OutputEventArgumentsCategory;
 import org.eclipse.lsp4j.debug.PauseArguments;
+import org.eclipse.lsp4j.debug.RestartArguments;
 import org.eclipse.lsp4j.debug.ScopesArguments;
 import org.eclipse.lsp4j.debug.ScopesResponse;
 import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
@@ -153,7 +154,7 @@ public class DebugTestRunner {
      *
      * @param executionKind Defines ballerina command type to be used to launch the debuggee.(If set to null, adapter
      *                      will try to attach to the debuggee, instead of launching)
-     * @param terminalKind The terminal type, if the debug session should be launched in a separate terminal
+     * @param terminalKind  The terminal type, if the debug session should be launched in a separate terminal
      * @throws BallerinaTestException if any exception is occurred during initialization.
      */
     public boolean initDebugSession(DebugUtils.DebuggeeExecutionKind executionKind, String terminalKind)
@@ -381,6 +382,21 @@ public class DebugTestRunner {
         } catch (Exception e) {
             LOGGER.warn("Pause request failed", e);
             throw new BallerinaTestException("Pause request failed", e);
+        }
+    }
+
+    /**
+     * Restarts the execution of the debuggee program.
+     *
+     * @throws BallerinaTestException if an error occurs when resuming program.
+     */
+    public void restartProgram() throws BallerinaTestException {
+        try {
+            RestartArguments restartArgs = new RestartArguments();
+            debugClientConnector.getRequestManager().restart(restartArgs);
+        } catch (Exception e) {
+            LOGGER.warn("Restart request failed", e);
+            throw new BallerinaTestException("Restart request failed", e);
         }
     }
 

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPRequestManager.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPRequestManager.java
@@ -33,6 +33,7 @@ import org.eclipse.lsp4j.debug.NextArguments;
 import org.eclipse.lsp4j.debug.OutputEventArguments;
 import org.eclipse.lsp4j.debug.PauseArguments;
 import org.eclipse.lsp4j.debug.ProcessEventArguments;
+import org.eclipse.lsp4j.debug.RestartArguments;
 import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
 import org.eclipse.lsp4j.debug.RunInTerminalRequestArgumentsKind;
 import org.eclipse.lsp4j.debug.RunInTerminalResponse;
@@ -273,6 +274,19 @@ public class DAPRequestManager {
         }
     }
 
+    public void restart(RestartArguments args) throws Exception {
+        restart(args, DefaultTimeouts.RESTART.getValue());
+    }
+
+    public void restart(RestartArguments args, long timeoutMillis) throws Exception {
+        if (checkStatus()) {
+            CompletableFuture<Void> resp = server.restart(args);
+            resp.get(timeoutMillis, TimeUnit.MILLISECONDS);
+        } else {
+            throw new IllegalStateException("DAP request manager is not active");
+        }
+    }
+
     public void disconnect(DisconnectArguments args) throws Exception {
         disconnect(args, DefaultTimeouts.DISCONNECT.getValue());
     }
@@ -381,6 +395,7 @@ public class DAPRequestManager {
         STEP_OUT(5000),
         RESUME(5000),
         PAUSE(5000),
+        RESTART(10000),
         DISCONNECT(5000);
 
         private final long value;


### PR DESCRIPTION
## Purpose
This PR
- implements support for `Restart` requests in the Ballerina debug server.
- adds required integration tests

Here's a quick glance of the new feature, where the debug server manages restart requests and handle new debug sessions using the same server instance. 

https://github.com/user-attachments/assets/bef8a79a-b922-4805-8d1b-613c99525848





Resolves https://github.com/ballerina-platform/ballerina-lang/issues/43679

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
