### PR TITLE
[2201.10.x] - Use Java exception to notify `cannot complete future twice`

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BalFuture.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BalFuture.java
@@ -19,11 +19,7 @@
 package io.ballerina.runtime.internal;
 
 import io.ballerina.runtime.api.Future;
-import io.ballerina.runtime.api.PredefinedTypes;
-import io.ballerina.runtime.api.creators.ErrorCreator;
-import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.internal.scheduling.Strand;
-import io.ballerina.runtime.internal.values.MapValueImpl;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -43,8 +39,7 @@ public class BalFuture extends Future {
     @Override
     public void complete(Object returnValue) {
         if (visited.getAndSet(true)) {
-            throw ErrorCreator.createError(StringUtils.fromString("cannot complete the same future twice."),
-                                           new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL));
+            throw new IllegalStateException("cannot complete the same future twice.");
         }
         strand.returnValue = returnValue;
         strand.scheduler.unblockStrand(strand);


### PR DESCRIPTION
## Purpose
> $subject

Fixes #43654 

## Approach
> The use of the `BError` removes the stacktrace related information because the `printStackTrace()` method is overridden within the `BError` class. We could use a Java Exception instead to retain that information.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
