### PR TITLE
Fix `IndexOutOfBoundsException` in Strand Dump Tool and refactor logic

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/troubleshoot/StrandDump.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/troubleshoot/StrandDump.java
@@ -28,7 +28,9 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -45,10 +47,10 @@ public final class StrandDump {
     private static final String WORKING_DIR = System.getProperty("user.dir") + "/";
     private static final String FILENAME = "threadDump" + LocalDateTime.now();
     private static final String VIRTUAL_THREAD_IDENTIFIER = "virtual";
-    private static final String ISOLATED_WORKER_IDENTIFIER = "io.ballerina.runtime.internal.scheduling." +
-            "Scheduler.lambda$startIsolatedWorker";
-    private static final String NON_ISOLATED_WORKER_IDENTIFIER = "io.ballerina.runtime.internal.scheduling." +
-            "Scheduler.lambda$startNonIsolatedWorker";
+    private static final String ISOLATED_IDENTIFIER = "io.ballerina.runtime.internal.scheduling." +
+            "Scheduler.lambda$startIsolated";
+    private static final String NON_ISOLATED_IDENTIFIER = "io.ballerina.runtime.internal.scheduling." +
+            "Scheduler.lambda$startNonIsolated";
     private static final String JAVA_TRACE_PATTERN = "java\\.|\\.java(?::\\d+)?";    // .java, java., .java:(any number)
     private static final String BAL_TRACE_PATTERN = "\\.bal:\\d+";                  // .bal:(any number)
     private static volatile HotSpotDiagnosticMXBean hotSpotDiagnosticMXBean;
@@ -69,16 +71,16 @@ public final class StrandDump {
     private static String generateOutput(String dump) {
         String[] dumpItems = dump.split("\\n\\n");
         int id = 0;
-        Set<Integer> isolatedWorkerList = new HashSet<>();
-        Set<Integer> nonIsolatedWorkerList = new HashSet<>();
-        ArrayList<ArrayList<String>> balTraces = new ArrayList<>();
+        Set<Integer> isolatedStrandList = new HashSet<>();
+        Set<Integer> nonIsolatedStrandList = new HashSet<>();
+        Map<Integer, ArrayList<String>> balTraces = new HashMap<>();
         Pattern javaPattern = Pattern.compile(JAVA_TRACE_PATTERN);
         Pattern balPattern = Pattern.compile(BAL_TRACE_PATTERN);
         for (String item : dumpItems) {
             String[] lines = item.split("\\n");
             String[] subitems = lines[0].split("\" ");
             ArrayList<String> balTraceItems = new ArrayList<>();
-            boolean balStrand = false;
+            boolean isBalStrand = false;
             if (subitems.length > 1 && subitems[1].equals(VIRTUAL_THREAD_IDENTIFIER)) {
                 balTraceItems.add("\tStrand " + lines[0].replace(VIRTUAL_THREAD_IDENTIFIER, ":") + "\n\t\tat");
                 String prefix = " ";
@@ -87,21 +89,21 @@ public final class StrandDump {
                         balTraceItems.add(prefix + line + "\n");
                         prefix = "\t\t   ";
                         if (balPattern.matcher(line).find()) {
-                            balStrand = true;
+                            isBalStrand = true;
                         }
                     } else {
-                        if (line.contains(ISOLATED_WORKER_IDENTIFIER)) {
-                            isolatedWorkerList.add(id);
-                        } else if (line.contains(NON_ISOLATED_WORKER_IDENTIFIER)) {
-                            nonIsolatedWorkerList.add(id);
+                        if (line.contains(ISOLATED_IDENTIFIER)) {
+                            isolatedStrandList.add(id);
+                        } else if (line.contains(NON_ISOLATED_IDENTIFIER)) {
+                            nonIsolatedStrandList.add(id);
                         }
                     }
                 }
-                if (balStrand) {
-                    balTraces.add(balTraceItems);
+                if (isBalStrand) {
+                    balTraces.put(id, balTraceItems);
                 } else {
-                    isolatedWorkerList.remove(id);
-                    nonIsolatedWorkerList.remove(id);
+                    isolatedStrandList.remove(id);
+                    nonIsolatedStrandList.remove(id);
                 }
                 id++;
             }
@@ -112,19 +114,23 @@ public final class StrandDump {
         outputStr.append(dateTimeFormatter.format(localDateTime));
         outputStr.append("]\n===============================================================\n\n");
         outputStr.append("Total Strand count       \t\t\t:\t").append(balTraces.size()).append("\n\n");
-        outputStr.append("Total Isolated Worker count       \t\t:\t").append(isolatedWorkerList.size()).append("\n\n");
-        outputStr.append("Total Non Isolated Worker count       \t\t:\t").append(nonIsolatedWorkerList.size()).
+        outputStr.append("Total Isolated Strand count       \t\t:\t").append(isolatedStrandList.size()).append("\n\n");
+        outputStr.append("Total Non Isolated Strand count       \t\t:\t").append(nonIsolatedStrandList.size()).
                 append("\n\n");
         outputStr.append("================================================================\n");
-        outputStr.append("\nIsolated Workers:\n\n");
-        for (int strandId: isolatedWorkerList) {
-            balTraces.get(strandId).forEach(outputStr::append);
-            outputStr.append("\n");
+        outputStr.append("\nIsolated Strands:\n\n");
+        for (int strandId: isolatedStrandList) {
+            if (balTraces.containsKey(strandId)) {
+                balTraces.get(strandId).forEach(outputStr::append);
+                outputStr.append("\n");
+            }
         }
-        outputStr.append("Non Isolated Workers:\n\n");
-        for (int strandId: nonIsolatedWorkerList) {
-            balTraces.get(strandId).forEach(outputStr::append);
-            outputStr.append("\n");
+        outputStr.append("Non Isolated Strands:\n\n");
+        for (int strandId: nonIsolatedStrandList) {
+            if (balTraces.containsKey(strandId)) {
+                balTraces.get(strandId).forEach(outputStr::append);
+                outputStr.append("\n");
+            }
         }
         return outputStr.toString();
     }

--- a/tests/jballerina-integration-test/src/test/resources/troubleshoot/strandDump/testOutputs/balProgram1StrandDumpRegEx.txt
+++ b/tests/jballerina-integration-test/src/test/resources/troubleshoot/strandDump/testOutputs/balProgram1StrandDumpRegEx.txt
@@ -3,13 +3,13 @@ Ballerina Strand Dump \[\d*/\d*/\d* \d*:\d*:\d*\]
 
 Total Strand count       \t\t\t:\t9
 
-Total Isolated Worker count       \t\t:\t2
+Total Isolated Strand count       \t\t:\t2
 
-Total Non Isolated Worker count       \t\t:\t7
+Total Non Isolated Strand count       \t\t:\t7
 
 ================================================================
 
-Isolated Workers:
+Isolated Strands:
 
 \tStrand #\d* \"\w*\" :
 \t\tat       balProgram1.\$lambda\$_0\(balProgram1.bal:\d*\)
@@ -19,7 +19,7 @@ Isolated Workers:
 \t\tat       balProgram1.\$lambda\$_1\(balProgram1.bal:\d*\)
 \t\t         lambdas.\$_generated1balProgram1.\$lambda\$_1\$lambda1\$\(balProgram1.bal:\d*\)
 
-Non Isolated Workers:
+Non Isolated Strands:
 
 \tStrand #\d* \"\w*\" :
 \t\tat       balProgram1.\$lambda\$_2\(balProgram1.bal:\d*\)

--- a/tests/jballerina-integration-test/src/test/resources/troubleshoot/strandDump/testOutputs/balTestStrandDumpRegEx.txt
+++ b/tests/jballerina-integration-test/src/test/resources/troubleshoot/strandDump/testOutputs/balTestStrandDumpRegEx.txt
@@ -3,15 +3,15 @@ Ballerina Strand Dump \[\d*/\d*/\d* \d*:\d*:\d*\]
 
 Total Strand count       \t\t\t:\t7
 
-Total Isolated Worker count       \t\t:\t0
+Total Isolated Strand count       \t\t:\t0
 
-Total Non Isolated Worker count       \t\t:\t7
+Total Non Isolated Strand count       \t\t:\t7
 
 ================================================================
 
-Isolated Workers:
+Isolated Strands:
 
-Non Isolated Workers:
+Non Isolated Strands:
 
 \tStrand #\d* \"\w*\" :
 \t\tat       testOrg.testPackageWithModules.0.main.bar\(main.bal:\d*\)

--- a/tests/jballerina-integration-test/src/test/resources/troubleshoot/strandDump/testOutputs/testPackageWithModulesStrandDumpRegEx.txt
+++ b/tests/jballerina-integration-test/src/test/resources/troubleshoot/strandDump/testOutputs/testPackageWithModulesStrandDumpRegEx.txt
@@ -3,13 +3,13 @@ Ballerina Strand Dump \[\d*/\d*/\d* \d*:\d*:\d*\]
 
 Total Strand count       \t\t\t:\t17
 
-Total Isolated Worker count       \t\t:\t4
+Total Isolated Strand count       \t\t:\t4
 
-Total Non Isolated Worker count       \t\t:\t13
+Total Non Isolated Strand count       \t\t:\t13
 
 ================================================================
 
-Isolated Workers:
+Isolated Strands:
 
 \tStrand #\d* \"\w*\" :
 \t\tat       ballerina.lang&0046runtime.0.runtime.sleep\(runtime.bal:\d*\)
@@ -32,7 +32,7 @@ Isolated Workers:
 \t\t         testOrg.testPackageWithModules&0046anotherutils.0.creators.\$_function_calls.call\(Unknown Source\)
 \t\t         testOrg.testPackageWithModules.0.lambdas.\$_generated1main.entryfunc\$lambda\$2\$\(main.bal:\d*\)
 
-Non Isolated Workers:
+Non Isolated Strands:
 
 \tStrand #\d* \"\w*\" :
 \t\tat       testOrg.testPackageWithModules.0.main.\$lambda\$_4\(main.bal:\d*\)


### PR DESCRIPTION
## Purpose
> Occasionally, when trying to generate a strand dump report, the user runs into an `IndexOutOfBoundsException`. This PR intends to fix that issue and also refactor the code to improve readability and the scope of the stand dump report.

## Approach
- **Fix**
When parsing the generated Java thread report, there can be cases where a virtual thread is present but its relevance to Ballerina cannot be established. Then, details about that thread won't be added to the list of Ballerina Strand details. Therefore, it is wrong to assume that the `balStand` array will have a 1:1 mapping for each `id` generated during the parsing resulting in an `IndexOutOfBoundsException`. This can be mitigated but using a `Map` with the `id` as the key instead of using an `ArrayList`.

- **Refactoring**
Broaden the scope of identifiers so that important ballerina related strands aren't missed.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
