### PR TITLE
[Debugger] Disable stepping into external sources in low-code mode

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -328,7 +328,7 @@ public class JBallerinaDebugServer implements BallerinaExtendedDebugServer {
         // Checks if the program VM is a read-only VM. If a method which modified the state of the VM is called
         // on a read-only VM, a `VMCannotBeModifiedException` will be thrown.
         if (!debuggeeVM.canBeModified()) {
-            getOutputLogger().sendConsoleOutput("Failed to suspend the remote VM due to: pause requests are not " +
+            getOutputLogger().sendDebugServerOutput("Failed to suspend the remote VM due to: pause requests are not " +
                     "supported on read-only VMs");
             return CompletableFuture.completedFuture(null);
         }
@@ -679,7 +679,7 @@ public class JBallerinaDebugServer implements BallerinaExtendedDebugServer {
         programRunner.getBallerinaCommand(sourceProjectRoot).toArray(command);
         runInTerminalRequestArguments.setArgs(command);
 
-        outputLogger.sendConsoleOutput("Launching debugger in terminal");
+        outputLogger.sendDebugServerOutput("Launching debugger in terminal");
         context.getAdapter().runInTerminal(runInTerminalRequestArguments);
     }
 

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
@@ -152,8 +152,8 @@ public class JDIEventProcessor {
             // to reach the ballerina source.
             // TODO: Revert once the low-code mode supports rendering external sources.
             if (clientConfigs.isLowCodeMode() && hasSteppedIntoExternalSource(stepEvent)) {
-                context.getAdapter().getOutputLogger().sendDebugServerOutput("Debugging external sources is not " +
-                        "supported in low-code mode. Stepping-out to reach the ballerina source.");
+                DebugOutputLogger logger = context.getAdapter().getOutputLogger();
+                logger.sendDebugServerOutput("Stepping into external sources is not supported in low-code mode.");
                 sendStepRequest(threadId, StepRequest.STEP_OUT);
             } else if (isBallerinaSource(stepEvent.location())) {
                 notifyStopEvent(event);

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/config/ClientConfigHolder.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/config/ClientConfigHolder.java
@@ -33,6 +33,7 @@ public class ClientConfigHolder {
     private final ClientConfigKind kind;
     private String sourcePath;
     private Integer debuggePort;
+    private Boolean isLowCodeMode;
     private ExtendedClientCapabilities extendedClientCapabilities;
 
     protected static final String ARG_FILE_PATH = "script";
@@ -43,6 +44,7 @@ public class ClientConfigHolder {
     private static final String ARG_SUPPORT_BP_VERIFICATION = "supportsBreakpointVerification";
     private static final String ARG_SUPPORT_FAST_RUN = "supportsFastRun";
     private static final String ARG_TERMINAL_KIND = "terminal";
+    private static final String ARG_LOW_CODE_MODE = "lowCodeMode";
     private static final String INTEGRATED_TERMINAL_KIND = "INTEGRATED";
     private static final String EXTERNAL_TERMINAL_KIND = "EXTERNAL";
 
@@ -120,6 +122,21 @@ public class ClientConfigHolder {
             }
         }
         return null;
+    }
+
+    public boolean isLowCodeMode() {
+        if (this.isLowCodeMode == null) {
+            Object isLowCodeMode = clientRequestArgs.get(ARG_LOW_CODE_MODE);
+            if (isLowCodeMode instanceof Boolean b) {
+                this.isLowCodeMode = b;
+            } else if (isLowCodeMode instanceof String s) {
+                this.isLowCodeMode = Boolean.parseBoolean(s);
+            } else {
+                this.isLowCodeMode = false;
+            }
+        }
+
+        return isLowCodeMode;
     }
 
     protected void failIfConfigMissing(String configName) throws ClientConfigurationException {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/PackageUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/PackageUtils.java
@@ -65,7 +65,7 @@ public final class PackageUtils {
     static final String PERSIST_DIR = "persist";
     static final String TEST_PKG_POSTFIX = "$test";
     private static final String URI_SCHEME_FILE = "file";
-    private static final String URI_SCHEME_BALA = "bala";
+    public static final String URI_SCHEME_BALA = "bala";
 
     private static final String FILE_SEPARATOR_REGEX = File.separatorChar == '\\' ? "\\\\" : File.separator;
 


### PR DESCRIPTION
## Purpose
This PR disables stepping into external sources in low-code mode while debugging. 
This is because the external resources renderings is not yet supported in low-code mode. 

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
