### PR TITLE
Disable intermittently failing debugger terminal tests on windows

### DIFF
--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/runinterminal/ProjectBasedRunInTerminalTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/runinterminal/ProjectBasedRunInTerminalTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.debugger.test.utils.DebugTestRunner;
 import org.ballerinalang.debugger.test.utils.DebugUtils;
 import org.ballerinalang.test.context.BallerinaTestException;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -29,6 +30,7 @@ import org.testng.annotations.Test;
  * Test class to test the runInTerminal feature for project based sources.
  */
 public class ProjectBasedRunInTerminalTest {
+
     DebugTestRunner debugTestRunner;
     boolean didRunInIntegratedTerminal;
 
@@ -41,6 +43,12 @@ public class ProjectBasedRunInTerminalTest {
 
     @Test(description = "Debug launch test in integrated terminal for project based source")
     public void testRunInIntegratedTerminal() throws BallerinaTestException {
+        // Skipping the test on Windows
+        // TODO: enable after fixing intermittent failures
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            throw new SkipException("Skipping test on Windows OS");
+        }
+
         String integratedTerminal = "integrated";
         debugTestRunner.setClientSupportsRunInTerminal(true);
         didRunInIntegratedTerminal = debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN,
@@ -50,6 +58,12 @@ public class ProjectBasedRunInTerminalTest {
 
     @Test(description = "Debug launch test in external terminal for project based source")
     public void testRunInExternalTerminal() throws BallerinaTestException {
+        // Skipping the test on Windows
+        // TODO: enable after fixing intermittent failures
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            throw new SkipException("Skipping test on Windows OS");
+        }
+
         String externalTerminal = "external";
         debugTestRunner.setClientSupportsRunInTerminal(true);
         didRunInIntegratedTerminal = debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN,
@@ -87,8 +101,7 @@ public class ProjectBasedRunInTerminalTest {
     @Test(description = "Debug launch test without runinterminal config")
     public void testLaunchWithoutConfig() throws BallerinaTestException {
         debugTestRunner.setClientSupportsRunInTerminal(true);
-        didRunInIntegratedTerminal = debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN,
-                "");
+        didRunInIntegratedTerminal = debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN, "");
 
         // returned value should be false since the runinterminal kind config wasn't set to launch the program in a
         // separate terminal

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/runinterminal/SingleFileRunInTerminalTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/runinterminal/SingleFileRunInTerminalTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.debugger.test.utils.DebugTestRunner;
 import org.ballerinalang.debugger.test.utils.DebugUtils;
 import org.ballerinalang.test.context.BallerinaTestException;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -43,6 +44,12 @@ public class SingleFileRunInTerminalTest extends BaseTestCase {
 
     @Test(description = "Debug launch test in integrated terminal for single file")
     public void testRunInIntegratedTerminal() throws BallerinaTestException {
+        // Skipping the test on Windows
+        // TODO: enable after fixing intermittent failures
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            throw new SkipException("Skipping test on Windows OS");
+        }
+
         String integratedTerminal = "integrated";
         debugTestRunner.setClientSupportsRunInTerminal(true);
         didRunInIntegratedTerminal = debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN,
@@ -52,6 +59,12 @@ public class SingleFileRunInTerminalTest extends BaseTestCase {
 
     @Test(description = "Debug launch test in external terminal for single file")
     public void testRunInExternalTerminal() throws BallerinaTestException {
+        // Skipping the test on Windows
+        // TODO: enable after fixing intermittent failures
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            throw new SkipException("Skipping test on Windows OS");
+        }
+
         String externalTerminal = "external";
         debugTestRunner.setClientSupportsRunInTerminal(true);
         didRunInIntegratedTerminal = debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN,


### PR DESCRIPTION
## Purpose
$subject 

Related issue: https://github.com/ballerina-platform/ballerina-lang/issues/43736

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
