### PR TITLE
[2201.11.x] Fix support for breakpoint changes inside Ballerina services during a debug session

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BreakpointProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BreakpointProcessor.java
@@ -175,10 +175,7 @@ public class BreakpointProcessor {
         }
 
         context.getEventManager().deleteAllBreakpoints();
-        for (Map.Entry<String, LinkedHashMap<Integer, BalBreakpoint>> entry : userBreakpoints.entrySet()) {
-            String qClassName = entry.getKey();
-            context.getDebuggeeVM().classesByName(qClassName).forEach(ref -> activateUserBreakPoints(ref, false));
-        }
+        context.getDebuggeeVM().allClasses().forEach(ref -> activateUserBreakPoints(ref, false));
     }
 
     /**

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
@@ -175,8 +175,7 @@ public class JDIEventProcessor {
 
         // Setting breakpoints to an already running debug session.
         context.getEventManager().deleteAllBreakpoints();
-        context.getDebuggeeVM().classesByName(qClassName)
-                .forEach(ref -> breakpointProcessor.activateUserBreakPoints(ref, false));
+        context.getDebuggeeVM().allClasses().forEach(ref -> breakpointProcessor.activateUserBreakPoints(ref, false));
     }
 
     void sendStepRequest(int threadId, int stepType) {


### PR DESCRIPTION
## Purpose
$subject.

## Remarks
Its not possible to cover this scenario using integration tests implemented in the lang repo, as we cant use/access stdlibs (hence services) in lang tests. Related tests will be added to the tooling integration test suite in the ballerina-distribution repository.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
