### PR TITLE
Fix invalid token diagnostic in NodeParser

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/AbstractParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/AbstractParser.java
@@ -257,7 +257,7 @@ public abstract class AbstractParser {
         while (peek().kind != SyntaxKind.EOF_TOKEN) {
             STToken invalidToken = consume();
             node = SyntaxErrors.cloneWithTrailingInvalidNodeMinutiae(node, invalidToken,
-                    DiagnosticErrorCode.ERROR_INVALID_TOKEN);
+                    DiagnosticErrorCode.ERROR_INVALID_TOKEN, invalidToken.text());
         }
 
         return node;

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/nodeparser/ParseExpressionTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/nodeparser/ParseExpressionTest.java
@@ -151,4 +151,13 @@ public class ParseExpressionTest {
         Assert.assertEquals(expressionNode.trailingInvalidTokens().size(), 0);
         Assert.assertEquals(expressionNode.toString(), "foo ?  MISSING[] MISSING[:] MISSING[]");
     }
+
+    @Test
+    public void testInvalidTokenDiagnostic() {
+        ExpressionNode expressionNode = NodeParser.parseExpression("ab cd");
+        Assert.assertEquals(expressionNode.kind(), SyntaxKind.SIMPLE_NAME_REFERENCE);
+        Assert.assertTrue(expressionNode.hasDiagnostics());
+        Assert.assertEquals(expressionNode.toString(), "ab  INVALID[cd]");
+        Assert.assertEquals(expressionNode.diagnostics().iterator().next().message(), "invalid token 'cd'");
+    }
 }


### PR DESCRIPTION
## Purpose
$subject.

`invalidateRestAndAddToTrailingMinutiae()` creates the diagnostic message `invalid token '{0}'` without passing the argument. This only affected the invalid tokens at the very end of the parsed content. 

Fixes #43797

## Approach
n/a

## Samples
Consider `NodeParser.parseExpression("ab cd");`. It previously gave the diagnostic `invalid token '{0}'`. Now is it fixed to give `invalid token 'cd'`

## Remarks
n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
