### PR TITLE
Add support for string template expression as constant expression

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantAnalyzer.java
@@ -38,6 +38,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNumericLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangStringTemplateLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangUnaryExpr;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
@@ -172,10 +173,16 @@ public class ConstantAnalyzer extends BLangNodeVisitor {
         analyzeExpr(spreadOpExpr.expr);
     }
 
+    @Override
+    public void visit(BLangStringTemplateLiteral stringTemplateLiteral) {
+        stringTemplateLiteral.exprs.forEach(this::analyzeExpr);
+    }
+
     void analyzeExpr(BLangExpression expr) {
         switch (expr.getKind()) {
             case LITERAL:
             case NUMERIC_LITERAL:
+            case STRING_TEMPLATE_LITERAL:
             case RECORD_LITERAL_EXPR:
             case LIST_CONSTRUCTOR_EXPR:
             case LIST_CONSTRUCTOR_SPREAD_OP:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantTypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantTypeChecker.java
@@ -86,6 +86,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNumericLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangStringTemplateLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangUnaryExpr;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
@@ -193,6 +194,7 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
         switch (expr.getKind()) {
             case LITERAL:
             case NUMERIC_LITERAL:
+            case STRING_TEMPLATE_LITERAL:
             case RECORD_LITERAL_EXPR:
             case LIST_CONSTRUCTOR_EXPR:
             case SIMPLE_VARIABLE_REF:
@@ -505,6 +507,36 @@ public class ConstantTypeChecker extends SimpleBLangNodeAnalyzer<ConstantTypeChe
 
         BType finiteType = getFiniteType(resolvedValue, constantSymbol, unaryExpr.pos, resultType);
         if (data.compoundExprCount == 0 && types.typeIncompatible(unaryExpr.pos, finiteType, data.expType)) {
+            data.resultType = symTable.semanticError;
+            return;
+        }
+        data.resultType = finiteType;
+    }
+
+    @Override
+    public void visit(BLangStringTemplateLiteral stringTemplateLiteral, AnalyzerData data) {
+        StringBuilder resultString = new StringBuilder();
+        stringTemplateLiteral.exprs.forEach(expr -> {
+            BType exprType = checkConstExpr(expr, data);
+            if (exprType == symTable.semanticError) {
+                data.resultType = symTable.semanticError;
+                return;
+            }
+            if (!types.isNonNilSimpleBasicTypeOrString(exprType)) {
+                dlog.error(expr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES, symTable.interpolationAllowedType,
+                        exprType);
+                data.resultType = symTable.semanticError;
+                return;
+            }
+
+
+            BLangLiteral exprLiteral = (BLangLiteral) ((BFiniteType) exprType).getValueSpace().iterator().next();
+            resultString.append(getValue(exprLiteral));
+        });
+
+        Location pos = stringTemplateLiteral.pos;
+        BType finiteType = getFiniteType(resultString.toString(), data.constantSymbol, pos, symTable.stringType);
+        if (data.compoundExprCount == 0 && types.typeIncompatible(pos, finiteType, data.expType)) {
             data.resultType = symTable.semanticError;
             return;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -8220,10 +8220,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             }
 
             if (!types.isNonNilSimpleBasicTypeOrString(type)) {
-                dlog.error(expr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES,
-                        BUnionType.create(null, symTable.intType, symTable.floatType,
-                                symTable.decimalType, symTable.stringType,
-                                symTable.booleanType), type);
+                dlog.error(expr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES, symTable.interpolationAllowedType, type);
             }
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -141,6 +141,8 @@ public class SymbolTable {
     public final BType readonlyType = new BReadonlyType(TypeTags.READONLY, null);
     public final BType pathParamAllowedType = BUnionType.create(null,
             intType, stringType, floatType, booleanType, decimalType);
+    public final BType interpolationAllowedType = BUnionType.create(null,
+            intType, stringType, floatType, booleanType, decimalType);
     public final BIntersectionType anyAndReadonly;
     public BUnionType anyAndReadonlyOrError;
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/StringTemplateConstantTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/StringTemplateConstantTest.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.types.constant;
+
+import org.ballerinalang.test.BAssertUtil;
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.BRunUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * This class contains a set of test cases to test the string template expression as a constant expression.
+ */
+public class StringTemplateConstantTest {
+
+    private CompileResult compileResult;
+
+    @BeforeClass
+    public void setup() {
+        compileResult = BCompileUtil.compile("test-src/types/constant/string-template-constant.bal");
+    }
+
+    @Test
+    public void testStringTemplateConstantExpr() {
+        Object returns = BRunUtil.invoke(compileResult, "testStringTemplateConstantExpr");
+        Assert.assertNull(returns);
+    }
+
+    @Test
+    public void testStringTemplateConstantExprNegative() {
+        CompileResult negativeResult = BCompileUtil.compile(
+                "test-src/types/constant/string-template-constant-negative.bal");
+        int index = 0;
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected '(int|string|" +
+                        "float|boolean|decimal)', found '(record {| 4 a; |} & readonly)'", 17, 27);
+        BAssertUtil.validateError(negativeResult, index++, "expression is not a constant expression",
+                20, 30);
+        BAssertUtil.validateError(negativeResult, index++, "expression is not a constant expression",
+                21, 30);
+
+        Assert.assertEquals(negativeResult.getErrorCount(), index);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/string-template-constant-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/string-template-constant-negative.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+const v1 = {a:4};
+const v2 = string `hello${v1}`;
+
+boolean bool = true;
+const v3 = string `This is ${bool}`;
+const v4 = string `This is ${foo()}`;
+
+function foo() returns boolean {
+    return false;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/string-template-constant.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/string-template-constant.bal
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+const v1 = string `hello ${"world"}`;
+const v2 = string `hello${" world"}`;
+
+const boolean bool = true;
+const v3 = string `This is ${bool}`;
+const v4 = string `This is ${!bool}`;
+
+const int intVal = 444;
+string v5 = string `${intVal} is greater than ${100}.`;
+
+const float floatVal = 5.0090;
+string v6 = string `this is a float value ${floatVal}. ${v2}. Have a nice day.`;
+
+const decimal b = 5.7888;
+const decimal c = 5.7888;
+const v7 = string `hello ${b + c}. This is ${b - c}.`;
+
+public function testStringTemplateConstantExpr() {
+   assertEquality("hello world", v1);
+   assertEquality("hello world", v2);
+   assertEquality("This is true", v3);
+   assertEquality("This is false", v4);
+   assertEquality("444 is greater than 100.", v5);
+   assertEquality("this is a float value 5.009. hello world. Have a nice day.", v6);
+   assertEquality("hello 11.5776. This is 0.0000.", v7);
+
+   // define a new non constant variables for the above v1 to v7 locally
+   string v11 = string `hello ${"world"}`;
+   string v12 = string `hello${" world"}`;
+   string v13 = string `This is ${bool}`;
+   string v14 = string `This is ${!bool}`;
+   string v15 = string `${intVal} is greater than ${100}.`;
+   string v16 = string `this is a float value ${floatVal}. ${v12}. Have a nice day.`;
+   string v17 = string `hello ${b + c}. This is ${b - c}.`;
+
+   // assert the equality of the above local variables with the constant variables
+   assertEquality(v1, v11);
+   assertEquality(v2, v12);
+   assertEquality(v3, v13);
+   assertEquality(v4, v14);
+   assertEquality(v5, v15);
+   assertEquality(v6, v16);
+   assertEquality(v7, v17); // Todo: This needs to be fixed
+}
+
+function assertEquality(anydata expected, anydata actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error(string `expected '${expected.toBalString()}', found '${actual.toBalString()}'`);
+}


### PR DESCRIPTION
## Purpose
$title

Fixes #43771

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
```bal
const v1 = string `hello ${"world"}`;
const v2 = string `hello${" world"}`;

const boolean bool = true;
const v3 = string `This is ${bool}`;
const v4 = string `This is ${!bool}`;

const int intVal = 444;
string v5 = string `${intVal} is greater than ${100}.`;

const float floatVal = 5.0090;
string v6 = string `this is a float value ${floatVal}. ${v2}. Have a nice day.`;

const decimal b = 5.7888;
const decimal c = 5.7888;
const v7 = string `hello ${b + c}. This is ${b - c}.`;
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
