### PR TITLE
[2201.12.x] Add raw template type to Semantic Model's types API

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/Types.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/Types.java
@@ -63,6 +63,7 @@ public abstract class Types {
     public final TypeSymbol BYTE;
     public final TypeSymbol COMPILATION_ERROR;
     public final TypeSymbol REGEX;
+    public final TypeSymbol RAW_TEMPLATE;
 
     protected Types(CompilerContext context) {
         this.context = context;
@@ -92,6 +93,7 @@ public abstract class Types {
         this.BYTE = typesFactory.getTypeDescriptor(symbolTable.byteType);
         this.COMPILATION_ERROR = typesFactory.getTypeDescriptor(symbolTable.semanticError);
         this.REGEX = typesFactory.getTypeDescriptor(symbolTable.regExpType);
+        this.RAW_TEMPLATE = typesFactory.getTypeDescriptor(symbolTable.rawTemplateType);
     }
 
     /**

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypesTest.java
@@ -39,6 +39,7 @@ import io.ballerina.compiler.api.impl.symbols.BallerinaReadonlyTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaStreamTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaStringTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaTypeDescTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaTypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaXMLTypeSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
@@ -149,6 +150,7 @@ public class TypesTest {
                 {types.JSON, JSON, BallerinaJSONTypeSymbol.class},
                 {types.BYTE, BYTE, BallerinaByteTypeSymbol.class},
                 {types.COMPILATION_ERROR, COMPILATION_ERROR, BallerinaCompilationErrorTypeSymbol.class},
+                {types.RAW_TEMPLATE, TYPE_REFERENCE, BallerinaTypeReferenceTypeSymbol.class}
         };
     }
 


### PR DESCRIPTION
(cherry picked from commit 47fc7b5fff8ea895d3717cb38c904b9d7f5e7b17)

original PR: https://github.com/ballerina-platform/ballerina-lang/pull/43871

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [x] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
