### PR TITLE
Allow the hyphen in buildtool name

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/BuildToolUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/BuildToolUtils.java
@@ -226,7 +226,7 @@ public final class BuildToolUtils {
         ValidationStatus status = ValidationStatus.VALID;
         if (cmdName == null || cmdName.isEmpty()) {
             status = ValidationStatus.EMPTY;
-        } else if (!cmdName.matches("^\\w+$")) {
+        } else if (!cmdName.matches("^[\\w-]+$")) {
             status = ValidationStatus.NON_ALPHANUMERIC;
         } else if (cmdName.startsWith("_")) {
             status = ValidationStatus.LEADING_UNDERSCORE;


### PR DESCRIPTION
## Purpose
> Allow the hyphen in buildtool name

Related to https://github.com/ballerina-platform/ballerina-spec/issues/1331#issuecomment-2705274302

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
