### PR TITLE
Fix Error Message Bug - Add User Friendly String Representation for NodeKind

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/NodeKind.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/NodeKind.java
@@ -31,7 +31,7 @@ public enum NodeKind {
     MARKDOWN_DOCUMENTATION,
     ENDPOINT,
     FUNCTION,
-    RESOURCE_FUNC,
+    RESOURCE_FUNC("resource function"),
     BLOCK_FUNCTION_BODY,
     EXPR_FUNCTION_BODY,
     EXTERN_FUNCTION_BODY,
@@ -274,5 +274,20 @@ public enum NodeKind {
     RESOURCE_PATH_IDENTIFIER_SEGMENT,
     RESOURCE_PATH_PARAM_SEGMENT,
     RESOURCE_PATH_REST_PARAM_SEGMENT,
-    RESOURCE_ROOT_PATH_SEGMENT
+    RESOURCE_ROOT_PATH_SEGMENT;
+
+    private String name;
+
+    NodeKind() {
+        this.name = super.toString();
+    }
+
+    NodeKind(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

- Fixes #43815 

- Updates the generated error message by replacing the keyword `resource_func` with a more user friendly string `resource function`

## Approach
> Describe how you are implementing the solutions along with the design details.

- Enhanced the `NodeKind` enum with custom string representation for user friendly messages

## Samples
> Provide high-level details about the samples related to this feature.

- Here is a sample image of the existing bug (same as attached to the issue)

![image](https://github.com/user-attachments/assets/b742ce21-eee6-454d-a9bb-af55ca8b7965)


## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

- While the changes in this PR have been limited to the scope of the issue (i.e. the `RESOURCE_FUNC` enum), it could be extended further to include custom labels for the other enums as well.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
