### PR TITLE
Fix invalid behavior for the cloud build option for the `test` and `run` commands 

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -345,6 +345,7 @@ public class RunCommand implements BLauncherCmd {
                 .setSkipTests(true)
                 .setTestReport(false)
                 .setObservabilityIncluded(observabilityIncluded)
+                .setCloud("") // Skip the cloud import for the run command
                 .setRemoteManagement(remoteManagement)
                 .setSticky(sticky)
                 .setDumpGraph(dumpGraph)

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -142,11 +142,6 @@ public class RunTestsTask implements Task {
     public void execute(Project project) {
         long start = 0;
 
-        //do not execute if cloud option is given, we only use the object to use the properties and methods in it
-        if (!project.buildOptions().cloud().isEmpty()) {
-            return;
-        }
-
         if (project.buildOptions().dumpBuildTime()) {
             start = System.currentTimeMillis();
         }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
@@ -154,7 +154,7 @@ public class TestProcessor {
         }
 
         // If not a cloud build, add the test execution dependencies
-        if (module.project().buildOptions().cloud().isEmpty()) {
+        if (!areTestsDelegated(module)) {
             addTestExecutionDependencies(module, jarResolver, testSuite);
         } else if (module.project().buildOptions().nativeImage()) {
             // If it is a cloud build, add the test execution dependencies only if native image is enabled
@@ -183,7 +183,7 @@ public class TestProcessor {
                 module.descriptor().name().toString(), testSuite);
         testSuite.setPackageName(module.descriptor().packageName().toString());
 
-        if (module.project().buildOptions().cloud().isEmpty()) {
+        if (!areTestsDelegated(module)) {
             testSuite.setSourceRootPath(module.project().sourceRoot().toString());
         } else {
             testSuite.setSourceRootPath("./");
@@ -614,5 +614,9 @@ public class TestProcessor {
         }
         //TODO: Throw an exception for not generating the test execution file. Currently, this handles at BTestRunner
         return executePath;
+    }
+
+    private boolean areTestsDelegated(Module module) {
+        return module.project().buildOptions().cloud().equals("docker");
     }
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/43940

## Approach
1. Passed hard-coded empty string for the cloud build option for the `run` command. This overrides any value passed for the `cloud` option in the toml.

2. Instead of checking if `cloud` option is present, checked if the `cloud` option is available, before skipping tests.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
