### PR TITLE
Add a notification to publish artifacts to the client

### DIFF
--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/client/ExtendedLanguageClient.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/client/ExtendedLanguageClient.java
@@ -30,4 +30,9 @@ public interface ExtendedLanguageClient extends LanguageClient {
 
     @JsonNotification("window/showTextDocument")
     void showTextDocument(Location location);
+
+    // TODO: This should be removed once a service loader implementation is added to allow LS extensions to define
+    //  notifications to the client
+    @JsonNotification("designModelService/publishArtifacts")
+    void publishArtifacts(Object artifacts);
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/publishers/ProjectUpdateEventPublisher.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/publishers/ProjectUpdateEventPublisher.java
@@ -59,7 +59,7 @@ public class ProjectUpdateEventPublisher extends AbstractEventPublisher {
         Executor delayedExecutor = CompletableFuture.delayedExecutor(DIAGNOSTIC_DELAY, TimeUnit.SECONDS);
         CompletableFuture<Boolean> scheduledFuture = CompletableFuture.supplyAsync(() -> true, delayedExecutor);
         latestScheduled = scheduledFuture;
-        scheduledFuture.thenAcceptAsync(aBoolean -> 
-                subscribers.forEach(subscriber -> subscriber.onEvent(client, context, serverContext)));
+        scheduledFuture.thenAcceptAsync(aBoolean -> subscribers.parallelStream()
+                .forEach(subscriber -> subscriber.onEvent(client, context, serverContext)));
     }
 }


### PR DESCRIPTION
## Purpose
The PR defines a new notification allowing the LS to send notifications to the client upon project updates. Additionally, this resolves concurrency issues in the event pub-sub handler.

Fixes https://github.com/wso2/product-ballerina-integrator/issues/88
