### PR TITLE
[2201.12.x] Provide a semantic API to obtain the type symbol from text input

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/Types.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/Types.java
@@ -24,6 +24,7 @@ import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.PackageCache;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.Map;
@@ -41,6 +42,7 @@ public abstract class Types {
     protected final SymbolFactory symbolFactory;
     protected final SymbolTable symbolTable;
     protected final PackageCache packageCache;
+    protected final BLangPackage bLangPackage;
 
     public final TypeSymbol BOOLEAN;
     public final TypeSymbol INT;
@@ -65,7 +67,8 @@ public abstract class Types {
     public final TypeSymbol REGEX;
     public final TypeSymbol RAW_TEMPLATE;
 
-    protected Types(CompilerContext context) {
+    protected Types(BLangPackage bLangPackage, CompilerContext context) {
+        this.bLangPackage = bLangPackage;
         this.context = context;
         TypesFactory typesFactory = TypesFactory.getInstance(context);
         this.symbolFactory = SymbolFactory.getInstance(context);
@@ -95,6 +98,16 @@ public abstract class Types {
         this.REGEX = typesFactory.getTypeDescriptor(symbolTable.regExpType);
         this.RAW_TEMPLATE = typesFactory.getTypeDescriptor(symbolTable.rawTemplateType);
     }
+
+    /**
+     * Parses a string representation of a Ballerina type descriptor into a {@link TypeSymbol}. Referenced named types
+     * within the {@code text} must be either built-in types or user-defined types declared within the current module.
+     *
+     * @param text The string representation of the Ballerina type descriptor to parse.
+     * @return An {@link Optional} containing the resolved {@link TypeSymbol}, or empty if parsing fails or the type is
+     * invalid in the current context.
+     */
+    public abstract Optional<TypeSymbol> getType(String text);
 
     /**
      * Lookup for the symbol of a user defined type within a given module. This would be considering type

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -106,6 +106,7 @@ public class BallerinaSemanticModel implements SemanticModel {
     private final SymbolFactory symbolFactory;
     private final TypesFactory typesFactory;
     private final SymbolTable symbolTable;
+    private final Types types;
 
     public BallerinaSemanticModel(BLangPackage bLangPackage, CompilerContext context) {
         this.compilerContext = context;
@@ -113,6 +114,7 @@ public class BallerinaSemanticModel implements SemanticModel {
         this.symbolFactory = SymbolFactory.getInstance(context);
         this.typesFactory = TypesFactory.getInstance(context);
         this.symbolTable = SymbolTable.getInstance(context);
+        this.types = new BallerinaTypes(bLangPackage, compilerContext);
     }
 
     /**
@@ -120,7 +122,7 @@ public class BallerinaSemanticModel implements SemanticModel {
      * */
     @Override
     public Types types() {
-        return BallerinaTypes.getInstance(this.compilerContext);
+        return types;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaTypes.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaTypes.java
@@ -19,16 +19,25 @@ package io.ballerina.compiler.api.impl;
 
 import io.ballerina.compiler.api.TypeBuilder;
 import io.ballerina.compiler.api.Types;
+import io.ballerina.compiler.api.impl.symbols.TypesFactory;
 import io.ballerina.compiler.api.impl.util.FieldMap;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.NodeParser;
+import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.symbols.SymbolOrigin;
+import org.wso2.ballerinalang.compiler.parser.BLangNodeBuilder;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.TypeResolver;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.tree.BLangNode;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.tree.types.BLangType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.util.Flags;
@@ -44,18 +53,44 @@ import java.util.Optional;
  */
 public class BallerinaTypes extends Types {
 
-    private BallerinaTypes(CompilerContext context) {
-        super(context);
+    private static final String COMPILATION_UNIT_NAME = "$types$compilation-unit$";
+    private final BLangNodeBuilder bLangNodeBuilder;
+    private final TypeResolver typeResolver;
+
+    public BallerinaTypes(BLangPackage bLangPackage, CompilerContext context) {
+        super(bLangPackage, context);
         context.put(TYPES_KEY, this);
+        this.bLangNodeBuilder = new BLangNodeBuilder(context, bLangPackage.packageID, COMPILATION_UNIT_NAME);
+        this.typeResolver = TypeResolver.getInstance(context);
     }
 
-    public static Types getInstance(CompilerContext context) {
-        Types types = context.get(TYPES_KEY);
-        if (types == null) {
-            types = new BallerinaTypes(context);
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<TypeSymbol> getType(String text) {
+        // Obtain the ST node
+        TypeDescriptorNode typeDescriptorNode = NodeParser.parseTypeDescriptor(text);
+        if (typeDescriptorNode == null) {
+            return Optional.empty();
         }
 
-        return types;
+        // Obtain the AST node
+        BLangNode bLangNode = typeDescriptorNode.apply(bLangNodeBuilder);
+        if (!(bLangNode instanceof BLangType)) {
+            return Optional.empty();
+        }
+
+        // Resolve the type
+        SymbolEnv pkgEnv = symbolTable.pkgEnvMap.get(bLangPackage.symbol);
+        try {
+            typeResolver.resolveTypeDesc((BLangType) bLangNode, pkgEnv);
+        } catch (Throwable ignored) {
+            return Optional.empty();
+        }
+
+        // Generate the type symbol
+        return Optional.of(TypesFactory.getInstance(context).getTypeDescriptor(bLangNode.getBType()));
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaTypes.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaTypes.java
@@ -71,7 +71,7 @@ public class BallerinaTypes extends Types {
     public Optional<TypeSymbol> getType(String text) {
         // Obtain the ST node
         TypeDescriptorNode typeDescriptorNode = NodeParser.parseTypeDescriptor(text);
-        if (typeDescriptorNode == null) {
+        if (typeDescriptorNode == null || typeDescriptorNode.hasDiagnostics()) {
             return Optional.empty();
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -698,6 +698,32 @@ public class TypeResolver {
         return resolveTypeDesc(symEnv, defn, depth, td, data, true);
     }
 
+    public void resolveTypeDesc(BLangType td, SymbolEnv symEnv) {
+        ResolverData data = new ResolverData();
+        data.modTable = new LinkedHashMap<>();
+        data.env = symEnv;
+
+        BType resultType = switch (td.getKind()) {
+            case VALUE_TYPE -> resolveTypeDesc((BLangValueType) td, symEnv);
+            case CONSTRAINED_TYPE -> resolveTypeDesc((BLangConstrainedType) td, data);
+            case ARRAY_TYPE -> resolveTypeDesc(((BLangArrayType) td), data);
+            case TUPLE_TYPE_NODE -> resolveTypeDesc((BLangTupleTypeNode) td, data);
+            case RECORD_TYPE -> resolveTypeDesc((BLangRecordTypeNode) td, data);
+            case OBJECT_TYPE -> resolveTypeDesc((BLangObjectTypeNode) td, data);
+            case FUNCTION_TYPE -> resolveTypeDesc((BLangFunctionTypeNode) td, data);
+            case ERROR_TYPE -> resolveTypeDesc((BLangErrorType) td, data);
+            case UNION_TYPE_NODE -> resolveTypeDesc((BLangUnionTypeNode) td, data);
+            case INTERSECTION_TYPE_NODE -> resolveTypeDesc((BLangIntersectionTypeNode) td, data, true);
+            case USER_DEFINED_TYPE -> resolveTypeDesc((BLangUserDefinedType) td, data);
+            case BUILT_IN_REF_TYPE -> resolveTypeDesc((BLangBuiltInRefTypeNode) td, symEnv);
+            case FINITE_TYPE_NODE -> resolveSingletonType((BLangFiniteTypeNode) td, symEnv);
+            case TABLE_TYPE -> resolveTypeDesc((BLangTableTypeNode) td, data);
+            case STREAM_TYPE -> resolveTypeDesc((BLangStreamType) td, data);
+            default -> throw new AssertionError("Invalid type");
+        };
+        td.setBType(resultType);
+    }
+
     private BType resolveTypeDesc(SymbolEnv symEnv, BLangTypeDefinition defn, int depth,
                                   BLangType td, ResolverData data, boolean anonymous) {
         SymbolEnv prevEnv = data.env;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypesTest.java
@@ -69,6 +69,7 @@ import static io.ballerina.compiler.api.symbols.SymbolKind.ENUM_MEMBER;
 import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE_DEFINITION;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ANY;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ANYDATA;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.BYTE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.COMPILATION_ERROR;
@@ -80,6 +81,7 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.FUTURE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.HANDLE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.JSON;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.NEVER;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
@@ -151,6 +153,47 @@ public class TypesTest {
                 {types.BYTE, BYTE, BallerinaByteTypeSymbol.class},
                 {types.COMPILATION_ERROR, COMPILATION_ERROR, BallerinaCompilationErrorTypeSymbol.class},
                 {types.RAW_TEMPLATE, TYPE_REFERENCE, BallerinaTypeReferenceTypeSymbol.class}
+        };
+    }
+
+    @Test(dataProvider = "GetTypes")
+    public void testGetType(String text, TypeDescKind expectedKind) {
+        Optional<TypeSymbol> type = types.getType(text);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), expectedKind);
+    }
+
+    @DataProvider(name = "GetTypes")
+    private Object[][] getTypes() {
+        return new Object[][] {
+                {"string", STRING},
+                {"string?", UNION},
+                {"ExampleDec", TYPE_REFERENCE},
+                {"int", INT},
+                {"float", FLOAT},
+                {"boolean", BOOLEAN},
+                {"map<string>", MAP},
+                {"ExampleDec[]", ARRAY},
+                {"string|error", UNION},
+                {"function (string) returns int", FUNCTION},
+                {"any", ANY}
+        };
+    }
+
+    @Test(dataProvider = "InvalidGetTypes")
+    public void testInvalidGetType(String text) {
+        Optional<TypeSymbol> type = types.getType(text);
+        assertTrue(type.isEmpty());
+    }
+
+    @DataProvider(name = "InvalidGetTypes")
+    private Object[][] getInvalidTypes() {
+        return new Object[][] {
+                {"undefinedType"},
+                {"str"},
+                {"map<>"},
+                {"[]int"},
+                {"error|"}
         };
     }
 


### PR DESCRIPTION

The API allows users to obtain type symbols by providing text input of a type descriptor.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/43965

Remarks:

- Currently, it does not support anonymous types like records and objects.