### PR TITLE
[2201.12.x] Add a new API to get types using imported packages

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/Types.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/Types.java
@@ -116,17 +116,17 @@ public abstract class Types {
     /**
      * Parses a string representation of a Ballerina type descriptor into a {@link TypeSymbol}. Resolves types using
      * built-ins, the current module (via {@code document}), its existing imports, and the additionally provided
-     * {@code importPackages}.
+     * {@code importModules}.
      *
-     * @param document       The document for resolving types within the current module and its imports.
-     * @param text           The string representation of the Ballerina type descriptor.
-     * @param importPackages Additional packages (prefix -> package node) available for type resolution, that are not
-     *                       imported in the {@code document}.
+     * @param document      The document for resolving types within the current module and its imports.
+     * @param text          The string representation of the Ballerina type descriptor.
+     * @param importModules Additional modules that are not imported in the {@code document} can be defined with
+     *                      'module_prefix -> module', and are accounted for in type resolution.
      * @return An {@link Optional} containing the resolved {@link TypeSymbol}, or empty if parsing fails or the type is
      * not found/invalid within the combined scope.
      */
     public abstract Optional<TypeSymbol> getType(Document document, String text,
-                                                 Map<String, BLangPackage> importPackages);
+                                                 Map<String, BLangPackage> importModules);
 
     /**
      * Lookup for the symbol of a user defined type within a given module. This would be considering type

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/Types.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/Types.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.impl.symbols.TypesFactory;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.Document;
 import org.wso2.ballerinalang.compiler.PackageCache;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
@@ -100,14 +101,17 @@ public abstract class Types {
     }
 
     /**
-     * Parses a string representation of a Ballerina type descriptor into a {@link TypeSymbol}. Referenced named types
-     * within the {@code text} must be either built-in types or user-defined types declared within the current module.
+     * Parses a string representation of a Ballerina type descriptor into a {@link TypeSymbol}.
+     * Referenced named types within the {@code text} are resolved by searching built-in types,
+     * user-defined types declared within the current module (provided by the {@code document}),
+     * and types accessible via the import statements within that {@code document}.
      *
-     * @param text The string representation of the Ballerina type descriptor to parse.
+     * @param document The document used to resolve types within the current module and its imports.
+     * @param text     The string representation of the Ballerina type descriptor to parse.
      * @return An {@link Optional} containing the resolved {@link TypeSymbol}, or empty if parsing fails or the type is
-     * invalid in the current context.
+     * invalid or not found within the accessible scope.
      */
-    public abstract Optional<TypeSymbol> getType(String text);
+    public abstract Optional<TypeSymbol> getType(Document document, String text);
 
     /**
      * Lookup for the symbol of a user defined type within a given module. This would be considering type

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/Types.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/Types.java
@@ -114,6 +114,21 @@ public abstract class Types {
     public abstract Optional<TypeSymbol> getType(Document document, String text);
 
     /**
+     * Parses a string representation of a Ballerina type descriptor into a {@link TypeSymbol}. Resolves types using
+     * built-ins, the current module (via {@code document}), its existing imports, and the additionally provided
+     * {@code importPackages}.
+     *
+     * @param document       The document for resolving types within the current module and its imports.
+     * @param text           The string representation of the Ballerina type descriptor.
+     * @param importPackages Additional packages (prefix -> package node) available for type resolution, that are not
+     *                       imported in the {@code document}.
+     * @return An {@link Optional} containing the resolved {@link TypeSymbol}, or empty if parsing fails or the type is
+     * not found/invalid within the combined scope.
+     */
+    public abstract Optional<TypeSymbol> getType(Document document, String text,
+                                                 Map<String, BLangPackage> importPackages);
+
+    /**
      * Lookup for the symbol of a user defined type within a given module. This would be considering type
      * definitions, constants, enums, enum members, and class definitions as valid user defined types when looking up.
      * An empty Optional instance is returned if the provided module is not found or, if the given type is either

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaTypes.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaTypes.java
@@ -21,13 +21,16 @@ import io.ballerina.compiler.api.TypeBuilder;
 import io.ballerina.compiler.api.Types;
 import io.ballerina.compiler.api.impl.symbols.TypesFactory;
 import io.ballerina.compiler.api.impl.util.FieldMap;
+import io.ballerina.compiler.api.impl.util.SymbolUtils;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.NodeParser;
 import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
+import io.ballerina.projects.Document;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.symbols.SymbolOrigin;
+import org.ballerinalang.model.tree.NodeKind;
 import org.wso2.ballerinalang.compiler.parser.BLangNodeBuilder;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.TypeResolver;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope;
@@ -35,8 +38,11 @@ import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
 import org.wso2.ballerinalang.compiler.tree.types.BLangType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
@@ -53,14 +59,11 @@ import java.util.Optional;
  */
 public class BallerinaTypes extends Types {
 
-    private static final String COMPILATION_UNIT_NAME = "$types$compilation-unit$";
-    private final BLangNodeBuilder bLangNodeBuilder;
     private final TypeResolver typeResolver;
 
     public BallerinaTypes(BLangPackage bLangPackage, CompilerContext context) {
         super(bLangPackage, context);
         context.put(TYPES_KEY, this);
-        this.bLangNodeBuilder = new BLangNodeBuilder(context, bLangPackage.packageID, COMPILATION_UNIT_NAME);
         this.typeResolver = TypeResolver.getInstance(context);
     }
 
@@ -68,29 +71,46 @@ public class BallerinaTypes extends Types {
      * {@inheritDoc}
      */
     @Override
-    public Optional<TypeSymbol> getType(String text) {
+    public Optional<TypeSymbol> getType(Document document, String text) {
         // Obtain the ST node
         TypeDescriptorNode typeDescriptorNode = NodeParser.parseTypeDescriptor(text);
         if (typeDescriptorNode == null || typeDescriptorNode.hasDiagnostics()) {
             return Optional.empty();
         }
 
-        // Obtain the AST node
-        BLangNode bLangNode = typeDescriptorNode.apply(bLangNodeBuilder);
-        if (!(bLangNode instanceof BLangType)) {
+        // Obtain the compilation unit
+        Optional<BLangCompilationUnit> compilationUnit = SymbolUtils.getCompilationUnit(bLangPackage, document);
+        if (compilationUnit.isEmpty()) {
             return Optional.empty();
         }
 
-        // Resolve the type
+        // Obtain the AST node
+        BLangNodeBuilder bLangNodeBuilder =
+                new BLangNodeBuilder(context, bLangPackage.packageID, compilationUnit.get().getName());
         SymbolEnv pkgEnv = symbolTable.pkgEnvMap.get(bLangPackage.symbol);
-        try {
-            typeResolver.resolveTypeDesc((BLangType) bLangNode, pkgEnv);
-        } catch (Throwable ignored) {
+        BLangNode bLangNode = typeDescriptorNode.apply(bLangNodeBuilder);
+
+        // Resolve the type
+        BType resolvedType;
+        if (bLangNode.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
+            BLangSimpleVarRef simpleVarRef = (BLangSimpleVarRef) bLangNode;
+            BSymbol symbolOfVarRef = typeResolver.getSymbolOfVarRef(simpleVarRef.pos, pkgEnv,
+                    Names.fromString(simpleVarRef.pkgAlias.value),
+                    Names.fromString(simpleVarRef.variableName.value));
+            resolvedType = symbolOfVarRef.type;
+        } else if (bLangNode instanceof BLangType bLangType) {
+            try {
+                typeResolver.resolveTypeDesc(bLangType, pkgEnv);
+                resolvedType = bLangType.getBType();
+            } catch (Throwable ignored) {
+                return Optional.empty();
+            }
+        } else {
             return Optional.empty();
         }
 
         // Generate the type symbol
-        return Optional.of(TypesFactory.getInstance(context).getTypeDescriptor(bLangNode.getBType()));
+        return Optional.of(TypesFactory.getInstance(context).getTypeDescriptor(resolvedType));
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaTypes.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaTypes.java
@@ -88,7 +88,7 @@ public class BallerinaTypes extends Types {
      * {@inheritDoc}
      */
     @Override
-    public Optional<TypeSymbol> getType(Document document, String text, Map<String, BLangPackage> importPackages) {
+    public Optional<TypeSymbol> getType(Document document, String text, Map<String, BLangPackage> importModules) {
         // Obtain the compilation unit
         Optional<BLangCompilationUnit> compilationUnit = SymbolUtils.getCompilationUnit(bLangPackage, document);
         if (compilationUnit.isEmpty()) {
@@ -98,7 +98,7 @@ public class BallerinaTypes extends Types {
         // Define the packages in the environment
         SymbolEnv pkgEnv = symbolTable.pkgEnvMap.get(bLangPackage.symbol);
         Name compUnitName = Names.fromString(compilationUnit.get().getName());
-        importPackages.forEach((prefix, importPackage) -> {
+        importModules.forEach((prefix, importPackage) -> {
             importPackage.symbol.compUnit = compUnitName;
             pkgEnv.scope.define(Names.fromString(prefix), importPackage.symbol);
         });

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/util/SymbolUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/util/SymbolUtils.java
@@ -31,15 +31,22 @@ import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.identifier.Utils;
+import io.ballerina.projects.Document;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
+import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Common util methods related to symbols.
@@ -100,5 +107,34 @@ public final class SymbolUtils {
              case ERROR -> null;
              default -> null;
          };
+    }
+
+    /**
+     * Gets the compilation unit for a given source file document within a package.
+     * @see #getCompilationUnit(BLangPackage, String)
+     *
+     * @param bLangPackage The package to search within.
+     * @param srcFile      The source file document.
+     * @return Optional containing the compilation unit if found, empty otherwise.
+     */
+    public static Optional<BLangCompilationUnit> getCompilationUnit(BLangPackage bLangPackage, Document srcFile) {
+        return getCompilationUnit(bLangPackage, srcFile.name());
+    }
+
+    /**
+     * Finds a compilation unit by its name within a package, including its testable packages.
+     *
+     * @param bLangPackage The package to search within.
+     * @param srcFile      The name of the source file to find.
+     * @return Optional containing the compilation unit if found, empty otherwise.
+     */
+    public static Optional<BLangCompilationUnit> getCompilationUnit(BLangPackage bLangPackage, String srcFile) {
+        List<BLangCompilationUnit> testSrcs = new ArrayList<>();
+        for (BLangTestablePackage pkg : bLangPackage.testablePkgs) {
+            testSrcs.addAll(pkg.compUnits);
+        }
+
+        Stream<BLangCompilationUnit> units = Stream.concat(bLangPackage.compUnits.stream(), testSrcs.stream());
+        return units.filter(unit -> unit.name.equals(srcFile)).findFirst();
     }
 }


### PR DESCRIPTION
## Purpose


This PR enhances the getType API by allowing users to specify additional modules for type resolution, even when those modules aren't imported in the files.

Part of https://github.com/ballerina-platform/ballerina-lang/issues/43965