### PR TITLE
[2201.12.x] Create the `Dependencies.toml` file if it doesn't exist in a build project

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
@@ -1429,6 +1429,10 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
                     .build();
             if (projectKind == ProjectKind.BUILD_PROJECT) {
                 project = BuildProject.load(projectRoot, options);
+                // Create a dependencies toml if not exists
+                if (project.currentPackage().dependenciesToml().isEmpty()) {
+                    project.save();
+                }
             } else if (projectKind == ProjectKind.SINGLE_FILE_PROJECT) {
                 project = SingleFileProject.load(projectRoot, options);
             } else {


### PR DESCRIPTION
## Purpose

$title to ensure that the `Dependencies.toml` exists throughout the LS.