### PR TITLE
[2201.12.x] Save the `Dependencies.toml` when the `optimizeDependencyCompilation` flag is set

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
@@ -83,6 +83,10 @@ public class BuildOptions {
         return this.compilationOptions.disableSyntaxTree();
     }
 
+    public boolean optimizeDependencyCompilation() {
+        return this.compilationOptions.optimizeDependencyCompilation();
+    }
+
     /**
      * Checks whether experimental compilation option is set.
      *

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
@@ -1429,8 +1429,15 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
                     .build();
             if (projectKind == ProjectKind.BUILD_PROJECT) {
                 project = BuildProject.load(projectRoot, options);
-                // Create a dependencies toml if not exists
-                if (project.currentPackage().dependenciesToml().isEmpty()) {
+
+                // TODO: Remove this once https://github.com/ballerina-platform/ballerina-lang/issues/43972 is resolved
+                // Save the dependencies.toml to resolve the inconsistencies issue in the subsequent builds
+                if (project.currentPackage().dependenciesToml().isEmpty() && project.buildOptions().optimizeDependencyCompilation()) {
+                    BuildOptions newOptions = BuildOptions.builder()
+                            .setOffline(CommonUtil.COMPILE_OFFLINE)
+                            .setSticky(false)
+                            .build();
+                    project = BuildProject.load(projectRoot, newOptions);
                     project.save();
                 }
             } else if (projectKind == ProjectKind.SINGLE_FILE_PROJECT) {


### PR DESCRIPTION
## Purpose
$title for the first compilation as a workaround from the LS for the issue: https://github.com/ballerina-platform/ballerina-lang/issues/43972