### PR TITLE
[2201.12.x] Improve the pulling modules UX in the language server

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
@@ -83,6 +83,10 @@ public class BuildOptions {
         return this.compilationOptions.disableSyntaxTree();
     }
 
+    public boolean optimizeDependencyCompilation() {
+        return this.compilationOptions.optimizeDependencyCompilation();
+    }
+
     /**
      * Checks whether experimental compilation option is set.
      *

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -26,13 +26,15 @@ import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.common.utils.PathUtil;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.ExecuteCommandContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
 import org.ballerinalang.langserver.commons.command.CommandArgument;
 import org.ballerinalang.langserver.commons.command.spi.LSCommandExecutor;
 import org.ballerinalang.langserver.commons.eventsync.EventKind;
+import org.ballerinalang.langserver.commons.eventsync.exceptions.EventSyncException;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.ballerinalang.langserver.contexts.ContextBuilder;
-import org.ballerinalang.langserver.diagnostic.DiagnosticsHelper;
 import org.ballerinalang.langserver.eventsync.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.exception.UserErrorException;
 import org.ballerinalang.langserver.workspace.BallerinaWorkspaceManager;
@@ -43,6 +45,7 @@ import org.eclipse.lsp4j.ProgressParams;
 import org.eclipse.lsp4j.WorkDoneProgressBegin;
 import org.eclipse.lsp4j.WorkDoneProgressCreateParams;
 import org.eclipse.lsp4j.WorkDoneProgressEnd;
+import org.eclipse.lsp4j.WorkDoneProgressReport;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import java.nio.file.Path;
@@ -60,7 +63,7 @@ import java.util.concurrent.CompletableFuture;
 public class PullModuleExecutor implements LSCommandExecutor {
 
     public static final String COMMAND = "PULL_MODULE";
-    
+
     private static final String TITLE_PULL_MODULE = "Pull Module";
 
     /**
@@ -83,18 +86,20 @@ public class PullModuleExecutor implements LSCommandExecutor {
                 default:
             }
         }
+        resolveModules(fileUri, context.getLanguageClient(), context.workspace(), context.languageServercontext());
+        return new Object();
+    }
 
+    public static void resolveModules(String fileUri, ExtendedLanguageClient languageClient,
+                                      WorkspaceManager workspaceManager, LanguageServerContext languageServerContext) {
         // TODO Prevent running parallel tasks for the same project in future
         String taskId = UUID.randomUUID().toString();
         Path filePath = PathUtil.getPathFromURI(fileUri)
                 .orElseThrow(() -> new UserErrorException("Couldn't determine file path"));
-
-        Project project = context.workspace().project(filePath)
+        Project project = workspaceManager.project(filePath)
                 .orElseThrow(() -> new UserErrorException("Couldn't find project to pull modules"));
 
-        ExtendedLanguageClient languageClient = context.getLanguageClient();
-        LSClientLogger clientLogger = LSClientLogger.getInstance(context.languageServercontext());
-        String finalFileUri = fileUri;
+        LSClientLogger clientLogger = LSClientLogger.getInstance(languageServerContext);
         CompletableFuture
                 .runAsync(() -> {
                     clientLogger.logTrace("Started pulling modules for project: " + project.sourceRoot().toString());
@@ -108,7 +113,7 @@ public class PullModuleExecutor implements LSCommandExecutor {
                     WorkDoneProgressBegin beginNotification = new WorkDoneProgressBegin();
                     beginNotification.setTitle(TITLE_PULL_MODULE);
                     beginNotification.setCancellable(false);
-                    beginNotification.setMessage("pulling missing ballerina modules");
+                    beginNotification.setMessage("pulling the missing ballerina modules");
                     languageClient.notifyProgress(new ProgressParams(Either.forLeft(taskId),
                             Either.forLeft(beginNotification)));
                 })
@@ -116,20 +121,33 @@ public class PullModuleExecutor implements LSCommandExecutor {
                 .thenRunAsync(() -> {
                     try {
                         // Refresh project
-                        ((BallerinaWorkspaceManager) context.workspace()).refreshProject(filePath);
+                        ((BallerinaWorkspaceManager) workspaceManager).refreshProject(filePath);
                     } catch (WorkspaceDocumentException e) {
                         throw new UserErrorException("Failed to refresh project");
                     }
                 })
                 .thenRunAsync(() -> {
-                    DocumentServiceContext docContext = ContextBuilder.buildDocumentServiceContext(finalFileUri,
-                            context.workspace(), LSContextOperation.TXT_DID_CHANGE,
-                            context.languageServercontext());
-                    DiagnosticsHelper.getInstance(context.languageServercontext())
-                            .schedulePublishDiagnostics(languageClient, docContext);
+                    DocumentServiceContext docContext = ContextBuilder.buildDocumentServiceContext(
+                            fileUri,
+                            workspaceManager,
+                            LSContextOperation.RELOAD_PROJECT,
+                            languageServerContext);
+                    try {
+                        EventSyncPubSubHolder.getInstance(languageServerContext)
+                                .getPublisher(EventKind.PROJECT_UPDATE)
+                                .publish(languageClient, languageServerContext, docContext);
+                    } catch (EventSyncException e) {
+                        // ignore
+                    }
                 })
                 .thenRunAsync(() -> {
-                    Optional<List<String>> missingModules = context.workspace()
+                    WorkDoneProgressReport workDoneProgressReport = new WorkDoneProgressReport();
+                    workDoneProgressReport.setCancellable(false);
+                    workDoneProgressReport.setMessage("compiling the project");
+                    languageClient.notifyProgress(new ProgressParams(Either.forLeft(taskId),
+                            Either.forLeft(workDoneProgressReport)));
+
+                    Optional<List<String>> missingModules = workspaceManager
                             .waitAndGetPackageCompilation(filePath)
                             .map(compilation -> compilation.diagnosticResult().diagnostics().stream()
                                     .filter(diagnostic -> DiagnosticErrorCode.MODULE_NOT_FOUND.diagnosticId()
@@ -163,14 +181,15 @@ public class PullModuleExecutor implements LSCommandExecutor {
                         CommandUtil.notifyClient(languageClient, MessageType.Info, "Module(s) pulled successfully!");
                         clientLogger
                                 .logTrace("Finished pulling modules for project: " + project.sourceRoot().toString());
+
                         try {
-                            DocumentServiceContext documentServiceContext = 
-                                    ContextBuilder.buildDocumentServiceContext(filePath.toUri().toString(), 
-                                            context.workspace(), LSContextOperation.WS_EXEC_CMD,
-                                            context.languageServercontext());
-                            EventSyncPubSubHolder.getInstance(context.languageServercontext())
+                            DocumentServiceContext documentServiceContext =
+                                    ContextBuilder.buildDocumentServiceContext(filePath.toUri().toString(),
+                                            workspaceManager, LSContextOperation.WS_EXEC_CMD,
+                                            languageServerContext);
+                            EventSyncPubSubHolder.getInstance(languageServerContext)
                                     .getPublisher(EventKind.PULL_MODULE)
-                                    .publish(languageClient, context.languageServercontext(), documentServiceContext);
+                                    .publish(languageClient, languageServerContext, documentServiceContext);
                         } catch (Throwable e) {
                             //ignore
                         }
@@ -185,8 +204,6 @@ public class PullModuleExecutor implements LSCommandExecutor {
                     languageClient.notifyProgress(new ProgressParams(Either.forLeft(taskId),
                             Either.forLeft(endNotification)));
                 });
-
-        return new Object();
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.common.utils;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
@@ -128,6 +129,7 @@ public final class CommonUtil {
             SyntaxKind.PUBLIC_KEYWORD, SyntaxKind.PRIVATE_KEYWORD, SyntaxKind.CONFIGURABLE_KEYWORD);
 
     private static final Pattern TYPE_NAME_DECOMPOSE_PATTERN = Pattern.compile("([\\w_.]*)/([\\w._]*):([\\w.-]*)");
+    private static final String UNRESOLVED_MODULE_CODE = "BCE2003";
 
     static {
         BALLERINA_HOME = System.getProperty("ballerina.home");
@@ -775,6 +777,17 @@ public final class CommonUtil {
                         diagnostics.contains(diagnostic.diagnosticInfo().code()) &&
                         PositionUtil.isWithinLineRange(diagnostic.location().lineRange(), node.lineRange())) &&
                 currentDiagnostic.diagnosticInfo().code().equals(prioritizedDiagnostic);
+    }
+
+    /**
+     * Checks if there are unresolved modules in the given semantic model.
+     *
+     * @param semanticModel The semantic model to check for unresolved modules.
+     * @return {@code true} if there are unresolved modules, {@code false} otherwise.
+     */
+    public static boolean hasUnresolvedModules(SemanticModel semanticModel) {
+        return semanticModel.diagnostics().stream()
+                .anyMatch(diagnostic -> UNRESOLVED_MODULE_CODE.equals(diagnostic.diagnosticInfo().code()));
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/EventSyncPubSubHolder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/EventSyncPubSubHolder.java
@@ -42,8 +42,8 @@ public class EventSyncPubSubHolder {
 
     private EventSyncPubSubHolder(LanguageServerContext serverContext) {
         LSClientLogger lsClientLogger = LSClientLogger.getInstance(serverContext);
-        serverContext.put(SUBSCRIBERS_HOLDER_KEY, this);
         initialize(lsClientLogger);
+        serverContext.put(SUBSCRIBERS_HOLDER_KEY, this);
     }
 
     private void initialize(LSClientLogger lsClientLogger) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/ResolveModulesSubscriber.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/ResolveModulesSubscriber.java
@@ -21,6 +21,7 @@ package org.ballerinalang.langserver.eventsync.subscribers;
 import io.ballerina.compiler.api.SemanticModel;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.command.executors.PullModuleExecutor;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
@@ -42,7 +43,6 @@ import java.util.Optional;
 public class ResolveModulesSubscriber implements EventSubscriber {
 
     public static final String NAME = "Resolve modules subscriber";
-    private static final String UNRESOLVED_MODULE_CODE = "BCE2003";
     private static final String PULL_MODULES_ACTION = "Pull Modules";
 
     @Override
@@ -58,9 +58,7 @@ public class ResolveModulesSubscriber implements EventSubscriber {
             return;
         }
 
-        boolean hasUnresolvedModules = semanticModel.get().diagnostics().stream()
-                .anyMatch(diagnostic -> UNRESOLVED_MODULE_CODE.equals(diagnostic.diagnosticInfo().code()));
-        if (!hasUnresolvedModules) {
+        if (!CommonUtil.hasUnresolvedModules(semanticModel.get())) {
             return;
         }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/ResolveModulesSubscriber.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/ResolveModulesSubscriber.java
@@ -20,9 +20,11 @@ package org.ballerinalang.langserver.eventsync.subscribers;
 
 import io.ballerina.compiler.api.SemanticModel;
 import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.command.executors.PullModuleExecutor;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
+import org.ballerinalang.langserver.commons.LSOperation;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
 import org.ballerinalang.langserver.commons.eventsync.EventKind;
@@ -35,7 +37,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Publisher to popup notification and resolve the missing dependencies on project updates
+ * Publisher to popup notification and resolve the missing dependencies on project updates.
  *
  * @since 2201.12.3
  */
@@ -53,6 +55,13 @@ public class ResolveModulesSubscriber implements EventSubscriber {
     @Override
     public void onEvent(ExtendedLanguageClient client, DocumentServiceContext context,
                         LanguageServerContext serverContext) {
+        // Do this only for the load project or did open
+        // TODO: Explore the UX on how we can provide this for each `didChange` with a proper interval
+        LSOperation operation = context.operation();
+        if (!operation.equals(LSContextOperation.LOAD_PROJECT) && !operation.equals(LSContextOperation.TXT_DID_OPEN)) {
+            return;
+        }
+
         Optional<SemanticModel> semanticModel = context.currentSemanticModel();
         if (semanticModel.isEmpty()) {
             return;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/ResolveModulesSubscriber.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/ResolveModulesSubscriber.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.eventsync.subscribers;
+
+import io.ballerina.compiler.api.SemanticModel;
+import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.command.executors.PullModuleExecutor;
+import org.ballerinalang.langserver.commons.DocumentServiceContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
+import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
+import org.ballerinalang.langserver.commons.eventsync.EventKind;
+import org.ballerinalang.langserver.commons.eventsync.spi.EventSubscriber;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Publisher to popup notification and resolve the missing dependencies on project updates
+ *
+ * @since 2201.12.3
+ */
+@JavaSPIService("org.ballerinalang.langserver.commons.eventsync.spi.EventSubscriber")
+public class ResolveModulesSubscriber implements EventSubscriber {
+
+    public static final String NAME = "Resolve modules subscriber";
+    private static final String UNRESOLVED_MODULE_CODE = "BCE2003";
+    private static final String PULL_MODULES_ACTION = "Pull Modules";
+
+    @Override
+    public EventKind eventKind() {
+        return EventKind.PROJECT_UPDATE;
+    }
+
+    @Override
+    public void onEvent(ExtendedLanguageClient client, DocumentServiceContext context,
+                        LanguageServerContext serverContext) {
+        Optional<SemanticModel> semanticModel = context.currentSemanticModel();
+        if (semanticModel.isEmpty()) {
+            return;
+        }
+
+        boolean hasUnresolvedModules = semanticModel.get().diagnostics().stream()
+                .anyMatch(diagnostic -> UNRESOLVED_MODULE_CODE.equals(diagnostic.diagnosticInfo().code()));
+        if (!hasUnresolvedModules) {
+            return;
+        }
+
+        ShowMessageRequestParams showMessageRequestParams = new ShowMessageRequestParams();
+        showMessageRequestParams.setType(MessageType.Warning);
+        showMessageRequestParams.setMessage(
+                "There are unresolved modules in your project. Some of the features may not work as expected.");
+        showMessageRequestParams.setActions(List.of(new MessageActionItem(PULL_MODULES_ACTION)));
+
+        client.showMessageRequest(showMessageRequestParams).thenAccept(action -> {
+            if (action != null && PULL_MODULES_ACTION.equals(action.getTitle())) {
+                PullModuleExecutor.resolveModules(context.fileUri(), client, context.workspace(),
+                        context.languageServercontext());
+            }
+        });
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentService.java
@@ -26,7 +26,6 @@ import io.ballerina.projects.Document;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
-import io.ballerina.projects.util.DependencyUtils;
 import io.ballerina.syntaxapicallsgen.SyntaxApiCallsGen;
 import io.ballerina.syntaxapicallsgen.config.SyntaxApiCallsGenConfig;
 import io.ballerina.tools.text.LinePosition;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
@@ -1429,8 +1429,15 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
                     .build();
             if (projectKind == ProjectKind.BUILD_PROJECT) {
                 project = BuildProject.load(projectRoot, options);
-                // Create a dependencies toml if not exists
-                if (project.currentPackage().dependenciesToml().isEmpty()) {
+
+                // TODO: Remove this once https://github.com/ballerina-platform/ballerina-lang/issues/43972 is resolved
+                // Save the dependencies.toml to resolve the inconsistencies issue in the subsequent builds
+                if (project.currentPackage().dependenciesToml().isEmpty() && project.buildOptions().optimizeDependencyCompilation()) {
+                    BuildOptions newOptions = BuildOptions.builder()
+                            .setOffline(CommonUtil.COMPILE_OFFLINE)
+                            .setSticky(false)
+                            .build();
+                    project = BuildProject.load(projectRoot, newOptions);
                     project.save();
                 }
             } else if (projectKind == ProjectKind.SINGLE_FILE_PROJECT) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
@@ -1450,13 +1450,12 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
 
                 // TODO: Remove this once https://github.com/ballerina-platform/ballerina-lang/issues/43972 is resolved
                 // Save the dependencies.toml to resolve the inconsistencies issue in the subsequent builds
-                if (project.currentPackage().dependenciesToml().isEmpty() && project.buildOptions().optimizeDependencyCompilation()) {
+                if (project.buildOptions().optimizeDependencyCompilation()) {
                     BuildOptions newOptions = BuildOptions.builder()
                             .setOffline(CommonUtil.COMPILE_OFFLINE)
                             .setSticky(false)
                             .build();
                     project = BuildProject.load(projectRoot, newOptions);
-                    project.save();
                 }
             } else if (projectKind == ProjectKind.SINGLE_FILE_PROJECT) {
                 project = SingleFileProject.load(projectRoot, options);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
@@ -50,7 +50,6 @@ import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.ballerinalang.langserver.BallerinaLanguageServer;
 import org.ballerinalang.langserver.LSClientLogger;
 import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
@@ -101,6 +100,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -133,6 +133,12 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
      * Mapping of source root to project instance.
      */
     protected final Map<Path, ProjectContext> sourceRootToProject;
+    /**
+     * TODO: This should be combined with the project context lock. The current implementation of the project context
+     *  lock does not consider the first compilation (before creating the project context).
+     */
+    private final Map<Path, Lock> projectLockMap;
+
     protected final LSClientLogger clientLogger;
     private final LanguageServerContext serverContext;
     private final Set<Path> openedDocuments = new HashSet<>();
@@ -146,6 +152,7 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
                 .build();
         this.pathToSourceRootCache = cache.asMap();
         this.sourceRootToProject = new SourceRootToProjectMap<>(pathToSourceRootCache);
+        this.projectLockMap = new ConcurrentHashMap<>();
 
         // We are only doing a best effort cleanup here. If we held a strong reference to the map
         // GC will not be able to clean the projects. It impacts tests since all run in the same JVM.
@@ -210,25 +217,30 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
      */
     @Override
     public Project loadProject(Path filePath) throws ProjectException, WorkspaceDocumentException, EventSyncException {
-        Project project;
         Optional<Project> optionalProject = project(filePath);
-
         if (optionalProject.isPresent()) {
-            project = optionalProject.get();
-        } else {
-            project = createOrGetProjectPair(filePath, LSContextOperation.LOAD_PROJECT.getName()).project();
+            return optionalProject.get();
+        }
 
-            BallerinaLanguageServer languageServer = new BallerinaLanguageServer();
+        Lock projectLock = projectLockMap.computeIfAbsent(projectRoot(filePath), k -> new ReentrantLock());
+        projectLock.lock();
+        try {
+            optionalProject = project(filePath);
+            if (optionalProject.isPresent()) {
+                return optionalProject.get();
+            }
+            Project project = createOrGetProjectPair(filePath, LSContextOperation.LOAD_PROJECT.getName()).project();
             DocumentServiceContext context = ContextBuilder.buildDocumentServiceContext(
                     filePath.toUri().toString(),
-                    languageServer.getWorkspaceManager(),
+                    this,
                     LSContextOperation.LOAD_PROJECT, this.serverContext);
             EventSyncPubSubHolder.getInstance(this.serverContext)
                     .getPublisher(EventKind.PROJECT_UPDATE)
-                    .publish(languageServer.getClient(), this.serverContext, context);
+                    .publish(this.serverContext.get(ExtendedLanguageClient.class), this.serverContext, context);
+            return project;
+        } finally {
+            projectLock.unlock();
         }
-
-        return project;
     }
 
     /**
@@ -245,6 +257,12 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
         }
         Optional<Document> document = document(filePath, project.get(), null);
         if (document.isEmpty()) {
+            // If the file path points to the project root, then return the default module
+            // TODO: Need to extend this to support module paths once we have an API to obtain the module root from
+            //  the given file path
+            if (filePath.equals(this.projectRoot(filePath))) {
+                return Optional.of(project.get().currentPackage().getDefaultModule());
+            }
             return Optional.empty();
         }
         return Optional.of(document.get().module());
@@ -1662,8 +1680,8 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
      * Represents a map of Path to ProjectContext.
      *
      * @param <K> cache key
-     * @param <V> cache value
-     *            Clear out front-faced cache implementation whenever a modification operation triggered for this map.
+     * @param <V> cache value Clear out front-faced cache implementation whenever a modification operation triggered for
+     *            this map.
      */
     private static class SourceRootToProjectMap<K, V> extends HashMap<K, V> {
 


### PR DESCRIPTION
## Purpose
The PR addresses the following improvements along with some bug fixes:

1. Provides a notification at startup to pull modules if there are unresolved modules
2. Ensures that resolve dependencies only pull modules when the respective diagnostic is found.
3. The compilation builds with the sticky flag disabled if the optimizeDependencyCompilation flag is set as a workaround for issue [[#43972](https://github.com/ballerina-platform/ballerina-lang/issues/43972)](https://github.com/ballerina-platform/ballerina-lang/issues/43972)
4. Fixes race conditions happening in the load project API
5. Removed zombie language server instances occurring before event sync
6. Fixes inconsistencies in the event pub-sub implementation

Fixes https://github.com/wso2/product-ballerina-integrator/issues/109

## Samples
https://github.com/user-attachments/assets/5f9a98b1-ad93-43d2-9d59-367c424273ae