### PR TITLE
Provide `lockingMode` compiler option

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -210,6 +210,10 @@ public class BuildCommand implements BLauncherCmd {
             description = "experimental memory optimization for large projects")
     private Boolean optimizeDependencyCompilation;
 
+    @CommandLine.Option(names = "--locking-mode", hidden = true,
+            description = "allow passing the package locking mode.")
+    private String lockingMode;
+
     @Override
     public void execute() {
         long start = 0;
@@ -326,7 +330,8 @@ public class BuildCommand implements BLauncherCmd {
                 .disableSyntaxTreeCaching(disableSyntaxTreeCaching)
                 .setGraalVMBuildOptions(graalVMBuildOptions)
                 .setShowDependencyDiagnostics(showDependencyDiagnostics)
-                .setOptimizeDependencyCompilation(optimizeDependencyCompilation);
+                .setOptimizeDependencyCompilation(optimizeDependencyCompilation)
+                .setLockingMode(lockingMode);
 
         if (targetDir != null) {
             buildOptionsBuilder.targetDir(targetDir.toString());

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
@@ -99,6 +99,10 @@ public class PackCommand implements BLauncherCmd {
             description = "experimental memory optimization for large projects")
     private Boolean optimizeDependencyCompilation;
 
+    @CommandLine.Option(names = "--locking-mode", hidden = true,
+            description = "allow passing the package locking mode.")
+    private String lockingMode;
+
     public PackCommand() {
         this.projectPath = Path.of(System.getProperty(ProjectConstants.USER_DIR));
         this.outStream = System.out;
@@ -289,7 +293,8 @@ public class PackCommand implements BLauncherCmd {
                 .setEnableCache(enableCache)
                 .disableSyntaxTreeCaching(disableSyntaxTreeCaching)
                 .setShowDependencyDiagnostics(showDependencyDiagnostics)
-                .setOptimizeDependencyCompilation(optimizeDependencyCompilation);
+                .setOptimizeDependencyCompilation(optimizeDependencyCompilation)
+                .setLockingMode(lockingMode);
 
         if (targetDir != null) {
             buildOptionsBuilder.targetDir(targetDir.toString());

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -134,6 +134,10 @@ public class RunCommand implements BLauncherCmd {
             description = "experimental memory optimization for large projects")
     private Boolean optimizeDependencyCompilation;
 
+    @CommandLine.Option(names = "--locking-mode", hidden = true,
+            description = "allow passing the package locking mode.")
+    private String lockingMode;
+
     private static final String runCmd =
             """
                     bal run [--debug <port>] <executable-jar>\s
@@ -353,7 +357,8 @@ public class RunCommand implements BLauncherCmd {
                 .disableSyntaxTreeCaching(disableSyntaxTreeCaching)
                 .setDumpBuildTime(dumpBuildTime)
                 .setShowDependencyDiagnostics(showDependencyDiagnostics)
-                .setOptimizeDependencyCompilation(optimizeDependencyCompilation);
+                .setOptimizeDependencyCompilation(optimizeDependencyCompilation)
+                .setLockingMode(lockingMode);
 
         if (targetDir != null) {
             buildOptionsBuilder.targetDir(targetDir.toString());

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -223,6 +223,10 @@ public class TestCommand implements BLauncherCmd {
             description = "experimental memory optimization for large projects")
     private Boolean optimizeDependencyCompilation;
 
+    @CommandLine.Option(names = "--locking-mode", hidden = true,
+            description = "allow passing the package locking mode.")
+    private String lockingMode;
+
     private static final String testCmd = "bal test [--OPTIONS]\n" +
             "                   [<ballerina-file> | <package-path>] [(-Ckey=value)...]";
 
@@ -429,7 +433,8 @@ public class TestCommand implements BLauncherCmd {
                 .disableSyntaxTreeCaching(disableSyntaxTreeCaching)
                 .setGraalVMBuildOptions(graalVMBuildOptions)
                 .setShowDependencyDiagnostics(showDependencyDiagnostics)
-                .setOptimizeDependencyCompilation(optimizeDependencyCompilation);
+                .setOptimizeDependencyCompilation(optimizeDependencyCompilation)
+                .setLockingMode(lockingMode);
 
         if (targetDir != null) {
             buildOptionsBuilder.targetDir(targetDir.toString());

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
@@ -51,7 +51,6 @@ public class BuildOptions {
         this.exportComponentModel = exportComponentModel;
         this.graalVMBuildOptions = graalVMBuildOptions;
         this.showDependencyDiagnostics = showDependencyDiagnostics;
-
     }
 
     public boolean testReport() {
@@ -213,6 +212,7 @@ public class BuildOptions {
         buildOptionsBuilder.setEnableCache(compilationOptions.enableCache);
         buildOptionsBuilder.setRemoteManagement(compilationOptions.remoteManagement);
         buildOptionsBuilder.setOptimizeDependencyCompilation(compilationOptions.optimizeDependencyCompilation);
+        buildOptionsBuilder.setLockingMode(compilationOptions.lockingMode);
 
         return buildOptionsBuilder.build();
     }
@@ -425,6 +425,11 @@ public class BuildOptions {
          */
         public BuildOptionsBuilder setOptimizeDependencyCompilation(Boolean value) {
             compilationOptionsBuilder.setOptimizeDependencyCompilation(value);
+            return this;
+        }
+
+        public BuildOptionsBuilder setLockingMode(String value) {
+            compilationOptionsBuilder.setLockingMode(value);
             return this;
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptions.java
@@ -41,13 +41,14 @@ public class CompilationOptions {
     Boolean disableSyntaxTree;
     Boolean remoteManagement;
     Boolean optimizeDependencyCompilation;
+    String lockingMode;
 
     CompilationOptions(Boolean offlineBuild, Boolean observabilityIncluded, Boolean dumpBir,
                        Boolean dumpBirFile, String cloud, Boolean listConflictedClasses, Boolean sticky,
                        Boolean dumpGraph, Boolean dumpRawGraphs, Boolean withCodeGenerators,
                        Boolean withCodeModifiers, Boolean configSchemaGen, Boolean exportOpenAPI,
                        Boolean exportComponentModel, Boolean enableCache, Boolean disableSyntaxTree,
-                       Boolean remoteManagement, Boolean optimizeDependencyCompilation) {
+                       Boolean remoteManagement, Boolean optimizeDependencyCompilation, String lockingMode) {
         this.offlineBuild = offlineBuild;
         this.observabilityIncluded = observabilityIncluded;
         this.dumpBir = dumpBir;
@@ -66,6 +67,7 @@ public class CompilationOptions {
         this.disableSyntaxTree = disableSyntaxTree;
         this.remoteManagement = remoteManagement;
         this.optimizeDependencyCompilation = optimizeDependencyCompilation;
+        this.lockingMode = lockingMode;
     }
 
     public boolean offlineBuild() {
@@ -134,6 +136,10 @@ public class CompilationOptions {
 
     boolean optimizeDependencyCompilation() {
         return toBooleanDefaultIfNull(this.optimizeDependencyCompilation);
+    }
+
+    public String lockingMode() {
+        return toStringDefaultIfNull(this.lockingMode);
     }
 
     /**
@@ -229,6 +235,11 @@ public class CompilationOptions {
         } else {
             compilationOptionsBuilder.setOptimizeDependencyCompilation(this.optimizeDependencyCompilation);
         }
+        if (theirOptions.lockingMode != null) {
+            compilationOptionsBuilder.setLockingMode(theirOptions.lockingMode);
+        } else {
+            compilationOptionsBuilder.setLockingMode(this.lockingMode);
+        }
         return compilationOptionsBuilder.build();
     }
 
@@ -285,6 +296,8 @@ public class CompilationOptions {
         private Boolean disableSyntaxTree;
         private Boolean remoteManagement;
         private Boolean optimizeDependencyCompilation;
+        // TODO: remove this after fixing https://github.com/ballerina-platform/ballerina-library/issues/7755
+        private String lockingMode;
 
         public CompilationOptionsBuilder setOffline(Boolean value) {
             offline = value;
@@ -376,12 +389,17 @@ public class CompilationOptions {
             return this;
         }
 
+        public CompilationOptionsBuilder setLockingMode(String value) {
+            lockingMode = value;
+            return this;
+        }
+
         public CompilationOptions build() {
             return new CompilationOptions(offline, observabilityIncluded, dumpBir,
                     dumpBirFile, cloud, listConflictedClasses, sticky, dumpGraph, dumpRawGraph,
                     withCodeGenerators, withCodeModifiers, configSchemaGen, exportOpenAPI,
                     exportComponentModel, enableCache, disableSyntaxTree, remoteManagement,
-                    optimizeDependencyCompilation);
+                    optimizeDependencyCompilation, lockingMode);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -577,7 +577,10 @@ public class PackageResolution {
         // For new projects, the locking mode will be SOFT unless sticky == true.
         // For existing projects, if the package was built with a previous distribution, the locking mode
         // will be SOFT unless sticky == true. A warning is issued to notify the detection of the new distribution.
-        if (rootPackageContext.dependenciesTomlContext().isPresent()) {
+        if ("soft".equals(rootPackageContext.project().buildOptions().compilationOptions().lockingMode())) {
+            packageLockingMode = PackageLockingMode.SOFT;
+            sticky = false;
+        } else if (rootPackageContext.dependenciesTomlContext().isPresent()) {
             // existing project
             if (prevDistributionVersion == null) {
                 // Built with Update 4 or less. Therefore, we issue a warning

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
@@ -918,6 +918,8 @@ public class ManifestBuilder {
                 BuildOptions.OptionName.SHOW_DEPENDENCY_DIAGNOSTICS.toString());
         Boolean optimizeDependencyCompilation = getBooleanFromBuildOptionsTableNode(tableNode,
                 BuildOptions.OptionName.OPTIMIZE_DEPENDENCY_COMPILATION.toString());
+        String lockingMode = getStringFromBuildOptionsTableNode(tableNode,
+                CompilerOptionName.LOCKING_MODE.toString());
 
         buildOptionsBuilder
                 .setOffline(offline)
@@ -934,7 +936,8 @@ public class ManifestBuilder {
                 .setGraalVMBuildOptions(graalVMBuildOptions)
                 .setRemoteManagement(remoteManagement)
                 .setShowDependencyDiagnostics(showDependencyDiagnostics)
-                .setOptimizeDependencyCompilation(optimizeDependencyCompilation);
+                .setOptimizeDependencyCompilation(optimizeDependencyCompilation)
+                .setLockingMode(lockingMode);
 
         if (targetDir != null) {
             buildOptionsBuilder.targetDir(targetDir);

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerOptionName.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerOptionName.java
@@ -64,6 +64,7 @@ public enum CompilerOptionName {
 
     ENABLE_CACHE("enableCache"),
     REMOTE_MANAGEMENT("remoteManagement"),
+    LOCKING_MODE("lockingMode"),
 
     /**
      * We've introduced this temporary option to support old-project structure and the new package structure.


### PR DESCRIPTION
## Purpose
$ subject

Provides a workaround for https://github.com/ballerina-platform/ballerina-lang/issues/42467

The soft locking mode will be enabled when a user provides `lockingMode="soft"` in the build options. If any other value is provided, they'll be ignored.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
