### PR TITLE
Compile the project with the experimental flag if the LS capability is set

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
@@ -90,9 +90,7 @@ public class BuildOptions {
      * Checks whether experimental compilation option is set.
      *
      * @return Is experimental compilation option is set
-     * @deprecated Since language no longer has experimental features
      */
-    @Deprecated(forRemoval = true)
     public boolean experimental() {
         return this.compilationOptions.experimental();
     }

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/ExperimentalClientCapabilities.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/ExperimentalClientCapabilities.java
@@ -35,4 +35,11 @@ public interface ExperimentalClientCapabilities {
      * @return True when enabled, False otherwise
      */
     boolean isShowTextDocumentEnabled();
+
+    /**
+     * Returns whether the experimental compilation enabled or not.
+     *
+     * @return True when enabled, False otherwise
+     */
+    boolean isExperimentalCompilationEnabled();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
+import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.util.ProjectConstants;
 import org.ballerinalang.langserver.command.LSCommandExecutorProvidersHolder;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
@@ -37,6 +38,7 @@ import org.ballerinalang.langserver.extensions.AbstractExtendedLanguageServer;
 import org.ballerinalang.langserver.extensions.ExtendedLanguageServer;
 import org.ballerinalang.langserver.semantictokens.SemanticTokensUtils;
 import org.ballerinalang.langserver.util.LSClientUtil;
+import org.ballerinalang.langserver.workspace.BallerinaWorkspaceManagerProxyImpl;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CodeLensOptions;
@@ -141,6 +143,18 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
         //Checks for instances in which the LS needs to be initiated in lightweight mode
         if (capabilities.getInitializationOptions().isEnableLightWeightMode()) {
             return CompletableFuture.supplyAsync(() -> res);
+        }
+
+        // Compile the project with the experimental flag if the client has it enabled
+        if (capabilities.getExperimentalCapabilities().isExperimentalCompilationEnabled()) {
+            BuildOptions buildOptions = BuildOptions.builder()
+                    .setOffline(CommonUtil.COMPILE_OFFLINE)
+                    .setSticky(true)
+                    .setExperimental(true)
+                    .build();
+            if (workspaceManagerProxy instanceof BallerinaWorkspaceManagerProxyImpl ballerinaWorkspaceManagerProxy) {
+                ballerinaWorkspaceManagerProxy.setBuildOptions(buildOptions);
+            }
         }
 
         final SignatureHelpOptions signatureHelpOptions = new SignatureHelpOptions(Arrays.asList("(", ","));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/Experimental.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/Experimental.java
@@ -25,6 +25,7 @@ public enum Experimental {
     INTROSPECTION("introspection"),
     AST_PROVIDER("astProvider"),
     SHOW_TEXT_DOCUMENT("showTextDocument"),
+    EXPERIMENTAL_COMPILATION("experimentalCompilation"),
     EXAMPLES_PROVIDER("examplesProvider"),
     API_EDITOR_PROVIDER("apiEditorProvider"),
     SEMANTIC_SCOPES("semanticScopes");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.ballerinalang.langserver.Experimental.EXPERIMENTAL_COMPILATION;
 import static org.ballerinalang.langserver.Experimental.INTROSPECTION;
 import static org.ballerinalang.langserver.Experimental.SHOW_TEXT_DOCUMENT;
 
@@ -116,9 +117,14 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
         Object showTextDocument = experimentalCapabilities.get(SHOW_TEXT_DOCUMENT.getValue());
         boolean showTextDocumentEnabled = showTextDocument instanceof Boolean && (Boolean) showTextDocument;
 
+        Object experimentalCompilation = experimentalCapabilities.get(EXPERIMENTAL_COMPILATION.getValue());
+        boolean experimentalCompilationEnabled = experimentalCompilation instanceof Boolean &&
+                (Boolean) experimentalCompilation;
+
         ExperimentalClientCapabilitiesImpl capabilities = new ExperimentalClientCapabilitiesImpl();
         capabilities.setIntrospectionEnabled(introspectionEnabled);
         capabilities.setShowTextDocumentEnabled(showTextDocumentEnabled);
+        capabilities.setExperimentalCompilationEnabled(experimentalCompilationEnabled);
 
         return capabilities;
     }
@@ -183,6 +189,7 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
 
         private boolean introspectionEnabled = false;
         private boolean showTextDocumentEnabled = false;
+        private boolean experimentalCompilationEnabled = false;
 
         /**
          * Returns whether the introspection enabled or not.
@@ -204,12 +211,24 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
             return showTextDocumentEnabled;
         }
 
+        /**
+         * @inheritDoc
+         */
+        @Override
+        public boolean isExperimentalCompilationEnabled() {
+            return experimentalCompilationEnabled;
+        }
+
         private void setIntrospectionEnabled(boolean introspectionEnabled) {
             this.introspectionEnabled = introspectionEnabled;
         }
 
         private void setShowTextDocumentEnabled(boolean showTextDocumentEnabled) {
             this.showTextDocumentEnabled = showTextDocumentEnabled;
+        }
+
+        private void setExperimentalCompilationEnabled(boolean experimentalCompilationEnabled) {
+            this.experimentalCompilationEnabled = experimentalCompilationEnabled;
         }
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManagerProxyImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManagerProxyImpl.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.langserver.workspace;
 
+import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.Project;
 import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
@@ -126,6 +127,18 @@ public class BallerinaWorkspaceManagerProxyImpl implements BallerinaWorkspaceMan
         public String uriScheme() {
             return CommonUtil.EXPR_SCHEME;
         }
+    }
+
+    /**
+     * Sets the build options for both base and cloned workspace managers.
+     *
+     * @param buildOptions The build options to be set
+     */
+    public void setBuildOptions(BuildOptions buildOptions) {
+        if (this.baseWorkspaceManager instanceof BallerinaWorkspaceManager ballerinaWorkspaceManager) {
+            ballerinaWorkspaceManager.setBuildOptions(buildOptions);
+        }
+        this.clonedWorkspaceManager.setBuildOptions(buildOptions);
     }
 
     private boolean isExprScheme(String uri) {


### PR DESCRIPTION
## Purpose
Introduced a new language server experimental capability flag that allows users to enable experimental compiler features. The PR modifies the workspace manager to adjust build options based on received configurations.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/44043

