### PR TITLE
Make the content of generated md files to be markdown compatible

### DIFF
--- a/cli/ballerina-cli/src/main/resources/new_cmd_defaults/lib-readme.md
+++ b/cli/ballerina-cli/src/main/resources/new_cmd_defaults/lib-readme.md
@@ -1,2 +1,63 @@
 # Package Overview
-Prints "Hello, World!" as the output to the command line using a hello function.
+
+This package provides a simple function to print "Hello, World!" to the command line. Additionally, you can provide a name to the function to print a personalized greeting.
+
+(Note: For this example, we are assuming the organization name is `user` and the package name is `socialMedia`.)
+
+## Functionality
+
+### hello Function
+
+```ballerina
+public function hello(string? name) returns string {
+    if name !is () {
+        return string `Hello, ${name}`;
+    }
+    return "Hello, World!";
+}
+```
+
+## Build from Source and Publish
+
+### Build the Package
+
+To build the package, use the following command:
+
+```bash
+bal pack
+```
+
+### Publish the Package
+
+To publish the package to a local repository, use the following command:
+
+```bash
+bal push --repository=local
+```
+
+## Usage
+
+### Importing the Package
+
+```ballerina
+import ballerina/io;
+import user/socialMedia;
+```
+
+### Using the hello Function
+
+```ballerina
+public function main() {
+    string greeting = socialMedia:hello("Ballerina");
+    io:println(greeting); // Output: Hello, Ballerina
+}
+```
+
+You can call the `hello` function without any arguments to get the default greeting:
+
+```ballerina
+public function main() {
+    string greeting = socialMedia:hello();
+    io:println(greeting); // Output: Hello, World!
+}
+```


### PR DESCRIPTION
## Purpose
This PR fixes the Markdown compatibility issue in the generated readme.md file for `bal new -t lib` command.

Fixes #42907

## Approach
Edit the static file `cli/ballerina-cli/src/main/resources/new_cmd_defaults/lib-readme.md`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
