### PR TITLE
[2201.12.x] Fix InvalidUpdate error in JSONUtils when readonly type is used

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/JsonValues.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/JsonValues.java
@@ -27,6 +27,8 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.json.JsonGenerator;
+import io.ballerina.runtime.internal.types.BIntersectionType;
+import io.ballerina.runtime.internal.types.BTypeReferenceType;
 import io.ballerina.runtime.internal.values.ErrorValue;
 
 import java.io.ByteArrayInputStream;
@@ -50,9 +52,13 @@ public final class JsonValues {
     }
 
     public static BMap<BString, Object> testConvertJSONToRecord(Object record, BTypedesc t) throws BError {
-        Type describingType = t.getDescribingType();
-        if (describingType instanceof StructureType) {
-            return convertJSONToRecord(record, (StructureType) describingType);
+        Type structType = t.getDescribingType();
+        if (structType.isReadOnly()) {
+            structType = ((BIntersectionType) ((BTypeReferenceType) structType).
+                    getReferredType()).getEffectiveType();
+        }
+        if (structType instanceof StructureType) {
+            return convertJSONToRecord(record, (StructureType) structType);
         } else {
             throw new ErrorValue(StringUtils.fromString("provided typedesc does not describe a record type."));
         }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/modules/jsons/jsons.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/modules/jsons/jsons.bal
@@ -38,6 +38,14 @@ type Shop record {
     funion union_status;
 };
 
+type readonlyShop record {
+    string name;
+    Status status;
+    num number;
+    ftype1 foo_status;
+    funion union_status;
+} & readonly;
+
 function testConvertJSONToRecord() {
     json j = {
         "name": "My Shop",
@@ -48,12 +56,15 @@ function testConvertJSONToRecord() {
     };
 
     map<anydata> recordValue = convertJSONToRecord(j, Shop);
+    map<anydata> recordValue2 = convertJSONToRecord(j, readonlyShop);
     string expectedOutput = "{\"name\":\"My Shop\",\"status\":\"OPEN\",\"number\":1,\"foo_status\":" +
     "\"foo\",\"union_status\":\"bar\"}";
     test:assertEquals(recordValue.toString(), expectedOutput);
-
+    test:assertEquals(recordValue2.toString(), expectedOutput);
     var jval_result = convertJSON(j, Shop);
+    var jval_result2 = convertJSON(j, readonlyShop);
     test:assertEquals(jval_result.toString(), expectedOutput);
+    test:assertEquals(jval_result2.toString(), expectedOutput);
 }
 
 type numUnion1 int|decimal|float;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/modules/jsons/jsons.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/utils/modules/jsons/jsons.bal
@@ -83,6 +83,8 @@ type union3 singletonunion|union1|union2;
 
 type intArray int[];
 
+type readonlyIntArray readonly & int[];
+
 type stringMap map<string>;
 
 function testConvertJSON() {
@@ -120,6 +122,10 @@ function testConvertJSON() {
 
     jval = [12, -1, 0, 15];
     jval_result = trap convertJSON(jval, intArray);
+    test:assertEquals(jval_result, [12, -1, 0, 15]);
+
+    jval = [12, -1, 0, 15];
+    jval_result = trap convertJSON(jval, readonlyIntArray);
     test:assertEquals(jval_result, [12, -1, 0, 15]);
 
     jval = {"a": "true"};


### PR DESCRIPTION
## Purpose
> When `readonly` flag is present within a type, the conversion of JSON to that type fails because the object construction and initialisation happens separately. 

Fixes #43969 
Duplicate of https://github.com/ballerina-platform/ballerina-lang/pull/43982

## Approach
> Construction and initialisation of the readonly object happens at once.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
