### PR TITLE
Fix consecutive build/test/run commands when a pack/profile executed in the middle

### DIFF
--- a/cli/ballerina-cli/spotbugs-exclude.xml
+++ b/cli/ballerina-cli/spotbugs-exclude.xml
@@ -18,6 +18,14 @@
 
 <FindBugsFilter>
     <Match>
+        <Class name="io.ballerina.cli.cmd.CacheArtifactsTask"/>
+        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+    </Match>
+    <Match>
+        <Class name="io.ballerina.cli.cmd.CommandUtil$1"/>
+        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+    </Match>
+    <Match>
         <Class name="io.ballerina.cli.cmd.PullCommand"/>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
     </Match>

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -338,7 +338,8 @@ public class BuildCommand implements BLauncherCmd {
         boolean rebuildStatus = isRebuildNeeded(project, skipExecutable);
         TaskExecutor taskExecutor = new TaskExecutor.TaskBuilder()
                 // clean the target directory(projects only)
-                .addTask(new CleanTargetDirTask(), !rebuildStatus || isSingleFile)
+                .addTask(new CleanTargetDirTask(),  isSingleFile)
+                .addTask(new RestoreCachedArtifactsTask(), rebuildStatus)
                 // Run build tools
                 .addTask(new RunBuildToolsTask(outStream, !rebuildStatus), isSingleFile)
                 // resolve maven dependencies in Ballerina.toml
@@ -348,6 +349,7 @@ public class BuildCommand implements BLauncherCmd {
                 .addTask(new CreateExecutableTask(outStream, this.output, null, false,
                          !rebuildStatus, skipExecutable))
                 .addTask(new DumpBuildTimeTask(outStream), !buildOptions.dumpBuildTime())
+                .addTask(new CacheArtifactsTask(BUILD_COMMAND, skipExecutable), !rebuildStatus || isSingleFile)
                 .addTask(new CreateFingerprintTask(false, skipExecutable), !rebuildStatus || isSingleFile)
                 .build();
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CacheArtifactsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CacheArtifactsTask.java
@@ -1,0 +1,69 @@
+package io.ballerina.cli.cmd;
+
+import io.ballerina.cli.task.Task;
+import io.ballerina.projects.Project;
+import io.ballerina.projects.internal.model.Target;
+import io.ballerina.projects.util.ProjectConstants;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+
+import static io.ballerina.cli.cmd.CommandUtil.JAR;
+import static io.ballerina.cli.cmd.Constants.BACKUP;
+import static io.ballerina.cli.cmd.Constants.BUILD_COMMAND;
+import static io.ballerina.cli.cmd.Constants.RUN_COMMAND;
+import static io.ballerina.cli.cmd.Constants.TEST_COMMAND;
+import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
+
+public class CacheArtifactsTask implements Task {
+    private final String currTask;
+    private boolean skipExecutable = false;
+    public CacheArtifactsTask(String currTask) {
+        this.currTask = currTask;
+    }
+
+    public CacheArtifactsTask(String currTask, boolean skipExecutable) {
+        this.currTask = currTask;
+        this.skipExecutable = skipExecutable;
+    }
+
+    @Override
+    public void execute(Project project) {
+        try {
+            Path targetDir = project.targetDir();
+            Path backupDir = project.targetDir().resolve(BACKUP);
+            Target target = new Target(targetDir);
+            if ((this.currTask.equals(BUILD_COMMAND) || this.currTask.equals(RUN_COMMAND)) && !skipExecutable) {
+                copyFile(target.getExecutablePath(project.currentPackage()), targetDir, backupDir);
+            }else if (this.currTask.equals(TEST_COMMAND)) {
+                Path testSuitePath = target.getTestsCachePath().resolve(ProjectConstants.TEST_SUITE_JSON);
+                String packageOrg = project.currentPackage().packageOrg().toString();
+                String packageName = project.currentPackage().packageName().toString();
+                String packageVersion = project.currentPackage().packageVersion().toString();
+                List<Path> testArtifactsPaths =
+                        Files.walk(target.cachesPath().resolve(packageOrg).resolve(packageName).resolve(packageVersion))
+                                .filter(Files::isRegularFile)
+                                .filter(path -> path.toString().endsWith(JAR))
+                                .toList();
+                copyFile(testSuitePath, targetDir, backupDir);
+                for (Path testArtifactPath : testArtifactsPaths) {
+                    copyFile(testArtifactPath, targetDir, backupDir);
+                }
+            }
+        } catch (IOException e) {
+            throw createLauncherException("unable to create the cache: " + e.getMessage());
+        }
+
+
+    }
+
+    private static void copyFile(Path sourceFilePath , Path sourceRootPath, Path destRootPath) throws IOException {
+        Path relativePath = sourceRootPath.relativize(sourceFilePath);
+        Path destFile = destRootPath.resolve(relativePath);
+        Files.createDirectories(destFile.getParent());
+        Files.copy(sourceFilePath, destFile, StandardCopyOption.REPLACE_EXISTING);
+    }
+}

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CacheArtifactsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CacheArtifactsTask.java
@@ -38,7 +38,7 @@ public class CacheArtifactsTask implements Task {
             Target target = new Target(targetDir);
             if ((this.currTask.equals(BUILD_COMMAND) || this.currTask.equals(RUN_COMMAND)) && !skipExecutable) {
                 copyFile(target.getExecutablePath(project.currentPackage()), targetDir, backupDir);
-            }else if (this.currTask.equals(TEST_COMMAND)) {
+            } else if (this.currTask.equals(TEST_COMMAND)) {
                 Path testSuitePath = target.getTestsCachePath().resolve(ProjectConstants.TEST_SUITE_JSON);
                 String packageOrg = project.currentPackage().packageOrg().toString();
                 String packageName = project.currentPackage().packageName().toString();

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/Constants.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/Constants.java
@@ -64,6 +64,7 @@ public final class Constants {
     public static final String DEBUG_OPTION = "--debug";
     public static final String VERSION_SHORT_OPTION = "-v";
     public static final String HELP_SHORT_OPTION = "-h";
+    public static final String BACKUP = "backup";
 
     private Constants() {
     }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RestoreCachedArtifactsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RestoreCachedArtifactsTask.java
@@ -1,0 +1,20 @@
+package io.ballerina.cli.cmd;
+
+import io.ballerina.cli.task.Task;
+import io.ballerina.projects.Project;
+
+import java.io.IOException;
+
+import static io.ballerina.cli.cmd.Constants.BACKUP;
+import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
+
+public class RestoreCachedArtifactsTask implements Task {
+    @Override
+    public void execute(Project project) {
+        try {
+            CommandUtil.copyOneDirectoryUp(project.targetDir().resolve(BACKUP));
+        } catch (IOException e) {
+            throw createLauncherException("unable to restore the cache: " + e.getMessage());
+        }
+    }
+}

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -321,8 +321,8 @@ public class RunCommand implements BLauncherCmd {
         boolean rebuildStatus = isRebuildNeeded(project, false);
         TaskExecutor taskExecutor = new TaskExecutor.TaskBuilder()
                 // clean target dir for projects
-                .addTask(new CleanTargetDirTask(), !rebuildStatus
-                        || isSingleFileBuild)
+                .addTask(new CleanTargetDirTask(), isSingleFileBuild)
+                .addTask(new RestoreCachedArtifactsTask(), rebuildStatus)
                 // Run build tools
                 .addTask(new RunBuildToolsTask(outStream, !rebuildStatus), isSingleFileBuild)
                 // resolve maven dependencies in Ballerina.toml
@@ -330,6 +330,7 @@ public class RunCommand implements BLauncherCmd {
                 // compile the modules
                 .addTask(new CompileTask(outStream, errStream, false, false, !rebuildStatus))
                 .addTask(new CreateExecutableTask(outStream, null, target, true, !rebuildStatus))
+                .addTask(new CacheArtifactsTask(RUN_COMMAND), !rebuildStatus || isSingleFileBuild)
                 .addTask(new CreateFingerprintTask(false, false), !rebuildStatus || isSingleFileBuild)
                 .addTask(runExecutableTask = new RunExecutableTask(args, outStream, errStream, target))
                 .addTask(new DumpBuildTimeTask(outStream), !project.buildOptions().dumpBuildTime())

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -557,8 +557,9 @@ public class TestCommand implements BLauncherCmd {
         boolean isSingleFile = project.kind().equals(ProjectKind.SINGLE_FILE_PROJECT);
         TaskExecutor preBuildTaskExecutor = new TaskExecutor.TaskBuilder()
                 .addTask(new CleanTargetCacheDirTask(),
-                        !rebuildStatus || isSingleFile) // clean the target cache dir(projects only)
-                .addTask(new CleanTargetBinTestsDirTask(), !rebuildStatus || (isSingleFile || !isTestingDelegated))
+                         isSingleFile) // clean the target cache dir(projects only)
+                .addTask(new CleanTargetBinTestsDirTask(),  (isSingleFile || !isTestingDelegated))
+                .addTask(new RestoreCachedArtifactsTask(), rebuildStatus)
                 .addTask(new RunBuildToolsTask(outStream), !rebuildStatus || isSingleFile) // run build tools
                 .build();
         preBuildTaskExecutor.executeTasks(project);
@@ -587,6 +588,7 @@ public class TestCommand implements BLauncherCmd {
                                 testReport),
                         (!project.buildOptions().nativeImage() || isTestingDelegated))
                 .addTask(new DumpBuildTimeTask(outStream), !project.buildOptions().dumpBuildTime())
+                .addTask(new CacheArtifactsTask(TEST_COMMAND), !rebuildStatus || isSingleFile)
                 .addTask(new CreateFingerprintTask(true, false),
                         !rebuildStatus || isSingleFile)
                 .build();

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateFingerprintTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateFingerprintTask.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static io.ballerina.cli.cmd.CommandUtil.getSHA256Digest;
+import static io.ballerina.cli.cmd.Constants.BACKUP;
 import static io.ballerina.projects.util.ProjectConstants.BUILD_FILE;
 import static io.ballerina.projects.util.ProjectUtils.readBuildJson;
 
@@ -109,7 +110,7 @@ public class CreateFingerprintTask implements Task {
     private static void createFingerPrintForArtifacts(Project project, BuildJson buildJson, boolean isTestExecution,
                                                       boolean skipExecutable)
                                                         throws IOException, NoSuchAlgorithmException {
-        Target target = new Target(project.targetDir());
+        Target target = new Target(project.targetDir().resolve(BACKUP));
         if (isTestExecution) {
             List<BuildJson.FileMetaInfo> testArtifactMetaInfoList = new ArrayList<>();
             File testSuiteFile = target.getTestsCachePath().resolve(ProjectConstants.TEST_SUITE_JSON).toFile();

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
@@ -64,7 +64,7 @@ import static io.ballerina.projects.util.ProjectUtils.readBuildJson;
  *
  * @since 2.0.0
  */
-public class BuildCommandTest extends BaseCommandTest {
+public class    BuildCommandTest extends BaseCommandTest {
     private Path testResources;
     private static final Path testBuildDirectory = Path.of("build").toAbsolutePath();
     private static final Path testDistCacheDirectory = testBuildDirectory.resolve(DIST_CACHE_DIRECTORY);
@@ -1995,5 +1995,29 @@ public class BuildCommandTest extends BaseCommandTest {
         // Hence, the build should not be up-to-date
         Assert.assertTrue(secondBuildLog.contains("Generating executable"));
         Assert.assertFalse(secondBuildLog.contains("Generating executable (UP-TO-DATE)"));
+    }
+
+    @Test(description = "Build a project twice with the pack command in the middle")
+    public void testBuildAProjectTwiceWithPackCommandMiddle() throws IOException {
+        Path projectPath = this.testResources.resolve("buildAProjectTwice");
+        deleteDirectory(projectPath.resolve("target"));
+        System.setProperty(USER_DIR_PROPERTY, projectPath.toString());
+        BuildCommand buildCommand = new BuildCommand(projectPath, printStream, printStream, false);
+        new CommandLine(buildCommand).parseArgs();
+        buildCommand.execute();
+        String firstBuildLog = readOutput(true);
+        PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
+        new CommandLine(packCommand).parseArgs();
+        packCommand.execute();
+        String middleBuildLog = readOutput(true);
+        buildCommand = new BuildCommand(projectPath, printStream, printStream, false);
+        new CommandLine(buildCommand).parseArgs();
+        buildCommand.execute();
+        String secondBuildLog = readOutput(true);
+        Assert.assertTrue(firstBuildLog.contains("Compiling source"));
+        Assert.assertFalse(firstBuildLog.contains("Compiling source (UP-TO-DATE)"));
+        Assert.assertTrue(middleBuildLog.contains("Compiling source"));
+        Assert.assertFalse(middleBuildLog.contains("Compiling source (UP-TO-DATE)"));
+        Assert.assertTrue(secondBuildLog.contains("Compiling source (UP-TO-DATE)"));
     }
 }

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/RunCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/RunCommandTest.java
@@ -653,6 +653,30 @@ public class RunCommandTest extends BaseCommandTest {
         Assert.assertTrue(secondBuildLog.contains("Compiling source (UP-TO-DATE)"));
     }
 
+    @Test(description = "Run a project twice with the pack command in the middle")
+    public void testBuildAProjectTwiceWithPackCommandMiddle() throws IOException {
+        Path projectPath = this.testResources.resolve("buildAProjectTwice");
+        deleteDirectory(projectPath.resolve("target"));
+        System.setProperty(USER_DIR_PROPERTY, projectPath.toString());
+        RunCommand runCommand = new RunCommand(projectPath, printStream, false);
+        new CommandLine(runCommand).parseArgs();
+        runCommand.execute();
+        String firstBuildLog = readOutput(true);
+        PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
+        new CommandLine(packCommand).parseArgs();
+        packCommand.execute();
+        String middleBuildLog = readOutput(true);
+        runCommand = new RunCommand(projectPath, printStream, false);
+        new CommandLine(runCommand).parseArgs();
+        runCommand.execute();
+        String secondBuildLog = readOutput(true);
+        Assert.assertTrue(firstBuildLog.contains("Compiling source"));
+        Assert.assertFalse(firstBuildLog.contains("Compiling source (UP-TO-DATE)"));
+        Assert.assertTrue(middleBuildLog.contains("Compiling source"));
+        Assert.assertFalse(middleBuildLog.contains("Compiling source (UP-TO-DATE)"));
+        Assert.assertTrue(secondBuildLog.contains("Compiling source (UP-TO-DATE)"));
+    }
+
     @AfterSuite
     public void cleanUp() throws IOException {
         Files.deleteIfExists(logFile);

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
@@ -295,6 +295,7 @@ public class TestCommandTest extends BaseCommandTest {
     @Test(description = "Test a ballerina project with --test-report", dataProvider = "optimizeDependencyCompilation")
     public void testTestWithReport(Boolean optimizeDependencyCompilation) {
         Path projectPath = this.testResources.resolve("validProjectWithTests");
+        deleteDirectory(projectPath.resolve("target"));
         TestCommand testCommand = new TestCommand(
                 projectPath, printStream, printStream, false, true, false, null, optimizeDependencyCompilation);
         new CommandLine(testCommand).parseArgs();

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
@@ -969,6 +969,54 @@ public class TestCommandTest extends BaseCommandTest {
         Assert.assertFalse(thirdBuildLog.contains("Compiling source (UP-TO-DATE)"));
     }
 
+    @Test(description = "Test a project twice with the build command in the middle")
+    public void testBuildAProjectTwiceWithBuildCommandMiddle() throws IOException {
+        Path projectPath = this.testResources.resolve("buildAProjectTwice");
+        deleteDirectory(projectPath.resolve("target"));
+        System.setProperty(USER_DIR_PROPERTY, projectPath.toString());
+        TestCommand testCommand = new TestCommand(projectPath, printStream, printStream, false);
+        new CommandLine(testCommand).parseArgs();
+        testCommand.execute();
+        String firstBuildLog = readOutput(true);
+        BuildCommand buildCommand = new BuildCommand(projectPath, printStream, printStream, false);
+        new CommandLine(buildCommand).parseArgs();
+        buildCommand.execute();
+        String middleBuildLog = readOutput(true);
+        testCommand = new TestCommand(projectPath, printStream, printStream, false);
+        new CommandLine(testCommand).parseArgs();
+        testCommand.execute();
+        String secondBuildLog = readOutput(true);
+        Assert.assertTrue(firstBuildLog.contains("Compiling source"));
+        Assert.assertFalse(firstBuildLog.contains("Compiling source (UP-TO-DATE)"));
+        Assert.assertTrue(middleBuildLog.contains("Compiling source"));
+        Assert.assertFalse(middleBuildLog.contains("Compiling source (UP-TO-DATE)"));
+        Assert.assertTrue(secondBuildLog.contains("Compiling source (UP-TO-DATE)"));
+    }
+
+    @Test(description = "Test a project twice with the pack command in the middle")
+    public void testBuildAProjectTwiceWithPackCommandMiddle() throws IOException {
+        Path projectPath = this.testResources.resolve("buildAProjectTwice");
+        deleteDirectory(projectPath.resolve("target"));
+        System.setProperty(USER_DIR_PROPERTY, projectPath.toString());
+        TestCommand testCommand = new TestCommand(projectPath, printStream, printStream, false);
+        new CommandLine(testCommand).parseArgs();
+        testCommand.execute();
+        String firstBuildLog = readOutput(true);
+        PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
+        new CommandLine(packCommand).parseArgs();
+        packCommand.execute();
+        String middleBuildLog = readOutput(true);
+        testCommand = new TestCommand(projectPath, printStream, printStream, false);
+        new CommandLine(testCommand).parseArgs();
+        testCommand.execute();
+        String secondBuildLog = readOutput(true);
+        Assert.assertTrue(firstBuildLog.contains("Compiling source"));
+        Assert.assertFalse(firstBuildLog.contains("Compiling source (UP-TO-DATE)"));
+        Assert.assertTrue(middleBuildLog.contains("Compiling source"));
+        Assert.assertFalse(middleBuildLog.contains("Compiling source (UP-TO-DATE)"));
+        Assert.assertTrue(secondBuildLog.contains("Compiling source (UP-TO-DATE)"));
+    }
+
     @Test(description = "Test a project with a new file within 24 hours of the last build")
     public void testBuildAProjectWithFileAddition() throws IOException {
         Path projectPath = this.testResources.resolve("buildAProjectTwice");


### PR DESCRIPTION
## Purpose
> Fix consecutive build/test/run commands when a pack/profile executed in the middle

Fixes #44308

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
