### PR TITLE
[2201.12.x] Include API to add custom tags to every observer context

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -147,6 +147,19 @@ public final class ObserveUtils {
     }
 
     /**
+     * Add a default tag to be added to all spans and metrics.
+     *
+     * @param tagKey   key of the tag
+     * @param tagValue value of the tag
+     */
+    public static void addDefaultTag(String tagKey, String tagValue) {
+        if (!enabled) {
+            return;
+        }
+        defaultTags.put(tagKey, tagValue);
+    }
+
+    /**
      * Add metrics and tracing observers.
      *
      * @param observer metrics or tracing observer

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -32,6 +32,7 @@ import io.ballerina.runtime.observability.tracer.BSpan;
 import io.opentelemetry.api.common.Attributes;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -66,6 +67,7 @@ import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_TRUE
 public final class ObserveUtils {
 
     private static final List<BallerinaObserver> observers = new CopyOnWriteArrayList<>();
+    private static final Map<String, String> defaultTags = new HashMap<>();
     private static final boolean enabled;
     private static final boolean metricsEnabled;
     private static final BString metricsProvider;
@@ -237,6 +239,12 @@ public final class ObserveUtils {
         if (observerContext.getEntrypointResourceAccessor() != null) {
             observerContext.addTag(TAG_KEY_ENTRYPOINT_RESOURCE_ACCESSOR,
                     observerContext.getEntrypointResourceAccessor());
+        }
+
+        if (!defaultTags.isEmpty()) {
+            for (String tagKey : defaultTags.keySet()) {
+                observerContext.addTag(tagKey, defaultTags.get(tagKey));
+            }
         }
 
         observerContext.setServer();
@@ -416,6 +424,12 @@ public final class ObserveUtils {
         }
         if (newObContext.getEntrypointResourceAccessor() != null) {
             newObContext.addTag(TAG_KEY_ENTRYPOINT_RESOURCE_ACCESSOR, newObContext.getEntrypointResourceAccessor());
+        }
+
+        if (!defaultTags.isEmpty()) {
+            for (String tagKey : defaultTags.keySet()) {
+                newObContext.addTag(tagKey, defaultTags.get(tagKey));
+            }
         }
 
         newObContext.setStarted();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -152,7 +152,7 @@ public final class ObserveUtils {
      * @param tagKey   key of the tag
      * @param tagValue value of the tag
      */
-    public static void addDefaultTag(String tagKey, String tagValue) {
+    public static void addTag(String tagKey, String tagValue) {
         if (!enabled) {
             return;
         }


### PR DESCRIPTION
## Purpose
We need to expose API to add custom tags to every observer context.

In the `ballerina/observe` module, this API will be used to let user add custom tags.

Fixes https://github.com/wso2/integration-control-plane/issues/22

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
