### PR TITLE
Fix compatible type check for unsigned32 compound assignment

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -225,6 +225,7 @@ import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.Unifier;
 import org.wso2.ballerinalang.util.AttachPoints;
 import org.wso2.ballerinalang.util.Flags;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -2282,10 +2283,26 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
                         compoundAssignment.varRef = simpleVarRef;
                     }
                 }
-
                 compoundAssignment.modifiedExpr.parent = compoundAssignment;
-                this.types.checkType(compoundAssignment.modifiedExpr,
+
+                // Fix for #44416: Allow implicit narrowing for Unsigned32 compound assignments.
+                // The addition operation returns an 'int', but for '+=' on an Unsigned32 variable,
+                // Allow the result to be assigned back without an explicit cast.
+                BType lhsType = compoundAssignment.varRef.getBType();
+                BType rhsType = compoundAssignment.modifiedExpr.getBType();
+
+                BType effectiveLhsType = lhsType;
+                while (effectiveLhsType instanceof BTypeReferenceType) {
+                    effectiveLhsType = ((BTypeReferenceType) effectiveLhsType).referredType;
+                }
+
+                boolean isUnsigned32Adjustment = (effectiveLhsType.tag == TypeTags.UNSIGNED32_INT 
+                                                  && rhsType.tag == TypeTags.INT);
+
+                if (!isUnsigned32Adjustment) {
+                    this.types.checkType(compoundAssignment.modifiedExpr,
                                      compoundAssignment.modifiedExpr.getBType(), compoundAssignment.varRef.getBType());
+                }
             }
         }
 


### PR DESCRIPTION
### Purpose
Fixes #44416

This PR addresses a usability bug where the compound assignment operator (+=) failed when used with int:Unsigned32 variables.

- The Issue: When performing tick += 1 on an Unsigned32 variable, the addition operation promotes the result to a standard 64-bit int to handle potential overflows.

- The Error: The compiler previously enforced a strict type check, rejecting the assignment of that int result back into the Unsigned32 variable without an explicit cast.

- The Fix: This change allows implicit narrowing for this specific scenario, aligning Ballerina's behavior with standard expectations for compound assignments.

### Approach
The fix was implemented in the `SemanticAnalyzer` phase of the compiler (`SemanticAnalyzer.java`).

1. Intercepted the visit(BLangCompoundAssignment) method: Added logic to inspect the types of the Left-Hand Side (LHS) and Right-Hand Side (RHS) before the final type check.

2. Type Unwrapping: Implemented a loop to unwrap BTypeReferenceType layers to correctly identify if the LHS is effectively an int:Unsigned32, even if it is wrapped in a type reference.
 
3. Conditional Bypass: Added a check to detect if the operation involves assigning an `int` (RHS) to an `Unsigned32` (LHS). If this condition is met during a compound assignment, the strict `checkType` call is bypassed, implicitly allowing the narrowing.

### Samples

The following code, which previously failed with an "incompatible types" error, now compiles and runs successfully:

``` Code snippet
import ballerina/io;

public class World {
    public int:Unsigned32 tick = 0;

    public function doTick() {
        // This previously failed, requiring a manual cast: <int:Unsigned32>(self.tick + 1)
        self.tick += 1; 
    }
}

public function main() {
    World w = new();
    w.doTick();
    io:println("Tick value: ", w.tick); // Output: 1
}
```
### Remarks
This fix improves the Quality of Life (QoL) for developers using unsigned integers by removing the need for verbose casting in common operations like loop increments.

TODO / Future Work:
- Extend this implicit narrowing logic to int:Unsigned16 and int:Unsigned8 types, which likely suffer from the same issue.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples