### PR TITLE
Standardize link formatting in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ We appreciate your help!
 ## Get started
 
 - Download [Ballerina](https://ballerina.io/downloads/) and go through the [learning resources](https://ballerina.io/learn/).
-- Read the <a href="https://ballerina.io/code-of-conduct">Ballerina Code of Conduct</a>.
+- Read the [Ballerina Code of Conduct](https://ballerina.io/code-of-conduct).
 
 - Join the [Ballerina community](https://ballerina.io/community/).
 
@@ -25,7 +25,7 @@ We appreciate your help!
 
 ## Build the source code 
 
-For instructions, see <a href="https://github.com/ballerina-platform/ballerina-distribution/blob/master/docs/build-ballerina-from-source.md">Building from source</a>.
+For instructions, see [Building from source](https://github.com/ballerina-platform/ballerina-distribution/blob/master/docs/build-ballerina-from-source.md).
 
 ## Set up the development environment
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ You can use the following resources to learn Ballerina.
 
 ### Open an issue
 
-  - Language, Tooling, Website: <a href="https://github.com/ballerina-platform/ballerina-lang/issues">ballerina-lang</a> repo
-  - Ballerina library: <a href="https://github.com/ballerina-platform/ballerina-standard-library/issues">ballerina-library</a> repo
+  - Language, Tooling, Website: [ballerina-lang](https://github.com/ballerina-platform/ballerina-lang/issues) repo
+  - Ballerina library: [ballerina-library](https://github.com/ballerina-platform/ballerina-standard-library/issues) repo
 
 ### Report security issues
-  - Send an email to security@ballerina.io. For details, see the <a href="https://ballerina.io/security-policy/">security policy</a>.
+  - Send an email to security@ballerina.io. For details, see the [security policy](https://ballerina.io/security-policy/).
 
 ## Contribute to Ballerina
 


### PR DESCRIPTION
## Description
This PR standardizes the link formatting across documentation files by converting HTML anchor tags to markdown link format for consistency.

## Changes
- Converted HTML anchor tags to markdown link format in README.md
- Converted HTML anchor tags to markdown link format in CONTRIBUTING.md

## Motivation
The documentation files use a mix of markdown links and HTML anchor tags. This PR ensures consistent formatting by using markdown link syntax throughout, which is:
- More consistent with the rest of the documentation
- Easier to read and maintain in markdown format
- Following markdown best practices

## Type of Change
- [x] Documentation fix