### PR TITLE
Ensure default module is always documented

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -578,8 +578,8 @@ public final class BallerinaDocGenerator {
                     summary = modulesMap.get(module.moduleName().toString()).description();
                 }
             }
-            // Skip modules that are not exported
-            if (!project.currentPackage().manifest().exportedModules().contains(moduleName)) {
+            // Skip modules that are not exported, UNLESS it is the default module
+            if (!module.isDefaultModule() && !project.currentPackage().manifest().exportedModules().contains(moduleName)) {
                 continue;
             }
             // find the resources of the package


### PR DESCRIPTION
## Purpose
Currently, `bal doc` generates a blank screen for the default module of certain libraries (like `ballerinax/mysql`) because the `docerina` generator skips modules that are not explicitly listed in the `exportedModules` list.

This PR fixes the issue by ensuring that **Default Modules** are always processed, regardless of the export list configuration.

## Approach
Updated `BallerinaDocGenerator.java` to bypass the `exportedModules` check if `module.isDefaultModule()` is true. This ensures the main module of a package is never hidden by the documentation tool.

## Automation Tests
- [ ] Unit tests added
- [x] Manual verification

**Verification Details:**
Verified locally by running the patched tool against a reproduction of the `ballerinax/mysql` project. The API documentation for the default module, which previously resulted in a blank screen, now generates correctly.

Fixes #44476

https://github.com/user-attachments/assets/9cc9c583-dee2-426c-b480-aefe578de032

