### PR TITLE
Fix docerina parameter doc scanning to stop at section headers

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -1001,7 +1001,11 @@ public final class Generator {
                 } else if (lookForMoreLines && docLine instanceof MarkdownDocumentationLineNode markdownDocLine) {
                     String docLineString = getDocLineString(markdownDocLine.documentElements());
                     if (!docLineString.isEmpty()) {
-                        parameterDoc.append(docLineString);
+                        if (docLineString.startsWith(DOC_HEADER_PREFIX)) {
+                            lookForMoreLines = false;
+                        } else {
+                            parameterDoc.append(docLineString);
+                        }
                     } else {
                         lookForMoreLines = false;
                     }


### PR DESCRIPTION
## Summary

Fixes #44487

`getParameterDocFromMetadataList()` in `Generator.java` did not stop scanning continuation lines when it encountered a Markdown section header (a doc line whose content starts with `# `). This caused `# # Deprecated:` section text to be incorrectly appended to the preceding parameter/return value documentation.

- Added the same `DOC_HEADER_PREFIX` guard that already exists in the sibling `getDocFromMetadata()` method
- When a continuation line starts with `# `, `lookForMoreLines` is set to `false` and the line is not appended to the parameter doc

## Test plan

- [ ] Verify that a function with `# + return - <desc>` immediately followed by `# # Deprecated: <notice>` generates a return doc containing only `<desc>` (not `<desc># Deprecated: <notice>`)
- [ ] Run existing docerina tests: `cd misc/docerina && mvn test`
- [ ] Confirm no regression in parameter doc extraction for multi-line parameter descriptions (separated by empty `#` lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes an issue in docerina where parameter and return type documentation was incorrectly including Markdown section headers (lines starting with "# ") in the generated documentation text.

## Changes

**File Modified:** `misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java`

The `getParameterDocFromMetadataList()` method was updated to recognize and stop scanning at section header lines, preventing headers from being concatenated into parameter documentation. Specifically, when iterating through continuation lines following a parameter's documentation, the logic now checks if a line begins with the "# " prefix and halts further accumulation if detected. This change mirrors existing header-detection logic already present in the `getDocFromMetadata()` method.

**Impact:** The fix ensures that section headers (such as "# # Deprecated:") immediately following parameter documentation are properly treated as separate sections rather than being appended to the parameter description, improving the accuracy of generated API documentation.

**Changes:** +5/-1 lines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->