### PR TITLE
Fix docerina isDeprecated flag for record fields with default values

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -802,7 +802,8 @@ public final class Generator {
                 }
                 String defaultValue = recordField.expression().toString();
                 Type type = Type.fromNode(recordField.typeName(), semanticModel, module);
-                DefaultableVariable defaultableVariable = new DefaultableVariable(name, doc, false, type,
+                DefaultableVariable defaultableVariable = new DefaultableVariable(name, doc,
+                        isDeprecated(recordField.metadata()), type,
                         defaultValue, extractAnnotationAttachmentsFromMetadataNode(semanticModel,
                         recordField.metadata()));
                 if (recordField.readonlyKeyword().isPresent()) {


### PR DESCRIPTION
## Summary

Fixes #44492

- `getDefaultableVariableList()` in `Generator.java` hardcoded `isDeprecated = false` for `RecordFieldWithDefaultValueNode` (fields with default values like `string path = "/"`)
- The sibling `RecordFieldNode` branch already correctly called `isDeprecated(recordField.metadata())`
- This one-line fix replaces the hardcoded `false` with `isDeprecated(recordField.metadata())`, making both branches consistent

## Test plan

- [ ] Verify a Ballerina record with a deprecated field that has a default value produces `isDeprecated: true` in the generated `api-docs.json`
- [ ] Confirm non-deprecated fields with default values still show `isDeprecated: false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes an inconsistency in the documentation generation process where the deprecation status of record fields with default values was not being correctly determined. 

**The Problem:**
The code generator was hardcoding the `isDeprecated` flag to `false` for record fields that have default values, even when those fields were marked with the `@deprecated` annotation. This caused the generated API documentation to incorrectly indicate that deprecated defaulted fields were not deprecated.

**The Solution:**
Updated the DefaultableVariable constructor call for RecordFieldWithDefaultValueNode to derive the deprecation flag from the field's metadata (via `isDeprecated(recordField.metadata())`), matching the behavior for record fields without default values. Additionally, the constructor was updated to accept and properly pass annotation attachments extracted from the field's metadata.

**Impact:**
- Record fields with default values now correctly reflect their deprecation status in generated API documentation
- The behavior is now consistent across all record field types
- Ensures that API documentation accurately represents which fields are deprecated

**Files Modified:**
- `misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java`
- Updated the `DefaultableVariable` constructor signature to include annotation attachments parameter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->