### PR TITLE
[2201.13.x] Fix param doc continuation scanning to stop at section headers

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -1001,7 +1001,11 @@ public final class Generator {
                 } else if (lookForMoreLines && docLine instanceof MarkdownDocumentationLineNode markdownDocLine) {
                     String docLineString = getDocLineString(markdownDocLine.documentElements());
                     if (!docLineString.isEmpty()) {
-                        parameterDoc.append(docLineString);
+                        if (docLineString.startsWith(DOC_HEADER_PREFIX)) {
+                            lookForMoreLines = false;
+                        } else {
+                            parameterDoc.append(docLineString);
+                        }
                     } else {
                         lookForMoreLines = false;
                     }


### PR DESCRIPTION
Backport of #44488 to 2201.13.x

## Summary

- Fix `getParameterDocFromMetadataList()` to stop scanning continuation lines when encountering `DOC_HEADER_PREFIX` (`"# "`)
- Prevents `# # Deprecated:` section headers from being appended to return-value descriptions

## Related Issue

Fixes #44487

🤖 Generated with [Claude Code](https://claude.com/claude-code)