### PR TITLE
[2201.13.x] Fix isDeprecated not set for record fields with default values

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -802,7 +802,8 @@ public final class Generator {
                 }
                 String defaultValue = recordField.expression().toString();
                 Type type = Type.fromNode(recordField.typeName(), semanticModel, module);
-                DefaultableVariable defaultableVariable = new DefaultableVariable(name, doc, false, type,
+                DefaultableVariable defaultableVariable = new DefaultableVariable(name, doc,
+                        isDeprecated(recordField.metadata()), type,
                         defaultValue, extractAnnotationAttachmentsFromMetadataNode(semanticModel,
                         recordField.metadata()));
                 if (recordField.readonlyKeyword().isPresent()) {


### PR DESCRIPTION
Backport of #44493 to 2201.13.x

## Summary

- Fix `isDeprecated` flag not being set for `RecordFieldWithDefaultValueNode` in docerina's `getDefaultableVariableList()`
- Record fields with default values (e.g., `string path = "/"`) now correctly show `isDeprecated: true` when annotated with `@deprecated`

## Related Issue

Fixes #44492

🤖 Generated with [Claude Code](https://claude.com/claude-code)