### PR TITLE
Fix resource function label in must-return diagnostic (#43815)

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
@@ -106,6 +106,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import static org.wso2.ballerinalang.compiler.util.Constants.WORKER_LAMBDA_VAR_PREFIX;
@@ -581,7 +582,7 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
                     !data.hasFunctionTerminated) {
                 Location closeBracePos = getEndCharPos(funcNode.pos);
                 this.dlog.error(closeBracePos, DiagnosticErrorCode.INVOKABLE_MUST_RETURN,
-                        funcNode.getKind().toString().toLowerCase());
+                        getInvokableKindNameForMessage(funcNode.getKind()));
             } else if (isNeverReturn && !data.hasFunctionTerminated) {
                 this.dlog.error(funcNode.pos, DiagnosticErrorCode.THIS_FUNCTION_SHOULD_PANIC);
             }
@@ -595,6 +596,20 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
                 this.dlog.warning(funcNode.returnTypeNode.pos,
                         DiagnosticWarningCode.FUNCTION_SHOULD_EXPLICITLY_RETURN_A_VALUE);
             }
+        }
+    }
+
+    /**
+     * User-facing invokable kind label for diagnostics (e.g. {@code resource function}, not {@code resource_func}).
+     */
+    private static String getInvokableKindNameForMessage(NodeKind kind) {
+        switch (kind) {
+            case RESOURCE_FUNC:
+                return "resource function";
+            case FUNCTION:
+                return "function";
+            default:
+                return kind.name().toLowerCase(Locale.ROOT).replace('_', ' ');
         }
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/klass/ServiceClassTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/klass/ServiceClassTest.java
@@ -247,7 +247,7 @@ public class ServiceClassTest {
     public void testResourceFunctionMustReturnErrorMessage() {
         CompileResult result =
                 BCompileUtil.compile("test-src/klass/resource_function_must_return_negative.bal");
-        validateError(result, 0, "this resource function must return a result", 8, 5);
+        validateError(result, 0, "this resource function must return a result", 7, 5);
         Assert.assertEquals(result.getErrorCount(), 1);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/klass/ServiceClassTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/klass/ServiceClassTest.java
@@ -243,6 +243,14 @@ public class ServiceClassTest {
         BRunUtil.invoke(compileResult, "testResourceMethodAssignability");
     }
 
+    @Test
+    public void testResourceFunctionMustReturnErrorMessage() {
+        CompileResult result =
+                BCompileUtil.compile("test-src/klass/resource_function_must_return_negative.bal");
+        validateError(result, 0, "this resource function must return a result", 8, 5);
+        Assert.assertEquals(result.getErrorCount(), 1);
+    }
+
     @AfterClass
     public void reset() {
         ServiceValue.reset();

--- a/tests/jballerina-unit-test/src/test/resources/test-src/klass/resource_function_must_return_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/klass/resource_function_must_return_negative.bal
@@ -1,0 +1,8 @@
+// Negative test: reachability error for resource function must use readable kind in message (issue #43815)
+service class Person {
+    resource function get age() returns int {
+        do {
+        } on fail error err {
+        }
+    }
+}


### PR DESCRIPTION
## Title
Fix diagnostic text for resource functions that must return a value

## Description

### Summary
When a `resource function` must return a value but the body does not guarantee a return (for example a `do`/`on fail` body that does not return), the compiler reported **`this resource_func must return a result`**. The kind string came from the `NodeKind` enum name, which is not valid Ballerina syntax.

This change maps `NodeKind` to user-facing labels so the message reads **`this resource function must return a result`**, consistent with other diagnostics that refer to “resource function” in plain language.

### Issue
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/43815

### Changes
- **`ReachabilityAnalyzer`**: Introduce `getInvokableKindNameForMessage` and use it for `INVOKABLE_MUST_RETURN` instead of `getKind().toString().toLowerCase()`.
- **Tests**: Add `resource_function_must_return_negative.bal` and `ServiceClassTest.testResourceFunctionMustReturnErrorMessage` to lock in the expected message.

### Testing
- [x] `.\gradlew.bat :jballerina-unit-test:test --tests "org.ballerinalang.test.klass.ServiceClassTest.testResourceFunctionMustReturnErrorMessage"` (requires JDK 21 per project build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request fixes compiler diagnostic wording so user-facing messages use plain-language invokable kind labels (e.g., "resource function") instead of the internal enum names (e.g., `resource_func`). The change corrects misleading diagnostic text for cases where an invokable (notably resource functions in service classes) must return a value but control flow does not guarantee a return.

## Changes

- ReachabilityAnalyzer.java
  - Added private helper getInvokableKindNameForMessage(NodeKind) to map NodeKind values to user-facing labels (e.g., RESOURCE_FUNC → "resource function", FUNCTION → "function") and to produce stable lowercase/space-separated fallbacks.
  - Updated the INVOKABLE_MUST_RETURN diagnostic construction to use the new helper instead of direct enum string conversion.

- Tests
  - Added resource_function_must_return_negative.bal (negative test triggering the must-return diagnostic for a service-class resource function).
  - Added ServiceClassTest.testResourceFunctionMustReturnErrorMessage to assert the corrected diagnostic message text and error count.

## Outcome

Compiler diagnostics now present correctly formatted, user-facing labels for invokables (including resource functions), improving the clarity of error messages and preventing regressions with the added tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->