### PR TITLE
Fix incorrect diagnostic message when reserved keyword is used in module import

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
@@ -729,7 +729,23 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         List<BLangIdentifier> pkgNameComps = new ArrayList<>();
         NodeList<IdentifierToken> names = importDeclaration.moduleName();
         Location position = getPosition(importDeclaration);
-        names.forEach(name -> pkgNameComps.add(this.createIdentifier(getPosition(name), name.text())));
+        names.forEach(name -> {
+            // If the token is missing (e.g. a reserved keyword like 'client' was used
+            // without the '^' escape), the parser synthesises a MISSING identifier and
+            // places the original keyword as a leading invalid-token minutiae.
+            // Recover that keyword text so that error messages like
+            // "cannot resolve module 'ballerinax/client.config'" are correct.
+            if (name.isMissing()) {
+                List<Token> leadingInvalid = name.leadingInvalidTokens();
+                String originalValue = name.text(); // empty string for missing tokens
+                if (!leadingInvalid.isEmpty()) {
+                    originalValue = leadingInvalid.get(0).text();
+                }
+                pkgNameComps.add(this.createIdentifier(getPosition(name), "", originalValue));
+            } else {
+                pkgNameComps.add(this.createIdentifier(getPosition(name), name.text()));
+            }
+        });
 
         BLangImportPackage importDcl = (BLangImportPackage) TreeBuilder.createImportPackageNode();
         importDcl.pos = position;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangImportPackage.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangImportPackage.java
@@ -134,7 +134,7 @@ public class BLangImportPackage extends BLangNode implements ImportPackageNode {
     public String getQualifiedPackageName() {
         String orgName = this.orgName.toString();
         String pkgName = String.join(".", pkgNameComps.stream()
-                .map(id -> id.value)
+                .map(id -> id.value.isEmpty() && id.originalValue != null ? id.originalValue : id.value)
                 .toList());
 
         String versionStr = (this.version.value != null) ? this.version.value : "";

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsNegativeTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsNegativeTests.java
@@ -56,4 +56,16 @@ public class ImportsNegativeTests {
         validateError(result, index++, "unknown type 'CallStackElement'", 51, 30);
         assertEquals(result.getErrorCount(), index);
     }
+
+    @Test(description = "Test diagnostic message for reserved keyword in module import path")
+    public void testReservedKeywordInModuleImportDiagnostic() {
+        CompileResult result = BCompileUtil.compile("test-src/imports/ReservedKeywordImportTestProject");
+        int index = 0;
+        // 'client' is a reserved keyword; the diagnostic must include it in the module path,
+        // i.e. "ballerinax/client.config", not "ballerinax/.config" (regression for #44509/#44519)
+        validateError(result, index++, "invalid token 'client'", 5, 19);
+        validateError(result, index++, "missing identifier", 5, 19);
+        validateError(result, index++, "cannot resolve module 'ballerinax/client.config as config'", 5, 1);
+        assertEquals(result.getErrorCount(), index);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsNegativeTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsNegativeTests.java
@@ -62,10 +62,12 @@ public class ImportsNegativeTests {
         CompileResult result = BCompileUtil.compile("test-src/imports/ReservedKeywordImportTestProject");
         int index = 0;
         // 'client' is a reserved keyword; the diagnostic must include it in the module path,
-        // i.e. "ballerinax/client.config", not "ballerinax/.config" (regression for #44509/#44519)
-        validateError(result, index++, "invalid token 'client'", 5, 19);
-        validateError(result, index++, "missing identifier", 5, 19);
+        // i.e. "ballerinax/client.config", not "ballerinax/.config" (regression for #44509/#44519).
+        // Diagnostics are ordered by source position; the import declaration starts at col 1,
+        // so the module-resolution error precedes the parser errors at col 19.
         validateError(result, index++, "cannot resolve module 'ballerinax/client.config as config'", 5, 1);
+        validateError(result, index++, "invalid token 'client'", 5, 19);
+        validateError(result, index++, "missing identifier", 5, 25);
         assertEquals(result.getErrorCount(), index);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/ReservedKeywordImportTestProject/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/ReservedKeywordImportTestProject/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "reservedkeywordimport"
+version = "1.0.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/ReservedKeywordImportTestProject/reserved-keyword-import-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/ReservedKeywordImportTestProject/reserved-keyword-import-negative.bal
@@ -1,0 +1,5 @@
+// Test: using a reserved keyword (client) in a module import path without '^' escape
+// should produce a diagnostic that includes the keyword in the module path,
+// i.e. "cannot resolve module 'ballerinax/client.config as config'"
+// NOT "cannot resolve module 'ballerinax/.config as config'"
+import ballerinax/client.config;


### PR DESCRIPTION
## Purpose
When a reserved keyword (e.g., `client`) is used in a module import path without the `^` escape prefix, the compiler produces misleading diagnostics. For instance, `import ballerinax/client.config;` results in the error `cannot resolve module 'ballerinax/.config as config'`. The reserved keyword is dropped from the module path in the diagnostic message because `BLangIdentifier.value` is empty for unescaped reserved keywords.

Fixes #44509 
Fixes #44519 

## Approach
In `BLangImportPackage.getQualifiedPackageName()`, updated the package name construction to fall back to `originalValue` when `.value` is empty. This ensures that the original source text of the reserved keyword is preserved when formatting the qualified package name for diagnostic messages. 

Added a negative test case in [ImportsNegativeTests.java](cci:7://file:///Users/realdulain/Documents/Projects/ballerina-lang/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsNegativeTests.java:0:0-0:0) to verify that the generated diagnostic includes the reserved keyword correctly stringified in the module path.

## Samples

N/A

## Remarks

N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This pull request fixes misleading compiler diagnostics that omitted unescaped reserved keywords (for example `client`) from module import paths shown in error messages. The change ensures the original source text for such identifiers is preserved when the compiler formats qualified package names for diagnostics.

## Changes Made
- Compiler: Preserve original identifier text when constructing qualified package names. BLangImportPackage.getQualifiedPackageName() now falls back to an identifier's originalValue when the parsed value is empty. BLangNodeBuilder was also updated to extract reserved-keyword text from parser-provided invalid-token minutiae when the parser synthesizes a missing identifier, ensuring the identifier's originalValue is set.
- Tests: Added a negative unit test (testReservedKeywordInModuleImportDiagnostic) and supporting test resources to verify diagnostics include the reserved keyword in the module path (e.g., `ballerinax/client.config as config`). Regression test assertions were adjusted to reflect parser-emitted diagnostic ordering and token positions.

## Impact
Improves the accuracy and clarity of compiler diagnostics for import errors involving unescaped reserved keywords, making troubleshooting more straightforward for developers.

Related issues: #44509, #44519
<!-- end of auto-generated comment: release notes by coderabbit.ai -->