### PR TITLE
[2201.13.x] Fix handling integer constants in the BIR packages

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -820,6 +820,18 @@ public class BIRPackageSymbolEnter {
         switch (valueType.tag) {
             case TypeTags.INT:
                 return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.intType);
+            case TypeTags.UNSIGNED8_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.unsigned8IntType);
+            case  TypeTags.UNSIGNED16_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.unsigned16IntType);
+            case  TypeTags.UNSIGNED32_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.unsigned32IntType);
+            case TypeTags.SIGNED8_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.signed8IntType);
+            case TypeTags.SIGNED16_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.signed16IntType);
+            case TypeTags.SIGNED32_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.signed32IntType);
             case TypeTags.BYTE:
                 return new BLangConstantValue(getByteCPEntryValue(dataInStream), symTable.byteType);
             case TypeTags.FLOAT:


### PR DESCRIPTION
## Purpose
As mentioned in the [issue](https://github.com/wso2-enterprise/wso2-integration-internal/issues/4886) `bal build` fails due to BIR loading issue.

```
error: failed to load the module '<org>/<package>:<version>' from its BIR due to: unexpected type: int:Unsigned32
```

This issue happens due to `readConstLiteralValue()` method not handling the following integer types.

| Type | TypeTag constant |
|---|---|
| intType | Tags.INT handled
| int:Unsigned32 | TypeTags.UNSIGNED32_INT missing |
| int:Unsigned16 | TypeTags.UNSIGNED16_INT missing |
| int:Unsigned8 | TypeTags.UNSIGNED8_INT missing |
| int:Signed32 | TypeTags.SIGNED32_INT missing |
| int:Signed16 | TypeTags.SIGNED16_INT missing |
| int:Signed8 | TypeTags.SIGNED8_INT missing |

This will handle these integer types. This resolves the above BIR loading issue as well.


Fixes https://github.com/wso2-enterprise/wso2-integration-internal/issues/4886

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
