### PR TITLE
Fix handling integer constants in the BIR packages

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -820,6 +820,18 @@ public class BIRPackageSymbolEnter {
         switch (valueType.tag) {
             case TypeTags.INT:
                 return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.intType);
+            case TypeTags.UNSIGNED8_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.unsigned8IntType);
+            case  TypeTags.UNSIGNED16_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.unsigned16IntType);
+            case  TypeTags.UNSIGNED32_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.unsigned32IntType);
+            case TypeTags.SIGNED8_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.signed8IntType);
+            case TypeTags.SIGNED16_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.signed16IntType);
+            case TypeTags.SIGNED32_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.signed32IntType);
             case TypeTags.BYTE:
                 return new BLangConstantValue(getByteCPEntryValue(dataInStream), symTable.byteType);
             case TypeTags.FLOAT:


### PR DESCRIPTION
## Purpose
As mentioned in the [issue](https://github.com/wso2-enterprise/wso2-integration-internal/issues/4886) `bal build` fails due to BIR loading issue.

```
error: failed to load the module '<org>/<package>:<version>' from its BIR due to: unexpected type: int:Unsigned32
```

This issue happens due to `readConstLiteralValue()` method not handling the following integer types.

| Type | TypeTag constant |
|---|---|
| intType | Tags.INT handled
| int:Unsigned32 | TypeTags.UNSIGNED32_INT missing |
| int:Unsigned16 | TypeTags.UNSIGNED16_INT missing |
| int:Unsigned8 | TypeTags.UNSIGNED8_INT missing |
| int:Signed32 | TypeTags.SIGNED32_INT missing |
| int:Signed16 | TypeTags.SIGNED16_INT missing |
| int:Signed8 | TypeTags.SIGNED8_INT missing |

This will handle these integer types. This resolves the above BIR loading issue as well.

Related PRs - https://github.com/ballerina-platform/ballerina-lang/pull/44547


## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request resolves a build failure that occurred when loading Ballerina IR (BIR) modules containing integer constant literals of specific subtypes. The issue manifested as an "unexpected type" error during `bal build` when encountering signed and unsigned 8-bit, 16-bit, or 32-bit integer constants.

## Changes

The `readConstLiteralValue()` method in `BIRPackageSymbolEnter.java` was updated to properly handle constant-literal decoding for six additional integer type tags: `UNSIGNED8_INT`, `UNSIGNED16_INT`, `UNSIGNED32_INT`, `SIGNED8_INT`, `SIGNED16_INT`, and `SIGNED32_INT`. For each type, the method now reads the corresponding integer value from the constant pool and constructs the appropriate `BLangConstantValue` object with the matching type from the symbol table.

This change ensures that modules with specialized integer type literals can be successfully loaded during the build process.

## Impact

- **Lines changed:** +12/-0
- **Scope:** Compiler module (BIR loading logic)
- **Backward compatibility:** No public API changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->