### PR TITLE
[Bug] Fix incorrect error message for resource functions (#43815)

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
@@ -580,8 +580,10 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
             if (!funcNode.symbol.type.getReturnType().isNullable() && !isNeverReturn &&
                     !data.hasFunctionTerminated) {
                 Location closeBracePos = getEndCharPos(funcNode.pos);
+                String funcKindStr = funcNode.getKind() == NodeKind.RESOURCE_FUNC ? "resource function" :
+                        funcNode.getKind().toString().toLowerCase();
                 this.dlog.error(closeBracePos, DiagnosticErrorCode.INVOKABLE_MUST_RETURN,
-                        funcNode.getKind().toString().toLowerCase());
+                        funcKindStr);
             } else if (isNeverReturn && !data.hasFunctionTerminated) {
                 this.dlog.error(funcNode.pos, DiagnosticErrorCode.THIS_FUNCTION_SHOULD_PANIC);
             }


### PR DESCRIPTION
## Purpose
Fixes issue #43815 by replacing the internal AST enum string `"resource_func"` with the correct language keyword `"resource function"` in the `BCE2095` compiler error message.

Previously, if a resource function was missing a return statement, the compiler logged:
> `this resource_func must return a result`

It will now correctly log:
> `this resource function must return a result`

## Related Issues
Fixes #43815

## Changes
- [ReachabilityAnalyzer.java](cci:7://file:///E:/GitHub%20Projects/WSO2/My/ballerina-lang/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java:0:0-0:0): Added a condition when formatting the `DiagnosticErrorCode.INVOKABLE_MUST_RETURN` argument so that `NodeKind.RESOURCE_FUNC` translates to `"resource function"` rather than relying on the bare `toLowerCase()` enum string representation.

## Testing
This relies on existing `jballerina-unit-test` suites for diagnostic message validation. Submitting so CI can verify standard reachability tests against the updated string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes an incorrect compiler diagnostic message that was using an internal AST enum representation instead of the proper language keyword. The change improves the clarity and user-friendliness of error messages reported by the Ballerina compiler.

## Changes

**Modified file:** `ReachabilityAnalyzer.java`

Updated the `INVOKABLE_MUST_RETURN` diagnostic message to display "resource function" instead of "resource_func" when a resource function is missing a return statement. The fix adds a specialized condition that checks if the function kind is `NodeKind.RESOURCE_FUNC` and maps it to the human-readable display string "resource function", while maintaining the existing behavior for other function types.

**Impact:** Users will now see the correct, language-appropriate error message: "this resource function must return a result" instead of the previous internal representation "this resource_func must return a result".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->