### PR TITLE
[2201.13.x] Fix handling integer constants in the BIR packages

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -820,6 +820,18 @@ public class BIRPackageSymbolEnter {
         switch (valueType.tag) {
             case TypeTags.INT:
                 return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.intType);
+            case TypeTags.UNSIGNED8_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.unsigned8IntType);
+            case  TypeTags.UNSIGNED16_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.unsigned16IntType);
+            case  TypeTags.UNSIGNED32_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.unsigned32IntType);
+            case TypeTags.SIGNED8_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.signed8IntType);
+            case TypeTags.SIGNED16_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.signed16IntType);
+            case TypeTags.SIGNED32_INT:
+                return new BLangConstantValue(getIntCPEntryValue(dataInStream), symTable.signed32IntType);
             case TypeTags.BYTE:
                 return new BLangConstantValue(getByteCPEntryValue(dataInStream), symTable.byteType);
             case TypeTags.FLOAT:

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/annotation/AnnotationTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/annotation/AnnotationTests.java
@@ -140,6 +140,40 @@ public class AnnotationTests {
     }
 
     @Test
+    public void testAnnotationWithIntSubtypeFields() {
+        BRunUtil.invoke(result, "testAnnotationWithIntSubtypeFields");
+    }
+
+    @Test
+    public void testAnnotationWithIntSubtypeFieldsViaBir() {
+        BLangPackage bLangPackage = (BLangPackage) result.getAST();
+        Map<Name, Scope.ScopeEntry> importedModuleEntries = bLangPackage.getImports().get(0).symbol.scope.entries;
+
+        BTypeDefinitionSymbol symbol =
+                (BTypeDefinitionSymbol) importedModuleEntries.get(
+                        Names.fromString("AnnotatedWithIntSubtype")).symbol;
+        List<? extends AnnotationAttachmentSymbol> attachments = symbol.getAnnotations();
+        Assert.assertEquals(attachments.size(), 1);
+
+        BAnnotationAttachmentSymbol annotAttachment = (BAnnotationAttachmentSymbol) attachments.get(0);
+        PackageID pkgID = annotAttachment.annotPkgID;
+        Assert.assertEquals(pkgID.orgName.value, "testorg");
+        Assert.assertEquals(pkgID.pkgName.value, "foo");
+        Assert.assertEquals(annotAttachment.annotTag.value, "SequenceAnnot");
+        Assert.assertTrue(annotAttachment.isConstAnnotation());
+
+        BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol constAttachment =
+                (BAnnotationAttachmentSymbol.BConstAnnotationAttachmentSymbol) annotAttachment;
+        Object value = constAttachment.attachmentValueSymbol.value.value;
+        Assert.assertTrue(value instanceof Map);
+        Map<String, BLangConstantValue> mapValue = (Map<String, BLangConstantValue>) value;
+        Assert.assertEquals(mapValue.size(), 2);
+        Assert.assertEquals(mapValue.get("minOccurs").value, 1L);
+        Assert.assertEquals(mapValue.get("maxOccurs").value, 10L);
+        Assert.assertEquals(constAttachment.attachmentValueSymbol.type.tag, TypeTags.TYPEREFDESC);
+    }
+
+    @Test
     public void testParamAnnotAttachmentsViaBir() {
         BLangPackage bLangPackage = (BLangPackage) birTestResult.getAST();
         Map<Name, Scope.ScopeEntry> importedModuleEntries = bLangPackage.getImports().get(0).symbol.scope.entries;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/annotations/annotation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/annotations/annotation.bal
@@ -167,6 +167,16 @@ function testConstAnnotationAccess() {
     assertTrue(config2.examples is readonly);
 }
 
+function testAnnotationWithIntSubtypeFields() {
+    foo:AnnotatedWithIntSubtype val = {name: "test"};
+    typedesc<any> td = typeof val;
+    foo:SequenceConfig? annot = td.@foo:SequenceAnnot;
+    assertTrue(annot is foo:SequenceConfig);
+    foo:SequenceConfig config = <foo:SequenceConfig>annot;
+    assertEquality(1, config.minOccurs);
+    assertEquality(10, config.maxOccurs);
+}
+
 function assertTrue(anydata actual) {
     assertEquality(true, actual);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/annotations.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/annotations.bal
@@ -76,3 +76,15 @@ public type Teacher record {|
     int id;
     string name;
 |};
+
+public type SequenceConfig record {|
+    int:Unsigned32 minOccurs;
+    int:Unsigned32 maxOccurs;
+|};
+
+public const annotation SequenceConfig SequenceAnnot on type;
+
+@SequenceAnnot {minOccurs: 1, maxOccurs: 10}
+public type AnnotatedWithIntSubtype record {|
+    string name;
+|};


### PR DESCRIPTION
## Description
As mentioned in the [issue](https://github.com/wso2-enterprise/wso2-integration-internal/issues/4886), `bal build` fails due to BIR loading issue.

It fixes: https://github.com/ballerina-platform/ballerina-lang/issues/44562

```
error: failed to load the module '<org>/<package>:<version>' from its BIR due to: unexpected type: int:Unsigned32
```

This issue happens due to `readConstLiteralValue()` method not handling the following integer types.

| Type | TypeTag constant |
|------|------------------|
| intType | Tags.INT handled |
| int:Unsigned32 | TypeTags.UNSIGNED32_INT missing |
| int:Unsigned16 | TypeTags.UNSIGNED16_INT missing |
| int:Unsigned8 | TypeTags.UNSIGNED8_INT missing |
| int:Signed32 | TypeTags.SIGNED32_INT missing |
| int:Signed16 | TypeTags.SIGNED16_INT missing |
| int:Signed8 | TypeTags.SIGNED8_INT missing |

This will handle these integer types. This resolves the above BIR loading issue as well.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
