### PR TITLE
feat: add toTopologicallySortedLevels() to DependencyGraph

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
@@ -206,6 +206,7 @@ public class DependencyGraph<T> {
         }
 
         List<Set<T>> levels = new ArrayList<>();
+        int sortedNodeCount = 0;
         while (!queue.isEmpty()) {
             Set<T> currentLevel = new LinkedHashSet<>(queue);
             queue.clear();
@@ -218,6 +219,14 @@ public class DependencyGraph<T> {
                 }
             }
             levels.add(Collections.unmodifiableSet(currentLevel));
+            sortedNodeCount += currentLevel.size();
+        }
+
+        if (sortedNodeCount != depCount.size()) {
+            Set<T> unsortedNodes = new LinkedHashSet<>(depCount.keySet());
+            levels.forEach(unsortedNodes::removeAll);
+            throw new IllegalStateException(
+                    "Cannot topologically sort dependency graph with cyclic dependencies: " + unsortedNodes);
         }
 
         return Collections.unmodifiableList(levels);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
@@ -186,7 +186,6 @@ public class DependencyGraph<T> {
         Map<T, Set<T>> reverseDeps = new HashMap<>();
 
         for (T node : dependencies.keySet()) {
-            depCount.putIfAbsent(node, 0);
             reverseDeps.putIfAbsent(node, new HashSet<>());
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
@@ -24,7 +24,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.LinkedList;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -168,6 +170,51 @@ public class DependencyGraph<T> {
         topologicallySortedNodes = Collections.unmodifiableList(sorted);
         cyclicDependencies.forEach(cycle -> cycle.add(cycle.get(0)));
         return topologicallySortedNodes;
+    }
+
+    /**
+     * Returns nodes grouped by their dependency levels.
+     * Level 0 contains nodes with no dependencies,
+     * level 1 contains nodes that depend only on level-0 nodes, and so on.
+     * Useful for parallel compilation of independent nodes within the same level.
+     *
+     * @return an ordered list of sets, where the index represents the level
+     *         and each set contains nodes at that level
+     */
+    public List<Set<T>> toTopologicallySortedLevels() {
+        Map<T, Integer> inDegree = new HashMap<>();
+        for (T node : dependencies.keySet()) {
+            inDegree.putIfAbsent(node, 0);
+            for (T dep : dependencies.get(node)) {
+                inDegree.merge(dep, 1, Integer::sum);
+            }
+        }
+
+        Queue<T> queue = new LinkedList<>();
+        for (Map.Entry<T, Integer> entry : inDegree.entrySet()) {
+            if (entry.getValue() == 0) {
+                queue.add(entry.getKey());
+            }
+        }
+
+        List<Set<T>> levels = new ArrayList<>();
+        while (!queue.isEmpty()) {
+            Set<T> currentLevel = new LinkedHashSet<>(queue);
+            queue.clear();
+            for (T node : currentLevel) {
+                for (T dependent : dependencies.keySet()) {
+                    if (dependencies.get(dependent).contains(node)) {
+                        inDegree.merge(dependent, -1, Integer::sum);
+                        if (inDegree.get(dependent) == 0) {
+                            queue.add(dependent);
+                        }
+                    }
+                }
+            }
+            levels.add(Collections.unmodifiableSet(currentLevel));
+        }
+
+        return Collections.unmodifiableList(levels);
     }
 
     public boolean isEmpty() {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
@@ -174,7 +174,7 @@ public class DependencyGraph<T> {
 
     /**
      * Returns nodes grouped by their dependency levels.
-     * Level 0 contains nodes with no dependencies,
+     * Level 0 contains nodes with no dependencies (leaves),
      * level 1 contains nodes that depend only on level-0 nodes, and so on.
      * Useful for parallel compilation of independent nodes within the same level.
      *
@@ -182,16 +182,24 @@ public class DependencyGraph<T> {
      *         and each set contains nodes at that level
      */
     public List<Set<T>> toTopologicallySortedLevels() {
-        Map<T, Integer> inDegree = new HashMap<>();
+        Map<T, Integer> depCount = new HashMap<>();
+        Map<T, Set<T>> reverseDeps = new HashMap<>();
+
         for (T node : dependencies.keySet()) {
-            inDegree.putIfAbsent(node, 0);
-            for (T dep : dependencies.get(node)) {
-                inDegree.merge(dep, 1, Integer::sum);
+            depCount.putIfAbsent(node, 0);
+            reverseDeps.putIfAbsent(node, new HashSet<>());
+        }
+
+        for (Map.Entry<T, Set<T>> entry : dependencies.entrySet()) {
+            T dependent = entry.getKey();
+            depCount.put(dependent, entry.getValue().size());
+            for (T dep : entry.getValue()) {
+                reverseDeps.computeIfAbsent(dep, k -> new HashSet<>()).add(dependent);
             }
         }
 
         Queue<T> queue = new LinkedList<>();
-        for (Map.Entry<T, Integer> entry : inDegree.entrySet()) {
+        for (Map.Entry<T, Integer> entry : depCount.entrySet()) {
             if (entry.getValue() == 0) {
                 queue.add(entry.getKey());
             }
@@ -202,12 +210,10 @@ public class DependencyGraph<T> {
             Set<T> currentLevel = new LinkedHashSet<>(queue);
             queue.clear();
             for (T node : currentLevel) {
-                for (T dependent : dependencies.keySet()) {
-                    if (dependencies.get(dependent).contains(node)) {
-                        inDegree.merge(dependent, -1, Integer::sum);
-                        if (inDegree.get(dependent) == 0) {
-                            queue.add(dependent);
-                        }
+                for (T dependent : reverseDeps.getOrDefault(node, Collections.emptySet())) {
+                    int remaining = depCount.merge(dependent, -1, Integer::sum);
+                    if (remaining == 0) {
+                        queue.add(dependent);
                     }
                 }
             }

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/TopologicallySortedLevelsTest.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/TopologicallySortedLevelsTest.java
@@ -1,0 +1,153 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.projects;
+
+import io.ballerina.projects.DependencyGraph.DependencyGraphBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Tests for {@link DependencyGraph#toTopologicallySortedLevels()}.
+ *
+ * @since 2201.12.0
+ */
+public class TopologicallySortedLevelsTest {
+
+    @Test
+    public void testDiamondGraph() {
+        // A depends on B and C; B and C both depend on D
+        // Expected levels: [D] -> [B, C] -> [A]
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.addDependency("A", "B");
+        builder.addDependency("A", "C");
+        builder.addDependency("B", "D");
+        builder.addDependency("C", "D");
+        DependencyGraph<String> graph = builder.build();
+
+        List<Set<String>> levels = graph.toTopologicallySortedLevels();
+
+        Assert.assertEquals(levels.size(), 3);
+        Assert.assertEquals(levels.get(0), Set.of("D"));
+        Assert.assertEquals(levels.get(1), Set.of("B", "C"));
+        Assert.assertEquals(levels.get(2), Set.of("A"));
+    }
+
+    @Test
+    public void testLinearChain() {
+        // A -> B -> C -> D (each depends on the next)
+        // Expected levels: [D] -> [C] -> [B] -> [A]
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.addDependency("A", "B");
+        builder.addDependency("B", "C");
+        builder.addDependency("C", "D");
+        DependencyGraph<String> graph = builder.build();
+
+        List<Set<String>> levels = graph.toTopologicallySortedLevels();
+
+        Assert.assertEquals(levels.size(), 4);
+        Assert.assertEquals(levels.get(0), Set.of("D"));
+        Assert.assertEquals(levels.get(1), Set.of("C"));
+        Assert.assertEquals(levels.get(2), Set.of("B"));
+        Assert.assertEquals(levels.get(3), Set.of("A"));
+    }
+
+    @Test
+    public void testDisconnectedComponents() {
+        // Two independent chains: A -> B, C -> D
+        // Expected levels: [B, D] -> [A, C]
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.addDependency("A", "B");
+        builder.addDependency("C", "D");
+        DependencyGraph<String> graph = builder.build();
+
+        List<Set<String>> levels = graph.toTopologicallySortedLevels();
+
+        Assert.assertEquals(levels.size(), 2);
+        Assert.assertEquals(levels.get(0), Set.of("B", "D"));
+        Assert.assertEquals(levels.get(1), Set.of("A", "C"));
+    }
+
+    @Test
+    public void testSingleNode() {
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.add("A");
+        DependencyGraph<String> graph = builder.build();
+
+        List<Set<String>> levels = graph.toTopologicallySortedLevels();
+
+        Assert.assertEquals(levels.size(), 1);
+        Assert.assertEquals(levels.get(0), Set.of("A"));
+    }
+
+    @Test
+    public void testAllIndependentNodes() {
+        // No dependencies between nodes
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.add("A");
+        builder.add("B");
+        builder.add("C");
+        DependencyGraph<String> graph = builder.build();
+
+        List<Set<String>> levels = graph.toTopologicallySortedLevels();
+
+        Assert.assertEquals(levels.size(), 1);
+        Assert.assertEquals(levels.get(0), Set.of("A", "B", "C"));
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class,
+          expectedExceptionsMessageRegExp = ".*cyclic dependencies.*")
+    public void testCyclicGraphThrowsException() {
+        // A -> B -> C -> A (cycle)
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.addDependency("A", "B");
+        builder.addDependency("B", "C");
+        builder.addDependency("C", "A");
+        DependencyGraph<String> graph = builder.build();
+
+        graph.toTopologicallySortedLevels();
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class,
+          expectedExceptionsMessageRegExp = ".*cyclic dependencies.*")
+    public void testPartialCycleThrowsException() {
+        // D -> A -> B -> C -> A (D is acyclic, A-B-C form a cycle)
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.addDependency("D", "A");
+        builder.addDependency("A", "B");
+        builder.addDependency("B", "C");
+        builder.addDependency("C", "A");
+        DependencyGraph<String> graph = builder.build();
+
+        graph.toTopologicallySortedLevels();
+    }
+
+    @Test
+    public void testLevelsAreUnmodifiable() {
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.addDependency("A", "B");
+        DependencyGraph<String> graph = builder.build();
+
+        List<Set<String>> levels = graph.toTopologicallySortedLevels();
+
+        Assert.assertThrows(UnsupportedOperationException.class, () -> levels.add(Set.of("X")));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> levels.get(0).add("X"));
+    }
+}


### PR DESCRIPTION
## Purpose

Resolves #43027 

Adds a `toTopologicallySortedLevels()` method to `DependencyGraph` that returns nodes grouped by their dependency levels. This enables parallel compilation of independent nodes within the same level.

## Approach

Uses Kahn's algorithm (BFS-based topological sort) to compute levels:
- **Level 0**: Nodes with no dependencies (leaves)
- **Level 1**: Nodes whose dependencies are all in level 0
- **Level N**: Nodes whose dependencies are all in levels 0..N-1

Returns `List<Set<T>>` where each index is the level and the set contains nodes at that level.

## Example

For the graph `A -> B -> D, A -> C -> D`:

| Level | Nodes |
|-------|-------|
| 0 | D |
| 1 | B, C |
| 2 | A |

Nodes at the same level can be compiled in parallel since they have no inter-dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds a new public method to DependencyGraph: toTopologicallySortedLevels(). The method computes dependency levels using a BFS/Kahn-style topological layering so nodes whose dependencies are satisfied at the same stage can be processed in parallel. It returns an unmodifiable List<Set<T>> where each list index is the dependency level (level 0 contains nodes with no unresolved dependencies). The implementation includes cycle detection and throws an IllegalStateException if the graph contains cycles that prevent full leveling.

## Changes

File: compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
- Added method: public List<Set<T>> toTopologicallySortedLevels() — computes and returns nodes grouped by dependency level to support parallel compilation scheduling.
- Implementation summary:
  - Builds per-node dependency counts and a reverse adjacency map (dependency → dependents).
  - Uses a queue-driven loop to collect zero-dependency nodes into successive immutable level sets and decrement dependents’ counts to release subsequent levels.
  - Detects cycles by comparing placed node count with total nodes and throws IllegalStateException listing remaining nodes when leveling cannot complete.
- New imports: LinkedList, Queue.

File: compiler/ballerina-lang/src/test/java/io/ballerina/projects/TopologicallySortedLevelsTest.java
- Added comprehensive TestNG unit tests covering:
  - Diamond graph, linear chain, disconnected components, single node, and all-independent nodes.
  - Cyclic and partial-cycle graphs asserting IllegalStateException with an explanatory message.
  - Immutability guarantees for the returned List and inner Sets.

Lines changed: +214/-0 (approximate: +61 in main, +153 in tests)

## Outcome

Enables the compiler driver to identify independent node groups for parallel compilation scheduling, improving potential build parallelism while failing fast on cyclic dependency graphs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->