### PR TITLE
feat: add toTopologicallySortedLevels() to DependencyGraph

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
@@ -24,7 +24,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.LinkedList;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -168,6 +170,65 @@ public class DependencyGraph<T> {
         topologicallySortedNodes = Collections.unmodifiableList(sorted);
         cyclicDependencies.forEach(cycle -> cycle.add(cycle.get(0)));
         return topologicallySortedNodes;
+    }
+
+    /**
+     * Returns nodes grouped by their dependency levels.
+     * Level 0 contains nodes with no dependencies (leaves),
+     * level 1 contains nodes that depend only on level-0 nodes, and so on.
+     * Useful for parallel compilation of independent nodes within the same level.
+     *
+     * @return an ordered list of sets, where the index represents the level
+     *         and each set contains nodes at that level
+     */
+    public List<Set<T>> toTopologicallySortedLevels() {
+        Map<T, Integer> depCount = new HashMap<>();
+        Map<T, Set<T>> reverseDeps = new HashMap<>();
+
+        for (T node : dependencies.keySet()) {
+            reverseDeps.putIfAbsent(node, new HashSet<>());
+        }
+
+        for (Map.Entry<T, Set<T>> entry : dependencies.entrySet()) {
+            T dependent = entry.getKey();
+            depCount.put(dependent, entry.getValue().size());
+            for (T dep : entry.getValue()) {
+                reverseDeps.computeIfAbsent(dep, k -> new HashSet<>()).add(dependent);
+            }
+        }
+
+        Queue<T> queue = new LinkedList<>();
+        for (Map.Entry<T, Integer> entry : depCount.entrySet()) {
+            if (entry.getValue() == 0) {
+                queue.add(entry.getKey());
+            }
+        }
+
+        List<Set<T>> levels = new ArrayList<>();
+        int sortedNodeCount = 0;
+        while (!queue.isEmpty()) {
+            Set<T> currentLevel = new LinkedHashSet<>(queue);
+            queue.clear();
+            for (T node : currentLevel) {
+                for (T dependent : reverseDeps.getOrDefault(node, Collections.emptySet())) {
+                    int remaining = depCount.merge(dependent, -1, Integer::sum);
+                    if (remaining == 0) {
+                        queue.add(dependent);
+                    }
+                }
+            }
+            levels.add(Collections.unmodifiableSet(currentLevel));
+            sortedNodeCount += currentLevel.size();
+        }
+
+        if (sortedNodeCount != depCount.size()) {
+            Set<T> unsortedNodes = new LinkedHashSet<>(depCount.keySet());
+            levels.forEach(unsortedNodes::removeAll);
+            throw new IllegalStateException(
+                    "Cannot topologically sort dependency graph with cyclic dependencies: " + unsortedNodes);
+        }
+
+        return Collections.unmodifiableList(levels);
     }
 
     public boolean isEmpty() {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
@@ -179,13 +179,16 @@ public class DependencyGraph<T> {
      * Useful for parallel compilation of independent nodes within the same level.
      *
      * @return an ordered list of sets, where the index represents the level
-     *         and each set contains nodes at that level
+     *         and each set contains nodes at that level; both the returned list
+     *         and each contained set are unmodifiable
+     * @throws IllegalStateException if the graph contains cyclic dependencies
      */
     public List<Set<T>> toTopologicallySortedLevels() {
         Map<T, Integer> depCount = new HashMap<>();
         Map<T, Set<T>> reverseDeps = new HashMap<>();
 
         for (T node : dependencies.keySet()) {
+            depCount.putIfAbsent(node, 0);
             reverseDeps.putIfAbsent(node, new HashSet<>());
         }
 
@@ -193,6 +196,7 @@ public class DependencyGraph<T> {
             T dependent = entry.getKey();
             depCount.put(dependent, entry.getValue().size());
             for (T dep : entry.getValue()) {
+                depCount.putIfAbsent(dep, 0);
                 reverseDeps.computeIfAbsent(dep, k -> new HashSet<>()).add(dependent);
             }
         }

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/TopologicallySortedLevelsTest.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/TopologicallySortedLevelsTest.java
@@ -22,6 +22,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -155,5 +156,16 @@ public class TopologicallySortedLevelsTest {
             Assert.assertThrows(UnsupportedOperationException.class, () -> level.remove("X"));
             Assert.assertThrows(UnsupportedOperationException.class, level::clear);
         });
+    }
+
+    @Test
+    public void testFromMapWithDependencyOnlyNode() {
+        DependencyGraph<String> graph = DependencyGraph.from(Map.of("A", Set.of("B")));
+
+        List<Set<String>> levels = graph.toTopologicallySortedLevels();
+
+        Assert.assertEquals(levels.size(), 2);
+        Assert.assertEquals(levels.get(0), Set.of("B"));
+        Assert.assertEquals(levels.get(1), Set.of("A"));
     }
 }

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/TopologicallySortedLevelsTest.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/TopologicallySortedLevelsTest.java
@@ -1,0 +1,153 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.projects;
+
+import io.ballerina.projects.DependencyGraph.DependencyGraphBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Tests for {@link DependencyGraph#toTopologicallySortedLevels()}.
+ *
+ * @since 2201.12.0
+ */
+public class TopologicallySortedLevelsTest {
+
+    @Test
+    public void testDiamondGraph() {
+        // A depends on B and C; B and C both depend on D
+        // Expected levels: [D] -> [B, C] -> [A]
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.addDependency("A", "B");
+        builder.addDependency("A", "C");
+        builder.addDependency("B", "D");
+        builder.addDependency("C", "D");
+        DependencyGraph<String> graph = builder.build();
+
+        List<Set<String>> levels = graph.toTopologicallySortedLevels();
+
+        Assert.assertEquals(levels.size(), 3);
+        Assert.assertEquals(levels.get(0), Set.of("D"));
+        Assert.assertEquals(levels.get(1), Set.of("B", "C"));
+        Assert.assertEquals(levels.get(2), Set.of("A"));
+    }
+
+    @Test
+    public void testLinearChain() {
+        // A -> B -> C -> D (each depends on the next)
+        // Expected levels: [D] -> [C] -> [B] -> [A]
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.addDependency("A", "B");
+        builder.addDependency("B", "C");
+        builder.addDependency("C", "D");
+        DependencyGraph<String> graph = builder.build();
+
+        List<Set<String>> levels = graph.toTopologicallySortedLevels();
+
+        Assert.assertEquals(levels.size(), 4);
+        Assert.assertEquals(levels.get(0), Set.of("D"));
+        Assert.assertEquals(levels.get(1), Set.of("C"));
+        Assert.assertEquals(levels.get(2), Set.of("B"));
+        Assert.assertEquals(levels.get(3), Set.of("A"));
+    }
+
+    @Test
+    public void testDisconnectedComponents() {
+        // Two independent chains: A -> B, C -> D
+        // Expected levels: [B, D] -> [A, C]
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.addDependency("A", "B");
+        builder.addDependency("C", "D");
+        DependencyGraph<String> graph = builder.build();
+
+        List<Set<String>> levels = graph.toTopologicallySortedLevels();
+
+        Assert.assertEquals(levels.size(), 2);
+        Assert.assertEquals(levels.get(0), Set.of("B", "D"));
+        Assert.assertEquals(levels.get(1), Set.of("A", "C"));
+    }
+
+    @Test
+    public void testSingleNode() {
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.add("A");
+        DependencyGraph<String> graph = builder.build();
+
+        List<Set<String>> levels = graph.toTopologicallySortedLevels();
+
+        Assert.assertEquals(levels.size(), 1);
+        Assert.assertEquals(levels.get(0), Set.of("A"));
+    }
+
+    @Test
+    public void testAllIndependentNodes() {
+        // No dependencies between nodes
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.add("A");
+        builder.add("B");
+        builder.add("C");
+        DependencyGraph<String> graph = builder.build();
+
+        List<Set<String>> levels = graph.toTopologicallySortedLevels();
+
+        Assert.assertEquals(levels.size(), 1);
+        Assert.assertEquals(levels.get(0), Set.of("A", "B", "C"));
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class,
+          expectedExceptionsMessageRegExp = ".*cyclic dependencies.*")
+    public void testCyclicGraphThrowsException() {
+        // A -> B -> C -> A (cycle)
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.addDependency("A", "B");
+        builder.addDependency("B", "C");
+        builder.addDependency("C", "A");
+        DependencyGraph<String> graph = builder.build();
+
+        graph.toTopologicallySortedLevels();
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class,
+          expectedExceptionsMessageRegExp = ".*cyclic dependencies.*")
+    public void testPartialCycleThrowsException() {
+        // D -> A -> B -> C -> A (D is acyclic, A-B-C form a cycle)
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.addDependency("D", "A");
+        builder.addDependency("A", "B");
+        builder.addDependency("B", "C");
+        builder.addDependency("C", "A");
+        DependencyGraph<String> graph = builder.build();
+
+        graph.toTopologicallySortedLevels();
+    }
+
+    @Test
+    public void testLevelsAreUnmodifiable() {
+        DependencyGraphBuilder<String> builder = DependencyGraphBuilder.getBuilder();
+        builder.addDependency("A", "B");
+        DependencyGraph<String> graph = builder.build();
+
+        List<Set<String>> levels = graph.toTopologicallySortedLevels();
+
+        Assert.assertThrows(UnsupportedOperationException.class, () -> levels.add(Set.of("X")));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> levels.get(0).add("X"));
+    }
+}

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/TopologicallySortedLevelsTest.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/TopologicallySortedLevelsTest.java
@@ -148,6 +148,12 @@ public class TopologicallySortedLevelsTest {
         List<Set<String>> levels = graph.toTopologicallySortedLevels();
 
         Assert.assertThrows(UnsupportedOperationException.class, () -> levels.add(Set.of("X")));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> levels.get(0).add("X"));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> levels.remove(0));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> levels.set(0, Set.of("X")));
+        levels.forEach(level -> {
+            Assert.assertThrows(UnsupportedOperationException.class, () -> level.add("X"));
+            Assert.assertThrows(UnsupportedOperationException.class, () -> level.remove("X"));
+            Assert.assertThrows(UnsupportedOperationException.class, level::clear);
+        });
     }
 }


### PR DESCRIPTION
## Summary

Adds a new public method `toTopologicallySortedLevels()` to `DependencyGraph<T>` that groups nodes by their dependency depth. This enables parallel compilation of independent modules within each level.

Resolves #43027

## Changes

### `DependencyGraph.java`
- **New method**: `List<Set<T>> toTopologicallySortedLevels()` using BFS-based Kahn's algorithm
- Level 0 = nodes with no dependencies (leaves), level 1 = nodes depending only on level-0, etc.
- Includes cycle detection: throws `IllegalStateException` with unsorted node set if cycles exist
- Returns fully unmodifiable structure (`Collections.unmodifiableList` of `Collections.unmodifiableSet`)

### `TopologicallySortedLevelsTest.java`
8 unit tests covering:
- Diamond graph (A→B→D, A→C→D) → `[D] [B,C] [A]`
- Linear chain → one node per level
- Disconnected components → independent roots share level 0
- Single node / all-independent nodes
- Cyclic graph → `IllegalStateException`
- Partial cycle (acyclic root + cyclic subgraph) → `IllegalStateException`
- Unmodifiable return guarantees (outer List + inner Sets)

### Example

```
Graph: A → {B, C}, B → {D}, C → {D}

Level 0: {D}       ← no dependencies, compile first
Level 1: {B, C}    ← depend only on D, compile in parallel
Level 2: {A}       ← depends on B and C
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request adds a new toTopologicallySortedLevels() method to DependencyGraph that groups nodes into dependency levels to enable parallel processing of independent modules.

## Changes

- New public API: DependencyGraph<T>.toTopologicallySortedLevels()
  - Produces levels where level 0 are nodes with no dependencies, level 1 depend only on level 0, etc.
  - Implements a BFS-style Kahn algorithm to build levels incrementally.
  - Returns fully unmodifiable results (Collections.unmodifiableList of Collections.unmodifiableSet).
  - Detects cyclic dependencies and throws IllegalStateException that includes the set of unsorted nodes.

- Bug fix
  - Ensures nodes that appear only as dependency values (not as keys) are included in initial dependency counts so dependency-only leaves are handled correctly and do not trigger spurious cycle detection.

- Javadoc
  - Documents the unmodifiable return guarantees and the IllegalStateException behavior for cycles.

- Tests
  - Adds TopologicallySortedLevelsTest with 9 unit tests covering: diamond graph, linear chain, disconnected components, single node, multiple independent nodes, full and partial cycles, regression for dependency-only nodes (DependencyGraph.from(Map.of("A", Set.of("B")))), and immutability.
  - Strengthens immutability assertions: outer List is asserted to throw UnsupportedOperationException for add/remove/set; every inner Set is asserted to throw UnsupportedOperationException for add/remove/clear.

## Business outcome

Provides a reliable way for the compiler driver (and other consumers) to obtain dependency levels so independent modules can be processed or compiled in parallel, improving compilation parallelism and correctness for graphs that include dependency-only nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->