### PR TITLE
Fix copy-paste bugs in DataflowAnalyzer equality checks

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -1267,7 +1267,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
                 return equality(attributeA.name, attributeB.name) && equality(attributeA.value, attributeB.value);
             case XML_QNAME:
                 BLangXMLQName xmlqNameA = (BLangXMLQName) nodeA;
-                BLangXMLQName xmlqNameB = (BLangXMLQName) nodeA;
+                BLangXMLQName xmlqNameB = (BLangXMLQName) nodeB;
                 return equality(xmlqNameA.localname, xmlqNameB.localname)
                         && equality(xmlqNameA.prefix, xmlqNameB.prefix);
             case XML_ELEMENT_LITERAL:
@@ -1390,7 +1390,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
                         && equality(ternaryExprA.elseExpr, ternaryExprB.elseExpr);
             case GROUP_EXPR:
                 BLangGroupExpr groupExprA = (BLangGroupExpr) nodeA;
-                BLangGroupExpr groupExprB = (BLangGroupExpr) nodeA;
+                BLangGroupExpr groupExprB = (BLangGroupExpr) nodeB;
                 return equality(groupExprA.expression, groupExprB.expression);
             default:
                 return false;


### PR DESCRIPTION
## Purpose
Fixes #44571

Two equality checks in `DataflowAnalyzer.java` incorrectly compared `nodeA` with itself, causing the `XML_QNAME` and `GROUP_EXPR` checks to always return true. This PR corrects them to compare `nodeA` with `nodeB`.

## Approach
- Line 1270 (`XML_QNAME`): `nodeA == nodeA` → `nodeA == nodeB`
- Line 1393 (`GROUP_EXPR`): `nodeA == nodeA` → `nodeA == nodeB`

## Check List
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage
- [ ] Added necessary documentation
  - [ ] API documentation
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request corrects two copy-paste errors in the `DataflowAnalyzer.java` equality comparison method where the second operand of the comparison was incorrectly referencing the first operand instead of the intended second operand. 

The fixes ensure that equality checks for `XML_QNAME` and `GROUP_EXPR` node types properly compare both operands as intended, rather than comparing each operand against itself. This improves the correctness and reliability of the dataflow analysis by ensuring equality comparisons work as designed.

**Changes made:**
- Line 1270 (XML_QNAME case): Corrected the second variable cast to use `nodeB` instead of `nodeA`
- Line 1393 (GROUP_EXPR case): Corrected the second variable cast to use `nodeB` instead of `nodeA`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->