### PR TITLE
Use gradle/actions/setup-gradle to cache Gradle distribution in publish workflow

### DIFF
--- a/.github/workflows/publish_timestamped_release.yml
+++ b/.github/workflows/publish_timestamped_release.yml
@@ -22,6 +22,9 @@ jobs:
             distribution: 'temurin'
             java-version: '21.0.3'
 
+      -   name: Setup Gradle
+          uses: gradle/actions/setup-gradle@v3
+
       - name: Checkout To Lang Branch
         run: |
           git checkout ${{ github.event.inputs.ballerina_lang_branch }}


### PR DESCRIPTION
## Summary

- Adds `gradle/actions/setup-gradle@v3` step to the publish timestamped release workflow
- Caches the Gradle distribution across runs so it does not need to be re-downloaded each time

## Problem

The Gradle wrapper downloads `gradle-8.7-bin.zip` from `services.gradle.org`, which redirects to a GitHub releases URL. This download intermittently fails with HTTP 502 (bad gateway) on GitHub Actions runners, causing the entire publish job to fail before any build work begins. See https://github.com/ballerina-platform/ballerina-lang/actions/runs/25057356505/job/73401325456

## Fix

`gradle/actions/setup-gradle` caches the Gradle distribution in the Actions tool cache so subsequent runs skip the download entirely, eliminating this class of transient failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)