### PR TITLE
Fix internal prefix exposed in redeclared worker symbol diagnostic

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -144,6 +144,7 @@ import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 import static org.wso2.ballerinalang.compiler.semantics.model.Scope.NOT_FOUND_ENTRY;
 import static org.wso2.ballerinalang.compiler.util.Constants.INFERRED_ARRAY_INDICATOR;
 import static org.wso2.ballerinalang.compiler.util.Constants.OPEN_ARRAY_INDICATOR;
+import static org.wso2.ballerinalang.compiler.util.Constants.WORKER_LAMBDA_VAR_PREFIX;
 
 /**
  * @since 0.94
@@ -239,6 +240,9 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         if (isRedeclaredSymbol(symbol, foundSym)) {
 
             Name name = symbol.name;
+            if (name.value.startsWith(WORKER_LAMBDA_VAR_PREFIX)) {
+                name = Names.fromString(name.value.substring(WORKER_LAMBDA_VAR_PREFIX.length()));
+            }
             if (Symbols.isRemote(symbol) ^ Symbols.isRemote(foundSym)) {
                 dlog.error(pos, DiagnosticErrorCode.UNSUPPORTED_REMOTE_METHOD_NAME_IN_SCOPE, name);
                 return false;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicForkNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicForkNegativeTest.java
@@ -45,6 +45,14 @@ public class BasicForkNegativeTest {
     }
 
     @Test
+    public void testDuplicateWorkerInFork() {
+        CompileResult result = BCompileUtil.compile("test-src/workers/fork_duplicate_worker_negative.bal");
+        int index = 0;
+        BAssertUtil.validateError(result, index++, "redeclared symbol 'worker1'", 21, 16);
+        Assert.assertEquals(result.getErrorCount(), index);
+    }
+
+    @Test
     public void workerPeerCommunicationNegativeTests() {
         CompileResult result = BCompileUtil.compile("test-src/workers/worker-peer-communication-negative.bal");
         int index = 0;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/fork_duplicate_worker_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/fork_duplicate_worker_negative.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+    fork {
+        worker worker1 {
+        }
+        worker worker1 {
+        }
+    }
+    map<any|error> waitResult = wait {worker1};
+    _ = waitResult;
+}


### PR DESCRIPTION
## Purpose

Fixes #44468 

When a named worker is declared inside a `fork` block, the compiler internally stores it as a lambda variable with a `0` prefix (e.g. `0worker1`) to avoid name collisions in the    
  surrounding scope. If the same worker name is declared twice within the same `fork`, `SymbolResolver.checkForUniqueSymbol` detects the collision and reports a `REDECLARED_SYMBOL`
  diagnostic using the internal symbol name, leaking the implementation detail to the user:                                                                                            
                                                                                                                                                                                     
  error: redeclared symbol '0worker1'

  The user-facing diagnostic should reference the source name they actually wrote (`worker1`), not the internal lambda variable name.

  ### Reproducer

  ```ballerina
  public function main() {
      fork {
          worker worker1 {
          }                                                                                                                                                                            
          worker worker1 {
          }                                                                                                                                                                            
      }                                                                                                                                                                              
  }
```

## Approach
In SymbolResolver.checkForUniqueSymbol, before constructing the REDECLARED_SYMBOL (and UNSUPPORTED_REMOTE_METHOD_NAME_IN_SCOPE) diagnostic, strip the WORKER_LAMBDA_VAR_PREFIX ("0") 
  from the symbol name when it is present. This keeps the internal naming scheme intact for symbol resolution while ensuring the user-facing message shows the original source name: 
                                                                                                                                                                                       
  error: redeclared symbol 'worker1'                                                                                                                                                 

  The change is local to the diagnostic construction path and does not affect symbol lookup, scoping, or codegen.

## Samples
N/A — diagnostic message fix.

## Remarks
None

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request improves the clarity of compiler diagnostic messages for duplicate worker declarations in fork blocks. When multiple workers with the same name are declared within a fork, the compiler internally uses a lambda-variable prefix for tracking purposes. Previously, this implementation detail would leak into error messages, showing users internal names like "0worker1" instead of the source names they wrote.

## Changes

**Compiler Logic (SymbolResolver.java)**
- Enhanced symbol validation to normalize internal names when constructing diagnostic messages
- When a redeclared symbol's name contains the lambda-variable prefix, the prefix is stripped before generating the error message
- This ensures users receive clear, readable error messages showing the original symbol names they wrote
- The underlying symbol lookup and scoping logic remains unchanged

**Test Coverage**
- Added a new test method to validate the behavior with duplicate worker declarations in fork blocks
- Added a negative test case file containing a fork with two workers declared using the same identifier
- Tests verify that compilation fails with the expected redeclaration error and that the error message displays the correct symbol name

## Impact

Users will now receive clearer diagnostic messages for duplicate worker declarations, with error messages referencing the actual symbol names from their source code rather than internal compiler representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->