### PR TITLE
Fix addServiceListener not injected for union service type in listener attach

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
@@ -30,6 +30,8 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -186,7 +188,20 @@ public class JvmObjectGen {
 
     private boolean isListenerAttach(BIRNode.BIRFunction func) {
         return func.name.value.equals("attach") &&
-                Symbols.isFlagOn(func.parameters.getFirst().type.getFlags(), Flags.SERVICE);
+                isServiceType(func.parameters.getFirst().type);
+    }
+
+    private boolean isServiceType(BType type) {
+        if (Symbols.isFlagOn(type.getFlags(), Flags.SERVICE)) {
+            return true;
+        }
+        if (type instanceof BUnionType unionType) {
+            return unionType.getMemberTypes().stream().allMatch(this::isServiceType);
+        }
+        if (type instanceof BTypeReferenceType refType) {
+            return isServiceType(refType.referredType);
+        }
+        return false;
     }
 
     public void createAndSplitGetMethod(ClassWriter cw, Map<String, BField> fields, String className,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
@@ -199,7 +199,7 @@ public class JvmObjectGen {
             return unionType.getMemberTypes().stream().allMatch(this::isServiceType);
         }
         if (type instanceof BTypeReferenceType refType) {
-            return isServiceType(refType.referredType);
+            return refType.referredType != null && isServiceType(refType.referredType);
         }
         return false;
     }


### PR DESCRIPTION
## Summary

`isListenerAttach` in `JvmObjectGen` only matched listener `attach()` methods whose first parameter had `Flags.SERVICE` set directly on its type. This worked for listeners that declare their service parameter as a plain `service object` type (e.g. `http:Service`), but failed silently for connectors that define their service type as a **union**:

```ballerina
// ballerinax/salesforce
public type Service CdcService|PlatformEventsService;  // union — no Flags.SERVICE

public isolated function attach(Service s, string[]|string? name) returns error? { ... }
```

Because `BUnionType.getFlags()` does not carry `Flags.SERVICE`, `isListenerAttach` returned `false`, the `RepositoryImpl.addServiceListener()` call was never injected into the listener's `call` dispatch method, and the service-listener pair was never registered in the runtime repository. Tools that rely on `env.getRepository().getArtifacts()` (such as the WSO2 ICP runtime bridge) saw empty listeners and services for any such connector.

## Fix

Replaced the single-flag check with `isServiceType()`, which recursively resolves:
- **Union types** — all members must be service types  
- **Type reference types** — resolved to their referred type  
- **Direct types** — existing `Flags.SERVICE` check  

```java
private boolean isServiceType(BType type) {
    if (Symbols.isFlagOn(type.getFlags(), Flags.SERVICE)) {
        return true;
    }
    if (type instanceof BUnionType unionType) {
        return unionType.getMemberTypes().stream().allMatch(this::isServiceType);
    }
    if (type instanceof BTypeReferenceType refType) {
        return isServiceType(refType.referredType);
    }
    return false;
}
```

## Impact

Any connector whose `attach()` takes a union or aliased service type (e.g. `ballerinax/salesforce`, and any future connectors following the same pattern) will now correctly register its service-listener pair in `RepositoryImpl`, making those services visible to runtime management tooling without any changes to the connector itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a type-detection bug in the Ballerina compiler's JVM code generation that prevented listener attach methods with union or aliased service parameter types from being recognized.

### Problem
The previous implementation identified listener attach methods by checking the SERVICE flag directly on the parameter type. That failed when the attach parameter was a union type or a type reference (alias), because union types don't carry the SERVICE flag even when all members are services. Consequently, RepositoryImpl.addServiceListener() was not injected and service-listener pairs were not registered for those connectors, causing runtime tooling to miss listeners/services.

### Solution
Introduce a robust isServiceType(BType) helper used by isListenerAttach():
- Returns true when the type has the SERVICE flag.
- For union types, returns true only if all member types are service types (recursively).
- For type references, resolves and checks the referred type (with a null check).
- Otherwise returns false.

isListenerAttach(...) now uses isServiceType(...) to correctly detect attach methods.

### Impact
Connectors whose attach() accepts union or aliased service types (for example, ballerinax/salesforce) will now have their service-listener pairs registered in RepositoryImpl. Runtime management tooling will correctly see and manage these services without changes to connectors.

### Files changed
- compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java: added isServiceType(BType) and updated isListenerAttach(...) to use it (+16/-1).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->