### PR TITLE
Fix addServiceListener not injected for union service type in listener attach

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
@@ -188,6 +188,7 @@ public class JvmObjectGen {
 
     private boolean isListenerAttach(BIRNode.BIRFunction func) {
         return func.name.value.equals("attach") &&
+                func.parameters.size() >= 2 &&
                 isServiceType(func.parameters.getFirst().type);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
@@ -30,6 +30,8 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -186,7 +188,20 @@ public class JvmObjectGen {
 
     private boolean isListenerAttach(BIRNode.BIRFunction func) {
         return func.name.value.equals("attach") &&
-                Symbols.isFlagOn(func.parameters.getFirst().type.getFlags(), Flags.SERVICE);
+                isServiceType(func.parameters.getFirst().type);
+    }
+
+    private boolean isServiceType(BType type) {
+        if (Symbols.isFlagOn(type.getFlags(), Flags.SERVICE)) {
+            return true;
+        }
+        if (type instanceof BUnionType unionType) {
+            return unionType.getMemberTypes().stream().allMatch(this::isServiceType);
+        }
+        if (type instanceof BTypeReferenceType refType) {
+            return refType.referredType != null && isServiceType(refType.referredType);
+        }
+        return false;
     }
 
     public void createAndSplitGetMethod(ClassWriter cw, Map<String, BField> fields, String className,


### PR DESCRIPTION
## Problem

When a Ballerina listener's `attach()` method accepts a **union service type** (e.g. `salesforce:Service = CdcService|PlatformEventsService`), the compiler skips injecting the `addServiceListener` call into the listener's generated `call` dispatch method. This causes those services to never appear in the runtime repository, so tools that rely on `env.getRepository().getArtifacts()` (such as WSO2 ICP) report empty listeners/services for any non-HTTP event-driven integration.

**Root cause:** `isListenerAttach()` checked `Flags.SERVICE` directly on the parameter type. `BUnionType` never carries `Flags.SERVICE` on its own flags, even when every member of the union is a service type.

## Fix

Introduce `isServiceType(BType)` that:
- Returns `true` if the type directly carries `Flags.SERVICE`
- Recurses into all members of a `BUnionType` (true only when every member is a service type)
- Unwraps `BTypeReferenceType` (guards against null `referredType`) before recursing

`isListenerAttach()` is updated to delegate to `isServiceType()`.

## Related

Backport of #44592 (merged into `2201.13.x`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request fixes a compiler code-generation bug that caused addServiceListener to be omitted for listener attach() methods when the attach parameter was a union of service types (e.g., CdcService|PlatformEventsService). As a result, services for such listeners were not registered in the runtime repository and were not discoverable by tools inspecting env.getRepository().getArtifacts().

## Changes

**File: `JvmObjectGen.java`**

- Replace direct flag check with a new helper method isServiceType(BType):
  - Returns true when the type directly carries the SERVICE flag.
  - For union types, returns true only if every union member is a service type (recursive).
  - For type references, unwraps the referred type (with null safety) and checks it.
- Update isListenerAttach() to use isServiceType() and add a guard ensuring the function parameter list has at least two parameters before accessing parameters.getFirst() and emitting the generated args[1] access. This prevents unsafe runtime access to args[1] and avoids emitting an AALOAD for index 1 when the argument is not guaranteed to be present.
- Add imports for BTypeReferenceType and BUnionType to support the new checks.

## Impact

Ensures addServiceListener is injected for listeners whose attach parameter is a union of service types, so those services are correctly registered in the runtime repository and visible to repository inspection tools. Also improves codegen safety by avoiding out-of-bounds argument access during call dispatch generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->