### PR TITLE
Guard against empty parameters and missing args[1] in isListenerAttach

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmObjectGen.java
@@ -188,6 +188,7 @@ public class JvmObjectGen {
 
     private boolean isListenerAttach(BIRNode.BIRFunction func) {
         return func.name.value.equals("attach") &&
+                func.parameters.size() >= 2 &&
                 isServiceType(func.parameters.getFirst().type);
     }
 


### PR DESCRIPTION
## Problem

Two unsafe accesses in `isListenerAttach` / the `addServiceListener` injection path introduced in #44592:

1. **`func.parameters.getFirst()` without an empty check** — if a function named `attach` has no parameters, `getFirst()` throws `NoSuchElementException` at compile time.
2. **`args[1]` accessed unconditionally at runtime** — the bytecode generated by the `isListenerAttach` injection reads `args[1]` (the attach-point argument) without verifying the args array has at least two elements. If an `attach` implementation declares only one parameter, the generated `AALOAD` at index 1 throws `ArrayIndexOutOfBoundsException` at runtime.

## Fix

Add a single `func.parameters.size() >= 2` guard in `isListenerAttach` before calling `getFirst()`. This handles both issues:
- `getFirst()` is safe (list is guaranteed non-empty)
- The injection code that reads `args[1]` is only emitted when the function has ≥ 2 parameters, so the runtime args array is guaranteed to contain `args[1]`

## Related

Follow-up to #44592. The same guard is included in the `master` backport PR #44594.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds input validation to the `JvmObjectGen.isListenerAttach()` method to improve the robustness of the listener attachment mechanism. The change introduces a guard condition to verify that `attach` functions have at least two parameters before processing them as listener attachment candidates. This validation prevents potential runtime and compile-time issues by ensuring safe access to function parameters and proper handling of generated bytecode that references method arguments. The fix applies a single, minimal parameter count check that aligns with the requirements of the listener attachment injection mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->