### PR TITLE
Exclude EI_EXPOSE_REP2 in Spotbugs

### DIFF
--- a/tests/ballerina-test-utils/spotbugs-exclude.xml
+++ b/tests/ballerina-test-utils/spotbugs-exclude.xml
@@ -48,4 +48,9 @@
     <Match>
         <Class name="org.ballerinalang.test.agent.server.WebServer"/>
     </Match>
+    
+    <Match>
+        <Class name="org.ballerinalang.test.agent.server.Request"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
```
Added a SpotBugs EI_EXPOSE_REP2 suppression for org.ballerinalang.test.agent.server.Request in spotbugs-exclude.xml.

This warning surfaced after the recent Netty version bump. The newer version of netty-codec-http causes SpotBugs to classify FullHttpRequest as an externally mutable object, triggering the EI_EXPOSE_REP2 check on the constructor that stores it directly into the field.

A defensive copy is not feasible here — FullHttpRequest is a Netty reference-counted object with no standard copy constructor, and duplicating it would require managing the ref-count lifecycle outside of this wrapper's responsibility. The Request class is internal to the test agent server and is not exposed to untrusted code, so the risk this warning guards against does not apply.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds a SpotBugs suppression entry to `spotbugs-exclude.xml` for the internal test agent server's `Request` class. The suppression was necessary following a Netty dependency update, which introduced static analysis warnings related to the handling of externally mutable Netty objects within the class. Since the `Request` class is internal to the test infrastructure and not exposed to external code, the warning was suppressed rather than implementing a defensive copy mechanism, which would be impractical due to Netty's reference-counted object model.

## Changes

- **tests/ballerina-test-utils/spotbugs-exclude.xml** (+5 lines): Added SpotBugs filter configuration to suppress analysis warnings for `org.ballerinalang.test.agent.server.Request`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->