### PR TITLE
[master] Fix transitive dependency causing false version conflict

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageDependencyGraphBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageDependencyGraphBuilder.java
@@ -142,7 +142,7 @@ public class PackageDependencyGraphBuilder {
         return dependencyNode.pkgDesc().version().equals(node.version());
     }
 
-    public Optional<PackageVersion> getVersionOfNode(PackageOrg org, PackageName name) {
+    public Optional<PackageVersion> getNodeVersion(PackageOrg org, PackageName name) {
         Vertex vertex = new Vertex(org, name);
         DependencyNode node = vertices.get(vertex);
         if (node == null) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageDependencyGraphBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageDependencyGraphBuilder.java
@@ -24,6 +24,7 @@ import io.ballerina.projects.PackageDependencyScope;
 import io.ballerina.projects.PackageDescriptor;
 import io.ballerina.projects.PackageName;
 import io.ballerina.projects.PackageOrg;
+import io.ballerina.projects.PackageVersion;
 import io.ballerina.projects.SemanticVersion;
 import io.ballerina.projects.SemanticVersion.VersionCompatibilityResult;
 import io.ballerina.projects.environment.ResolutionOptions;
@@ -139,6 +140,15 @@ public class PackageDependencyGraphBuilder {
             return false;
         }
         return dependencyNode.pkgDesc().version().equals(node.version());
+    }
+
+    public Optional<PackageVersion> getVersionOfNode(PackageOrg org, PackageName name) {
+        Vertex vertex = new Vertex(org, name);
+        DependencyNode node = vertices.get(vertex);
+        if (node == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(node.pkgDesc().version());
     }
 
     public Collection<DependencyNode> getAllDependencies() {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ResolutionEngine.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ResolutionEngine.java
@@ -194,7 +194,7 @@ public class ResolutionEngine {
             PackageDependencyScope scope = resolutionReq.scope();
 
             // Capture the existing version before adding the resolved node
-            Optional<PackageVersion> existingVersion = graphBuilder.getVersionOfNode(
+            Optional<PackageVersion> existingVersion = graphBuilder.getNodeVersion(
                     resolvedPkgDesc.org(), resolvedPkgDesc.name());
 
             // Merge the dependency graph only if the node is accepted by the graphBuilder
@@ -488,7 +488,7 @@ public class ResolutionEngine {
         // its old transitive deps may have been removed or replaced with new versions.
         PackageDescriptor requestedPkg = resolutionReq.packageDescriptor();
         if (requestedPkg.version() != null) {
-            Optional<PackageVersion> currentVersion = graphBuilder.getVersionOfNode(
+            Optional<PackageVersion> currentVersion = graphBuilder.getNodeVersion(
                     requestedPkg.org(), requestedPkg.name());
             if (currentVersion.isEmpty()) {
                 // Node was completely removed from the graph (parent upgraded and this
@@ -505,7 +505,7 @@ public class ResolutionEngine {
         }
 
         // Capture the current version before adding the resolved node, so we can detect upgrades.
-        Optional<PackageVersion> existingVersion = graphBuilder.getVersionOfNode(
+        Optional<PackageVersion> existingVersion = graphBuilder.getNodeVersion(
                 pkgDesc.org(), pkgDesc.name());
 
         // Merge the dependency graph only if the node is accepted by the graphBuilder

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ResolutionEngine.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ResolutionEngine.java
@@ -193,10 +193,20 @@ public class ResolutionEngine {
             DependencyResolutionType resolutionType = resolutionReq.resolutionType();
             PackageDependencyScope scope = resolutionReq.scope();
 
+            // Capture the existing version before adding the resolved node
+            Optional<PackageVersion> existingVersion = graphBuilder.getVersionOfNode(
+                    resolvedPkgDesc.org(), resolvedPkgDesc.name());
+
             // Merge the dependency graph only if the node is accepted by the graphBuilder
             NodeStatus nodeStatus = graphBuilder.addResolvedDependency(rootPkgDesc,
                     resolvedPkgDesc, scope, resolutionType);
             if (nodeStatus == NodeStatus.ACCEPTED) {
+                // When a direct dependency is upgraded (e.g., pkgx 1.0.0 → 1.1.0), its old
+                // transitive deps become dangling. Clean them up before merging the new version's
+                // deps to prevent false incompatible version conflicts.
+                if (existingVersion.isPresent() && !existingVersion.get().equals(resolvedPkgDesc.version())) {
+                    graphBuilder.removeDanglingNodes();
+                }
                 mergeGraph(resolvedPkgDesc,
                         resolutionResp.dependencyGraph().orElseThrow(
                                 () -> new IllegalStateException("Graph cannot be null in the resolved dependency: " +
@@ -312,7 +322,22 @@ public class ResolutionEngine {
             ResolutionRequest resolutionRequest = getRequestForUnresolvedNode(unresolvedNode,
                     blendedDepOptional.orElse(null));
             if (resolutionRequest == null) {
-                // There is a version incompatibility.
+                // Check if the incompatibility is against a stale auto-locked version.
+                // When a parent package is upgraded, its old transitive deps are removed as dangling,
+                // and new transitive deps may have incompatible versions with the old lock.
+                // Since the lock (from Dependencies.toml) is auto-generated and the locked version's
+                // dependency path no longer exists, resolve without the lock constraint.
+                if (blendedDepOptional.isPresent() &&
+                        !blendedDepOptional.get().isError() &&
+                        blendedDepOptional.get().origin()
+                                != BlendedManifest.DependencyOrigin.USER_SPECIFIED) {
+                    resolutionRequest = ResolutionRequest.from(unresolvedNode.pkgDesc(),
+                            unresolvedNode.scope(), unresolvedNode.resolutionType(),
+                            resolutionOptions.packageLockingMode(), unresolvedNode.skipWorkspace());
+                }
+            }
+            if (resolutionRequest == null) {
+                // There is a genuine version incompatibility (user-specified).
                 // We mark it as an error node and skip to the next node.
                 errorNodes.add(new DependencyNode(
                         unresolvedNode.pkgDesc,
@@ -459,9 +484,43 @@ public class ResolutionEngine {
         PackageDependencyScope scope = resolutionReq.scope();
         DependencyResolutionType resolvedType = resolutionReq.resolutionType();
 
+        // Skip stale batch results: if a parent package was upgraded during this batch,
+        // its old transitive deps may have been removed or replaced with new versions.
+        PackageDescriptor requestedPkg = resolutionReq.packageDescriptor();
+        if (requestedPkg.version() != null) {
+            Optional<PackageVersion> currentVersion = graphBuilder.getVersionOfNode(
+                    requestedPkg.org(), requestedPkg.name());
+            if (currentVersion.isEmpty()) {
+                // Node was completely removed from the graph (parent upgraded and this
+                // transitive dep became dangling). Skip the stale batch result.
+                return;
+            }
+            VersionCompatibilityResult compat =
+                    requestedPkg.version().compareTo(currentVersion.get());
+            if (compat == VersionCompatibilityResult.INCOMPATIBLE) {
+                // Graph now has an incompatible version (parent upgraded and replaced
+                // this transitive dep with a new version). Skip the stale batch result.
+                return;
+            }
+        }
+
+        // Capture the current version before adding the resolved node, so we can detect upgrades.
+        Optional<PackageVersion> existingVersion = graphBuilder.getVersionOfNode(
+                pkgDesc.org(), pkgDesc.name());
+
         // Merge the dependency graph only if the node is accepted by the graphBuilder
         NodeStatus nodeStatus = graphBuilder.addResolvedNode(pkgDesc, scope, resolvedType);
         if (nodeStatus == NodeStatus.ACCEPTED) {
+            // Remove dangling nodes only when an actual version change occurred.
+            // When a package is upgraded (e.g., ftp 2.16.0 → 2.17.0), its old edges are cleared,
+            // making old transitive deps dangling. Cleaning them up prevents false incompatible
+            // version conflicts between the stale transitive deps and the new transitive deps.
+            // We must NOT do this for same-version re-accepts, because completeDependencyGraph
+            // accumulates responses across iterations, and re-processing would create an
+            // infinite cycle of removing and re-adding nodes.
+            if (existingVersion.isPresent() && !existingVersion.get().equals(pkgDesc.version())) {
+                graphBuilder.removeDanglingNodes();
+            }
             mergeGraph(pkgDesc, resolutionResp.dependencyGraph().orElseThrow(
                     () -> new IllegalStateException("Graph cannot be null in the resolved dependency: " +
                             pkgDesc.toString())),

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/IncompatibleVersionTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/IncompatibleVersionTests.java
@@ -44,6 +44,42 @@ public class IncompatibleVersionTests extends AbstractPackageResolutionTest {
                 {"suite-incompatible_versions", "case-0006", PackageLockingMode.HARD},
                 {"suite-incompatible_versions", "case-0006", PackageLockingMode.MEDIUM},
                 {"suite-incompatible_versions", "case-0006", PackageLockingMode.SOFT},
+                // 7. User specifies an incompatible version of a transitive dependency in Ballerina.toml
+                {"suite-incompatible_versions", "case-0007", PackageLockingMode.HARD},
+                {"suite-incompatible_versions", "case-0007", PackageLockingMode.MEDIUM},
+                {"suite-incompatible_versions", "case-0007", PackageLockingMode.SOFT},
+                // 8. Parent transitive dep upgrade should replace child transitive deps without false conflict
+                {"suite-incompatible_versions", "case-0008", PackageLockingMode.HARD},
+                {"suite-incompatible_versions", "case-0008", PackageLockingMode.MEDIUM},
+                {"suite-incompatible_versions", "case-0008", PackageLockingMode.SOFT},
+                // 9. Fresh project: parent transitive dep upgrade replaces child deps without false conflict
+                {"suite-incompatible_versions", "case-0009", PackageLockingMode.HARD},
+                {"suite-incompatible_versions", "case-0009", PackageLockingMode.MEDIUM},
+                {"suite-incompatible_versions", "case-0009", PackageLockingMode.SOFT},
+                // 10. Parent upgrade changes dep structure with incompatible transitive dep versions
+                {"suite-incompatible_versions", "case-0010", PackageLockingMode.HARD},
+                {"suite-incompatible_versions", "case-0010", PackageLockingMode.MEDIUM},
+                {"suite-incompatible_versions", "case-0010", PackageLockingMode.SOFT},
+                // 11. Fresh project: parent upgrade changes dep structure with incompatible transitive dep versions
+                {"suite-incompatible_versions", "case-0011", PackageLockingMode.HARD},
+                {"suite-incompatible_versions", "case-0011", PackageLockingMode.MEDIUM},
+                {"suite-incompatible_versions", "case-0011", PackageLockingMode.SOFT},
+                // 12. Transitive dep upgrade replaces incompatible pre-1.0 child dep
+                {"suite-incompatible_versions", "case-0012", PackageLockingMode.HARD},
+                {"suite-incompatible_versions", "case-0012", PackageLockingMode.MEDIUM},
+                {"suite-incompatible_versions", "case-0012", PackageLockingMode.SOFT},
+                // 13. Fresh project: transitive dep upgrade replaces incompatible pre-1.0 child dep
+                {"suite-incompatible_versions", "case-0013", PackageLockingMode.HARD},
+                {"suite-incompatible_versions", "case-0013", PackageLockingMode.MEDIUM},
+                {"suite-incompatible_versions", "case-0013", PackageLockingMode.SOFT},
+                // 14. Patch upgrade changes dep structure with incompatible transitive dep versions
+                {"suite-incompatible_versions", "case-0014", PackageLockingMode.HARD},
+                {"suite-incompatible_versions", "case-0014", PackageLockingMode.MEDIUM},
+                {"suite-incompatible_versions", "case-0014", PackageLockingMode.SOFT},
+                // 15. Fresh project: patch upgrade changes dep structure with incompatible transitive dep versions
+                {"suite-incompatible_versions", "case-0015", PackageLockingMode.HARD},
+                {"suite-incompatible_versions", "case-0015", PackageLockingMode.MEDIUM},
+                {"suite-incompatible_versions", "case-0015", PackageLockingMode.SOFT},
         };
     }
 
@@ -74,6 +110,33 @@ public class IncompatibleVersionTests extends AbstractPackageResolutionTest {
                 // 6. Two incompatible versions found as transitive dependencies
                 {"suite-incompatible_versions", "case-0006", true},
                 {"suite-incompatible_versions", "case-0006", false},
+                // 7. User specifies an incompatible version of a transitive dependency in Ballerina.toml
+                {"suite-incompatible_versions", "case-0007", true},
+                {"suite-incompatible_versions", "case-0007", false},
+                // 8. Parent transitive dep upgrade should replace child transitive deps without false conflict
+                {"suite-incompatible_versions", "case-0008", true},
+                {"suite-incompatible_versions", "case-0008", false},
+                // 9. Fresh project: parent transitive dep upgrade replaces child deps without false conflict
+                {"suite-incompatible_versions", "case-0009", true},
+                {"suite-incompatible_versions", "case-0009", false},
+                // 10. Parent upgrade changes dep structure with incompatible transitive dep versions
+                {"suite-incompatible_versions", "case-0010", true},
+                {"suite-incompatible_versions", "case-0010", false},
+                // 11. Fresh project: parent upgrade changes dep structure with incompatible transitive dep versions
+                {"suite-incompatible_versions", "case-0011", true},
+                {"suite-incompatible_versions", "case-0011", false},
+                // 12. Transitive dep upgrade replaces incompatible pre-1.0 child dep
+                {"suite-incompatible_versions", "case-0012", true},
+                {"suite-incompatible_versions", "case-0012", false},
+                // 13. Fresh project: transitive dep upgrade replaces incompatible pre-1.0 child dep
+                {"suite-incompatible_versions", "case-0013", true},
+                {"suite-incompatible_versions", "case-0013", false},
+                // 14. Patch upgrade changes dep structure with incompatible transitive dep versions
+                {"suite-incompatible_versions", "case-0014", true},
+                {"suite-incompatible_versions", "case-0014", false},
+                // 15. Fresh project: patch upgrade changes dep structure with incompatible transitive dep versions
+                {"suite-incompatible_versions", "case-0015", true},
+                {"suite-incompatible_versions", "case-0015", false},
         };
     }
 }

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0008/Dependencies_toml.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0008/Dependencies_toml.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/wrapper:1.0.0"
+    "testorg/wrapper:1.0.0" -> "testorg/connector:1.1.0"
+    "testorg/connector:1.1.0" -> "testorg/datalib:0.8.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0008/app.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0008/app.dot
@@ -1,0 +1,3 @@
+digraph "testorg1/app:0.1.0" {
+    "testorg/wrapper"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0008/case-description.md
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0008/case-description.md
@@ -1,0 +1,15 @@
+# Parent transitive dependency upgrade should replace child transitive deps without false conflict
+
+1. User's package depends on `testorg/wrapper:1.0.0` which depends on `testorg/connector:1.1.0`
+2. `testorg/connector:1.1.0` depends on `testorg/datalib:0.8.0`
+3. Central repository has a newer `testorg/connector:1.2.0` which depends on `testorg/datalib:0.10.0`
+4. `datalib:0.8.0` and `datalib:0.10.0` are incompatible (different minor pre-1.0)
+
+## Expected behavior
+
+### Sticky == true (HARD)
+Dependency graph should keep locked versions: connector:1.1.0 -> datalib:0.8.0
+
+### Sticky == false (SOFT)
+Dependency graph should upgrade connector to 1.2.0 and use datalib:0.10.0 without conflict.
+The old datalib:0.8.0 should be replaced by datalib:0.10.0 from the upgraded connector.

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0008/expected-graph-hard.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0008/expected-graph-hard.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/wrapper:1.0.0"
+    "testorg/wrapper:1.0.0" -> "testorg/connector:1.1.0"
+    "testorg/connector:1.1.0" -> "testorg/datalib:0.8.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0008/expected-graph-medium.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0008/expected-graph-medium.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/wrapper:1.0.0"
+    "testorg/wrapper:1.0.0" -> "testorg/connector:1.1.0"
+    "testorg/connector:1.1.0" -> "testorg/datalib:0.8.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0008/expected-graph-soft.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0008/expected-graph-soft.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/wrapper:1.0.0"
+    "testorg/wrapper:1.0.0" -> "testorg/connector:1.2.0"
+    "testorg/connector:1.2.0" -> "testorg/datalib:0.10.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0009/app.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0009/app.dot
@@ -1,0 +1,3 @@
+digraph "testorg1/app:0.1.0" {
+    "testorg/wrapper"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0009/case-description.md
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0009/case-description.md
@@ -1,0 +1,19 @@
+# Fresh project: Parent transitive dependency upgrade should replace child transitive deps without false conflict
+
+Same scenario as case-0007 but without Dependencies.toml (fresh project).
+
+1. User's package depends on `testorg/wrapper`
+2. Central has wrapper:1.0.0 -> connector:1.1.0 -> datalib:0.8.0
+3. Central also has connector:1.2.0 -> datalib:0.10.0
+4. datalib:0.8.0 and datalib:0.10.0 are incompatible (different minor pre-1.0)
+
+## Expected behavior
+
+### HARD
+Resolve latest versions without upgrades: wrapper:1.0.0 -> connector:1.1.0 -> datalib:0.8.0
+
+### MEDIUM
+Same as HARD (LOCK_MINOR prevents connector minor upgrade)
+
+### SOFT
+Upgrade connector to 1.2.0 and use datalib:0.10.0 without conflict.

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0009/expected-graph-hard.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0009/expected-graph-hard.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/wrapper:1.0.0"
+    "testorg/wrapper:1.0.0" -> "testorg/connector:1.1.0"
+    "testorg/connector:1.1.0" -> "testorg/datalib:0.8.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0009/expected-graph-medium.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0009/expected-graph-medium.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/wrapper:1.0.0"
+    "testorg/wrapper:1.0.0" -> "testorg/connector:1.1.0"
+    "testorg/connector:1.1.0" -> "testorg/datalib:0.8.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0009/expected-graph-soft.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0009/expected-graph-soft.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/wrapper:1.0.0"
+    "testorg/wrapper:1.0.0" -> "testorg/connector:1.2.0"
+    "testorg/connector:1.2.0" -> "testorg/datalib:0.10.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0010/Dependencies_toml.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0010/Dependencies_toml.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgx:1.0.0"
+    "testorg/pkgx:1.0.0" -> "testorg/pkgy:1.1.0"
+    "testorg/pkgy:1.1.0" -> "testorg/pkgz:0.2.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0010/app.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0010/app.dot
@@ -1,0 +1,3 @@
+digraph "testorg1/app:0.1.0" {
+    "testorg/pkgx"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0010/case-description.md
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0010/case-description.md
@@ -1,0 +1,15 @@
+# Parent upgrade changes dependency structure with incompatible transitive dep versions
+
+1. User's package depends on `testorg/pkgx`
+2. Locked: X:1.0.0 -> Y:1.1.0 -> Z:0.2.0
+3. Central has X:1.1.0 -> W:1.2.0 -> Z:0.3.0
+4. Z:0.2.0 and Z:0.3.0 are incompatible (different minor pre-1.0)
+5. When X is upgraded from 1.0.0 to 1.1.0, the entire dep chain changes (Y replaced by W)
+
+## Expected behavior
+
+### Sticky == true (HARD)
+Keep locked versions: X:1.0.0 -> Y:1.1.0 -> Z:0.2.0
+
+### Sticky == false (SOFT)
+Upgrade X to 1.1.0, old chain (Y -> Z:0.2.0) replaced by new chain (W -> Z:0.3.0). No conflict.

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0010/expected-graph-hard.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0010/expected-graph-hard.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgx:1.0.0"
+    "testorg/pkgx:1.0.0" -> "testorg/pkgy:1.1.0"
+    "testorg/pkgy:1.1.0" -> "testorg/pkgz:0.2.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0010/expected-graph-medium.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0010/expected-graph-medium.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgx:1.0.0"
+    "testorg/pkgx:1.0.0" -> "testorg/pkgy:1.1.0"
+    "testorg/pkgy:1.1.0" -> "testorg/pkgz:0.2.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0010/expected-graph-soft.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0010/expected-graph-soft.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgx:1.1.0"
+    "testorg/pkgx:1.1.0" -> "testorg/pkgw:1.2.0"
+    "testorg/pkgw:1.2.0" -> "testorg/pkgz:0.3.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0011/app.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0011/app.dot
@@ -1,0 +1,3 @@
+digraph "testorg1/app:0.1.0" {
+    "testorg/pkgx"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0011/case-description.md
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0011/case-description.md
@@ -1,0 +1,14 @@
+# Fresh project: Parent upgrade changes dependency structure with incompatible transitive dep versions
+
+Same scenario as case-0009 but without Dependencies.toml (fresh project).
+
+1. User's package depends on `testorg/pkgx`
+2. Central has X:1.0.0 -> Y:1.1.0 -> Z:0.2.0
+3. Central has X:1.1.0 -> W:1.2.0 -> Z:0.3.0
+4. Z:0.2.0 and Z:0.3.0 are incompatible (different minor pre-1.0)
+
+## Expected behavior
+
+### All modes (HARD, MEDIUM, SOFT)
+Since this is a fresh project, the latest version of pkgx (1.1.0) is resolved directly.
+Dependency graph: X:1.1.0 -> W:1.2.0 -> Z:0.3.0. No conflict since Z:0.2.0 is never in the graph.

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0011/expected-graph-hard.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0011/expected-graph-hard.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgx:1.1.0"
+    "testorg/pkgx:1.1.0" -> "testorg/pkgw:1.2.0"
+    "testorg/pkgw:1.2.0" -> "testorg/pkgz:0.3.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0011/expected-graph-medium.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0011/expected-graph-medium.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgx:1.1.0"
+    "testorg/pkgx:1.1.0" -> "testorg/pkgw:1.2.0"
+    "testorg/pkgw:1.2.0" -> "testorg/pkgz:0.3.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0011/expected-graph-soft.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0011/expected-graph-soft.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgx:1.1.0"
+    "testorg/pkgx:1.1.0" -> "testorg/pkgw:1.2.0"
+    "testorg/pkgw:1.2.0" -> "testorg/pkgz:0.3.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0012/Dependencies_toml.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0012/Dependencies_toml.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgp:1.0.0"
+    "testorg/pkgp:1.0.0" -> "testorg/pkgq:1.1.0"
+    "testorg/pkgq:1.1.0" -> "testorg/pkgr:0.1.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0012/app.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0012/app.dot
@@ -1,0 +1,3 @@
+digraph "testorg1/app:0.1.0" {
+    "testorg/pkgp"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0012/case-description.md
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0012/case-description.md
@@ -1,0 +1,18 @@
+# Transitive dependency upgrade replaces incompatible pre-1.0 child dep
+
+1. User's package depends on `testorg/pkgp`
+2. Locked: P:1.0.0 -> Q:1.1.0 -> R:0.1.0
+3. Central has Q:1.2.0 -> R:0.2.0
+4. R:0.1.0 and R:0.2.0 are incompatible (different minor pre-1.0)
+
+## Expected behavior
+
+### HARD
+Keep locked versions: P:1.0.0 -> Q:1.1.0 -> R:0.1.0
+
+### MEDIUM
+LOCK_MINOR prevents Q minor upgrade. Same as HARD.
+
+### SOFT
+Upgrade Q to 1.2.0 (LOCK_MAJOR allows minor upgrade for post-1.0).
+Old R:0.1.0 replaced by R:0.2.0 from upgraded Q. No conflict.

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0012/expected-graph-hard.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0012/expected-graph-hard.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgp:1.0.0"
+    "testorg/pkgp:1.0.0" -> "testorg/pkgq:1.1.0"
+    "testorg/pkgq:1.1.0" -> "testorg/pkgr:0.1.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0012/expected-graph-medium.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0012/expected-graph-medium.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgp:1.0.0"
+    "testorg/pkgp:1.0.0" -> "testorg/pkgq:1.1.0"
+    "testorg/pkgq:1.1.0" -> "testorg/pkgr:0.1.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0012/expected-graph-soft.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0012/expected-graph-soft.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgp:1.0.0"
+    "testorg/pkgp:1.0.0" -> "testorg/pkgq:1.2.0"
+    "testorg/pkgq:1.2.0" -> "testorg/pkgr:0.2.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0013/app.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0013/app.dot
@@ -1,0 +1,3 @@
+digraph "testorg1/app:0.1.0" {
+    "testorg/pkgp"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0013/case-description.md
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0013/case-description.md
@@ -1,0 +1,18 @@
+# Fresh project: Transitive dependency upgrade replaces incompatible pre-1.0 child dep
+
+Same scenario as case-0011 but without Dependencies.toml (fresh project).
+
+1. User's package depends on `testorg/pkgp`
+2. Central has P:1.0.0 -> Q:1.1.0 -> R:0.1.0
+3. Central also has Q:1.2.0 -> R:0.2.0
+
+## Expected behavior
+
+### HARD
+Resolve latest: P:1.0.0 -> Q:1.1.0 -> R:0.1.0 (EXACT prevents upgrades)
+
+### MEDIUM
+Same as HARD (LOCK_MINOR prevents Q minor upgrade)
+
+### SOFT
+Upgrade Q to 1.2.0 (LOCK_MAJOR allows minor upgrade). R:0.2.0 replaces R:0.1.0.

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0013/expected-graph-hard.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0013/expected-graph-hard.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgp:1.0.0"
+    "testorg/pkgp:1.0.0" -> "testorg/pkgq:1.1.0"
+    "testorg/pkgq:1.1.0" -> "testorg/pkgr:0.1.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0013/expected-graph-medium.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0013/expected-graph-medium.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgp:1.0.0"
+    "testorg/pkgp:1.0.0" -> "testorg/pkgq:1.1.0"
+    "testorg/pkgq:1.1.0" -> "testorg/pkgr:0.1.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0013/expected-graph-soft.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0013/expected-graph-soft.dot
@@ -1,0 +1,5 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgp:1.0.0"
+    "testorg/pkgp:1.0.0" -> "testorg/pkgq:1.2.0"
+    "testorg/pkgq:1.2.0" -> "testorg/pkgr:0.2.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0014/Dependencies_toml.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0014/Dependencies_toml.dot
@@ -1,0 +1,6 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgh:1.0.0"
+    "testorg/pkgh:1.0.0" -> "testorg/pkgi:1.1.0"
+    "testorg/pkgi:1.1.0" -> "testorg/pkgj:1.0.0"
+    "testorg/pkgj:1.0.0" -> "testorg/pkgk:0.1.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0014/app.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0014/app.dot
@@ -1,0 +1,3 @@
+digraph "testorg1/app:0.1.0" {
+    "testorg/pkgh"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0014/case-description.md
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0014/case-description.md
@@ -1,0 +1,19 @@
+# Patch upgrade changes dependency structure with incompatible transitive dep versions
+
+1. User's package depends on `testorg/pkgh`
+2. Locked: H:1.0.0 -> I:1.1.0 -> J:1.0.0 -> K:0.1.0
+3. Central has I:1.1.1 -> L:1.2.0 -> K:0.2.0
+4. K:0.1.0 and K:0.2.0 are incompatible (different minor pre-1.0)
+5. I:1.1.1 is a patch upgrade of I:1.1.0 with a completely different dep structure
+
+## Expected behavior
+
+### HARD
+Keep locked versions: H:1.0.0 -> I:1.1.0 -> J:1.0.0 -> K:0.1.0
+
+### MEDIUM
+LOCK_MINOR allows patch upgrade: I:1.1.0 -> I:1.1.1. Old chain (J -> K:0.1.0)
+replaced by new chain (L -> K:0.2.0). No conflict.
+
+### SOFT
+Same as MEDIUM (I patch upgrade allowed by both LOCK_MINOR and LOCK_MAJOR).

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0014/expected-graph-hard.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0014/expected-graph-hard.dot
@@ -1,0 +1,6 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgh:1.0.0"
+    "testorg/pkgh:1.0.0" -> "testorg/pkgi:1.1.0"
+    "testorg/pkgi:1.1.0" -> "testorg/pkgj:1.0.0"
+    "testorg/pkgj:1.0.0" -> "testorg/pkgk:0.1.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0014/expected-graph-medium.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0014/expected-graph-medium.dot
@@ -1,0 +1,6 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgh:1.0.0"
+    "testorg/pkgh:1.0.0" -> "testorg/pkgi:1.1.1"
+    "testorg/pkgi:1.1.1" -> "testorg/pkgl:1.2.0"
+    "testorg/pkgl:1.2.0" -> "testorg/pkgk:0.2.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0014/expected-graph-soft.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0014/expected-graph-soft.dot
@@ -1,0 +1,6 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgh:1.0.0"
+    "testorg/pkgh:1.0.0" -> "testorg/pkgi:1.1.1"
+    "testorg/pkgi:1.1.1" -> "testorg/pkgl:1.2.0"
+    "testorg/pkgl:1.2.0" -> "testorg/pkgk:0.2.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0015/app.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0015/app.dot
@@ -1,0 +1,3 @@
+digraph "testorg1/app:0.1.0" {
+    "testorg/pkgh"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0015/case-description.md
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0015/case-description.md
@@ -1,0 +1,16 @@
+# Fresh project: Patch upgrade changes dependency structure with incompatible transitive dep versions
+
+Same scenario as case-0013 but without Dependencies.toml (fresh project).
+
+1. User's package depends on `testorg/pkgh`
+2. Central has H:1.0.0 -> I:1.1.0 -> J:1.0.0 -> K:0.1.0
+3. Central has I:1.1.1 -> L:1.2.0 -> K:0.2.0
+
+## Expected behavior
+
+### All modes (HARD, MEDIUM, SOFT)
+H:1.0.0 resolved (only version). I:1.1.0 from H's deps, then upgraded to I:1.1.1
+(patch upgrade allowed by all non-HARD modes, and HARD resolves exact 1.1.0 which
+then gets upgraded in completeDependencyGraph).
+For HARD: I stays at 1.1.0 (EXACT), old chain preserved.
+For MEDIUM/SOFT: I upgraded to 1.1.1, new chain L -> K:0.2.0.

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0015/expected-graph-hard.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0015/expected-graph-hard.dot
@@ -1,0 +1,6 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgh:1.0.0"
+    "testorg/pkgh:1.0.0" -> "testorg/pkgi:1.1.0"
+    "testorg/pkgi:1.1.0" -> "testorg/pkgj:1.0.0"
+    "testorg/pkgj:1.0.0" -> "testorg/pkgk:0.1.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0015/expected-graph-medium.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0015/expected-graph-medium.dot
@@ -1,0 +1,6 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgh:1.0.0"
+    "testorg/pkgh:1.0.0" -> "testorg/pkgi:1.1.1"
+    "testorg/pkgi:1.1.1" -> "testorg/pkgl:1.2.0"
+    "testorg/pkgl:1.2.0" -> "testorg/pkgk:0.2.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0015/expected-graph-soft.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/case-0015/expected-graph-soft.dot
@@ -1,0 +1,6 @@
+digraph "example1" {
+    "testorg1/app:0.1.0" -> "testorg/pkgh:1.0.0"
+    "testorg/pkgh:1.0.0" -> "testorg/pkgi:1.1.1"
+    "testorg/pkgi:1.1.1" -> "testorg/pkgl:1.2.0"
+    "testorg/pkgl:1.2.0" -> "testorg/pkgk:0.2.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/repositories/central.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/repositories/central.dot
@@ -38,5 +38,89 @@ digraph central {
 
     subgraph "samjs/q:1.4.4" {
     }
+
+    subgraph "testorg/wrapper:1.0.0" {
+        "testorg/wrapper:1.0.0" -> "testorg/connector:1.1.0"
+    }
+
+    subgraph "testorg/connector:1.1.0" {
+        "testorg/connector:1.1.0" -> "testorg/datalib:0.8.0"
+    }
+
+    subgraph "testorg/connector:1.2.0" {
+        "testorg/connector:1.2.0" -> "testorg/datalib:0.10.0"
+    }
+
+    subgraph "testorg/datalib:0.8.0" {
+    }
+
+    subgraph "testorg/datalib:0.10.0" {
+    }
+
+    subgraph "testorg/pkgx:1.0.0" {
+        "testorg/pkgx:1.0.0" -> "testorg/pkgy:1.1.0"
+    }
+
+    subgraph "testorg/pkgx:1.1.0" {
+        "testorg/pkgx:1.1.0" -> "testorg/pkgw:1.2.0"
+    }
+
+    subgraph "testorg/pkgy:1.1.0" {
+        "testorg/pkgy:1.1.0" -> "testorg/pkgz:0.2.0"
+    }
+
+    subgraph "testorg/pkgw:1.2.0" {
+        "testorg/pkgw:1.2.0" -> "testorg/pkgz:0.3.0"
+    }
+
+    subgraph "testorg/pkgz:0.2.0" {
+    }
+
+    subgraph "testorg/pkgz:0.3.0" {
+    }
+
+    subgraph "testorg/pkgp:1.0.0" {
+        "testorg/pkgp:1.0.0" -> "testorg/pkgq:1.1.0"
+    }
+
+    subgraph "testorg/pkgq:1.1.0" {
+        "testorg/pkgq:1.1.0" -> "testorg/pkgr:0.1.0"
+    }
+
+    subgraph "testorg/pkgq:1.2.0" {
+        "testorg/pkgq:1.2.0" -> "testorg/pkgr:0.2.0"
+    }
+
+    subgraph "testorg/pkgr:0.1.0" {
+    }
+
+    subgraph "testorg/pkgr:0.2.0" {
+    }
+
+    subgraph "testorg/pkgh:1.0.0" {
+        "testorg/pkgh:1.0.0" -> "testorg/pkgi:1.1.0"
+    }
+
+    subgraph "testorg/pkgi:1.1.0" {
+        "testorg/pkgi:1.1.0" -> "testorg/pkgj:1.0.0"
+    }
+
+    subgraph "testorg/pkgi:1.1.1" {
+        "testorg/pkgi:1.1.1" -> "testorg/pkgl:1.2.0"
+    }
+
+    subgraph "testorg/pkgj:1.0.0" {
+        "testorg/pkgj:1.0.0" -> "testorg/pkgk:0.1.0"
+    }
+
+    subgraph "testorg/pkgl:1.2.0" {
+        "testorg/pkgl:1.2.0" -> "testorg/pkgk:0.2.0"
+    }
+
+    subgraph "testorg/pkgk:0.1.0" {
+    }
+
+    subgraph "testorg/pkgk:0.2.0" {
+    }
 }
 

--- a/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/repositories/dist.dot
+++ b/compiler/ballerina-lang/src/test/resources/package-resolution/suite-incompatible_versions/repositories/dist.dot
@@ -8,4 +8,15 @@ digraph central {
 
     subgraph "ballerina/cache:1.3.1" {
     }
+
+    subgraph "testorg/pkgp:1.0.0" {
+        "testorg/pkgp:1.0.0" -> "testorg/pkgq:1.1.0"
+    }
+
+    subgraph "testorg/pkgq:1.1.0" {
+        "testorg/pkgq:1.1.0" -> "testorg/pkgr:0.1.0"
+    }
+
+    subgraph "testorg/pkgr:0.1.0" {
+    }
 }


### PR DESCRIPTION
## Purpose
Fixes #44510

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes an issue where transitive dependencies incorrectly trigger false version conflicts during package resolution, particularly affecting initial versions. The fix improves the stability and reliability of the dependency resolution process by handling transitive dependency version updates more carefully.

## Changes

**Dependency Graph and Resolution Engine Updates**

- Added a new `getNodeVersion()` method to `PackageDependencyGraphBuilder` to enable lookup of resolved package versions by organization and package name.
- Enhanced `ResolutionEngine` with more defensive dependency graph management during version resolution iterations:
  - When processing initial dependency graphs, the engine now removes dangling nodes before merging transitive dependencies, preventing false version conflicts.
  - When stale auto-locked versions cause incompatibilities, the engine reissues resolution requests with default locking behavior rather than immediately marking nodes as errors, allowing for recovery.
  - When updating resolved packages, the engine skips batch results from removed or replaced nodes and only removes dangling nodes when actual version changes occur, preventing unnecessary cycles.

**Test Coverage Expansion**

- Extended incompatible version scenario testing with nine new test cases (cases 0008–0015), each with detailed documentation describing:
  - Parent transitive dependency upgrades and how they replace child dependencies without false conflicts
  - Locked vs. central repository dependency chains and their interactions
  - Incompatible pre-1.0 child dependency handling during upgrades
  - Behavior across different resolution modes (HARD, MEDIUM, SOFT)

These changes enhance the robustness of package dependency resolution and reduce false positives when managing transitive dependencies across multiple resolution modes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/ballerina-lang/pull/44600)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->