### PR TITLE
Fix decimal:fromString() panicking on exponent pattern

### DIFF
--- a/langlib/lang.decimal/src/main/java/org/ballerinalang/langlib/decimal/FromString.java
+++ b/langlib/lang.decimal/src/main/java/org/ballerinalang/langlib/decimal/FromString.java
@@ -49,6 +49,8 @@ public class FromString {
             return TypeConverter.stringToDecimal(decimalFloatingPointNumber);
         } catch (NumberFormatException e) {
             return getTypeConversionError(decimalFloatingPointNumber);
+        } catch (BError e) {
+            return e;
         }
     }
 

--- a/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
@@ -422,6 +422,18 @@ function testFromStringFunctionWithInvalidValues() {
         assertEquality("{ballerina}NumberOverflow", a1.message());
         assertEquality("decimal range overflow", <string> checkpanic a1.detail()["message"]);
     }
+
+    a1 = decimal:fromString("ENT 12 N 0000");
+    assertEquality(true, a1 is error);
+    if (a1 is error) {
+        assertEquality("{ballerina}DecimalExponentError", a1.message());
+    }
+
+    a1 = decimal:fromString("E11 99 0 000");
+    assertEquality(true, a1 is error);
+    if (a1 is error) {
+        assertEquality("{ballerina}DecimalExponentError", a1.message());
+    }
 }
 
 function testQuantize() {


### PR DESCRIPTION
## Purpose
`decimal:fromString()` was panicking instead of returning an error when the input string started with `E`/`e` followed by non-numeric characters (e.g. `"ENT 12 N 0000"`). The function signature returns `decimal|error`, so it should never panic for invalid inputs.

Fixes #43377

## Remarks
- Only the panic behaviour is fixed. The error type remains `DecimalExponentError` as it is consistent with the existing error reason from Java's BigDecimal parser.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Added necessary tests
  - [x] Unit Tests
  - [x] Ballerina By Example Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes a stability issue in the `decimal:fromString()` function where invalid input strings would cause a panic instead of returning an error as intended.

## Changes

**Java Implementation (`FromString.java`)**
- Enhanced error handling to catch `BError` exceptions from `TypeConverter.stringToDecimal()` and return them directly to the caller
- Maintains existing handling of `NumberFormatException` to produce typed conversion errors

**Test Coverage (`decimallib_test.bal`)**
- Added two new test cases with invalid decimal inputs containing spaces in exponent patterns (`"ENT 12 N 0000"` and `"E11 99 0 000"`)
- Tests verify that the function now returns errors with the correct error type (`DecimalExponentError`) instead of panicking

## Impact

The function now properly returns errors for invalid exponent patterns through its documented error return path, improving the stability and predictability of error handling for consumers of this API. The error type classification remains unchanged to maintain compatibility with existing error handling logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/ballerina-lang/pull/44603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->