### PR TITLE
Fix compiler crash when if keyword is missing before condition

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
@@ -19115,19 +19115,28 @@ public class BallerinaParser extends AbstractParser {
                         STNode rhsTypeDesc = getTypeDescFromExpr(binaryExpr.rhsExpr);
                         return mergeTypes(lhsTypeDesc, binaryExpr.operator, rhsTypeDesc);
                     default:
-                        break;
+                        return createMissingTypeDesc(expression);
                 }
-                return expression;
             case SIMPLE_NAME_REFERENCE:
             case QUALIFIED_NAME_REFERENCE:
                 return expression;
             default:
-                STNode simpleTypeDescIdentifier = SyntaxErrors.createMissingTokenWithDiagnostics(
-                        SyntaxKind.IDENTIFIER_TOKEN, DiagnosticErrorCode.ERROR_MISSING_TYPE_DESC);
-                simpleTypeDescIdentifier = SyntaxErrors.cloneWithTrailingInvalidNodeMinutiae(simpleTypeDescIdentifier, 
-                        expression);
-                return STNodeFactory.createSimpleNameReferenceNode(simpleTypeDescIdentifier);
+                return createMissingTypeDesc(expression);
         }
+    }
+
+    /**
+     * Create a missing type descriptor node with the given expression as invalid node minutiae.
+     *
+     * @param expression Expression that is not a valid type descriptor
+     * @return Missing type descriptor node
+     * */
+    private STNode createMissingTypeDesc(STNode expression) {
+        STNode simpleTypeDescIdentifier = SyntaxErrors.createMissingTokenWithDiagnostics(
+                SyntaxKind.IDENTIFIER_TOKEN, DiagnosticErrorCode.ERROR_MISSING_TYPE_DESC);
+        simpleTypeDescIdentifier = SyntaxErrors.cloneWithTrailingInvalidNodeMinutiae(
+                simpleTypeDescIdentifier, expression);
+        return STNodeFactory.createSimpleNameReferenceNode(simpleTypeDescIdentifier);
     }
 
     private List<STNode> getBindingPatternsList(List<STNode> ambibuousList, boolean isListBP) {

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/IfElseStatementTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/IfElseStatementTest.java
@@ -72,4 +72,9 @@ public class IfElseStatementTest extends AbstractStatementTest {
     public void testMissingIfKeyword() {
         testFile("if-else/if_else_source_09.bal", "if-else/if_else_assert_09.json");
     }
+
+    @Test
+    public void testMissingIfKeywordWithBracedCondition() {
+        testFile("if-else/if_else_source_10.bal", "if-else/if_else_assert_10.json");
+    }
 }

--- a/compiler/ballerina-parser/src/test/resources/statements/if-else/if_else_assert_10.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/if-else/if_else_assert_10.json
@@ -1,0 +1,323 @@
+{
+  "kind": "FUNCTION_DEFINITION",
+  "hasDiagnostics": true,
+  "children": [
+    {
+      "kind": "LIST",
+      "children": [
+        {
+          "kind": "PUBLIC_KEYWORD",
+          "trailingMinutiae": [
+            {
+              "kind": "WHITESPACE_MINUTIAE",
+              "value": " "
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "FUNCTION_KEYWORD",
+      "trailingMinutiae": [
+        {
+          "kind": "WHITESPACE_MINUTIAE",
+          "value": " "
+        }
+      ]
+    },
+    {
+      "kind": "IDENTIFIER_TOKEN",
+      "value": "fn"
+    },
+    {
+      "kind": "LIST",
+      "children": []
+    },
+    {
+      "kind": "FUNCTION_SIGNATURE",
+      "children": [
+        {
+          "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+          "kind": "LIST",
+          "children": []
+        },
+        {
+          "kind": "CLOSE_PAREN_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "WHITESPACE_MINUTIAE",
+              "value": " "
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "FUNCTION_BODY_BLOCK",
+      "hasDiagnostics": true,
+      "children": [
+        {
+          "kind": "OPEN_BRACE_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "END_OF_LINE_MINUTIAE",
+              "value": "\n"
+            }
+          ]
+        },
+        {
+          "kind": "LIST",
+          "hasDiagnostics": true,
+          "children": [
+            {
+              "kind": "LOCAL_VAR_DECL",
+              "children": [
+                {
+                  "kind": "LIST",
+                  "children": []
+                },
+                {
+                  "kind": "TYPED_BINDING_PATTERN",
+                  "children": [
+                    {
+                      "kind": "BOOLEAN_TYPE_DESC",
+                      "children": [
+                        {
+                          "kind": "BOOLEAN_KEYWORD",
+                          "leadingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": "    "
+                            }
+                          ],
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "CAPTURE_BINDING_PATTERN",
+                      "children": [
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "i",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "EQUAL_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
+                },
+                {
+                  "kind": "BOOLEAN_LITERAL",
+                  "children": [
+                    {
+                      "kind": "FALSE_KEYWORD"
+                    }
+                  ]
+                },
+                {
+                  "kind": "SEMICOLON_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "LOCAL_VAR_DECL",
+              "hasDiagnostics": true,
+              "children": [
+                {
+                  "kind": "LIST",
+                  "children": []
+                },
+                {
+                  "kind": "TYPED_BINDING_PATTERN",
+                  "hasDiagnostics": true,
+                  "children": [
+                    {
+                      "kind": "PARENTHESISED_TYPE_DESC",
+                      "hasDiagnostics": true,
+                      "children": [
+                        {
+                          "kind": "OPEN_PAREN_TOKEN",
+                          "leadingMinutiae": [
+                            {
+                              "kind": "END_OF_LINE_MINUTIAE",
+                              "value": "\n"
+                            },
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": "    "
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "SIMPLE_NAME_REFERENCE",
+                          "hasDiagnostics": true,
+                          "children": [
+                            {
+                              "kind": "IDENTIFIER_TOKEN",
+                              "isMissing": true,
+                              "hasDiagnostics": true,
+                              "diagnostics": [
+                                "ERROR_MISSING_TYPE_DESC"
+                              ],
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "INVALID_NODE_MINUTIAE",
+                                  "invalidNode": {
+                                    "kind": "INVALID_TOKEN_MINUTIAE_NODE",
+                                    "children": [
+                                      {
+                                        "kind": "IDENTIFIER_TOKEN",
+                                        "value": "i"
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                },
+                                {
+                                  "kind": "INVALID_NODE_MINUTIAE",
+                                  "invalidNode": {
+                                    "kind": "INVALID_TOKEN_MINUTIAE_NODE",
+                                    "children": [
+                                      {
+                                        "kind": "DOUBLE_EQUAL_TOKEN"
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                },
+                                {
+                                  "kind": "INVALID_NODE_MINUTIAE",
+                                  "invalidNode": {
+                                    "kind": "INVALID_TOKEN_MINUTIAE_NODE",
+                                    "children": [
+                                      {
+                                        "kind": "TRUE_KEYWORD"
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "CLOSE_PAREN_TOKEN",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "MAPPING_BINDING_PATTERN",
+                      "children": [
+                        {
+                          "kind": "OPEN_BRACE_TOKEN",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "END_OF_LINE_MINUTIAE",
+                              "value": "\n"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "LIST",
+                          "children": []
+                        },
+                        {
+                          "kind": "CLOSE_BRACE_TOKEN",
+                          "leadingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": "    "
+                            }
+                          ],
+                          "trailingMinutiae": [
+                            {
+                              "kind": "END_OF_LINE_MINUTIAE",
+                              "value": "\n"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "EQUAL_TOKEN",
+                  "isMissing": true,
+                  "hasDiagnostics": true,
+                  "diagnostics": [
+                    "ERROR_VARIABLE_DECL_HAVING_BP_MUST_BE_INITIALIZED"
+                  ]
+                },
+                {
+                  "kind": "SIMPLE_NAME_REFERENCE",
+                  "children": [
+                    {
+                      "kind": "IDENTIFIER_TOKEN",
+                      "isMissing": true
+                    }
+                  ]
+                },
+                {
+                  "kind": "SEMICOLON_TOKEN",
+                  "isMissing": true,
+                  "hasDiagnostics": true,
+                  "diagnostics": [
+                    "ERROR_MISSING_SEMICOLON_TOKEN"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "CLOSE_BRACE_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "END_OF_LINE_MINUTIAE",
+              "value": "\n"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/if-else/if_else_source_10.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/if-else/if_else_source_10.bal
@@ -1,0 +1,6 @@
+public function fn() {
+    boolean i = false;
+
+    (i == true) {
+    }
+}


### PR DESCRIPTION
## Purpose
When a user writes a condition block without the `if` keyword e.g:

```ballerina
function fn() {
    boolean i = false;
    (i == true) {
    }
}
```

The compiler crashed with an unhandled `ClassCastException` instead of reporting a meaningful error message.

Fixes #44179

## Approach
The parser was incorrectly identifying `(i == true)` as a `PARENTHESISED_TYPE_DESC` when followed by `{`. This caused `BLangNodeBuilder` to attempt casting a `BinaryExpressionNode` to a `TypeDescriptorNode`, resulting in a crash.
The root cause was in `getTypeDescFromExpr`. When a `BINARY_EXPRESSION` with a non-type operator (e.g. ==) was passed, it was not handled gracefully.

Fix:
- Added handling in `getTypeDescFromExpr` for `BINARY_EXPRESSION` with non-type operators to return a missing type descriptor node instead of crashing
- Extracted a helper method `createMissingTypeDesc` to eliminate code duplication between the `BINARY_EXPRESSION` default case and the outer default case

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Added necessary tests
  - [x] Unit Tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request addresses a compiler crash that occurs when an `if` keyword is missing before a condition block (e.g., `(i == true) { }`). The fix improves compiler stability and error handling by preventing unintended type casting errors.

## Changes Made

**Parser Logic Refactoring:**
- Refactored the `BallerinaParser` class to improve handling of malformed syntax
- Extracted a new helper method `createMissingTypeDesc()` to standardize creation of missing type descriptor nodes when expressions are incorrectly interpreted as type declarations
- This ensures consistent error handling when parenthesized expressions with non-type operators are followed by braced blocks

**Test Coverage:**
- Added a new test case `testMissingIfKeywordWithBracedCondition()` to verify the parser correctly handles the specific scenario of a missing `if` keyword
- Added corresponding test fixtures (source file and expected AST assertion) to validate proper error recovery and diagnostic reporting

## Outcome

The change enhances compiler robustness by replacing a silent crash with meaningful error diagnostics, allowing the parser to gracefully handle incomplete syntax patterns while maintaining proper error reporting to developers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/ballerina-lang/pull/44611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->