### PR TITLE
Add test for equality on boxed floats - fixes #32245

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/floattype/BFloatValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/floattype/BFloatValueTest.java
@@ -331,6 +331,11 @@ public class BFloatValueTest {
         Assert.assertEquals(result.getErrorCount(), i);
     }
 
+@Test(description = "Test equality on boxed floats - issue #32245")
+public void testEqualityOnBoxedFloats() {
+    BRunUtil.invoke(result, "testEqualityOnBoxedFloats");
+}
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/floattype/BFloatValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/floattype/BFloatValueTest.java
@@ -331,10 +331,10 @@ public class BFloatValueTest {
         Assert.assertEquals(result.getErrorCount(), i);
     }
 
-@Test(description = "Test equality on boxed floats - issue #32245")
-public void testEqualityOnBoxedFloats() {
-    BRunUtil.invoke(result, "testEqualityOnBoxedFloats");
-}
+    @Test(description = "Test equality on boxed floats - issue #32245")
+    public void testEqualityOnBoxedFloats() {
+        BRunUtil.invoke(result, "testEqualityOnBoxedFloats");
+    }
 
     @AfterClass
     public void tearDown() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/float/float-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/float/float-value.bal
@@ -107,3 +107,9 @@ function assertEqual(any expected, any actual) {
     string actualValAsString = actual.toString();
     panic error(string `Assertion error: expected ${expectedValAsString} found ${actualValAsString}`);
 }
+
+function testEqualityOnBoxedFloats() {
+    anydata x = 0.0;
+    anydata y = -0.0;
+    assertEqual(x, y);
+}


### PR DESCRIPTION
## Purpose
Fixes #32245 - Added missing test case for equality on boxed floats.
The bug was fixed in slbeta3 but no regression test was added.

## Approach
- Added `testEqualityOnBoxedFloats()` function in `float-value.bal` 
  that verifies `0.0 == -0.0` returns true when compared as `anydata`
- Added corresponding Java test method `testEqualityOnBoxedFloats()` 
  in `BFloatValueTest.java` to invoke the Ballerina test

## Samples
N/A

## Remarks
This is a regression test for issue #32245.

## Check List 
- [x] Read the Contributing Guide
- [x] Added necessary tests
  - [x] Unit Tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds a regression test to ensure correct equality semantics for boxed floating-point values (addresses regression from issue `#32245`).

### Changes

- Ballerina test: added function testEqualityOnBoxedFloats() in tests/jballerina-unit-test/src/test/resources/test-src/types/float/float-value.bal. The test boxes 0.0 and -0.0 as anydata and asserts they compare equal using existing test helpers.
- Java test: added testEqualityOnBoxedFloats() to tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/floattype/BFloatValueTest.java. The TestNG method invokes the new Ballerina test via the existing test harness.

### Outcome

Provides a focused regression test that verifies boxed float equality matches unboxed behavior (specifically that 0.0 == -0.0 when values are boxed), preventing future regressions in float equality semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->