### PR TITLE
Disable openapi tools repo tests

### DIFF
--- a/.github/workflows/pull_request_full_build.yml
+++ b/.github/workflows/pull_request_full_build.yml
@@ -132,6 +132,7 @@ jobs:
             else
               repo_name="${module_name}"
             fi
+            # TODO: Remove -x :openapi-cli:test once https://github.com/ballerina-platform/ballerina-library/issues/8825 is fixed
             if [[ $repo_name == "openapi-tools" ]]; then
               echo "Building Standard Library: $repo_name" && cd $repo_name && ./gradlew clean build -x :openapi-cli:test --stacktrace --scan && cd ..
             else

--- a/.github/workflows/pull_request_full_build.yml
+++ b/.github/workflows/pull_request_full_build.yml
@@ -132,7 +132,11 @@ jobs:
             else
               repo_name="${module_name}"
             fi
-            echo "Building Standard Library: $repo_name" && cd $repo_name && ./gradlew clean build --stacktrace --scan && cd ..
+            if [[ $repo_name == "openapi-tools" ]]; then
+              echo "Building Standard Library: $repo_name" && cd $repo_name && ./gradlew clean build -x :openapi-cli:test --stacktrace --scan && cd ..
+            else
+              echo "Building Standard Library: $repo_name" && cd $repo_name && ./gradlew clean build --stacktrace --scan && cd ..
+            fi
           done
         shell: bash
         env:


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request updates the CI build workflow to improve pipeline reliability by conditionally skipping the `openapi-cli` test suite during the standard Gradle build when building the `openapi-tools` module, while keeping the existing full build behavior for all other modules.

## Changes

- Updated `.github/workflows/pull_request_full_build.yml`:
  - In the `build-stdlib-level` job’s module build loop, the workflow now runs a modified Gradle command for `openapi-tools` that excludes `:openapi-cli:test`.
  - For all other modules, it continues using the standard `./gradlew clean build` command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->