### PR TITLE
Fix crash in query expr with group by clause

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -8896,6 +8896,9 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             indexBasedAccessExpr.originalType = actualType;
 
             if (actualType == symTable.semanticError) {
+                if (varRefType.tag == TypeTags.SEQUENCE) {
+                    return actualType;
+                }
                 if (isConstExpr(indexExpr)) {
                     dlog.error(indexBasedAccessExpr.indexExpr.pos,
                             DiagnosticErrorCode.LIST_INDEX_OUT_OF_RANGE, getConstIndex(indexExpr));
@@ -9110,6 +9113,10 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
         if (type.tag == TypeTags.TUPLE) {
             return checkTupleIndexBasedAccess(accessExpr, (BTupleType) type, accessExpr.indexExpr.getBType());
+        }
+
+        if (type.tag == TypeTags.SEQUENCE) {
+            return symTable.semanticError;
         }
 
         LinkedHashSet<BType> fieldTypeMembers = new LinkedHashSet<>();

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/GroupByClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/GroupByClauseTest.java
@@ -304,6 +304,8 @@ public class GroupByClauseTest {
                 191, 24);
         BAssertUtil.validateError(negativeResult, i++, "sequence variable can be used in a single element " +
                 "list constructor or function invocation", 191, 24);
+        BAssertUtil.validateError(negativeResult, i++, "sequence variable can be used in a single element " +
+                "list constructor or function invocation", 205, 16);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/group_by_clause_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/group_by_clause_negative.bal
@@ -191,3 +191,16 @@ function testSeqVarInInvalidPositions5() {
         let string _ = name2 // error
         select count(name1);
 }
+
+type Account record {
+    int? id;
+    string name;
+    string token;
+};
+
+function testGroupBySequenceDirectIndexAccess() {
+    Account[] accounts = [];
+    Account[] result = from Account account in accounts
+        group by int aid = <int>(account.id)
+        select account[0]; // invalid: direct index access on sequence variable
+}


### PR DESCRIPTION
## Purpose
When a query expression contains a `group by` clause, variables in the `select` clause become sequence variables (`BSequenceType`). If a user attempts direct index access on a sequence variable (e.g. `account[0]`), the compiler crashes with a `ClassCastException` instead of emitting a proper diagnostic.

Fixes #44481

## Approach

`checkListIndexBasedAccess` in `TypeChecker.java` is called from `checkIndexAccessExpr` when the variable's type satisfies `isSubTypeOfList`. It handles `ARRAY` and `TUPLE` types explicitly, then falls through to treat any remaining type as `BUnionType`. `BSequenceType` satisfies `isSubTypeOfList` but is not a `BUnionType`, so it reaches the fallthrough cast and crashes.

The crash occurs during type checking of the query expression because `QueryTypeChecker.solveSelectTypeAndResolveType` silently probes the select expression type via `checkExprSilent` before the sequence variable validator (`BCE4047`) has a chance to run.

Two changes were made in `TypeChecker.java`:

1. `checkListIndexBasedAccess` - Added a guard for `TypeTags.SEQUENCE` that returns `symTable.semanticError` silently before the fallthrough cast, preventing the `ClassCastException`.

2. `checkIndexAccessExpr` - Without this fix, `checkIndexAccessExpr` misinterprets the `semanticError` returned for a sequence type as a bad index and emits `LIST_INDEX_OUT_OF_RANGE`. Added a check for `TypeTags.SEQUENCE` to skip that and return `semanticError` directly, deferring to `BCE4047` which emits the correct diagnostic during actual semantic analysis.

## Samples

The following now produces a proper diagnostic instead of crashing:

```ballerina
type Account record {
    int? id;
    string name;
    string token;
};

public function main() {
    Account[] accounts = [];
    Account[] result = from Account account in accounts
        let int? aid = account.id
        where aid is int
        group by aid
        select account[0]; // error: sequence variable can be used in a
                           // single element list constructor or function invocation
}
```

## Remarks
Direct index access on sequence variables is intentionally disallowed by the language spec. This fix only prevents the compiler crash. It does not add support for index access on sequence variables.

## Check List
- [x] Read the [[Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Added necessary tests
  - [x] Unit Tests
- [x] Increased Test Coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change improves compiler stability for grouped query expressions that attempt invalid direct index access on sequence variables. The type checker now handles sequence types safely during index access analysis, avoids misclassifying the failure as a list index error, and lets normal semantic analysis produce the appropriate diagnostic instead of crashing. Related negative tests were updated to cover the new grouped-query sequence indexing case and its expected error location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->