### PR TITLE
Fix ClassCastException for non-object 'self'

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -1983,9 +1983,13 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     }
 
     private boolean isSelfKeyWordExpr(BLangExpression expr) {
-
-        return expr.getKind() == NodeKind.SIMPLE_VARIABLE_REF &&
-                Names.SELF.value.equals(((BLangSimpleVarRef) expr).getVariableName().getValue());
+        if (expr.getKind() != NodeKind.SIMPLE_VARIABLE_REF) {
+            return false;
+        }
+        BLangSimpleVarRef varRef = (BLangSimpleVarRef) expr;
+        return Names.SELF.value.equals(varRef.getVariableName().getValue())
+                && varRef.symbol != null
+                && varRef.symbol.type instanceof BObjectType;
     }
 
     private StringBuilder getUninitializedFieldsForSelfKeyword(BObjectType objType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -1989,7 +1989,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         BLangSimpleVarRef varRef = (BLangSimpleVarRef) expr;
         return Names.SELF.value.equals(varRef.getVariableName().getValue())
                 && varRef.symbol != null
-                && varRef.symbol.type instanceof BObjectType;
+                && varRef.symbol.type.tag == TypeTags.OBJECT;
     }
 
     private StringBuilder getUninitializedFieldsForSelfKeyword(BObjectType objType) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/identifiers/IdentifierTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/identifiers/IdentifierTest.java
@@ -84,7 +84,11 @@ public class IdentifierTest {
     public Object[] functionsWithSelfAsIdentifier() {
         return new String[]{
                 "testFuncWithSelfAsParamName",
-                "testSelfAsIdentifier"
+                "testSelfAsIdentifier",
+                "testSelfAsVariableName",
+                "testSelfAsArgument",
+                "testQuotedSelfAsVariableName",
+                "testQuotedSelfAsArgument"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/identifiers/self_as_identifier.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/identifiers/self_as_identifier.bal
@@ -53,3 +53,25 @@ function testSelfAsIdentifier() {
     int n = x.n + self;
     test:assertEquals(n, 20);
 }
+
+function testSelfAsVariableName() {
+    int self = 3;
+    test:assertEquals(self, 3);
+}
+
+function testSelfAsArgument() {
+    int self = 3;
+    int result = funcWithSelfAsParamName(self);
+    test:assertEquals(result, 8);
+}
+
+function testQuotedSelfAsVariableName() {
+    int 'self = 3;
+    test:assertEquals('self, 3);
+}
+
+function testQuotedSelfAsArgument() {
+    int 'self = 3;
+    int result = funcWithSelfAsParamName('self);
+    test:assertEquals(result, 8);
+}


### PR DESCRIPTION
## Purpose
Using `self` as a plain variable name (e.g. `int self = 3`) in a non-object context caused a `ClassCastException` crash in `DataflowAnalyzer.isSelfKeyWordExpr`. The method identified any variable named `self` as an object self-reference purely by name, leading to an invalid cast to `BObjectType` downstream.

Fixes #42772 

## Approach
Added an `instanceof BObjectType` check to `isSelfKeyWordExpr` so it only returns `true` for a genuine object `self`.

## Samples
```ballerina
// Previously crashed with ClassCastException, now compiles correctly
public function main() {
    int self = 3;
    io:println(self);
}

// Quoted 'self also crashed with the same error
public function main() {
    int 'self = 3;
    io:println('self);
}

// Passing self/`self as an argument also crashed
public function main() {
    int self = 3;
    io:println(funcWithSelfAsParamName(self));
}
```

## Remarks
`self` is not a reserved keyword in Ballerina. Using it as a variable name is valid and should compile without errors.

## Check List
- [x] Read the [[Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Added necessary tests
  - [x] Unit Tests (`IdentifierTest.java`, `self_as_identifier.bal`)
- [x] Increased Test Coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `DataflowAnalyzer` to only treat `self` as the object keyword when it is backed by an actual object-typed symbol, preventing incorrect handling of normal identifiers named `self`.

Expanded identifier tests to cover `self` and quoted `'self` used as local variables and as function arguments, confirming they compile and behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->