### PR TITLE
Fix ClassCastException for non-object 'self'

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -1983,9 +1983,13 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     }
 
     private boolean isSelfKeyWordExpr(BLangExpression expr) {
-
-        return expr.getKind() == NodeKind.SIMPLE_VARIABLE_REF &&
-                Names.SELF.value.equals(((BLangSimpleVarRef) expr).getVariableName().getValue());
+        if (expr.getKind() != NodeKind.SIMPLE_VARIABLE_REF) {
+            return false;
+        }
+        BLangSimpleVarRef varRef = (BLangSimpleVarRef) expr;
+        return Names.SELF.value.equals(varRef.getVariableName().getValue())
+                && varRef.symbol != null
+                && varRef.symbol.type instanceof BObjectType;
     }
 
     private StringBuilder getUninitializedFieldsForSelfKeyword(BObjectType objType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -1989,7 +1989,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         BLangSimpleVarRef varRef = (BLangSimpleVarRef) expr;
         return Names.SELF.value.equals(varRef.getVariableName().getValue())
                 && varRef.symbol != null
-                && varRef.symbol.type instanceof BObjectType;
+                && varRef.symbol.type.tag == TypeTags.OBJECT;
     }
 
     private StringBuilder getUninitializedFieldsForSelfKeyword(BObjectType objType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -1997,6 +1997,11 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         boolean isFirstUninitializedField = true;
         StringBuilder uninitializedFields = new StringBuilder();
         for (BField field : objType.fields.values()) {
+            if (Symbols.isPrivate(field.symbol)) {
+                // Private fields can remain uninitialized as long as they are not accessed before
+                // initialization, and they are not accessible outside the object.
+                continue;
+            }
             if (this.uninitializedVars.containsKey(field.symbol)) {
                 if (isFirstUninitializedField) {
                     uninitializedFields = new StringBuilder(field.symbol.getName().value);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -1737,10 +1737,10 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         if (!isFieldsInitializedForSelfArgument(invocationExpr)) {
             return;
         }
-        if (!isFieldsInitializedForSelfInvocation(invocationExpr.requiredArgs, invocationExpr.pos)) {
+        if (!isFieldsInitializedForSelfInvocation(invocationExpr.requiredArgs, invocationExpr.pos, symbol)) {
             return;
         }
-        if (!isFieldsInitializedForSelfInvocation(invocationExpr.restArgs, invocationExpr.pos)) {
+        if (!isFieldsInitializedForSelfInvocation(invocationExpr.restArgs, invocationExpr.pos, symbol)) {
             return;
         }
 
@@ -1926,7 +1926,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         }
         StringBuilder uninitializedFields =
                 getUninitializedFieldsForSelfKeyword((BObjectType) ((BLangSimpleVarRef)
-                        invocationExpr.expr).symbol.type);
+                        invocationExpr.expr).symbol.type, false);
         if (!uninitializedFields.isEmpty()) {
             this.dlog.error(invocationExpr.pos, DiagnosticErrorCode.CONTAINS_UNINITIALIZED_FIELDS,
                     uninitializedFields.toString());
@@ -1936,12 +1936,14 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     }
 
     private boolean isFieldsInitializedForSelfInvocation(List<BLangExpression> argExpressions,
-                                                         Location location) {
+                                                         Location location, BSymbol invokedSymbol) {
 
         for (BLangExpression expr : argExpressions) {
             if (isSelfKeyWordExpr(expr)) {
+                BObjectType objType = (BObjectType) ((BLangSimpleVarRef) expr).symbol.type;
+                boolean checkPrivateFields = invokedSymbol != null && invokedSymbol.owner == objType.tsymbol;
                 StringBuilder uninitializedFields =
-                        getUninitializedFieldsForSelfKeyword((BObjectType) ((BLangSimpleVarRef) expr).symbol.type);
+                        getUninitializedFieldsForSelfKeyword(objType, checkPrivateFields);
                 if (!uninitializedFields.isEmpty()) {
                     this.dlog.error(location, DiagnosticErrorCode.CONTAINS_UNINITIALIZED_FIELDS,
                             uninitializedFields.toString());
@@ -1992,12 +1994,12 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
                 && varRef.symbol.type.tag == TypeTags.OBJECT;
     }
 
-    private StringBuilder getUninitializedFieldsForSelfKeyword(BObjectType objType) {
+    private StringBuilder getUninitializedFieldsForSelfKeyword(BObjectType objType, boolean checkPrivateFields) {
 
         boolean isFirstUninitializedField = true;
         StringBuilder uninitializedFields = new StringBuilder();
         for (BField field : objType.fields.values()) {
-            if (Symbols.isPrivate(field.symbol)) {
+            if (!checkPrivateFields && Symbols.isPrivate(field.symbol)) {
                 // Private fields can remain uninitialized as long as they are not accessed before
                 // initialization, and they are not accessible outside the object.
                 continue;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/identifiers/IdentifierTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/identifiers/IdentifierTest.java
@@ -84,7 +84,11 @@ public class IdentifierTest {
     public Object[] functionsWithSelfAsIdentifier() {
         return new String[]{
                 "testFuncWithSelfAsParamName",
-                "testSelfAsIdentifier"
+                "testSelfAsIdentifier",
+                "testSelfAsVariableName",
+                "testSelfAsArgument",
+                "testQuotedSelfAsVariableName",
+                "testQuotedSelfAsArgument"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/identifiers/IdentifierTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/identifiers/IdentifierTest.java
@@ -89,6 +89,8 @@ public class IdentifierTest {
                 "testSelfAsArgument",
                 "testQuotedSelfAsVariableName",
                 "testQuotedSelfAsArgument",
+                "testObjectTypedSelfAsVariableName",
+                "testObjectTypedSelfAsArgument",
                 "testObjectTypedQuotedSelfAsVariableName",
                 "testObjectTypedQuotedSelfAsArgument"
         };

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/identifiers/IdentifierTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/identifiers/IdentifierTest.java
@@ -88,7 +88,9 @@ public class IdentifierTest {
                 "testSelfAsVariableName",
                 "testSelfAsArgument",
                 "testQuotedSelfAsVariableName",
-                "testQuotedSelfAsArgument"
+                "testQuotedSelfAsArgument",
+                "testObjectTypedQuotedSelfAsVariableName",
+                "testObjectTypedQuotedSelfAsArgument"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectWithFunctionInvocationUsingSelfKeyword.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectWithFunctionInvocationUsingSelfKeyword.java
@@ -44,4 +44,12 @@ public class ObjectWithFunctionInvocationUsingSelfKeyword {
         BAssertUtil.validateError(compileResult, 6, "field(s) 'name' not initialized", 151, 9);
         BAssertUtil.validateError(compileResult, 7, "field(s) 'name' not initialized", 168, 9);
     }
+
+    @Test(description = "Test that passing self as an argument does not report uninitialized private fields, " +
+            "since private fields are not accessible outside the object")
+    public void testSelfKeywordInvocationWithUninitializedPrivateFields() {
+        CompileResult compileResult = BCompileUtil.compile(
+                "test-src/object/object_self_function_invocation_positive.bal");
+        Assert.assertEquals(compileResult.getErrorCount(), 0);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectWithFunctionInvocationUsingSelfKeyword.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectWithFunctionInvocationUsingSelfKeyword.java
@@ -34,7 +34,7 @@ public class ObjectWithFunctionInvocationUsingSelfKeyword {
         CompileResult compileResult = BCompileUtil.compile("test-src/object/object_self_function_invocation_negative" +
                 ".bal");
 
-        Assert.assertEquals(compileResult.getErrorCount(), 8);
+        Assert.assertEquals(compileResult.getErrorCount(), 9);
         BAssertUtil.validateError(compileResult, 0, "field(s) 'name, age' not initialized", 6, 9);
         BAssertUtil.validateError(compileResult, 1, "field(s) 'name, city' not initialized", 30, 13);
         BAssertUtil.validateError(compileResult, 2, "field(s) 'name, city' not initialized", 55, 13);
@@ -43,6 +43,7 @@ public class ObjectWithFunctionInvocationUsingSelfKeyword {
         BAssertUtil.validateError(compileResult, 5, "field(s) 'name, city' not initialized", 129, 17);
         BAssertUtil.validateError(compileResult, 6, "field(s) 'name' not initialized", 151, 9);
         BAssertUtil.validateError(compileResult, 7, "field(s) 'name' not initialized", 168, 9);
+        BAssertUtil.validateError(compileResult, 8, "field(s) 'pending' not initialized", 186, 9);
     }
 
     @Test(description = "Test that passing self as an argument does not report uninitialized private fields, " +

--- a/tests/jballerina-unit-test/src/test/resources/test-src/identifiers/self_as_identifier.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/identifiers/self_as_identifier.bal
@@ -53,3 +53,25 @@ function testSelfAsIdentifier() {
     int n = x.n + self;
     test:assertEquals(n, 20);
 }
+
+function testSelfAsVariableName() {
+    int self = 3;
+    test:assertEquals(self, 3);
+}
+
+function testSelfAsArgument() {
+    int self = 3;
+    int result = funcWithSelfAsParamName(self);
+    test:assertEquals(result, 8);
+}
+
+function testQuotedSelfAsVariableName() {
+    int 'self = 3;
+    test:assertEquals('self, 3);
+}
+
+function testQuotedSelfAsArgument() {
+    int 'self = 3;
+    int result = funcWithSelfAsParamName('self);
+    test:assertEquals(result, 8);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/identifiers/self_as_identifier.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/identifiers/self_as_identifier.bal
@@ -76,24 +76,26 @@ function testQuotedSelfAsArgument() {
     test:assertEquals(result, 8);
 }
 
-class MyClassForQuotedSelf {
-    int n;
+function testObjectTypedSelfAsVariableName() {
+    MyClass self = new MyClass(5);
+    test:assertEquals(self.n, 5);
+}
 
-    function init(int n) {
-        self.n = n;
-    }
+function testObjectTypedSelfAsArgument() {
+    MyClass self = new MyClass(5);
+    test:assertEquals(funcTakingMyClass(self).n, 5);
 }
 
 function testObjectTypedQuotedSelfAsVariableName() {
-    MyClassForQuotedSelf 'self = new MyClassForQuotedSelf(5);
+    MyClass 'self = new MyClass(5);
     test:assertEquals('self.n, 5);
 }
 
 function testObjectTypedQuotedSelfAsArgument() {
-    MyClassForQuotedSelf 'self = new MyClassForQuotedSelf(5);
+    MyClass 'self = new MyClass(5);
     test:assertEquals(funcTakingMyClass('self).n, 5);
 }
 
-function funcTakingMyClass(MyClassForQuotedSelf c) returns MyClassForQuotedSelf {
+function funcTakingMyClass(MyClass c) returns MyClass {
     return c;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/identifiers/self_as_identifier.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/identifiers/self_as_identifier.bal
@@ -75,3 +75,25 @@ function testQuotedSelfAsArgument() {
     int result = funcWithSelfAsParamName('self);
     test:assertEquals(result, 8);
 }
+
+class MyClassForQuotedSelf {
+    int n;
+
+    function init(int n) {
+        self.n = n;
+    }
+}
+
+function testObjectTypedQuotedSelfAsVariableName() {
+    MyClassForQuotedSelf 'self = new MyClassForQuotedSelf(5);
+    test:assertEquals('self.n, 5);
+}
+
+function testObjectTypedQuotedSelfAsArgument() {
+    MyClassForQuotedSelf 'self = new MyClassForQuotedSelf(5);
+    test:assertEquals(funcTakingMyClass('self).n, 5);
+}
+
+function funcTakingMyClass(MyClassForQuotedSelf c) returns MyClassForQuotedSelf {
+    return c;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object_self_function_invocation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object_self_function_invocation_negative.bal
@@ -176,3 +176,22 @@ function change(Person8... person) {
 public function testSelfKeywordInvocationWithModuleLevelFunctionInvocationWithRestArgs() {
     Person8 _ = new("person");
 }
+
+class Person9 {
+    int n;
+    private int pending;
+
+    function init(int n) {
+        self.n = n;
+        self.modify(self);
+        self.pending = 0;
+    }
+
+    function modify(Person9 value) {
+        int _ = value.pending;
+    }
+}
+
+public function testUninitializedPrivateFieldSameClass() {
+    Person9 _ = new(1);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object_self_function_invocation_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object_self_function_invocation_positive.bal
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+class C {
+    int n;
+    private int pending;
+
+    function init(int n) {
+        self.n = n;
+    }
+}
+
+function take(C value) {
+}
+
+function testUninitializedPrivateFieldPassedAsSelf() {
+    C c = new C(1);
+    take(c);
+}
+
+class D {
+    int n;
+    private int pending;
+
+    function init(int n) {
+        self.n = n;
+        self.modify(self);
+        self.pending = 0;
+    }
+
+    function modify(D value) {
+    }
+}
+
+function testUninitializedPrivateFieldPassedAsSelfWithinMethod() {
+    D _ = new D(1);
+}
+
+class E {
+    int n;
+    private int pending;
+
+    function init(int n) {
+        self.n = n;
+        self.helper();
+    }
+
+    function helper() {
+        take(self);
+    }
+}
+
+function testUninitializedPrivateFieldPassedAsSelfFromNestedMethod() {
+    E _ = new E(1);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object_self_function_invocation_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object_self_function_invocation_positive.bal
@@ -31,24 +31,6 @@ function testUninitializedPrivateFieldPassedAsSelf() {
     take(c);
 }
 
-class D {
-    int n;
-    private int pending;
-
-    function init(int n) {
-        self.n = n;
-        self.modify(self);
-        self.pending = 0;
-    }
-
-    function modify(D value) {
-    }
-}
-
-function testUninitializedPrivateFieldPassedAsSelfWithinMethod() {
-    D _ = new D(1);
-}
-
 class E {
     int n;
     private int pending;


### PR DESCRIPTION
## Purpose
Using `self` as a plain variable name (e.g. `int self = 3`) in a non-object context caused a `ClassCastException` crash in `DataflowAnalyzer.isSelfKeyWordExpr`. The method identified any variable named `self` as an object self-reference purely by name, leading to an invalid cast to `BObjectType` downstream.

Fixes #42772 

## Approach
Added an `instanceof BObjectType` check to `isSelfKeyWordExpr` so it only returns `true` for a genuine object `self`.

## Samples
```ballerina
// Previously crashed with ClassCastException, now compiles correctly
public function main() {
    int self = 3;
    io:println(self);
}

// Quoted 'self also crashed with the same error
public function main() {
    int 'self = 3;
    io:println('self);
}

// Passing self/`self as an argument also crashed
public function main() {
    int self = 3;
    io:println(funcWithSelfAsParamName(self));
}
```

## Remarks
`self` is not a reserved keyword in Ballerina. Using it as a variable name is valid and should compile without errors.

## Check List
- [x] Read the [[Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Added necessary tests
  - [x] Unit Tests (`IdentifierTest.java`, `self_as_identifier.bal`)
- [x] Increased Test Coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change improves compiler stability by updating `DataflowAnalyzer` to recognize `self` as an object reference only when the referenced symbol has object type. It also checks private fields for same-class self-invocations and excludes them when the invocation targets code outside the owning class.

The test suite now covers `self` and `'self` as local variables and function arguments, including object-typed scenarios and self references involving uninitialized private fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->