### PR TITLE
Fix NPE in BIR optimizer for check in do/on-fail

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -5533,23 +5533,24 @@ public class Desugar extends BLangNodeVisitor {
         return errorVarDef;
     }
 
+    private void setEnclosingOnFail() {
+        int currentOnFailIndex = this.enclosingOnFailClause.indexOf(this.onFailClause);
+        int enclosingOnFailIndex = currentOnFailIndex <= 0 ? this.enclosingOnFailClause.size() - 1
+                : (currentOnFailIndex - 1);
+        if (enclosingOnFailIndex >= 0 && !this.enclosingOnFailClause.isEmpty()) {
+            this.onFailClause = this.enclosingOnFailClause.get(enclosingOnFailIndex);
+        } else {
+            this.onFailClause = null;
+        }
+    }
+
     private BLangBlockStmt rewriteNestedOnFail(BLangOnFailClause onFailClause, BLangFail fail) {
         BLangOnFailClause currentOnFail = this.onFailClause;
 
-        if (!onFailClause.desugared) {
-            // Step back to the enclosing on-fail context before rewriting the body, so that
-            // any check/fail expression inside the on-fail body resolves against the correct
-            // outer clause rather than looping back into the current one.
-            int currentOnFailIndex = this.enclosingOnFailClause.indexOf(this.onFailClause);
-            int enclosingOnFailIndex = currentOnFailIndex <= 0 ? this.enclosingOnFailClause.size() - 1
-                    : (currentOnFailIndex - 1);
-            if (enclosingOnFailIndex >= 0 && !this.enclosingOnFailClause.isEmpty()) {
-                this.onFailClause = this.enclosingOnFailClause.get(enclosingOnFailIndex);
-            } else {
-                this.onFailClause = null;
-            }
+        if (!onFailClause.bodyDesugared) {
+            setEnclosingOnFail();
             onFailClause.body = rewrite(onFailClause.body, env);
-            onFailClause.desugared = true;
+            onFailClause.bodyDesugared = true;
             this.onFailClause = currentOnFail;
         }
 
@@ -5561,14 +5562,7 @@ public class Desugar extends BLangNodeVisitor {
 
         handleOnFailErrorVarDefNode(onFailClause.variableDefinitionNode, onFailBody, fail);
 
-        int currentOnFailIndex = this.enclosingOnFailClause.indexOf(this.onFailClause);
-        int enclosingOnFailIndex = currentOnFailIndex <= 0 ? this.enclosingOnFailClause.size() - 1
-                : (currentOnFailIndex - 1);
-        if (enclosingOnFailIndex >= 0 && !this.enclosingOnFailClause.isEmpty()) {
-            this.onFailClause = this.enclosingOnFailClause.get(enclosingOnFailIndex);
-        } else {
-            this.onFailClause = null;
-        }
+        setEnclosingOnFail();
         onFailBody = rewrite(onFailBody, env);
         BLangFail failToEndBlock = new BLangFail();
         if (onFailClause.isInternal && fail.exprStmt != null) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -5536,6 +5536,23 @@ public class Desugar extends BLangNodeVisitor {
     private BLangBlockStmt rewriteNestedOnFail(BLangOnFailClause onFailClause, BLangFail fail) {
         BLangOnFailClause currentOnFail = this.onFailClause;
 
+        if (!onFailClause.desugared) {
+            // Step back to the enclosing on-fail context before rewriting the body, so that
+            // any check/fail expression inside the on-fail body resolves against the correct
+            // outer clause rather than looping back into the current one.
+            int currentOnFailIndex = this.enclosingOnFailClause.indexOf(this.onFailClause);
+            int enclosingOnFailIndex = currentOnFailIndex <= 0 ? this.enclosingOnFailClause.size() - 1
+                    : (currentOnFailIndex - 1);
+            if (enclosingOnFailIndex >= 0 && !this.enclosingOnFailClause.isEmpty()) {
+                this.onFailClause = this.enclosingOnFailClause.get(enclosingOnFailIndex);
+            } else {
+                this.onFailClause = null;
+            }
+            onFailClause.body = rewrite(onFailClause.body, env);
+            onFailClause.desugared = true;
+            this.onFailClause = currentOnFail;
+        }
+
         BLangBlockStmt onFailBody = ASTBuilderUtil.createBlockStmt(onFailClause.pos);
         onFailBody.stmts.addAll(onFailClause.body.stmts);
         onFailBody.scope = onFailClause.body.scope;
@@ -5547,7 +5564,11 @@ public class Desugar extends BLangNodeVisitor {
         int currentOnFailIndex = this.enclosingOnFailClause.indexOf(this.onFailClause);
         int enclosingOnFailIndex = currentOnFailIndex <= 0 ? this.enclosingOnFailClause.size() - 1
                 : (currentOnFailIndex - 1);
-        this.onFailClause = this.enclosingOnFailClause.get(enclosingOnFailIndex);
+        if (enclosingOnFailIndex >= 0 && !this.enclosingOnFailClause.isEmpty()) {
+            this.onFailClause = this.enclosingOnFailClause.get(enclosingOnFailIndex);
+        } else {
+            this.onFailClause = null;
+        }
         onFailBody = rewrite(onFailBody, env);
         BLangFail failToEndBlock = new BLangFail();
         if (onFailClause.isInternal && fail.exprStmt != null) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/clauses/BLangOnFailClause.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/clauses/BLangOnFailClause.java
@@ -47,6 +47,9 @@ public class BLangOnFailClause extends BLangNode implements OnFailClauseNode {
     public boolean bodyContainsFail;
     public boolean isInternal;
 
+    // Desugar State
+    public boolean bodyDesugared = false;
+
     public BLangOnFailClause() {
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/checkingstatement/CheckingStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/checkingstatement/CheckingStmtTest.java
@@ -51,7 +51,9 @@ public class CheckingStmtTest {
                 "testNilLiteral",
                 "testVariableReference",
                 "testFieldAccessExpr",
-                "testMemberAccessExpr"
+                "testMemberAccessExpr",
+                "testCheckInsideForeachAndOnFail",
+                "testSingleFailSiteCheck"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/checkingstatement/CheckingStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/checkingstatement/CheckingStmtTest.java
@@ -53,7 +53,8 @@ public class CheckingStmtTest {
                 "testFieldAccessExpr",
                 "testMemberAccessExpr",
                 "testCheckInsideForeachAndOnFail",
-                "testSingleFailSiteCheck"
+                "testSingleFailSiteCheck",
+                "testCheckInsideMatchAndOnFail"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/checkingstatement/checking-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/checkingstatement/checking-stmt.bal
@@ -58,7 +58,7 @@ function checkingFunc5() returns error? {
 
 function checkingFunc6() returns error {
     error e = error("msg6");
-    check e;  
+    check e;
     return error("new msg");
 }
 
@@ -72,7 +72,7 @@ type REC2 record {
 
 function testFieldAccessExpr() {
     REC1 rec = { n: () };
-    check rec.n; // no error    
+    check rec.n; // no error
     error? e = checkingFunc7();
     assertTrue(e is error && e.message() == "msg7");
 }
@@ -110,4 +110,37 @@ function assertEquality(anydata expected, anydata actual) {
     }
 
     panic error("expected '" + expected.toString() + "', found '" + actual.toString() + "'");
+}
+
+function testCheckInsideForeachAndOnFail() returns error? {
+    int[] items = [1, 2];
+    do {
+        if items.length() == 0 {
+            fail error("empty");
+        }
+        foreach int item in items {
+            _ = check mockOperation();
+        }
+    } on fail error e {
+        foreach int item in items {
+            _ = check mockOperation();
+        }
+    }
+}
+
+function mockOperation() returns error? {
+    return ();
+}
+
+function testSingleFailSiteCheck() returns error? {
+    int[] items = [1, 2];
+    boolean onFailReached = false;
+    do {
+        foreach int item in items {
+            _ = check mockOperation();
+        }
+    } on fail error e {
+        onFailReached = true;
+    }
+    assertTrue(!onFailReached);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/checkingstatement/checking-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/checkingstatement/checking-stmt.bal
@@ -144,3 +144,25 @@ function testSingleFailSiteCheck() returns error? {
     }
     assertTrue(!onFailReached);
 }
+
+function testCheckInsideMatchAndOnFail() returns error? {
+    int[] items = [1, 2];
+    int selector = 0;
+
+    match selector {
+        0 => {
+            if items.length() == 0 {
+                fail error("empty");
+            }
+        }
+        1 => {
+            foreach int item in items {
+                _ = check mockOperation();
+            }
+        }
+    } on fail error e {
+        foreach int item in items {
+            _ = check mockOperation();
+        }
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/checkingstatement/checking-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/checkingstatement/checking-stmt.bal
@@ -146,8 +146,11 @@ function testSingleFailSiteCheck() returns error? {
 }
 
 function testCheckInsideMatchAndOnFail() returns error? {
-    int[] items = [1, 2];
+    int[] items = [];
+    int[] onFailItems = [1, 2];
     int selector = 0;
+    boolean onFailReached = false;
+    int count = 0;
 
     match selector {
         0 => {
@@ -161,8 +164,12 @@ function testCheckInsideMatchAndOnFail() returns error? {
             }
         }
     } on fail error e {
-        foreach int item in items {
+        onFailReached = true;
+        foreach int item in onFailItems {
             _ = check mockOperation();
+            count += 1;
         }
     }
+    assertTrue(onFailReached);
+    assertEquality(2, count);
 }


### PR DESCRIPTION
## Purpose
Fixes a `NullPointerException` thrown by the BIR optimizer when a `do` block contains more than one fail-producing site (e.g. an explicit `fail` statement and a `check` expression inside a `foreach`) that share the same `on fail` clause.

Fixes #44623

## Approach
`rewriteNestedOnFail` is invoked once per fail site that targets a given `on fail` clause. Each invocation rewrote `onFailClause.body` from scratch, but all fail sites referencing the same clause hold references to the same underlying AST nodes. When a second fail site triggered a second rewrite, already-desugared nodes were processed again.

This caused `BIRGen` to overwrite `symbolVarMap` entries for variables created during `check` expression desugaring, leaving earlier `BIROperand` references pointing at a `variableDcl` that no longer matched any map entry. When the BIR optimizer later inlined a `MOVE` instruction referencing one of these stale operands, it dereferenced a `null` `variableDcl`.

The fix guards the body rewrite in `rewriteNestedOnFail` with the existing `onFailClause.desugared` flag, so the body of a given `on fail` clause is rewritten exactly once regardless of how many fail sites reference it. Subsequent calls reuse the already-rewritten body and only generate the fail-site-specific scaffolding.

## Samples
```ballerina
public function main() returns error? {
    int[] items = [1, 2];
    do {
        if items.length() == 0 {
            fail error("empty");
        }
        foreach int item in items {
            _ = check mockOperation();
        }
    } on fail error e {
        foreach int item in items {
            _ = check mockOperation();
        }
    }
}

function mockOperation() returns error? {
    return ();
}
```

## Remarks
`createOnFailInvocation` (the `bodyContainsFail == false` counterpart) was reviewed and does not currently exhibit the same multi-rewrite issue for the cases tested, but may be worth auditing separately if a similar symptom surfaces there.

## Check List
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Added necessary tests
  - [x] Unit Tests
- [x] Increased Test Coverage