### PR TITLE
Fix false positive return-check error for match on error|any

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -4124,8 +4124,8 @@ public class Desugar extends BLangNodeVisitor {
 
         return switch (bindingPattern.getKind()) {
             case WILDCARD_BINDING_PATTERN ->
-                    createConditionForWildCardBindingPattern((BLangWildCardBindingPattern) bindingPattern,
-                            matchExprVarRef);
+                    createConditionForWildCardBindingPatternMatchPattern(
+                            (BLangWildCardBindingPattern) bindingPattern, matchExprVarRef);
             case CAPTURE_BINDING_PATTERN ->
                     createConditionForCaptureBindingPattern((BLangCaptureBindingPattern) bindingPattern,
                             matchExprVarRef, pos);
@@ -4141,6 +4141,21 @@ public class Desugar extends BLangNodeVisitor {
             // TODO : Remove this after all patterns are implemented
             default -> null;
         };
+    }
+
+    private BLangExpression createConditionForWildCardBindingPatternMatchPattern(
+            BLangWildCardBindingPattern wildCardBindingPattern,
+            BLangSimpleVarRef matchExprVarRef) {
+
+        if (types.isAssignable(matchExprVarRef.getBType(), wildCardBindingPattern.getBType())) {
+            return ASTBuilderUtil.createLiteral(wildCardBindingPattern.pos,
+                    symTable.booleanType, true);
+        }
+
+        BLangValueType anyType = (BLangValueType) TreeBuilder.createValueTypeNode();
+        anyType.setBType(symTable.anyType);
+        anyType.typeKind = TypeKind.ANY;
+        return createTypeCheckExpr(wildCardBindingPattern.pos, matchExprVarRef, anyType);
     }
 
     private BLangExpression createConditionForCaptureBindingPattern(BLangCaptureBindingPattern captureBindingPattern,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3926,12 +3926,6 @@ public class Desugar extends BLangNodeVisitor {
         return createBinaryExpression(constPattern.pos, matchExprVarRef, constPattern.expr);
     }
 
-    private BLangExpression createConditionForWildCardBindingPattern(BLangWildCardBindingPattern wildCardBindingPattern,
-                                                                     BLangSimpleVarRef matchExprVarRef) {
-        return ASTBuilderUtil.createLiteral(wildCardBindingPattern.pos, symTable.booleanType,
-                types.isAssignable(matchExprVarRef.getBType(), wildCardBindingPattern.getBType()));
-    }
-
     private BLangExpression createConditionForCaptureBindingPattern(BLangCaptureBindingPattern captureBindingPattern,
                                                                     BLangSimpleVarRef matchExprVarRef) {
         Location pos = captureBindingPattern.pos;
@@ -4034,7 +4028,8 @@ public class Desugar extends BLangNodeVisitor {
         NodeKind bindingPatternKind = bindingPattern.getKind();
         return switch (bindingPatternKind) {
             case WILDCARD_BINDING_PATTERN ->
-                    createConditionForWildCardBindingPattern((BLangWildCardBindingPattern) bindingPattern, varRef);
+                    createConditionForWildCardBindingPatternMatchPattern(
+                            (BLangWildCardBindingPattern) bindingPattern, varRef);
             case CAPTURE_BINDING_PATTERN ->
                     createConditionForCaptureBindingPattern((BLangCaptureBindingPattern) bindingPattern, varRef);
             case LIST_BINDING_PATTERN ->

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -796,6 +796,7 @@ public class NodeCloner extends BLangNodeVisitor {
         BLangErrorMatchPattern clone = new BLangErrorMatchPattern();
         source.cloneRef = clone;
         clone.matchExpr = clone(source.matchExpr);
+        clone.matchGuardIsAvailable = source.matchGuardIsAvailable;
         clone.errorMessageMatchPattern = clone(source.errorMessageMatchPattern);
         clone.errorFieldMatchPatterns = clone(source.errorFieldMatchPatterns);
         clone.errorCauseMatchPattern = clone(source.errorCauseMatchPattern);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -802,21 +802,10 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
         if (onFailExists) {
             data.failureHandled = true;
         }
-        List<BLangMatchClause> matchClauses = matchStatement.matchClauses;
+
         boolean hasErrorMatchPattern = data.hasErrorMatchPattern;
         data.hasErrorMatchPattern = false;
-        for (BLangMatchClause clause : matchClauses) {
-            if (clause.matchGuard != null) {
-                continue;
-            }
-            for (BLangMatchPattern pattern : clause.matchPatterns) {
-                if (pattern.getKind() == NodeKind.ERROR_MATCH_PATTERN) {
-                    data.hasErrorMatchPattern = true;
-                    break;
-                }
-            }
-        }
-
+        List<BLangMatchClause> matchClauses = matchStatement.matchClauses;
         int clausesSize = matchClauses.size();
         for (int i = 0; i < clausesSize; i++) {
             BLangMatchClause firstClause = matchClauses.get(i);
@@ -1496,7 +1485,6 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
 
     @Override
     public void visit(BLangErrorBindingPattern errorBindingPattern, AnalyzerData data) {
-
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -1480,7 +1480,10 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
 
     @Override
     public void visit(BLangErrorMatchPattern errorMatchPattern, AnalyzerData data) {
-        data.hasErrorMatchPattern = true;
+        if (errorMatchPattern.errorTypeReference == null ||
+                types.isAssignable(symTable.errorType, errorMatchPattern.errorTypeReference.getBType())) {
+            data.hasErrorMatchPattern = true;
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -803,6 +803,20 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
             data.failureHandled = true;
         }
         List<BLangMatchClause> matchClauses = matchStatement.matchClauses;
+        boolean hasErrorMatchPattern = data.hasErrorMatchPattern;
+        data.hasErrorMatchPattern = false;
+        for (BLangMatchClause clause : matchClauses) {
+            if (clause.matchGuard != null) {
+                continue;
+            }
+            for (BLangMatchPattern pattern : clause.matchPatterns) {
+                if (pattern.getKind() == NodeKind.ERROR_MATCH_PATTERN) {
+                    data.hasErrorMatchPattern = true;
+                    break;
+                }
+            }
+        }
+
         int clausesSize = matchClauses.size();
         for (int i = 0; i < clausesSize; i++) {
             BLangMatchClause firstClause = matchClauses.get(i);
@@ -818,6 +832,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
             }
             analyzeNode(firstClause, data);
         }
+        data.hasErrorMatchPattern = hasErrorMatchPattern;
         data.failureHandled = failureHandled;
         analyzeOnFailClause(matchStatement.onFailClause, data);
     }
@@ -1378,9 +1393,17 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
 
     @Override
     public void visit(BLangWildCardMatchPattern wildCardMatchPattern, AnalyzerData data) {
-        wildCardMatchPattern.isLastPattern =
-                wildCardMatchPattern.matchExpr != null && types.isAssignable(wildCardMatchPattern.matchExpr.getBType(),
-                                                                             symTable.anyType);
+        if (wildCardMatchPattern.matchExpr == null) {
+            return;
+        }
+
+        // if error portion exists but is already handled by a prior error clause,
+        // subtract error from the type before checking exhaustiveness
+        BType matchExprType = wildCardMatchPattern.matchExpr.getBType();
+        BType effectiveType = data.hasErrorMatchPattern
+                ? types.getRemainingType(matchExprType, symTable.errorType, data.env)
+                : matchExprType;
+        wildCardMatchPattern.isLastPattern = types.isAssignable(effectiveType, symTable.anyType);
     }
 
     @Override
@@ -1394,10 +1417,13 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
         analyzeNode(bindingPattern, data);
         switch (bindingPattern.getKind()) {
             case WILDCARD_BINDING_PATTERN:
+                BType matchExprType = varBindingPattern.matchExpr.getBType();
+                BType effectiveType = data.hasErrorMatchPattern
+                        ? types.getRemainingType(matchExprType, symTable.errorType, data.env)
+                        : matchExprType;
                 varBindingPattern.isLastPattern =
                         varBindingPattern.matchExpr != null && types.isAssignable(
-                                varBindingPattern.matchExpr.getBType(),
-                                symTable.anyType);
+                                effectiveType, symTable.anyType);
                 return;
             case CAPTURE_BINDING_PATTERN:
                 varBindingPattern.isLastPattern =
@@ -1465,7 +1491,7 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
 
     @Override
     public void visit(BLangErrorMatchPattern errorMatchPattern, AnalyzerData data) {
-
+        data.hasErrorMatchPattern = true;
     }
 
     @Override
@@ -4445,5 +4471,6 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
         Types.QueryConstructType queryConstructType;
         Deque<LinkedHashSet<BType>> returnTypes = new ArrayDeque<>();
         DefaultValueState defaultValueState = DefaultValueState.NOT_IN_DEFAULT_VALUE;
+        boolean hasErrorMatchPattern;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -1406,13 +1406,14 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
         analyzeNode(bindingPattern, data);
         switch (bindingPattern.getKind()) {
             case WILDCARD_BINDING_PATTERN:
+                if (varBindingPattern.matchExpr == null) {
+                    return;
+                }
                 BType matchExprType = varBindingPattern.matchExpr.getBType();
                 BType effectiveType = data.hasErrorMatchPattern
                         ? types.getRemainingType(matchExprType, symTable.errorType, data.env)
                         : matchExprType;
-                varBindingPattern.isLastPattern =
-                        varBindingPattern.matchExpr != null && types.isAssignable(
-                                effectiveType, symTable.anyType);
+                varBindingPattern.isLastPattern = types.isAssignable(effectiveType, symTable.anyType);
                 return;
             case CAPTURE_BINDING_PATTERN:
                 varBindingPattern.isLastPattern =
@@ -1480,6 +1481,9 @@ public class CodeAnalyzer extends SimpleBLangNodeAnalyzer<CodeAnalyzer.AnalyzerD
 
     @Override
     public void visit(BLangErrorMatchPattern errorMatchPattern, AnalyzerData data) {
+        if (errorMatchPattern.matchGuardIsAvailable) {
+            return;
+        }
         if (errorMatchPattern.errorTypeReference == null ||
                 types.isAssignable(symTable.errorType, errorMatchPattern.errorTypeReference.getBType())) {
             data.hasErrorMatchPattern = true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
@@ -66,6 +66,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTrapExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTupleVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangVarBindingPatternMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
@@ -482,7 +483,13 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
                             hasWildCard = true;
                             break;
                         case ERROR_MATCH_PATTERN:
-                            hasErrorPattern = true;
+                            BLangErrorMatchPattern errorPattern = (BLangErrorMatchPattern) pattern;
+                            // only count as exhaustive if it's a generic error pattern
+                            if (errorPattern.errorTypeReference == null
+                                    || types.isAssignable(symTable.errorType,
+                                    errorPattern.errorTypeReference.getBType())) {
+                                hasErrorPattern = true;
+                            }
                             break;
                         case VAR_BINDING_PATTERN_MATCH_PATTERN:
                             BLangBindingPattern bindingPattern =

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
@@ -45,6 +45,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangResourceFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable;
 import org.wso2.ballerinalang.compiler.tree.SimpleBLangNodeAnalyzer;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangBindingPattern;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangCollectClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangDoClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangGroupByClause;
@@ -66,6 +67,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangTrapExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTupleVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangVarBindingPatternMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBreak;
@@ -461,6 +463,42 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
         data.statementReturnsPanicsOrFails = allClausesReturns && data.hasLastPatternInStatement;
         data.breakAsLastStatement = allClausesBreak && data.hasLastPatternInStatement;
         data.continueAsLastStatement = allClausesContinue && data.hasLastPatternInStatement;
+
+        // collective exhaustiveness check
+        if (allClausesReturns && !data.statementReturnsPanicsOrFails
+                && types.isAssignable(symTable.errorType, matchStatement.expr.getBType())) {
+            boolean hasWildCard = false;
+            boolean hasErrorPattern = false;
+
+            for (BLangMatchClause clause : matchStatement.matchClauses) {
+                if (clause.matchGuard != null) {
+                    continue;
+                }
+                for (BLangMatchPattern pattern : clause.matchPatterns) {
+                    switch (pattern.getKind()) {
+                        case WILDCARD_MATCH_PATTERN:
+                            hasWildCard = true;
+                            break;
+                        case ERROR_MATCH_PATTERN:
+                            hasErrorPattern = true;
+                            break;
+                        case VAR_BINDING_PATTERN_MATCH_PATTERN:
+                            BLangBindingPattern bindingPattern =
+                                    ((BLangVarBindingPatternMatchPattern) pattern).getBindingPattern();
+                            if (bindingPattern.getKind() == NodeKind.WILDCARD_BINDING_PATTERN
+                                    || bindingPattern.getKind() == NodeKind.CAPTURE_BINDING_PATTERN) {
+                                hasWildCard = true;
+                            }
+                            break;
+                    }
+                }
+            }
+            if (hasWildCard && hasErrorPattern) {
+                data.statementReturnsPanicsOrFails = allClausesReturns;
+                data.breakAsLastStatement = allClausesBreak;
+                data.continueAsLastStatement = allClausesContinue;
+            }
+        }
         data.errorThrown = currentErrorThrown;
         analyzeOnFailClause(matchStatement.onFailClause, data);
         data.hasLastPatternInStatement = hasLastPatternInStatement;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ReachabilityAnalyzer.java
@@ -442,6 +442,8 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
         boolean currentErrorThrown = data.errorThrown;
         boolean hasLastPatternInStatement = data.hasLastPatternInStatement;
         data.hasLastPatternInStatement = false;
+        boolean hasNonErrorWildCardMatchPattern = data.hasNonErrorWildCardMatchPattern;
+        data.hasNonErrorWildCardMatchPattern = false;
         boolean allClausesReturns = true;
         boolean allClausesBreak = true;
         boolean allClausesContinue = true;
@@ -502,21 +504,54 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
         data.errorThrown = currentErrorThrown;
         analyzeOnFailClause(matchStatement.onFailClause, data);
         data.hasLastPatternInStatement = hasLastPatternInStatement;
+        data.hasNonErrorWildCardMatchPattern = hasNonErrorWildCardMatchPattern;
     }
 
     @Override
     public void visit(BLangMatchClause matchClause, AnalyzerData data) {
         boolean hasLastPatternInClause = false;
+        boolean hasNonErrorWildCardMatchPatternInClause = false;
+        boolean matchGuardAvailable = matchClause.matchGuard != null;
         List<BLangMatchPattern> matchPatterns = matchClause.matchPatterns;
         for (BLangMatchPattern matchPattern : matchPatterns) {
-            if (data.hasLastPatternInStatement || (hasLastPatternInClause && matchClause.matchGuard == null)) {
+            if (data.hasLastPatternInStatement || (hasLastPatternInClause && !matchGuardAvailable) ||
+                    ((data.hasNonErrorWildCardMatchPattern || hasNonErrorWildCardMatchPatternInClause) &&
+                            !matchGuardAvailable && cannotMatchErrorValue(matchPattern))) {
                 dlog.warning(matchPattern.pos, DiagnosticWarningCode.MATCH_STMT_PATTERN_UNREACHABLE);
             }
             hasLastPatternInClause = hasLastPatternInClause || matchPattern.isLastPattern;
+            hasNonErrorWildCardMatchPatternInClause =
+                    hasNonErrorWildCardMatchPatternInClause || isNonErrorWildCardMatchPattern(matchPattern);
         }
         analyzeReachability(matchClause.blockStmt, data);
         data.hasLastPatternInStatement = data.hasLastPatternInStatement ||
-                (matchClause.matchGuard == null && hasLastPatternInClause);
+                (!matchGuardAvailable && hasLastPatternInClause);
+        data.hasNonErrorWildCardMatchPattern = data.hasNonErrorWildCardMatchPattern ||
+                (!matchGuardAvailable && hasNonErrorWildCardMatchPatternInClause);
+    }
+
+    private boolean isNonErrorWildCardMatchPattern(BLangMatchPattern matchPattern) {
+        return switch (matchPattern.getKind()) {
+            case WILDCARD_MATCH_PATTERN -> true;
+            case VAR_BINDING_PATTERN_MATCH_PATTERN -> {
+                BLangBindingPattern bindingPattern =
+                        ((BLangVarBindingPatternMatchPattern) matchPattern).getBindingPattern();
+                yield bindingPattern.getKind() == NodeKind.WILDCARD_BINDING_PATTERN;
+            }
+            default -> false;
+        };
+    }
+
+    private boolean cannotMatchErrorValue(BLangMatchPattern matchPattern) {
+        return switch (matchPattern.getKind()) {
+            case ERROR_MATCH_PATTERN -> false;
+            case VAR_BINDING_PATTERN_MATCH_PATTERN -> {
+                BLangBindingPattern bindingPattern =
+                        ((BLangVarBindingPatternMatchPattern) matchPattern).getBindingPattern();
+                yield bindingPattern.getKind() != NodeKind.CAPTURE_BINDING_PATTERN;
+            }
+            default -> true;
+        };
     }
 
     @Override
@@ -1057,6 +1092,7 @@ public class ReachabilityAnalyzer extends SimpleBLangNodeAnalyzer<ReachabilityAn
         boolean unreachableBlock;
         boolean breakStmtFound;
         boolean hasLastPatternInStatement;
+        boolean hasNonErrorWildCardMatchPattern;
         boolean failureHandled;
         boolean returnedWithinQuery;
         boolean skipFurtherAnalysisInUnreachableBlock;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtErrorMatchPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtErrorMatchPatternTest.java
@@ -162,7 +162,6 @@ public class MatchStmtErrorMatchPatternTest {
 
     @Test
     public void testErrorMatchPatternNegative() {
-        Assert.assertEquals(resultNegative.getErrorCount(), 1);
         //Assert.assertEquals(resultNegative.getWarnCount(), 10);
         int i = 0;
         BAssertUtil.validateWarning(resultNegative, i++, patternNotMatched, 31, 9);
@@ -203,6 +202,9 @@ public class MatchStmtErrorMatchPatternTest {
         BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorB'", 121, 9);
         BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorC'", 126, 9);
         BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorD'", 127, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 148, 9);
+        BAssertUtil.validateError(resultNegative, i++, "this function must return a result", 167, 1);
+        Assert.assertEquals(resultNegative.getErrorCount(), 2);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtErrorMatchPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtErrorMatchPatternTest.java
@@ -131,6 +131,11 @@ public class MatchStmtErrorMatchPatternTest {
     }
 
     @Test
+    public void testErrorMatchPattern18() {
+        BRunUtil.invoke(result, "testErrorMatchPattern18");
+    }
+
+    @Test
     public void testErrorMatchPatternWithRestPattern1() {
         BRunUtil.invoke(restPatternResult, "testErrorMatchPattern1");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtErrorMatchPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtErrorMatchPatternTest.java
@@ -141,6 +141,11 @@ public class MatchStmtErrorMatchPatternTest {
     }
 
     @Test
+    public void testErrorMatchPattern20() {
+        BRunUtil.invoke(result, "testErrorMatchPattern20");
+    }
+
+    @Test
     public void testErrorMatchPatternWithRestPattern1() {
         BRunUtil.invoke(restPatternResult, "testErrorMatchPattern1");
     }
@@ -204,7 +209,8 @@ public class MatchStmtErrorMatchPatternTest {
         BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorD'", 127, 9);
         BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 148, 9);
         BAssertUtil.validateError(resultNegative, i++, "this function must return a result", 167, 1);
-        Assert.assertEquals(resultNegative.getErrorCount(), 2);
+        BAssertUtil.validateError(resultNegative, i++, "this function must return a result", 179, 1);
+        Assert.assertEquals(resultNegative.getErrorCount(), 3);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtErrorMatchPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtErrorMatchPatternTest.java
@@ -136,6 +136,11 @@ public class MatchStmtErrorMatchPatternTest {
     }
 
     @Test
+    public void testErrorMatchPattern19() {
+        BRunUtil.invoke(result, "testErrorMatchPattern19");
+    }
+
+    @Test
     public void testErrorMatchPatternWithRestPattern1() {
         BRunUtil.invoke(restPatternResult, "testErrorMatchPattern1");
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
@@ -438,3 +438,55 @@ function assertEquals(anydata expected, anydata actual) {
 
     panic error("expected '" + expected.toString() + "', found '" + actual.toString () + "'");
 }
+
+// Tests for exhaustiveness with error + wildcard pattern on json|error type
+function errorMatchPattern21(json j) returns string {
+    match j.kind {
+        "a" => {
+        return "A";
+        }
+        error(var _) => {
+        return "E";
+        }
+        _ => {
+        return "B";
+        }
+    }
+}
+
+function errorMatchPattern22(json j) returns string {
+    match j.kind {
+        "a" => {
+        return "A";
+        }
+        _ => {
+        return "B";
+        }
+        error(var _) => {
+        return "E";
+        }
+    }
+}
+
+function errorMatchPattern23(json j) returns string {
+    match j.kind {
+        "a" => {
+        return "A";
+        }
+        error(var _) => {
+        return "E";
+        }
+        var _ => {
+            return "B";
+        }
+    }
+}
+
+function testErrorMatchPattern18() {
+    assertEquals("A", errorMatchPattern21({kind: "a"}));
+    assertEquals("B", errorMatchPattern21({kind: "b"}));
+    assertEquals("A", errorMatchPattern22({kind: "a"}));
+    assertEquals("B", errorMatchPattern22({kind: "b"}));
+    assertEquals("A", errorMatchPattern23({kind: "a"}));
+//    assertEquals("B", errorMatchPattern23({kind: "b"})); // Bug. Uncomment after fix.
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
@@ -443,13 +443,13 @@ function assertEquals(anydata expected, anydata actual) {
 function errorMatchPattern21(json j) returns string {
     match j.kind {
         "a" => {
-        return "A";
+            return "A";
         }
         error(var _) => {
-        return "E";
+            return "E";
         }
         _ => {
-        return "B";
+            return "B";
         }
     }
 }
@@ -457,13 +457,13 @@ function errorMatchPattern21(json j) returns string {
 function errorMatchPattern22(json j) returns string {
     match j.kind {
         "a" => {
-        return "A";
+            return "A";
         }
         _ => {
-        return "B";
+            return "B";
         }
         error(var _) => {
-        return "E";
+            return "E";
         }
     }
 }
@@ -471,10 +471,10 @@ function errorMatchPattern22(json j) returns string {
 function errorMatchPattern23(json j) returns string {
     match j.kind {
         "a" => {
-        return "A";
+            return "A";
         }
         error(var _) => {
-        return "E";
+            return "E";
         }
         var _ => {
             return "B";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
@@ -488,5 +488,5 @@ function testErrorMatchPattern18() {
     assertEquals("A", errorMatchPattern22({kind: "a"}));
     assertEquals("B", errorMatchPattern22({kind: "b"}));
     assertEquals("A", errorMatchPattern23({kind: "a"}));
-//    assertEquals("B", errorMatchPattern23({kind: "b"})); // Bug. Uncomment after fix.
+    assertEquals("B", errorMatchPattern23({kind: "b"}));
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
@@ -465,6 +465,7 @@ function errorMatchPattern22(json j) returns string {
         error(var _) => {
             return "E";
         }
+        "b" => { return "C"; }
     }
 }
 
@@ -489,4 +490,35 @@ function testErrorMatchPattern18() {
     assertEquals("B", errorMatchPattern22({kind: "b"}));
     assertEquals("A", errorMatchPattern23({kind: "a"}));
     assertEquals("B", errorMatchPattern23({kind: "b"}));
+}
+
+function errorMatchPattern24(json j) returns string {
+    match j.kind {
+        "a" => {
+            match j.value {
+                "x" => {
+                    return "A-X";
+                }
+            error(var _) => {
+                    return "A-E";
+                }
+            _ => {
+                    return "A-other";
+                }
+            }
+        }
+        error(var _) => {
+            return "E";
+        }
+        _ => {
+            return "B";
+        }
+    }
+}
+
+function testErrorMatchPattern19() {
+    assertEquals("A-X", errorMatchPattern24({kind: "a", value: "x"}));
+    assertEquals("A-other", errorMatchPattern24({kind: "a", value: "y"}));
+    assertEquals("A-E", errorMatchPattern24({kind: "a"}));
+    assertEquals("B", errorMatchPattern24({kind: "b"}));
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
@@ -465,7 +465,6 @@ function errorMatchPattern22(json j) returns string {
         error(var _) => {
             return "E";
         }
-        "b" => { return "C"; }
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
@@ -521,3 +521,21 @@ function testErrorMatchPattern19() {
     assertEquals("A-E", errorMatchPattern24({kind: "a"}));
     assertEquals("B", errorMatchPattern24({kind: "b"}));
 }
+
+// Test for a nested `var _` binding pattern (within a list pattern) matching against an any|error subject.
+function errorMatchPattern25(anydata|error x) returns string {
+    [int, anydata|error] t = [1, x];
+    match t {
+        [1, var _] => {
+            return "matched";
+        }
+        _ => {
+            return "no match";
+        }
+    }
+}
+
+function testErrorMatchPattern20() {
+    assertEquals("matched", errorMatchPattern25("text"));
+    assertEquals("no match", errorMatchPattern25(error("e")));
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern_negative.bal
@@ -131,3 +131,37 @@ function testNegative7() {
 function getCustomError() returns error {
     return error MyError1("Message", x = 2);
 }
+
+type MyError error<record {| string message?; |}>;
+
+function testNegative8(json j) returns string {
+    match j.kind {
+        "a" => {
+            return "A";
+        }
+        _ => {
+            return "B";
+        }
+        error(var _) => {
+            return "E";
+        }
+        "b" => {            // unreachable pattern
+            return "C";
+        }
+    }
+}
+
+// specific error type + _ does not make match exhaustive
+function testNegative9(json j) returns string { // this function must return a result
+    match j.kind {
+        "a" => {
+            return "A";
+        }
+        error MyError(var _) => {
+            return "MY-E";
+        }
+        _ => {
+            return "B";
+        }
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern_negative.bal
@@ -165,3 +165,15 @@ function testNegative9(json j) returns string { // this function must return a r
         }
     }
 }
+
+// a guarded generic error pattern does not make match exhaustive
+function testNegative10(any|error e) returns string { // this function must return a result
+    match e {
+        error(var _) if false => {
+            return "ERR";
+        }
+        _ => {
+            return "OTHER";
+        }
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/structured_match_patterns.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/structured_match_patterns.bal
@@ -77,5 +77,4 @@ function testErrorNotMatchingVarIgnoreAndFallThroughToErrorPattern() returns str
         var _ => { return "other"; }
         error(var r) => { return <string> r; }
     }
-    return "no-match";
 }


### PR DESCRIPTION
## Purpose
Fixes the false positive `this function must return a result` diagnostic when a match statement has both an `error(var _)` clause and a wildcard `_` clause on a match expression whose type contains `error` (e.g. JSON field access producing `json|error`). The compiler incorrectly treated the match as non-exhaustive because the wildcard exhaustiveness check used `anyType` which excludes `error`, making it unable to recognize that `error(var _)` + `_` together collectively cover the full type.

Fixes #44646 

## Approach
The fix is in `CodeAnalyzer.java`:

1. Added a `hasErrorMatchPattern` boolean flag to `AnalyzerData` to track whether any unguarded error match pattern exists in the current match statement.

2. `data.hasErrorMatchPattern = true` is set if any unguarded clause contains an `ERROR_MATCH_PATTERN`.

3. In `visit(BLangWildCardMatchPattern)` and the `WILDCARD_BINDING_PATTERN` case of `visit(BLangVarBindingPatternMatchPattern)`, when `data.hasErrorMatchPattern = true`, the match expression's type is narrowed by subtracting the `error` portion using `types.getRemainingType(matchExprType, symTable.errorType, data.env)` before checking assignability to `anyType`. This correctly sets `isLastPattern = true` for the wildcard when the error portion has already been handled.

## Samples

```ballerina
// Previously gave: ERROR this function must return a result
// Now compiles cleanly
function getKind(json j) returns string {
    match j.kind {
        "a" => {
            return "A";
        }
        error(var _) => {
            return "E";
        }
        _ => {
            return "B";
        }
    }
}
```

## Remarks
Without an explicit `error(var _)` clause, the wildcard `_` alone is correctly flagged as non-exhaustive for `json|error`. This behavior is preserved.

## Check List
- [x] Read the [[Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Added necessary tests
  - [x] Unit Tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fix match exhaustiveness analysis for subjects that include `error`.
- Recognize `error(var _)` with `_` as complete coverage.
- Improve reachability checks for wildcard, binding, and error patterns.
- Add coverage for nested matches and `json|error` values.
- Update negative tests for unreachable patterns and missing returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->