### PR TITLE
Add endpoint artifact export support for compiler plugins

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -22,6 +22,7 @@ import io.ballerina.cli.TaskExecutor;
 import io.ballerina.cli.task.CacheArtifactsTask;
 import io.ballerina.cli.task.CleanTargetDirTask;
 import io.ballerina.cli.task.CompileTask;
+import io.ballerina.cli.task.ConsolidateEndpointsTask;
 import io.ballerina.cli.task.CreateExecutableTask;
 import io.ballerina.cli.task.CreateFingerprintTask;
 import io.ballerina.cli.task.DumpBuildTimeTask;
@@ -375,6 +376,7 @@ public class BuildCommand implements BLauncherCmd {
                 // compile the modules
                 .addTask(new CompileTask(outStream, errStream, false, true,
                         !rebuildNeeded, buildToolDiagnostics))
+                .addTask(new ConsolidateEndpointsTask(), !buildOptions.exportEndpoints())
                 .addTask(new CreateExecutableTask(outStream, this.output, null, false,
                          !rebuildNeeded, skipExecutable))
                 .addTask(new DumpBuildTimeTask(outStream), !buildOptions.dumpBuildTime())

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/ConsolidateEndpointsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/ConsolidateEndpointsTask.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.cli.task;
+
+import io.ballerina.projects.Project;
+import io.ballerina.projects.plugins.EndpointArtifact;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
+
+/**
+ * Consolidates endpoint metadata emitted by protocol compiler plugins.
+ *
+ * @since 2201.14.0
+ */
+public class ConsolidateEndpointsTask implements Task {
+
+    private static final String ARTIFACT_DIR = "artifact";
+    private static final String ENDPOINTS_FILE = "endpoints.yaml";
+    private static final String ENDPOINTS_KEY = "endpoints";
+    private static final String NAME_KEY = "name";
+    private static final String PORT_KEY = "port";
+    private static final String BASE_PATH_KEY = "basePath";
+    private static final String TYPE_KEY = "type";
+    private static final String SCHEMA_PATH_KEY = "schemaPath";
+
+    @Override
+    public void execute(Project project) {
+        try {
+            writeEndpointArtifacts(project.targetDir().resolve(ARTIFACT_DIR), project.endpointArtifacts());
+        } catch (IOException e) {
+            throw createLauncherException("unable to export endpoint artifacts: " + e.getMessage());
+        }
+    }
+
+    static void writeEndpointArtifacts(Path artifactDir, List<EndpointArtifact> endpointArtifacts) throws IOException {
+        if (endpointArtifacts.isEmpty()) {
+            return;
+        }
+        Files.createDirectories(artifactDir);
+        Files.writeString(artifactDir.resolve(ENDPOINTS_FILE), toYaml(endpointArtifacts), StandardCharsets.UTF_8);
+    }
+
+    private static String toYaml(List<EndpointArtifact> endpoints) {
+        StringBuilder content = new StringBuilder();
+        content.append(ENDPOINTS_KEY).append(':').append(System.lineSeparator());
+        for (EndpointArtifact endpoint : endpoints) {
+            content.append("  - ").append(NAME_KEY).append(": ").append(quote(endpoint.name()))
+                    .append(System.lineSeparator());
+            content.append("    ").append(PORT_KEY).append(": ").append(endpoint.port()).append(System.lineSeparator());
+            content.append("    ").append(BASE_PATH_KEY).append(": ").append(quote(endpoint.basePath()))
+                    .append(System.lineSeparator());
+            content.append("    ").append(TYPE_KEY).append(": ").append(quote(endpoint.type()))
+                    .append(System.lineSeparator());
+            content.append("    ").append(SCHEMA_PATH_KEY).append(": ").append(quote(endpoint.schemaPath()))
+                    .append(System.lineSeparator());
+        }
+        return content.toString();
+    }
+
+    private static String quote(String value) {
+        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
@@ -85,6 +85,7 @@ public class PackageCompilation {
     }
 
     static PackageCompilation from(PackageContext rootPackageContext, CompilationOptions compilationOptions) {
+        rootPackageContext.project().clearEndpointArtifacts();
         PackageCompilation compilation = new PackageCompilation(rootPackageContext, compilationOptions);
         return compile(compilation);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Project.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Project.java
@@ -20,11 +20,13 @@ package io.ballerina.projects;
 import io.ballerina.projects.buildtools.ToolContext;
 import io.ballerina.projects.directory.WorkspaceProject;
 import io.ballerina.projects.environment.ProjectEnvironment;
+import io.ballerina.projects.plugins.EndpointArtifact;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -42,6 +44,7 @@ public abstract class Project {
     private final ProjectKind projectKind;
     private Map<PackageManifest.Tool.Field, ToolContext> toolContextMap;
     private final List<CompilerPluginContextIml> compilerPluginContexts;
+    private final List<EndpointArtifact> endpointArtifacts;
     protected WorkspaceProject workspaceProject;
 
     protected Project(ProjectKind projectKind, Path projectPath,
@@ -52,6 +55,7 @@ public abstract class Project {
         this.buildOptions = buildOptions;
         this.projectEnvironment = projectEnvironmentBuilder.build(this);
         this.compilerPluginContexts = new ArrayList<>();
+        this.endpointArtifacts = new ArrayList<>();
         this.workspaceProject = workspaceProject;
     }
 
@@ -60,6 +64,7 @@ public abstract class Project {
         this.sourceRoot = projectPath.toAbsolutePath().normalize();
         this.buildOptions = buildOptions;
         this.compilerPluginContexts = new ArrayList<>();
+        this.endpointArtifacts = new ArrayList<>();
     }
 
     void setBuildOptions(BuildOptions buildOptions) {
@@ -159,6 +164,18 @@ public abstract class Project {
 
     List<CompilerPluginContextIml> compilerPluginContexts() {
         return this.compilerPluginContexts;
+    }
+
+    public void addEndpointArtifact(EndpointArtifact endpointArtifact) {
+        this.endpointArtifacts.add(endpointArtifact);
+    }
+
+    public void clearEndpointArtifacts() {
+        this.endpointArtifacts.clear();
+    }
+
+    public List<EndpointArtifact> endpointArtifacts() {
+        return Collections.unmodifiableList(this.endpointArtifacts);
     }
 
     public Optional<WorkspaceProject> workspaceProject () {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/SyntaxNodeAnalysisContextImpl.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/SyntaxNodeAnalysisContextImpl.java
@@ -20,6 +20,7 @@ package io.ballerina.projects;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.plugins.EndpointArtifact;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.tools.diagnostics.Diagnostic;
 
@@ -96,6 +97,11 @@ class SyntaxNodeAnalysisContextImpl implements SyntaxNodeAnalysisContext {
     @Override
     public void reportDiagnostic(Diagnostic diagnostic) {
         diagnostics.add(diagnostic);
+    }
+
+    @Override
+    public void addEndpointArtifact(EndpointArtifact endpointArtifact) {
+        currentPackage.project().addEndpointArtifact(endpointArtifact);
     }
 
     List<Diagnostic> reportedDiagnostics() {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/SyntaxNodeAnalysisContextImpl.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/SyntaxNodeAnalysisContextImpl.java
@@ -20,7 +20,6 @@ package io.ballerina.projects;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
-import io.ballerina.projects.plugins.EndpointArtifact;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.tools.diagnostics.Diagnostic;
 
@@ -97,11 +96,6 @@ class SyntaxNodeAnalysisContextImpl implements SyntaxNodeAnalysisContext {
     @Override
     public void reportDiagnostic(Diagnostic diagnostic) {
         diagnostics.add(diagnostic);
-    }
-
-    @Override
-    public void addEndpointArtifact(EndpointArtifact endpointArtifact) {
-        currentPackage.project().addEndpointArtifact(endpointArtifact);
     }
 
     List<Diagnostic> reportedDiagnostics() {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/EndpointArtifact.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/EndpointArtifact.java
@@ -28,4 +28,15 @@ package io.ballerina.projects.plugins;
  * @since 2201.14.0
  */
 public record EndpointArtifact(String name, int port, String basePath, String type, String schemaPath) {
+
+    public EndpointArtifact {
+        name = defaultIfNull(name);
+        basePath = defaultIfNull(basePath);
+        type = defaultIfNull(type);
+        schemaPath = defaultIfNull(schemaPath);
+    }
+
+    private static String defaultIfNull(String value) {
+        return value == null ? "" : value;
+    }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/EndpointArtifact.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/EndpointArtifact.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.projects.plugins;
+
+/**
+ * Represents endpoint metadata emitted by protocol compiler plugins.
+ *
+ * @param name endpoint name
+ * @param port endpoint port
+ * @param basePath endpoint base path
+ * @param type endpoint type
+ * @param schemaPath endpoint schema path
+ * @since 2201.14.0
+ */
+public record EndpointArtifact(String name, int port, String basePath, String type, String schemaPath) {
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/SyntaxNodeAnalysisContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/SyntaxNodeAnalysisContext.java
@@ -90,11 +90,4 @@ public interface SyntaxNodeAnalysisContext {
      */
     void reportDiagnostic(Diagnostic diagnostic);
 
-    /**
-     * Adds endpoint metadata to be exported at the end of the build.
-     *
-     * @param endpointArtifact endpoint metadata to export
-     */
-    default void addEndpointArtifact(EndpointArtifact endpointArtifact) {
-    }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/SyntaxNodeAnalysisContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/SyntaxNodeAnalysisContext.java
@@ -89,4 +89,12 @@ public interface SyntaxNodeAnalysisContext {
      * @param diagnostic the {@code Diagnostic} to be reported
      */
     void reportDiagnostic(Diagnostic diagnostic);
+
+    /**
+     * Adds endpoint metadata to be exported at the end of the build.
+     *
+     * @param endpointArtifact endpoint metadata to export
+     */
+    default void addEndpointArtifact(EndpointArtifact endpointArtifact) {
+    }
 }


### PR DESCRIPTION
## Purpose
> $title.

Fixes: https://github.com/wso2/product-integrator/issues/1427

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added centralized endpoint artifact export to `artifact/endpoints.yaml`, including endpoint name, port, base path, type, and schema path.
- Added project-level storage and lifecycle management for compiler-generated endpoint artifacts.
- Normalized nullable endpoint metadata fields to empty strings.
- Cleared stale endpoint artifacts before compilation.
- Removed endpoint artifact registration from `SyntaxNodeAnalysisContext` in favor of project-level handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->