### PR TITLE
Fix duplicate $td$ typedesc var for const type alias

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -419,6 +419,7 @@ public class Desugar extends BLangNodeVisitor {
     private final Map<BLangOnFailClause, BLangSimpleVarRef> enclosingShouldPanic = new HashMap<>();
     private final List<BLangSimpleVarRef> enclosingShouldContinue = new ArrayList<>();
     private List<BLangSimpleVariableDef> typedescList = new ArrayList<>();
+    private final Set<String> typedescCreatedForNames = new HashSet<>();
     private BLangSimpleVarRef shouldRetryRef;
 
     private SymbolEnv env;
@@ -898,6 +899,13 @@ public class Desugar extends BLangNodeVisitor {
 
     private void createTypedescVariable(BType type, Location pos) {
         BType finalType = type;
+        Name name = generateTypedescVariableName(type);
+
+        if (!typedescCreatedForNames.add(name.value)) {
+            // A typedesc var with this generated name was already created
+            return;
+        }
+
         if ((Types.getReferredType(type).tag != TypeTags.INTERSECTION && this.env.enclPkg.typeDefinitions.stream()
                 .anyMatch(typeDef ->
                         (Types.getReferredType(typeDef.typeNode.getBType()).tag == TypeTags.INTERSECTION) &&
@@ -907,7 +915,6 @@ public class Desugar extends BLangNodeVisitor {
             return;
         }
 
-        Name name = generateTypedescVariableName(type);
         if (type.tag == TypeTags.TYPEREFDESC) {
             BType referredType = ((BTypeReferenceType) type).referredType;
             int tag = referredType.tag;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -901,7 +901,7 @@ public class Desugar extends BLangNodeVisitor {
         BType finalType = type;
         Name name = generateTypedescVariableName(type);
 
-        if (!typedescCreatedForNames.add(name.value)) {
+        if (typedescCreatedForNames.contains(name.value)) {
             // A typedesc var with this generated name was already created
             return;
         }
@@ -927,6 +927,7 @@ public class Desugar extends BLangNodeVisitor {
         BVarSymbol varSymbol  = new BVarSymbol(0, name, owner.pkgID, typedescType, owner, pos, VIRTUAL);
         BLangTypedescExpr typedescExpr = ASTBuilderUtil.createTypedescExpr(pos, typedescType, type);
         typedescList.add(createSimpleVariableDef(pos, name.value, typedescType, typedescExpr, varSymbol));
+        typedescCreatedForNames.add(name.value);
     }
 
     private void createTypedescVariableForAnonType(BLangType typeNode) {
@@ -11065,6 +11066,7 @@ public class Desugar extends BLangNodeVisitor {
         this.funcParamCount = 1;
         this.typedescCount = 0;
         this.transactionBlockCount = 0;
+        this.typedescCreatedForNames.clear();
     }
 
     private BLangSimpleVariableDef createGeneratorVariableDefinition(BLangNaturalExpression naturalExpression,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantInTypeDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantInTypeDefinitionTest.java
@@ -144,6 +144,20 @@ public class ConstantInTypeDefinitionTest {
         Assert.assertEquals(returns.toString(), "Ballerina rocks");
     }
 
+    @Test
+    public void testMapConstAlias() {
+        Object returns = BRunUtil.invoke(compileResult, "testMapConstAlias");
+        Assert.assertNotNull(returns);
+        Assert.assertEquals(returns.toString(), "{\"foo\":\"bar\"}");
+    }
+
+    @Test
+    public void testArrConstAlias() {
+        Object returns = BRunUtil.invoke(compileResult, "testArrConstAlias");
+        Assert.assertNotNull(returns);
+        Assert.assertEquals(returns.toString(), "[\"a\",\"b\"]");
+    }
+
     @AfterClass
     public void tearDown() {
         compileResult = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/const-in-type-definitions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/const-in-type-definitions.bal
@@ -136,3 +136,25 @@ function testStringTypeWithoutType() returns StringTypeWithoutType {
     StringTypeWithoutType t = "Ballerina rocks";
     return t;
 }
+
+// -----------------------------------------------------------
+
+const MAP = {"foo": "bar"};
+
+type MapConstAlias MAP;
+
+function testMapConstAlias() returns MapConstAlias {
+    MapConstAlias m = {"foo": "bar"};
+    return m;
+}
+
+// -----------------------------------------------------------
+
+const ARR = ["a", "b"];
+
+type ArrConstAlias ARR;
+
+function testArrConstAlias() returns ArrConstAlias {
+    ArrConstAlias t = ["a", "b"];
+    return t;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/const-in-type-definitions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/const-in-type-definitions.bal
@@ -139,7 +139,7 @@ function testStringTypeWithoutType() returns StringTypeWithoutType {
 
 // -----------------------------------------------------------
 
-const MAP = {"foo": "bar"};
+public const MAP = {"foo": "bar"};
 
 type MapConstAlias MAP;
 


### PR DESCRIPTION
## Purpose
Compiling a module containing a type definition that aliases directly to a constant fails with a generic, unhelpful error.

Fixes #44586 

## Approach
The fix tracks generated typedesc variable names per module in `createTypedescVariable` and skips creation if a variable with that name already exists, with the tracking reset per module (not per type-definition or per statement list, so as not to disturb the existing, narrower `typedescList` batching) deduping by generated name rather than by `BType` object identity, since the two colliding types are structurally related but not the same Java object.

## Samples
```ballerina
import ballerina/io;

public const MAP = {
    "foo" : "bar"
};

public type Alias MAP;

public function main() {
    io:println("hello world");
}
```

## Remarks
The current fix dedupes by generated name within a module. This mirrors an existing name-based guard in the same method, but in principle two distinct types could theoretically share a generated name (e.g. via import-shadowing of simple names). This wasn't observed as an issue and is considered out of scope for this fix; flagging for awareness.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Added necessary tests
  - [x] Unit Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed compilation failures for type aliases that reference map or array constants.
- Prevented duplicate generated typedesc variables by tracking names per module.
- Added coverage for map and array constant aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->