### PR TITLE
Add opentelemetry-common dependency

### DIFF
--- a/bvm/ballerina-rt/build.gradle
+++ b/bvm/ballerina-rt/build.gradle
@@ -103,6 +103,7 @@ dependencies {
     dist libs.commons.logging
     dist libs.open.telemetry.api
     dist libs.open.telemetry.context
+    dist libs.open.telemetry.common
     dist libs.awaitility
     dist libs.hdr.histogram
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.vfs.watch=false
 systemProp.scan.capture-build-logging=false
 systemProp.scan.capture-test-logging=false
 
-version=2201.13.4-SNAPSHOT
+version=2201.13.5-SNAPSHOT
 group=org.ballerinalang
 bootstrappedOn=1.1.0-alpha
 specVersion=2024R1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,6 +99,7 @@ okhttpVersion="4.9.2"
 openhftCompilerVersion="2.23ea0"
 openTelemetryApiVersion="1.63.0"
 openTelemetryContextVersion="1.63.0"
+openTelemetryCommonVersion="1.63.0"
 openTelemetrySdkTestingVersion="1.63.0"
 openTelemetrySdkTraceVersion="1.63.0"
 ow2AsmAnalysisVersion="9.7"
@@ -226,6 +227,7 @@ netty-transport-native-epoll = { module = "io.netty:netty-transport-native-epoll
 netty-transport-native-kqueue = { module = "io.netty:netty-transport-native-kqueue", version.ref = "nettyTransportNativeKqueueVersion"}
 open-telemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "openTelemetryApiVersion"}
 open-telemetry-context = { module = "io.opentelemetry:opentelemetry-context", version.ref = "openTelemetryContextVersion"}
+open-telemetry-common = { module = "io.opentelemetry:opentelemetry-common", version.ref = "openTelemetryCommonVersion"}
 open-telemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "openTelemetrySdkTestingVersion"}
 open-telemetry-sdk-trace = { module = "io.opentelemetry:opentelemetry-sdk-trace", version.ref = "openTelemetrySdkTraceVersion"}
 openhft-compiler = { module = "net.openhft:compiler", version.ref = "openhftCompilerVersion"}


### PR DESCRIPTION
## Purpose
`io.opentelemetry/opentelemetry-common` is now a separate dependency for `io.opentelemetry/opentelemetry-context`. Previously it was packed inside the `opentelemetry-context`. With the version upgrade for `opentelemetry-context`, it breaks the runtime.

Related issue - https://github.com/ballerina-platform/ballerina-lang/issues/44622

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
