### PR TITLE
docs: fix duplicated word in regexp split doc comment

### DIFF
--- a/langlib/lang.regexp/src/main/ballerina/regexp.bal
+++ b/langlib/lang.regexp/src/main/ballerina/regexp.bal
@@ -415,7 +415,7 @@ isolated function getReplacementString(Groups groups, Replacement replacement) r
 }
 
 # Splits a string into substrings separated by matches of a regular expression.
-# This finds the the non-overlapping matches of a regular expression and
+# This finds the non-overlapping matches of a regular expression and
 # returns a list of substrings of `str` that occur before the first match,
 # between matches, or after the last match.  If there are no matches, then
 # `[str]` will be returned.


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

No related issue was filed for this. It's a single duplicated word caught while reading through the langlib doc comments. The API doc comment for `regexp:split()` reads "This finds the the non-overlapping matches...", with "the" duplicated. This text is published as-is on the public API reference (lib.ballerina.io / BallerinaCentral, `lang.regexp` module) and has been live there across multiple versions.

## Approach
> Describe how you are implementing the solutions along with the design details.

Single-line text edit removing the duplicate word from the doc comment. No code,
logic, or behavior changes — the function itself is untouched.

## Samples
> Provide high-level details about the samples related to this feature.

Not applicable it's a documentation text fix only, no new or changed samples.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

Not tied to an existing issue since it's a trivial typo; happy to file one first if that's preferred for future doc-only fixes.

## Check List
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage
- [x] Added necessary documentation
  - [x] API documentation
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Corrected a duplicated word in the `regexp:split()` API documentation comment. This documentation-only change does not affect functionality, APIs, samples, or tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->