### PR TITLE
docs: fix duplicated word in language server extension guide

### DIFF
--- a/docs/language-server/WritingExtendedServices.md
+++ b/docs/language-server/WritingExtendedServices.md
@@ -13,7 +13,7 @@ The Language Server Protocol(LSP) defines various namespaces for LSP operations.
 
 By default, the language server protocol defines two services as the `WorkspaceService` and the `TextDocumentService`.
 
-With the extended service capability, we are are going to introduce an extensible API to allow the third parties to bind custom services and extend the Language Server Protocol's default behavior.
+With the extended service capability, we are going to introduce an extensible API to allow the third parties to bind custom services and extend the Language Server Protocol's default behavior.
 
 <a name="ComponentsOfAService"></a>
 ## Components of a Service


### PR DESCRIPTION
## Purpose
No related issue was filed for this. It's a duplicated word caught while reading through the language server developer docs. The introduction of docs/language-server/WritingExtendedServices.md reads "we are are going to introduce...", with "are" duplicated. This guide is the primary reference for contributors implementing extended language server services.

## Approach
Single-line text edit removing the duplicate word from the introduction paragraph. No code, logic, or behavior changes.

## Samples
Not applicable, it's a documentation text fix only, no new or changed samples.

## Remarks
Not tied to an existing issue since it's a trivial typo; happy to file one first if that's preferred for future doc-only fixes.

## Check List
- [x] Read the Contributing Guide
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage
- [ ] Added necessary documentation
  - [ ] API documentation
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples

Removed a duplicated word from the language server extension developer guide. This documentation-only change does not affect functionality, APIs, samples, or tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Corrected a duplicated “are” in the introduction to “What is a Service?” in `WritingExtendedServices.md`.
- Documentation-only change with no impact on code, APIs, behavior, samples, or tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->