### PR TITLE
docs: fix grammar in semtypes README

### DIFF
--- a/semtypes/src/main/java/io/ballerina/types/README.md
+++ b/semtypes/src/main/java/io/ballerina/types/README.md
@@ -1,9 +1,9 @@
 # Notes about semtype port
 
-This this a Java port of semantic subtype implementation found in 
+This is a Java port of semantic subtype implementation found in 
 [https://github.com/ballerina-platform/nballerina/tree/main/compiler/modules/types](https://github.com/ballerina-platform/nballerina/tree/main/compiler/modules/types)
 
-The aim to resemble the original Ballerina implementation as closely as possible, any bug found here should be checked 
+The aim is to resemble the original Ballerina implementation as closely as possible, any bug found here should be checked 
 against the original implementation and if applicable, should be fixed there too.
 
 - Operations on sem types are separated into XXXXOps classes and the data into derivatives of `SubtypeData`.


### PR DESCRIPTION
## Purpose
No related issue was filed for this. Two related grammar issues caught while reading the semtypes module README. The opening lines of semtypes/src/main/java/io/ballerina/types/README.md read "This this a Java port..." and "The aim to resemble...", both missing the verb "is". This README is the entry point for compiler contributors working on the Java port of the semantic subtype implementation.

## Approach
Two related single-line text edits in the opening lines of the README, adding the missing "is" in each sentence. No code, logic, or behavior changes.

## Samples
Not applicable, it's a documentation text fix only, no new or changed samples.

## Remarks
Not tied to an existing issue since it's a trivial grammar fix; happy to file one first if that's preferred for future doc-only fixes.

## Check List
- [x] Read the Contributing Guide
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage
- [ ] Added necessary documentation
  - [ ] API documentation
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples

Corrected two related grammar issues in the semtypes module README. This documentation-only change does not affect functionality, APIs, samples, or tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the semtypes README to correct grammar and improve wording and line wrapping. No code, behavior, API, sample, or test changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->