### PR TITLE
Fix REPL hang with jline 3.30.14 (disable exec terminal provider)

### DIFF
--- a/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/ReplShellApplication.java
+++ b/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/ReplShellApplication.java
@@ -58,7 +58,10 @@ public final class ReplShellApplication {
                     .streams(configuration.getInputStream(), configuration.getOutputStream())
                     .jna(false).jansi(false).dumb(true).build();
         } else {
-            terminal = TerminalBuilder.terminal();
+            // Disable the 'exec' terminal provider: in non-interactive/CI environments (no TTY) it
+            // spawns an 'stty' subprocess that blocks indefinitely, hanging the REPL. Real terminals
+            // are still served by the native providers; otherwise jline falls back to a dumb terminal.
+            terminal = TerminalBuilder.builder().exec(false).build();
             configuration.setDumb(terminal.getType().equals(Terminal.TYPE_DUMB));
         }
 

--- a/distribution/zip/jballerina/bin/bal
+++ b/distribution/zip/jballerina/bin/bal
@@ -227,6 +227,7 @@ CMD_LINE_ARGS="-Xbootclasspath/a:"$BALLERINA_XBOOTCLASSPATH" \
                -Djava.security.egd=file:/dev/./urandom \
                -Dfile.encoding=UTF8 \
                -Dballerina.target=jvm \
+               -Dorg.jline.terminal.exec=false \
                -Djava.command=$JAVACMD"
 
 if [[ $1 == "native-img" ]]; then

--- a/distribution/zip/jballerina/bin/bal.bat
+++ b/distribution/zip/jballerina/bin/bal.bat
@@ -192,7 +192,7 @@ rem BALLERINA_CLASSPATH_EXT is for outsiders to additionally add
 rem classpath locations, e.g. AWS Lambda function libraries.
 if not "%BALLERINA_CLASSPATH_EXT%" == "" set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;%BALLERINA_CLASSPATH_EXT%
 
-set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError -Dcom.sun.management.jmxremote -classpath "%BALLERINA_CLASSPATH%" %JAVA_OPTS% -Dballerina.home="%BALLERINA_HOME%" -Dballerina.target="jvm" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Denable.nonblocking=false -Dfile.encoding=UTF8 -Dballerina.version=${project.version}
+set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError -Dcom.sun.management.jmxremote -classpath "%BALLERINA_CLASSPATH%" %JAVA_OPTS% -Dballerina.home="%BALLERINA_HOME%" -Dballerina.target="jvm" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Denable.nonblocking=false -Dfile.encoding=UTF8 -Dorg.jline.terminal.exec=false -Dballerina.version=${project.version}
 
 set jar=%~2
 if "%1" == "run" if "%jar:~-4%" == ".jar" goto runJar


### PR DESCRIPTION
Keeps jline on the **secure 3.30.14** (fixes CVE-2026-56740/56741) and resolves the CI Ubuntu hang from #44669 at its root.

**Cause:** In non-interactive/CI (no TTY), jline's `exec` terminal provider spawns an `stty` subprocess that blocks indefinitely, hanging the `bal shell` REPL until the 2h30m CI cap.

**Fix:** `ReplShellApplication` now builds the terminal with `.exec(false)`. Real terminals are still served by native providers (ffm/jni/jansi); non-TTY environments fall back to a dumb terminal instead of hanging.

Net diff vs base is a single line (jline stays at 3.30.14, already in the base branch).