### PR TITLE
Fix test file-tree deletion

### DIFF
--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
@@ -116,9 +116,7 @@ public final class BFileUtil {
                     if (exc != null) {
                         throw exc;
                     }
-                    if (Files.exists(dir)) {
-                        Files.delete(dir);
-                    }
+                    Files.deleteIfExists(dir);
                     return FileVisitResult.CONTINUE;
                 }
             });

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
@@ -60,8 +60,8 @@ public final class BFileUtil {
             Files.walkFileTree(sourcePath, new SimpleFileVisitor<Path>() {
 
                 @Override
-                public FileVisitResult visitFileFailed(Path file, IOException exc) {
-                    return FileVisitResult.CONTINUE;
+                public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                    throw exc;
                 }
 
                 @Override
@@ -99,8 +99,8 @@ public final class BFileUtil {
             Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
 
                 @Override
-                public FileVisitResult visitFileFailed(Path file, IOException exc) {
-                    return FileVisitResult.CONTINUE;
+                public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                    throw exc;
                 }
 
                 @Override
@@ -113,10 +113,11 @@ public final class BFileUtil {
 
                 @Override
                 public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    if (exc != null) {
+                        throw exc;
+                    }
                     if (Files.exists(dir)) {
-                        try (Stream<Path> paths = Files.list(dir)) {
-                            paths.forEach(BFileUtil::delete);
-                        }
+                        Files.delete(dir);
                     }
                     return FileVisitResult.CONTINUE;
                 }


### PR DESCRIPTION
## Purpose

Make test file-tree cleanup fail visibly when traversal or deletion fails. The previous visitors continued after `visitFileFailed` and could ignore the exception passed to `postVisitDirectory`, which could leave incomplete test cleanup while hiding the underlying I/O failure.

This recommendation originated from the latest accepted revision of [Stack Overflow answer 18454342](https://stackoverflow.com/a/18454342). No corresponding GitHub issue was found or opened for this research-derived maintenance fix.

## Approach

- Rethrow the `IOException` received by `visitFileFailed` during copy and delete traversal.
- Rethrow a non-null `postVisitDirectory` exception.
- Delete each directory after its children have been visited so the traversal also removes the root directory.

## Samples

No user-facing sample is applicable. This change is limited to the internal Java test utility `BFileUtil` and does not add or change Ballerina language syntax, APIs, or examples.

## Remarks

- The change affects test cleanup behavior only; product/runtime behavior is unchanged.
- Repository CI exercised the modified code. The Codecov report for this PR states that all modified coverable lines are covered by tests.
- This contribution is part of a research project by Mahidol University, Thailand, and the State University of Ceará, Brazil. The study was approved by Mahidol University's Institutional Review Board; the [participant information sheet](https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing) provides further details.

## Check List

- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Updated Change Log — not required because this only changes an internal test utility
- [x] Checked Tooling Support — not applicable; no language, compiler, editor, or tooling behavior changes
- [x] Added necessary tests — existing tests exercise the modified utility, and Codecov reports coverage for all modified coverable lines
  - [x] Unit Tests — existing coverage is sufficient; no new unit test was required
  - [x] Spec Conformance Tests — not applicable
  - [x] Integration Tests — not applicable
  - [x] Ballerina By Example Tests — not applicable
- [x] Increased Test Coverage — no additional coverage was required; the modified coverable lines are already covered
- [x] Added necessary documentation — not applicable for an internal test utility
  - [x] API documentation — not applicable
  - [x] Module documentation in Module.md files — not applicable
  - [x] Ballerina By Examples — not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `BFileUtil` test utilities to propagate file-tree traversal and deletion failures. Directory cleanup now deletes child directories before the root and uses `Files.deleteIfExists` to improve reliability. No product or runtime behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->