### PR TITLE
Fix bal test exit code

### DIFF
--- a/distribution/zip/jballerina/bin/bal.bat
+++ b/distribution/zip/jballerina/bin/bal.bat
@@ -202,7 +202,7 @@ if "%1" == "run" if "%~2" == "--debug" if "%jar:~-4%" == ".jar" goto debugJar
 
 :runJava
 "%JAVA_HOME%\bin\java" %CMD_LINE_ARGS% io.ballerina.cli.launcher.Main %CMD%
-goto end
+exit /b %ERRORLEVEL%
 
 :runJar
 for /f "tokens=1,*" %%a in ("%*") do set ARGS=%%b

--- a/distribution/zip/jballerina/bin/bal.bat
+++ b/distribution/zip/jballerina/bin/bal.bat
@@ -207,7 +207,7 @@ exit /b %ERRORLEVEL%
 :runJar
 for /f "tokens=1,*" %%a in ("%*") do set ARGS=%%b
 "%JAVA_HOME%\bin\java" %CMD_LINE_ARGS% -jar %ARGS%
-goto end
+exit /b %ERRORLEVEL%
 
 :debugJar
 setlocal ENABLEDELAYEDEXPANSION
@@ -226,7 +226,7 @@ for /f "tokens=1,* " %%a in ("%t%") do (
 )
 if defined t goto :loop
 "%JAVA_HOME%\bin\java" %CMD_LINE_ARGS% -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=%3 -jar %ARGS%
-goto end
+exit /b %ERRORLEVEL%
 
 :end
 goto endlocal

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/RerunFailedTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/RerunFailedTest.java
@@ -20,7 +20,6 @@ package org.ballerinalang.testerina.test;
 
 import org.ballerinalang.test.context.BMainInstance;
 import org.ballerinalang.test.context.BallerinaTestException;
-import org.ballerinalang.test.context.Utils;
 import org.ballerinalang.testerina.test.utils.AssertionUtils;
 import org.ballerinalang.testerina.test.utils.CommonUtils;
 import org.ballerinalang.testerina.test.utils.FileUtils;
@@ -57,10 +56,7 @@ public class RerunFailedTest extends BaseTestCase {
         String endString = "lineNumber";
         output = CommonUtils.replaceVaryingString(firstString, endString, output);
         AssertionUtils.assertOutput("RerunFailedTest-testFullTest.txt", output.replaceAll("\r", ""));
-        if (!Utils.isWindowsOS()) {
-            //  Skip the exit code check on Windows due to PowerShell always setting the exit code to 0.
-            Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
-        }
+        Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
     }
 
     @Test (dependsOnMethods = "testFullTest")
@@ -72,10 +68,7 @@ public class RerunFailedTest extends BaseTestCase {
         String endString = "lineNumber";
         output = CommonUtils.replaceVaryingString(firstString, endString, output);
         AssertionUtils.assertOutput("RerunFailedTest-testRerunFailedTest.txt", output.replaceAll("\r", ""));
-        if (!Utils.isWindowsOS()) {
-            //  Skip the exit code check on Windows due to PowerShell always setting the exit code to 0.
-            Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
-        }
+        Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
     }
 
     @Test (dependsOnMethods = "testRerunFailedTest")
@@ -88,10 +81,7 @@ public class RerunFailedTest extends BaseTestCase {
         String output = balClient.runMainAndReadStdOut("test", args, new HashMap<>(), projectPath, false);
         AssertionUtils.assertOutput("RerunFailedTest-testRerunFailedTestWithoutAnInitialRun.txt",
                 output.replaceAll("\r", ""));
-        if (!Utils.isWindowsOS()) {
-            //  Skip the exit code check on Windows due to PowerShell always setting the exit code to 0.
-            Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
-        }
+        Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
     }
 
     @Test

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/SkipTestsTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/SkipTestsTestCase.java
@@ -19,7 +19,6 @@ package org.ballerinalang.testerina.test.negative;
 
 import org.ballerinalang.test.context.BMainInstance;
 import org.ballerinalang.test.context.BallerinaTestException;
-import org.ballerinalang.test.context.Utils;
 import org.ballerinalang.testerina.test.BaseTestCase;
 import org.ballerinalang.testerina.test.utils.AssertionUtils;
 import org.testng.Assert;
@@ -52,10 +51,7 @@ public class SkipTestsTestCase extends BaseTestCase {
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
         AssertionUtils.assertOutput("SkipTestsTestCase-testSkipWhenDependsOnFunctionFails.txt", output);
-        if (!Utils.isWindowsOS()) {
-            //  Skip the exit code check on Windows due to PowerShell always setting the exit code to 0.
-            Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
-        }
+        Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
     }
 
     @Test
@@ -67,10 +63,7 @@ public class SkipTestsTestCase extends BaseTestCase {
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
         AssertionUtils.assertOutput("SkipTestsTestCase-testSkipWhenBeforeFails.txt", output);
-        if (!Utils.isWindowsOS()) {
-            //  Skip the exit code check on Windows due to PowerShell always setting the exit code to 0.
-            Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
-        }
+        Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
     }
 
     @Test
@@ -82,10 +75,7 @@ public class SkipTestsTestCase extends BaseTestCase {
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
         AssertionUtils.assertOutput("SkipTestsTestCase-testSkipWhenAfterFails.txt", output);
-        if (!Utils.isWindowsOS()) {
-            //  Skip the exit code check on Windows due to PowerShell always setting the exit code to 0.
-            Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
-        }
+        Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
     }
 
     @Test
@@ -97,10 +87,7 @@ public class SkipTestsTestCase extends BaseTestCase {
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
         AssertionUtils.assertOutput("SkipTestsTestCase-testSkipWhenBeforeEachFails.txt", output);
-        if (!Utils.isWindowsOS()) {
-            //  Skip the exit code check on Windows due to PowerShell always setting the exit code to 0.
-            Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
-        }
+        Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
     }
 
 
@@ -113,10 +100,7 @@ public class SkipTestsTestCase extends BaseTestCase {
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
         AssertionUtils.assertOutput("SkipTestsTestCase-testSkipWhenAfterEachFails.txt", output);
-        if (!Utils.isWindowsOS()) {
-            //  Skip the exit code check on Windows due to PowerShell always setting the exit code to 0.
-            Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
-        }
+        Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
     }
 
     @Test
@@ -128,10 +112,7 @@ public class SkipTestsTestCase extends BaseTestCase {
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
         AssertionUtils.assertOutput("SkipTestsTestCase-testSkipWhenBeforeSuiteFails.txt", output);
-        if (!Utils.isWindowsOS()) {
-            //  Skip the exit code check on Windows due to PowerShell always setting the exit code to 0.
-            Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
-        }
+        Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
     }
 
     @Test
@@ -143,10 +124,7 @@ public class SkipTestsTestCase extends BaseTestCase {
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
         AssertionUtils.assertOutput("SkipTestsTestCase-testSkipWhenBeforeGroupsFails.txt", output);
-        if (!Utils.isWindowsOS()) {
-            //  Skip the exit code check on Windows due to PowerShell always setting the exit code to 0.
-            Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
-        }
+        Assert.assertEquals(balClient.getLastExitCode(), 1, "The exit code is not as expected.");
     }
 
 }


### PR DESCRIPTION
Nota Bene: the current target branch of this MR is currently `release-2201.13.5`. If this not the right way to create a PR, don't hesitate to tell me.

## Purpose

Thank to this contribution, if a test failed during the execution of the commande "bal test", the resulting exit code would be different than 0.

This change concerns only the Windows distribution. From Codex, the linux implementation is already fine.

Fixes #44410

## Approach

A simple fix of one line have been applied in the "distribution\zip\jballerina-tools\build\extracted-distributions\jballerina-tools-2201.13.5\bin\bal.bat" script to return the correct exit code.

Existing tests which check if the current environment which run them is Windows doesn't do this check anymore.

## Samples

Details about usage can be found in Issue #44410.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Improved existing tests
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
