### PR TITLE
Fix incorrect type narrowing around if/else statements without complete else branches

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -2883,13 +2883,12 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
 
             if (elseStmt.getKind() == NodeKind.IF) {
                 data.notCompletedNormally = ifCompletionStatus && data.notCompletedNormally;
+            } else if (elseStmt.getKind() == NodeKind.BLOCK && ((BLangBlockStmt) elseStmt).stmts.isEmpty()) {
+                // A trivial (empty) else always completes normally on its own, so it carries no information about
+                // whether this if/else statement can fall through.
+                data.notCompletedNormally = ifCompletionStatus;
             } else {
-                boolean elseCompletesNormally = !data.notCompletedNormally;
-                if (elseCompletesNormally) {
-                    data.notCompletedNormally = ifCompletionStatus;
-                } else {
-                    data.notCompletedNormally = ifCompletionStatus && data.notCompletedNormally;
-                }
+                data.notCompletedNormally = ifCompletionStatus && data.notCompletedNormally;
             }
         }
         data.narrowedTypeInfo = prevNarrowedTypeInfo;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -616,19 +616,23 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
 
         data.prevEnvs.push(blockEnv);
         SymbolEnv env = blockEnv;
+        BLangStatement prev = prevStatement;
 
         for (int i = startIndex; i < stmts.size(); i++) {
             BLangStatement currentStmt = stmts.get(i);
-            BLangStatement prev = i == startIndex ? prevStatement : stmts.get(i - 1);
 
             if (prev.getKind() == NodeKind.IF && data.notCompletedNormally) {
                 BLangIf ifStmt = (BLangIf) prev;
-                if (ifStmt.elseStmt == null || endsWithEmptyElse(ifStmt)) {
+                if (hasTrivialOrNoElse(ifStmt)) {
                     data.notCompletedNormally =
                             ConditionResolver.checkConstCondition(types, symTable, ifStmt.expr) == symTable.trueType;
                     if (ifStmt.elseStmt == null) {
                         env = typeNarrower.evaluateFalsity(ifStmt.expr, currentStmt, env, false);
                     } else {
+                        // Re-derive falsity narrowing against currentStmt for every link in the chain: the
+                        // narrowedTypeInfo cached on each condition during the original visit(BLangIf) pass was
+                        // computed against a different target, so it must be nulled out and recomputed here for
+                        // this statement.
                         BLangIf currentIf = ifStmt;
                         while (currentIf != null) {
                             currentIf.expr.narrowedTypeInfo = null;
@@ -642,10 +646,17 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
 
             data.env = env;
             analyzeStmt(currentStmt, data);
+            prev = currentStmt;
         }
 
         data.prevEnvs.pop();
         return true;
+    }
+
+    // An if/else-if chain whose final else is absent or trivially empty never diverts control on its own:
+    // reaching the statement after it implies every condition in the chain was false.
+    private boolean hasTrivialOrNoElse(BLangIf ifStmt) {
+        return ifStmt.elseStmt == null || endsWithEmptyElse(ifStmt);
     }
 
     private boolean endsWithEmptyElse(BLangIf ifStmt) {
@@ -653,9 +664,11 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         while (elseStmt != null && elseStmt.getKind() == NodeKind.IF) {
             elseStmt = ((BLangIf) elseStmt).elseStmt;
         }
-        return elseStmt != null
-                && elseStmt.getKind() == NodeKind.BLOCK
-                && ((BLangBlockStmt) elseStmt).stmts.isEmpty();
+        return elseStmt != null && isEmptyBlock(elseStmt);
+    }
+
+    private boolean isEmptyBlock(BLangStatement stmt) {
+        return stmt.getKind() == NodeKind.BLOCK && ((BLangBlockStmt) stmt).stmts.isEmpty();
     }
 
     @Override
@@ -2202,6 +2215,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
     public void visit(BLangBlockStmt blockNode, AnalyzerData data) {
         data.env = SymbolEnv.createBlockEnv(blockNode, data.env);
         SymbolEnv blockEnv = data.env;
+
         int stmtCount = -1;
         for (BLangStatement stmt : blockNode.stmts) {
             stmtCount++;
@@ -2215,7 +2229,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
             BLangStatement lastStmt = blockNode.stmts.get(blockNode.stmts.size() - 1);
             if (lastStmt.getKind() == NodeKind.IF) {
                 BLangIf lastIf = (BLangIf) lastStmt;
-                if (lastIf.elseStmt == null || endsWithEmptyElse(lastIf)) {
+                if (hasTrivialOrNoElse(lastIf)) {
                     data.notCompletedNormally = false;
                 }
             }
@@ -2850,6 +2864,9 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         data.narrowedTypeInfo = new HashMap<>();
 
         data.env = ifEnv;
+        // Whatever completion status was carried in from before this if-statement is irrelevant to whether its own
+        // true-branch terminates.
+        resetNotCompletedNormally(data);
         analyzeStmt(ifNode.body, data);
 
         if (ifNode.expr.narrowedTypeInfo == null || ifNode.expr.narrowedTypeInfo.isEmpty()) {
@@ -2883,7 +2900,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
 
             if (elseStmt.getKind() == NodeKind.IF) {
                 data.notCompletedNormally = ifCompletionStatus && data.notCompletedNormally;
-            } else if (elseStmt.getKind() == NodeKind.BLOCK && ((BLangBlockStmt) elseStmt).stmts.isEmpty()) {
+            } else if (isEmptyBlock(elseStmt)) {
                 // A trivial (empty) else always completes normally on its own, so it carries no information about
                 // whether this if/else statement can fall through.
                 data.notCompletedNormally = ifCompletionStatus;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -1122,6 +1122,8 @@ public class TypeGuardTest {
                 "incompatible types: expected 'int', found '(int|error)'", 450, 12);
         BAssertUtil.validateError(result, index++,
                 "incompatible types: expected 'int', found '(int|error)'", 459, 12);
+        BAssertUtil.validateError(result, index++,
+                "incompatible types: expected 'int', found '(int|error)'", 470, 12);
         Assert.assertEquals(result.getDiagnostics().length, index);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -1124,6 +1124,8 @@ public class TypeGuardTest {
                 "incompatible types: expected 'int', found '(int|error)'", 459, 12);
         BAssertUtil.validateError(result, index++,
                 "incompatible types: expected 'int', found '(int|error)'", 470, 12);
+        BAssertUtil.validateError(result, index++,
+                "incompatible types: expected 'int', found '(int|error)'", 484, 13);
         Assert.assertEquals(result.getDiagnostics().length, index);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/test_type_guard_type_narrow_3.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/test_type_guard_type_narrow_3.bal
@@ -469,3 +469,18 @@ function test37(int|error x, boolean b) returns int {
     }
     return x; // ERROR incompatible types: expected 'int', found '(int|error)'
 }
+
+function test38(int|error a, int|error cond) returns int {
+    if a is error {
+        return 0;
+    } else {
+        return 1;
+    }
+
+    if cond is error {
+        // empty - no-op
+    }
+
+    int y = cond; // ERROR incompatible types: expected 'int', found '(int|error)'
+    return y;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/test_type_guard_type_narrow_3.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/test_type_guard_type_narrow_3.bal
@@ -458,3 +458,14 @@ function test36(int|error x) returns int {
     }
     return x; // ERROR incompatible types: expected 'int', found '(int|error)'
 }
+
+function test37(int|error x, boolean b) returns int {
+    if x is error {
+        if b {
+            return 0;
+        } else {
+            int y = 1;
+        }
+    }
+    return x; // ERROR incompatible types: expected 'int', found '(int|error)'
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/test_type_guard_type_narrow_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/test_type_guard_type_narrow_positive.bal
@@ -393,3 +393,14 @@ function test21(int|error x) returns int {
     int y = x;
     return y;
 }
+
+function test22(int|error x, boolean b) returns int {
+    if x is error {
+        if b {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
+    return x; // OK: inner if-else has a genuinely terminating (non-trivial) else, so it always terminates
+}


### PR DESCRIPTION
## Purpose
Several related bugs in the compiler's "does this if/else chain always terminate" analysis caused type narrowing to be silently applied or silently skipped in cases where it wasn't valid, letting real type errors go undetected in code following certain if shapes.

Fixes #43532 

## Approach
Iterative fixes to SemanticAnalyzer:
1. Correctly derive completion status for an if-without-else (or else-if chain ending in an empty else), including re-deriving it from a compile-time-constant condition where applicable.
2. Fix false narrowing from a nested if with an empty else inside an outer if's body.
3. Fix the same false-narrowing bug for a non-empty, non-terminating else block, which the empty-else-specific fix didn't cover.
4. Add a symmetric reset of the completion-status flag before analyzing an if's own true-branch body, closing the last leak where staleness from a preceding, unrelated statement survived through an empty if-body.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Added necessary tests
  - [x] Unit Tests
- [x] Increased Test Coverage
