### PR TITLE
Fix error propagation in lax optional field access

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -8810,7 +8810,8 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
     private boolean accessCouldResultInError(BType bType) {
         SemType s = bType.semType();
-        return SemTypes.containsBasicType(s, PredefinedType.XML) ||
+        return SemTypes.containsBasicType(s, PredefinedType.ERROR) ||
+                SemTypes.containsBasicType(s, PredefinedType.XML) ||
                 SemTypes.containsType(types.semTypeCtx, s, Core.createJson(types.semTypeCtx));
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/OptionalFieldAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/OptionalFieldAccessTest.java
@@ -75,6 +75,7 @@ public class OptionalFieldAccessTest {
                 "support optional field access", 141, 14);
         validateError(negativeResult, i++, "incompatible types: expected 'string', found 'int?'", 144, 17);
         validateError(negativeResult, i++, "incompatible types: expected 'string', found 'int?'", 145, 17);
+        validateError(negativeResult, i++, "incompatible types: expected 'json', found '(json|error)'", 150, 27);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 
@@ -140,7 +141,8 @@ public class OptionalFieldAccessTest {
                 { "testOptionalFieldAccessNilReturnOnLaxUnion" },
                 { "testOptionalFieldAccessNilLiftingOnLaxUnion" },
                 { "testOptionalFieldAccessErrorReturnOnLaxUnion" },
-                { "testOptionalFieldAccessErrorLiftingOnLaxUnion" }
+                { "testOptionalFieldAccessErrorLiftingOnLaxUnion" },
+                { "testOptionalFieldAccessErrorReturnOnChainedLaxAccess" }
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access.bal
@@ -733,3 +733,10 @@ function getOptionalField2() returns int? {
     AllOptionalBasicTypeField r = {val: 5};
     return r.val;
 }
+
+function testOptionalFieldAccessErrorReturnOnChainedLaxAccess() returns boolean {
+    map<map<json>> value = {};
+    json|error res = value.missing?.x;
+    return res is error && res.message() == "{ballerina/lang.map}KeyNotFound";
+}
+

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/optional_field_access_negative.bal
@@ -144,3 +144,9 @@ public function testNestedOptionalFieldAccessOnIntersectionTypesNegative() {
     string v3 = q2?.baz?.i;
     string v4 = q2?.baz["i"];
 }
+
+function testInvalidOptionalFieldAccessOnChainedLaxAccess() {
+    map<map<json>> value = {};
+    json assignedAsJson = value.missing?.x;
+}
+


### PR DESCRIPTION
## Purpose
A chained lax optional-field-access expression (such as `value.missing?.x` where `value` is `map<map<json>>`) was incorrectly considered assignable to `json` at compile time, despite the inner expression evaluating to `map<json> | error` and propagating an error at runtime. This allowed an `error` value to be held in a `json`-typed variable.

Fixes #44691

## Approach
In `TypeChecker.java`, updated `accessCouldResultInError(BType bType)` to check `SemTypes.containsBasicType(s, PredefinedType.ERROR)`. When an expression on the LHS of `?.` includes `error` (e.g., from an inner lax field access), the resulting optional field access expression will properly include `error` in its static union type (`json | error`), preventing invalid assignment to `json`.

## Samples
```ballerina
map<map<json>> value = {};

// Negative case: Compile-time error: 'incompatible types: expected 'json', found '(json|error)''
json assignedAsJson = value.missing?.x;

// Positive case: Allowed assignment
json|error assignedAsJsonOrError = value.missing?.x;
```

## Remarks
- Added negative unit test in `optional_field_access_negative.bal`
- Added positive runtime unit test in `optional_field_access.bal`
- Verified with unit tests and checkstyle.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#44691)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated `TypeChecker.java` to include `error` in the static type when optional field access can produce an error.
- Prevented invalid assignment of chained lax optional-field-access results to `json`.
- Added compile-time and runtime tests for valid and invalid chained access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->