### PR TITLE
Rename SBOM file to be unique per package and improve missing-coordinates warning

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
@@ -527,7 +527,7 @@ public class PushCommand implements BLauncherCmd {
             String name = balaProject.currentPackage().manifest().name().toString();
             String version = balaProject.currentPackage().manifest().version().toString();
 
-            Path sbomPath = findSiblingSbomFile(balaPath);
+            Path sbomPath = findSiblingSbomFile(balaPath, name, version);
             try {
                 Path customRepoPath = Files.createTempDirectory("ballerina-" + System.nanoTime());
                 client.pushPackage(balaPath, org, name, version, customRepoPath, sbomPath);
@@ -579,9 +579,9 @@ public class PushCommand implements BLauncherCmd {
         File[] balaFiles = new File(balaOutputDir.toString()).listFiles();
         if (balaFiles != null && balaFiles.length > 0) {
             for (File balaFile : balaFiles) {
-                // The name check alone is not enough to disambiguate: the standalone SBOM file `bal pack` writes
-                // next to the bala (see BalaWriter#writeBomToTargetDir) shares the same "<org>-<name>" prefix, so
-                // the extension must also be checked here.
+                // The name check alone is not enough to disambiguate, so the extension must also be checked
+                // to avoid picking up the standalone SBOM file (`<packageName>-<version>.cdx.json`) written
+                // next to the bala (see BalaWriter#writeBomToTargetDir).
                 if (balaFile != null && balaFile.getName().startsWith(orgName + "-" + pkgName)
                         && balaFile.getName().endsWith(ProjectConstants.BLANG_COMPILED_PKG_BINARY_EXT)) {
                     balaFilePath = balaFile.toPath();
@@ -593,18 +593,16 @@ public class PushCommand implements BLauncherCmd {
     }
 
     /**
-     * Find the standalone SBOM file {@code bal pack} writes next to the bala, under the fixed name
-     * {@link ProjectConstants#BOM_JSON} (see {@code BalaWriter#writeBomToTargetDir}).
-     *
-     * <p>Because this name is fixed rather than derived from the bala, it always reflects the most recently
-     * packed bala in this directory. If {@code balaPath} is a stale bala left over from an earlier pack (e.g.
-     * after a version bump), the SBOM found here will belong to the newer bala, not this one.</p>
+     * Find the standalone SBOM file {@code bal pack} writes next to the bala, named after the package and
+     * version being pushed (see {@code BalaWriter#writeBomToTargetDir}).
      *
      * @param balaPath path to the bala file being pushed
+     * @param name     name of the package being pushed
+     * @param version  version of the package being pushed
      * @return path to the sibling SBOM file, or {@code null} if none exists next to it
      */
-    private static Path findSiblingSbomFile(Path balaPath) {
-        Path sbomPath = balaPath.resolveSibling(ProjectConstants.BOM_JSON);
+    private static Path findSiblingSbomFile(Path balaPath, String name, String version) {
+        Path sbomPath = balaPath.resolveSibling(name + "-" + version + ".cdx.json");
         return Files.exists(sbomPath) ? sbomPath : null;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalaWriter.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalaWriter.java
@@ -207,10 +207,13 @@ public abstract class BalaWriter {
             return;
         }
         if (!jarsWithoutMavenCoordinates.isEmpty()) {
-            err.println("WARNING: SBOM for package '" + this.packageContext.packageName() + "' includes "
-                    + jarsWithoutMavenCoordinates.size() + " JAR(s) with no Maven coordinates, identified only by "
-                    + "file name and content hash: " + String.join(", ", jarsWithoutMavenCoordinates)
-                    );
+            String bulletedJars = jarsWithoutMavenCoordinates.stream()
+                    .map(jarName -> "     - " + jarName + ", ")
+                    .collect(Collectors.joining(System.lineSeparator()));
+            err.println("WARNING: The package '" + this.packageContext.packageName() + "' includes "
+                    + jarsWithoutMavenCoordinates.size() + " platform libraries with no Maven coordinates "
+                    + "(group-id, artifact-id and version), this will result in missing features in "
+                    + "vulnerability scanners: " + System.lineSeparator() + bulletedJars);
         }
         try {
             putZipEntry(balaOutputStream, Path.of(BOM_JSON),

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalaWriter.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalaWriter.java
@@ -211,9 +211,8 @@ public abstract class BalaWriter {
                     .map(jarName -> "     - " + jarName + ", ")
                     .collect(Collectors.joining(System.lineSeparator()));
             err.println("WARNING: The package '" + this.packageContext.packageName() + "' includes "
-                    + jarsWithoutMavenCoordinates.size() + " platform libraries with no Maven coordinates "
-                    + "(group-id, artifact-id and version), this will result in missing features in "
-                    + "vulnerability scanners: " + System.lineSeparator() + bulletedJars);
+                    + jarsWithoutMavenCoordinates.size() + " platform libraries with no 'group-id', "
+                    + "'artifact-id', and 'version' fields: " + System.lineSeparator() + bulletedJars);
         }
         try {
             putZipEntry(balaOutputStream, Path.of(BOM_JSON),

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalaWriter.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalaWriter.java
@@ -141,8 +141,8 @@ public abstract class BalaWriter {
      * bala, so it can be published as a separate artifact alongside the bala. Writing this file is best-effort:
      * a failure here should not fail the pack, since the BOM is already embedded inside the bala itself.
      *
-     * <p>Named after the package and version so each package's standalone SBOM remains uniquely identifiable and separate from any
-     * other package's (or version's) SBOM written into the same {@code balaDir}.</p>
+     * <p>Named after the package and version so each package's standalone SBOM remains uniquely identifiable and
+     * separate from any other package's (or version's) SBOM written into the same {@code balaDir}.</p>
      *
      * @param balaDir directory the bala was written to
      */

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalaWriter.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalaWriter.java
@@ -141,10 +141,8 @@ public abstract class BalaWriter {
      * bala, so it can be published as a separate artifact alongside the bala. Writing this file is best-effort:
      * a failure here should not fail the pack, since the BOM is already embedded inside the bala itself.
      *
-     * <p>Uses the fixed {@link #BOM_JSON} name rather than one derived from the bala (org/name/version/platform):
-     * {@code balaDir} is expected to hold a single bala at a time, so this file is always overwritten by the most
-     * recently packed bala. If a stale bala from an earlier pack is pushed later from the same directory, its
-     * published SBOM will reflect the most recently packed version instead, not the one being pushed.</p>
+     * <p>Named after the package and version so each package's standalone SBOM remains uniquely identifiable and separate from any
+     * other package's (or version's) SBOM written into the same {@code balaDir}.</p>
      *
      * @param balaDir directory the bala was written to
      */
@@ -152,10 +150,12 @@ public abstract class BalaWriter {
         if (this.bomJson == null) {
             return;
         }
+        String bomFileName = this.packageContext.packageName().value() + "-"
+                + this.packageContext.packageVersion().value().toString() + ".cdx.json";
         try {
-            Files.writeString(balaDir.resolve(BOM_JSON), this.bomJson, StandardCharsets.UTF_8);
+            Files.writeString(balaDir.resolve(bomFileName), this.bomJson, StandardCharsets.UTF_8);
         } catch (IOException e) {
-            err.println("Failed to write '" + BOM_JSON + "' file: " + e.getMessage());
+            err.println("Failed to write '" + bomFileName + "' file: " + e.getMessage());
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/SbomGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/SbomGenerator.java
@@ -161,10 +161,13 @@ public final class SbomGenerator {
                 dependsOn.add(ballerinaPurl(directDependency.packageInstance().descriptor()));
             }
 
+            boolean isRootPackage = purl.equals(rootPurl);
+            String declaringPackageLabel = isRootPackage ? null
+                    : descriptor.org().value() + "/" + descriptor.name().value() + ":" + descriptor.version();
             collectPlatformDependencies(nodePackage, backend, componentsByRef, dependsOnByRef, dependsOn,
-                    jarsWithoutMavenCoordinates);
+                    jarsWithoutMavenCoordinates, declaringPackageLabel);
 
-            if (purl.equals(rootPurl)) {
+            if (isRootPackage) {
                 collectBundledJars(nodePackage, bundledJarsByRole, componentsByRef, dependsOnByRef, dependsOn,
                         jarsWithoutMavenCoordinates);
             }
@@ -182,13 +185,16 @@ public final class SbomGenerator {
      * @param dependsOnByRef  accumulating dependency map, so each library also gets its own leaf entry
      * @param dependsOn       dependsOn set of the declaring package
      * @param jarsWithoutMavenCoordinates populated with the file name of each coordinate-less JAR encountered
+     * @param declaringPackageLabel {@code org/name:version} of {@code pkg}, or {@code null} if it is the root
+     *                              package
      */
     private static void collectPlatformDependencies(Package pkg,
                                                     CompilerBackend backend,
                                                     Map<String, Map<String, Object>> componentsByRef,
                                                     Map<String, Set<String>> dependsOnByRef,
                                                     Set<String> dependsOn,
-                                                    List<String> jarsWithoutMavenCoordinates) {
+                                                    List<String> jarsWithoutMavenCoordinates,
+                                                    String declaringPackageLabel) {
         if (backend == null) {
             return;
         }
@@ -204,7 +210,7 @@ public final class SbomGenerator {
             String sha256 = sha256(jarLibrary.path());
             String ref = jarRef(jarLibrary, pkg, sha256);
             componentsByRef.computeIfAbsent(ref,
-                    key -> jarComponent(jarLibrary, ref, sha256, jarsWithoutMavenCoordinates));
+                    key -> jarComponent(jarLibrary, ref, sha256, jarsWithoutMavenCoordinates, declaringPackageLabel));
 
             Set<String> jarDependsOn = dependsOnByRef.computeIfAbsent(ref, key -> new TreeSet<>());
             dependsOn.add(ref);
@@ -425,10 +431,13 @@ public final class SbomGenerator {
      * @param ref        bom-ref of the library
      * @param sha256     hash of the library's JAR file, or {@code null} when it could not be computed
      * @param jarsWithoutMavenCoordinates appended with this JAR's file name when it carries no Maven coordinates
+     * @param declaringPackageLabel {@code org/name:version} of the declaring package, or {@code null} if it is
+     *                              the root package
      * @return CycloneDX component
      */
     private static Map<String, Object> jarComponent(JarLibrary jarLibrary, String ref, String sha256,
-                                                     List<String> jarsWithoutMavenCoordinates) {
+                                                     List<String> jarsWithoutMavenCoordinates,
+                                                     String declaringPackageLabel) {
         Map<String, Object> component = new LinkedHashMap<>();
         component.put("type", COMPONENT_TYPE_LIBRARY);
         component.put("bom-ref", ref);
@@ -442,8 +451,10 @@ public final class SbomGenerator {
             component.put("version", version.get());
             component.put("purl", mavenPurl(groupId.get(), artifactId.get(), version.get()));
         } else {
-            component.put("name", fileName(jarLibrary));
-            jarsWithoutMavenCoordinates.add(fileName(jarLibrary));
+            String fileName = fileName(jarLibrary);
+            component.put("name", fileName);
+            jarsWithoutMavenCoordinates.add(declaringPackageLabel == null ? fileName
+                    : declaringPackageLabel + " - " + fileName);
         }
 
         if (sha256 != null) {

--- a/misc/maven-resolver/src/main/java/org/ballerinalang/maven/bala/client/MavenResolverClient.java
+++ b/misc/maven-resolver/src/main/java/org/ballerinalang/maven/bala/client/MavenResolverClient.java
@@ -198,14 +198,12 @@ public class MavenResolverClient {
     /**
      * Deploys the provided artifact, together with its SBOM, into the repository.
      *
-     /**
      * <p>The SBOM is uploaded separately as a raw file named {@code <packageName>-<version>.cdx.json}, next to
      * the bala/pom, rather than as a classified Maven artifact via {@link SubArtifact}. A classified artifact
      * would be renamed by Maven's repository layout to {@code <artifactId>-<version>-<classifier>.<extension>};
      * uploading it directly through the repository's {@link Transporter} instead keeps this exact file name, at
      * the cost of it no longer being resolvable via Maven GAV+classifier coordinates — a consumer needs to know
      * this naming convention to fetch it back.</p>
-
      *
      * @param balaPath      path to the bala
      * @param orgName       organization name

--- a/misc/maven-resolver/src/main/java/org/ballerinalang/maven/bala/client/MavenResolverClient.java
+++ b/misc/maven-resolver/src/main/java/org/ballerinalang/maven/bala/client/MavenResolverClient.java
@@ -111,11 +111,8 @@ public class MavenResolverClient {
     public static final String ARTIFACT_SEPERATOR = "-";
     private static final String METADATA_UPDATE_INTERVAL = "interval:10";
     private static final int CACHE_MAX_SIZE = 100;
-    // Fixed name the SBOM is uploaded under, matching ProjectConstants.BOM_JSON in the ballerina-lang module
-    // (duplicated here since this module does not depend on ballerina-lang). Uploaded as a raw file via
-    // Transporter rather than as a classified Maven artifact, so it keeps this exact name in the repository
-    // instead of being renamed to <artifactId>-<version>-<classifier>.<extension> per Maven layout conventions.
-    public static final String SBOM_FILE_NAME = "bom.cdx.json";
+
+    private static final String SBOM_FILE_EXTENSION = ".cdx.json";
 
     private final RepositorySystem system;
     private final DefaultRepositorySystemSession session;
@@ -201,12 +198,14 @@ public class MavenResolverClient {
     /**
      * Deploys the provided artifact, together with its SBOM, into the repository.
      *
-     * <p>The SBOM is uploaded separately as a raw file under the fixed name {@value #SBOM_FILE_NAME}, next to
+     /**
+     * <p>The SBOM is uploaded separately as a raw file named {@code <packageName>-<version>.cdx.json}, next to
      * the bala/pom, rather than as a classified Maven artifact via {@link SubArtifact}. A classified artifact
      * would be renamed by Maven's repository layout to {@code <artifactId>-<version>-<classifier>.<extension>};
      * uploading it directly through the repository's {@link Transporter} instead keeps this exact file name, at
      * the cost of it no longer being resolvable via Maven GAV+classifier coordinates — a consumer needs to know
-     * this fixed relative path convention to fetch it back.</p>
+     * this naming convention to fetch it back.</p>
+
      *
      * @param balaPath      path to the bala
      * @param orgName       organization name
@@ -230,7 +229,8 @@ public class MavenResolverClient {
             deployRequest.addArtifact(new SubArtifact(mainArtifact, "", POM, temporaryPom));
             system.deploy(session, deployRequest);
             if (sbomPath != null && Files.isRegularFile(sbomPath)) {
-                uploadRawFile(remoteRepository, mainArtifact, sbomPath, SBOM_FILE_NAME);
+                uploadRawFile(remoteRepository, mainArtifact, sbomPath, packageName + "-" + version
+                        + SBOM_FILE_EXTENSION);
             }
         } catch (DeploymentException | IOException e) {
             throw new MavenResolverClientException(e.getMessage());


### PR DESCRIPTION
## Purpose
>  Renames the standalone SBOM file written next to the bala from the fixed bom.cdx.json to `<pkgName>-<version>.cdx.json`, so each package's SBOM stays uniquely identifiable when multiple packages are pushed to a custom repository. Also rewords the warning printed for platform dependencies with no Maven coordinates.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
