### PR TITLE
Temporarily disable the warning for non-maven jars for sbom creation

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalaWriter.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BalaWriter.java
@@ -206,14 +206,16 @@ public abstract class BalaWriter {
         if (this.bomJson == null) {
             return;
         }
-        if (!jarsWithoutMavenCoordinates.isEmpty()) {
-            String bulletedJars = jarsWithoutMavenCoordinates.stream()
-                    .map(jarName -> "     - " + jarName + ", ")
-                    .collect(Collectors.joining(System.lineSeparator()));
-            err.println("WARNING: The package '" + this.packageContext.packageName() + "' includes "
-                    + jarsWithoutMavenCoordinates.size() + " platform libraries with no 'group-id', "
-                    + "'artifact-id', and 'version' fields: " + System.lineSeparator() + bulletedJars);
-        }
+        // TODO: enable this after fixing the standard libraries.
+//        if (!jarsWithoutMavenCoordinates.isEmpty()) {
+//            String bulletedJars = jarsWithoutMavenCoordinates.stream()
+//                    .map(jarName -> "     - " + jarName + ", ")
+//                    .collect(Collectors.joining(System.lineSeparator()));
+//            err.println("WARNING: The package '" + this.packageContext.packageName() + "' includes "
+//                    + jarsWithoutMavenCoordinates.size() + " platform libraries with no 'group-id', "
+//                    + "'artifact-id', and 'version' fields. This may result in missing features in " +
+//                    "vulnerability scanners: " + System.lineSeparator() + bulletedJars);
+//        }
         try {
             putZipEntry(balaOutputStream, Path.of(BOM_JSON),
                     new ByteArrayInputStream(this.bomJson.getBytes(StandardCharsets.UTF_8)));


### PR DESCRIPTION
## Purpose
> Temporarily disable the warning for non-maven jars for sbom creation

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
