### PR TITLE
Implicitly import OTel module for `observabilityIncluded` packages

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -346,11 +346,16 @@ public class PackageResolution {
                         PackageDependencyScope.DEFAULT, DependencyResolutionType.PLATFORM_PROVIDED);
             allModuleLoadRequests.add(observeModuleLoadReq);
 
-            String otelModuleName = Names.OTEL.getValue();
-            ModuleLoadRequest otelModuleLoadReq = new ModuleLoadRequest(
-                        PackageOrg.from(Names.BALLERINA_ORG.value), otelModuleName,
-                        PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE);
-            allModuleLoadRequests.add(otelModuleLoadReq);
+            // The ballerina/otel package is resolved from source so that improvements can be pulled
+            // from Ballerina Central. For BALA projects the dependency graph is already locked at
+            // build time, hence we must not inject the otel SOURCE dependency into that graph.
+            if (rootPackageContext.project().kind() != ProjectKind.BALA_PROJECT) {
+                String otelModuleName = Names.OTEL.getValue();
+                ModuleLoadRequest otelModuleLoadReq = new ModuleLoadRequest(
+                            PackageOrg.from(Names.BALLERINA_ORG.value), otelModuleName,
+                            PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE);
+                allModuleLoadRequests.add(otelModuleLoadReq);
+            }
         }
 
         // TODO Can we make this a builtin compiler plugin

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -345,6 +345,12 @@ public class PackageResolution {
                         PackageOrg.from(Names.BALLERINA_INTERNAL_ORG.value), moduleName,
                         PackageDependencyScope.DEFAULT, DependencyResolutionType.PLATFORM_PROVIDED);
             allModuleLoadRequests.add(observeModuleLoadReq);
+
+            String otelModuleName = Names.OTEL.getValue();
+            ModuleLoadRequest otelModuleLoadReq = new ModuleLoadRequest(
+                        PackageOrg.from(Names.BALLERINA_ORG.value), otelModuleName,
+                        PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE);
+            allModuleLoadRequests.add(otelModuleLoadReq);
         }
 
         // TODO Can we make this a builtin compiler plugin

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -782,6 +782,7 @@ public class Desugar extends BLangNodeVisitor {
             return;
         }
         observabilityDesugar.addObserveInternalModuleImport(pkgNode);
+        observabilityDesugar.addOtelModuleImport(pkgNode);
 
         code2CloudDesugar.addCode2CloudModuleImport(pkgNode);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ObservabilityDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ObservabilityDesugar.java
@@ -20,6 +20,7 @@ import io.ballerina.projects.ProjectKind;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.PackageCache;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
@@ -64,6 +65,28 @@ public class ObservabilityDesugar {
             importDcl.symbol = packageCache.getSymbol(PackageID.OBSERVE_INTERNAL);
             pkgNode.imports.add(0, importDcl);
             pkgNode.symbol.imports.add(importDcl.symbol);
+        }
+    }
+
+    void addOtelModuleImport(BLangPackage pkgNode) {
+        if (pkgNode.moduleContextDataHolder != null && pkgNode.moduleContextDataHolder.isObservabiltyIncluded()
+                && !pkgNode.moduleContextDataHolder.projectKind().equals(ProjectKind.BALA_PROJECT)) {
+            final BPackageSymbol otelSymbol = packageCache.getSymbol(Names.BALLERINA_ORG.value
+                    + Names.ORG_NAME_SEPARATOR.value + Names.OTEL.value);
+            if (otelSymbol == null) {
+                return;
+            }
+            BLangImportPackage otelImportDcl = (BLangImportPackage) TreeBuilder.createImportPackageNode();
+            List<BLangIdentifier> otelPkgNameComps = new ArrayList<>();
+            otelPkgNameComps.add(ASTBuilderUtil.createIdentifier(pkgNode.pos, Names.OTEL.value));
+            otelImportDcl.pkgNameComps = otelPkgNameComps;
+            otelImportDcl.pos = pkgNode.symbol.pos;
+            otelImportDcl.orgName = ASTBuilderUtil.createIdentifier(pkgNode.pos, Names.BALLERINA_ORG.value);
+            otelImportDcl.alias = ASTBuilderUtil.createIdentifier(pkgNode.pos, "_");
+            otelImportDcl.version = ASTBuilderUtil.createIdentifier(pkgNode.pos, "");
+            otelImportDcl.symbol = packageCache.getSymbol(otelSymbol.pkgID);
+            pkgNode.imports.add(1, otelImportDcl);
+            pkgNode.symbol.imports.add(otelImportDcl.symbol);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Names.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Names.java
@@ -68,6 +68,7 @@ public class Names {
     public static final Name TRANSACTION = new Name("transaction");
     public static final Name NATURAL_PROGRAMMING = new Name("ai.np");
     public static final Name OBSERVE = new Name("observe");
+    public static final Name OTEL = new Name("otel");
     public static final Name CLOUD = new Name("cloud");
     public static final Name TABLE = new Name("table");
     public static final Name TEST = new Name("test");


### PR DESCRIPTION
## Purpose
Implicitly import OTel module for `observabilityIncluded` packages

Partially Fixes https://github.com/ballerina-platform/ballerina-lang/issues/44705

## Approach
Add the `ballerina/otel` at desugar level for packages with `observabilityIncluded` set to true.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds an implicit `ballerina/otel` import for packages with `observabilityIncluded` enabled. Updates dependency resolution and desugaring to register the module, and adds the `Names.OTEL` constant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->