### PR TITLE
Fix arbitrary file write via malicious Maven BALA (CWE-22)

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
@@ -1120,6 +1120,7 @@ public final class CommandUtil {
         try (BufferedReader bufferedReader = Files.newBufferedReader(packageJsonPath, StandardCharsets.UTF_8)) {
             JsonObject resultObj = new Gson().fromJson(bufferedReader, JsonObject.class);
             String platform = resultObj.get(PLATFORM).getAsString();
+            ProjectUtils.validatePlatformIdentifier(platform);
             Path actualBalaPath = finalCachePath.resolve(platform);
             org.apache.commons.io.FileUtils.copyDirectory(temporaryExtractionPath.toFile(),
                     actualBalaPath.toFile());

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
@@ -374,6 +374,9 @@ public class PullCommand implements BLauncherCmd {
             } catch (IOException e) {
                 throw createLauncherException(
                         "unexpected error occurred while creating package repository in bala cache: " + e.getMessage());
+            } catch (ProjectException e) {
+                errStream.println("unexpected error occurred while pulling package:" + e.getMessage());
+                CommandUtil.exitError(this.exitWhenFinish);
             }
             PrintStream out = System.out;
             out.println("Successfully pulled the package from the custom repository.");

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PackCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PackCommandTest.java
@@ -3,6 +3,7 @@ package io.ballerina.cli.cmd;
 import com.google.gson.Gson;
 import io.ballerina.cli.launcher.BLauncherException;
 import io.ballerina.projects.JvmTarget;
+import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.internal.bala.PackageJson;
 import io.ballerina.projects.util.ProjectUtils;
 import org.ballerinalang.test.BCompileUtil;
@@ -18,11 +19,14 @@ import picocli.CommandLine;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Objects;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static io.ballerina.cli.cmd.CommandOutputUtils.assertTomlFilesEquals;
 import static io.ballerina.cli.cmd.CommandOutputUtils.getOutput;
@@ -109,6 +113,43 @@ public class PackCommandTest extends BaseCommandTest {
         String packageJsonContent = Files.readString(extractedPath.resolve(PACKAGE_JSON));
         PackageJson packageJson = new Gson().fromJson(packageJsonContent, PackageJson.class);
         Assert.assertEquals(BALA_DOCS_DIR + "/" + README_MD_FILE_NAME, packageJson.getReadme());
+    }
+
+    @Test(description = "tests that a bala with a path-traversal zip entry is rejected during extraction")
+    public void testExtractBalaWithPathTraversalEntryRejected() throws IOException {
+        Path testRoot = Files.createTempDirectory("bala-zip-slip-test");
+        try {
+            // extractionDir is the intended extraction directory; the malicious entry below tries to
+            // escape it and write two directories up, into testRoot.
+            Path extractionDir = testRoot.resolve("nested").resolve("extracted");
+            Files.createDirectories(extractionDir);
+            Path maliciousBala = testRoot.resolve("testorg-attackpkg-any-0.1.0.bala");
+            try (ZipOutputStream zipOut = new ZipOutputStream(Files.newOutputStream(maliciousBala))) {
+                writeZipEntry(zipOut, "package.json", "{"
+                        + "\"organization\":\"testorg\",\"name\":\"attackpkg\",\"version\":\"0.1.0\","
+                        + "\"platform\":\"any\"}");
+                writeZipEntry(zipOut, "../../evil-marker.txt", "owned");
+            }
+
+            try {
+                ProjectUtils.extractBala(maliciousBala, extractionDir);
+                Assert.fail("expected a ProjectException due to the path traversal zip entry");
+            } catch (ProjectException e) {
+                Assert.assertTrue(e.getMessage().contains("resolves outside the extraction directory"),
+                        "unexpected exception message: " + e.getMessage());
+            }
+
+            Assert.assertFalse(Files.exists(testRoot.resolve("evil-marker.txt")),
+                    "zip entry path traversal wrote a file outside the intended extraction directory");
+        } finally {
+            ProjectUtils.deleteDirectory(testRoot);
+        }
+    }
+
+    private static void writeZipEntry(ZipOutputStream zipOut, String entryName, String content) throws IOException {
+        zipOut.putNextEntry(new ZipEntry(entryName));
+        zipOut.write(content.getBytes(StandardCharsets.UTF_8));
+        zipOut.closeEntry();
     }
 
     @Test(description = "Pack a ballerina project with the engagement of all type of compiler plugins",

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PullCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PullCommandTest.java
@@ -18,9 +18,11 @@
 
 package io.ballerina.cli.cmd;
 
+import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.Settings;
 import io.ballerina.projects.TomlDocument;
 import io.ballerina.projects.internal.SettingsBuilder;
+import io.ballerina.projects.util.ProjectUtils;
 import org.ballerinalang.maven.bala.client.MavenResolverClient;
 import org.ballerinalang.maven.bala.client.MavenResolverClientException;
 import org.mockito.MockedConstruction;
@@ -32,8 +34,11 @@ import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 /**
  * Pull command tests.
@@ -251,6 +256,52 @@ public class PullCommandTest extends BaseCommandTest {
         Path pulledCacheDir = mockBallerinaHome.resolve("repositories").resolve("central.ballerina.io")
                 .resolve("bala").resolve("luheerathan").resolve("pact1").resolve("0.1.0");
         Assert.assertTrue(Files.exists(pulledCacheDir.resolve("any")));
+    }
+
+    @Test(description = "tests that a maven bala with a path-traversal platform value is rejected")
+    public void testExtractAndCopyBalaWithPathTraversalPlatformRejected() throws Exception {
+        Path testRoot = Files.createTempDirectory("maven-bala-platform-traversal-test");
+        try {
+            Path repository = testRoot.resolve("repository");
+            Path artifact = repository.resolve("testorg/attackpkg/0.1.0/attackpkg-0.1.0.bala");
+            Files.createDirectories(artifact.getParent());
+
+            // The malicious "platform" value points outside the intended cache directory entirely.
+            Path outsideDir = testRoot.resolve("outside-cache").toAbsolutePath();
+            String maliciousPlatform = outsideDir.toString().replace("\\", "\\\\");
+            String packageJson = "{\"organization\":\"testorg\",\"name\":\"attackpkg\",\"version\":\"0.1.0\","
+                    + "\"platform\":\"" + maliciousPlatform + "\"}";
+            try (ZipOutputStream zipOut = new ZipOutputStream(Files.newOutputStream(artifact))) {
+                zipOut.putNextEntry(new ZipEntry("package.json"));
+                zipOut.write(packageJson.getBytes(StandardCharsets.UTF_8));
+                zipOut.closeEntry();
+            }
+            Files.writeString(artifact.resolveSibling("attackpkg-0.1.0.pom"), """
+                    <project xmlns="http://maven.apache.org/POM/4.0.0">
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>testorg</groupId>
+                      <artifactId>attackpkg</artifactId>
+                      <version>0.1.0</version>
+                    </project>
+                    """);
+
+            MavenResolverClient client = new MavenResolverClient();
+            client.addRepository("path-traversal-test-repo", repository.toUri().toString());
+            Path cache = testRoot.resolve("cache");
+
+            try {
+                CommandUtil.extractAndCopyBala(client, "testorg", "attackpkg", "0.1.0", cache);
+                Assert.fail("expected a ProjectException due to the path traversal platform value");
+            } catch (ProjectException e) {
+                Assert.assertTrue(e.getMessage().contains("invalid platform identifier"),
+                        "unexpected exception message: " + e.getMessage());
+            }
+
+            Assert.assertFalse(Files.exists(outsideDir),
+                    "platform path traversal wrote outside the intended cache directory");
+        } finally {
+            ProjectUtils.deleteDirectory(testRoot);
+        }
     }
 
     private static Settings readMockSettings(Path settingsFilePath, String repoPath) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/MavenPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/MavenPackageRepository.java
@@ -276,6 +276,7 @@ public class MavenPackageRepository implements PackageRepository {
             try (BufferedReader bufferedReader = Files.newBufferedReader(packageJsonPath, StandardCharsets.UTF_8)) {
                 JsonObject resultObj = new Gson().fromJson(bufferedReader, JsonObject.class);
                 String platform = resultObj.get(PLATFORM).getAsString();
+                ProjectUtils.validatePlatformIdentifier(platform);
                 Path actualBalaPath = Path.of(this.repoLocation).resolve(org).resolve(name)
                         .resolve(version).resolve(platform);
                 FileUtils.copyDirectory(temporaryExtractionPath.toFile(),

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectUtils.java
@@ -25,6 +25,7 @@ import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.projects.AnyTarget;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.JarLibrary;
@@ -191,6 +192,23 @@ public final class ProjectUtils {
         return validateDotSeparatedIdentifiers(packageName)
                 && validateUnderscoresOfName(packageName)
                 && validateInitialNumericsOfName(packageName);
+    }
+
+    /**
+     * Validates that a bala's {@code platform} identifier (read from {@code package.json}) is one of the
+     * known target platforms. This value is untrusted (it comes from bala metadata that may originate from a
+     * third-party repository) and must never be interpreted as a filesystem path, so it is checked against an
+     * allowlist rather than sanitized.
+     *
+     * @param platform the platform identifier read from the bala's {@code package.json}
+     * @throws ProjectException if the platform identifier is not a known target platform
+     */
+    public static void validatePlatformIdentifier(String platform) {
+        boolean valid = AnyTarget.ANY.code().equals(platform)
+                || Stream.of(JvmTarget.values()).anyMatch(jvmTarget -> jvmTarget.code().equals(platform));
+        if (!valid) {
+            throw new ProjectException("invalid platform identifier in bala metadata: '" + platform + "'");
+        }
     }
 
     public static Set<String> getPackageImports(Package pkg) {
@@ -1018,6 +1036,15 @@ public final class ProjectUtils {
                     String fileName = zipEntry.getName();
                     // Construct the output file.
                     Path outputPath = balaFileDestPath.resolve(fileName);
+                    // Reject zip entries (absolute paths, or relative paths containing '..') that would
+                    // otherwise cause a file to be written outside the intended extraction directory (Zip Slip).
+                    Path canonicalDestPath = outputPath.toAbsolutePath().normalize();
+                    Path canonicalRootPath = balaFileDestPath.toAbsolutePath().normalize();
+                    if (!canonicalDestPath.startsWith(canonicalRootPath)) {
+                        throw new ProjectException(
+                                "invalid bala: zip entry '" + fileName + "' resolves outside the extraction " +
+                                        "directory");
+                    }
                     // If the zip entry is for a directory, we create the directory and continue with the next entry.
                     if (zipEntry.isDirectory()) {
                         Files.createDirectories(outputPath);

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/MavenPackageRepositoryTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/MavenPackageRepositoryTests.java
@@ -25,6 +25,7 @@ import io.ballerina.projects.environment.ResolutionResponse;
 import io.ballerina.projects.internal.ImportModuleRequest;
 import io.ballerina.projects.internal.ImportModuleResponse;
 import io.ballerina.projects.internal.repositories.MavenPackageRepository;
+import io.ballerina.projects.util.ProjectUtils;
 import org.ballerinalang.maven.bala.client.MavenResolverClient;
 import org.ballerinalang.maven.bala.client.MavenResolverClientException;
 import org.ballerinalang.maven.bala.client.model.PackageResolutionResponse;
@@ -34,6 +35,7 @@ import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,6 +46,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -511,5 +515,47 @@ public class MavenPackageRepositoryTests {
         Assert.assertTrue(graph.getNodes().contains(packC));
 
         verify(mockClient).resolveDependency(anyString(), anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test(description = "Proxy: getPackageFromRemoteRepo rejects a bala with a path-traversal platform value",
+            groups = {"proxy"})
+    public void testGetPackageFromRemoteRepoWithPathTraversalPlatformRejected()
+            throws IOException, MavenResolverClientException {
+        Path testRoot = Files.createTempDirectory("maven-package-repo-platform-traversal-test");
+        try {
+            // The malicious "platform" value points outside the intended repo location entirely.
+            Path outsideDir = testRoot.resolve("outside-repo-location").toAbsolutePath();
+            String maliciousPlatform = outsideDir.toString().replace("\\", "\\\\");
+            String packageJson = "{\"organization\":\"testorg\",\"name\":\"attackpkg\",\"version\":\"0.1.0\","
+                    + "\"platform\":\"" + maliciousPlatform + "\"}";
+
+            MavenResolverClient mockClient = Mockito.mock(MavenResolverClient.class);
+            Mockito.doAnswer(invocation -> {
+                String targetLocation = invocation.getArgument(3);
+                Path balaPath = Path.of(targetLocation).resolve("testorg").resolve("attackpkg").resolve("0.1.0")
+                        .resolve("attackpkg-0.1.0.bala");
+                Files.createDirectories(balaPath.getParent());
+                try (ZipOutputStream zipOut = new ZipOutputStream(Files.newOutputStream(balaPath))) {
+                    zipOut.putNextEntry(new ZipEntry("package.json"));
+                    zipOut.write(packageJson.getBytes(StandardCharsets.UTF_8));
+                    zipOut.closeEntry();
+                }
+                return null;
+            }).when(mockClient).pullPackage(anyString(), anyString(), anyString(), anyString());
+
+            MavenPackageRepository repo = proxyRepo(mockClient);
+            try {
+                repo.getPackageFromRemoteRepo("testorg", "attackpkg", "0.1.0");
+                Assert.fail("expected a ProjectException due to the path traversal platform value");
+            } catch (ProjectException e) {
+                Assert.assertTrue(e.getMessage().contains("invalid platform identifier"),
+                        "unexpected exception message: " + e.getMessage());
+            }
+
+            Assert.assertFalse(Files.exists(outsideDir),
+                    "platform path traversal wrote outside the intended repo location");
+        } finally {
+            ProjectUtils.deleteDirectory(testRoot);
+        }
     }
 }


### PR DESCRIPTION
## Summary
Fixes path-traversal sinks that let a malicious Maven repository write files outside the intended extraction/cache directory during `bal pull` or automatic Maven-based dependency resolution.

## Vulnerable call sites
1. `ProjectUtils.extractBala` — ZIP entry names were resolved against the extraction directory with no confinement check.
2. `CommandUtil.extractAndCopyBala` — `package.json`'s `platform` field was trusted as a raw path segment.
3. `MavenPackageRepository.getPackageFromRemoteRepo` — same unguarded pattern as (2), duplicated.

## Fix
- Added a containment check for ZIP entries in `extractBala`.
- Added a shared `ProjectUtils.validatePlatformIdentifier` allowlist (`any` + supported JVM targets), used by both platform-consuming call sites.
- `PullCommand` now catches the new `ProjectException` for a clean error message instead of an uncaught crash.
- Added a regression test per call site.

